### PR TITLE
OAK-533 - Define behaviour for and implement mix:lastModified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.metadata
 .settings
 .classpath
 .project

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/MixLastModifiedCommitHook.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/MixLastModifiedCommitHook.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.commit;
+
+import java.security.AccessController;
+import java.util.Set;
+
+import javax.jcr.Credentials;
+import javax.jcr.SimpleCredentials;
+import javax.security.auth.Subject;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.plugins.memory.LongPropertyState;
+import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeState;
+import org.apache.jackrabbit.oak.plugins.memory.StringPropertyState;
+import org.apache.jackrabbit.oak.plugins.nodetype.NodeTypeConstants;
+import org.apache.jackrabbit.oak.spi.commit.NodeTypeCommitHook;
+import org.apache.jackrabbit.oak.spi.security.authentication.ImpersonationCredentials;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStateDiff;
+
+/**
+ * This class provides a commit hook for nodes of type {@code mix:lastModified} that properly implements section
+ * 3.7.11.8 of JSR283:
+ * 
+ * <pre>
+ * [mix:lastModified] mixin
+ * - jcr:lastModified (DATE) autocreated protected? OPV?
+ * - jcr:lastModifiedBy (STRING) autocreated protected? OPV?
+ * </pre>
+ * 
+ */
+public class MixLastModifiedCommitHook extends NodeTypeCommitHook {
+
+    private Long lastModified;
+    private String userID;
+
+    public MixLastModifiedCommitHook() {
+        super(NodeTypeConstants.MIX_LASTMODIFIED);
+    }
+
+    @Override
+    public void processChangedNode(NodeState before, NodeState after, NodeBuilder nodeBuilder) {
+        after.compareAgainstBaseState(before, new AllChangesNodeStateDiff(nodeBuilder));
+        if (lastModified != null) {
+            PropertyState jcrLastModifiedDate = LongPropertyState.createDateProperty(JcrConstants.JCR_LASTMODIFIED,
+                    lastModified);
+            nodeBuilder.setProperty(jcrLastModifiedDate);
+        }
+        if (userID != null) {
+            PropertyState jcrLastModifiedBy = StringPropertyState.stringProperty(NodeTypeConstants.JCR_LASTMODIFIEDBY,
+                    userID);
+            nodeBuilder.setProperty(jcrLastModifiedBy);
+        }
+    }
+
+    private final class AllChangesNodeStateDiff implements NodeStateDiff {
+
+        private NodeBuilder node;
+
+        public AllChangesNodeStateDiff(NodeBuilder node) {
+            this.node = node;
+        }
+
+        @Override
+        public void propertyAdded(PropertyState after) {
+            if (after.getName().equals(JcrConstants.JCR_LASTMODIFIED)) {
+                return;
+            }
+            updateLastModifiedDate();
+            updateLastModifiedBy();
+        }
+
+        @Override
+        public void propertyChanged(PropertyState before, PropertyState after) {
+            if (after.getName().equals(JcrConstants.JCR_LASTMODIFIED)) {
+                return;
+            }
+            updateLastModifiedDate();
+            updateLastModifiedBy();
+        }
+
+        @Override
+        public void propertyDeleted(PropertyState before) {
+            updateLastModifiedDate();
+            updateLastModifiedBy();
+        }
+
+        @Override
+        public void childNodeAdded(String name, NodeState after) {
+            childNodeChanged(name, MemoryNodeState.EMPTY_NODE, after);
+        }
+
+        @Override
+        public void childNodeChanged(String name, NodeState before, NodeState after) {
+            after.compareAgainstBaseState(before, new AllChangesNodeStateDiff(node.child(name)));
+            updateLastModifiedDate();
+            updateLastModifiedBy();
+        }
+
+        @Override
+        public void childNodeDeleted(String name, NodeState before) {
+            NodeState after = MemoryNodeState.EMPTY_NODE;
+            after.compareAgainstBaseState(before, new AllChangesNodeStateDiff(after.builder()));
+            updateLastModifiedDate();
+            updateLastModifiedBy();
+        }
+
+        private void updateLastModifiedDate() {
+            lastModified = System.currentTimeMillis();
+        }
+        
+        private void updateLastModifiedBy() {
+            Subject subject = Subject.getSubject(AccessController.getContext());
+            Set<Credentials> credentials = subject.getPublicCredentials(Credentials.class);
+            userID = null;
+            for (Credentials c : credentials) {
+                if (c instanceof SimpleCredentials) {
+                    userID = ((SimpleCredentials) c).getUserID();
+                } else if (c instanceof ImpersonationCredentials) {
+                    userID = ((ImpersonationCredentials) c).getImpersonatorInfo().getUserID();
+                }
+            }
+        }
+    }
+}

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/spi/commit/NodeTypeCommitHook.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/spi/commit/NodeTypeCommitHook.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.spi.commit;
+
+import static org.apache.jackrabbit.oak.api.Type.STRING;
+import static org.apache.jackrabbit.oak.api.Type.STRINGS;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeState;
+import org.apache.jackrabbit.oak.spi.state.DefaultNodeStateDiff;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+
+/**
+ * This abstract class provides node-type extensible commit hooks. One can extend this class to create
+ * {@link CommitHook}s for specific node types or mixin types. For more details check this class' constructor.
+ */
+public abstract class NodeTypeCommitHook implements CommitHook {
+
+    protected String nodeType;
+
+    /**
+     * Creates a {@link NodeTypeCommitHook} for a specified node type or mixin type.
+     * 
+     * @param nodeType
+     *            the type of the node / mixin
+     */
+    protected NodeTypeCommitHook(String nodeType) {
+        this.nodeType = nodeType;
+    }
+
+    @Override
+    public NodeState processCommit(NodeState before, NodeState after) throws CommitFailedException {
+        NodeBuilder node = after.builder();
+        after.compareAgainstBaseState(before, new ModifiedNodeStateDiff(nodeType, node));
+        return node.getNodeState();
+    }
+
+    private class ModifiedNodeStateDiff extends DefaultNodeStateDiff {
+
+        private final String nodeType;
+        private final NodeBuilder nodeBuilder;
+
+        public ModifiedNodeStateDiff(String nodeType, NodeBuilder nodeBuilder) {
+            this.nodeType = nodeType;
+            this.nodeBuilder = nodeBuilder;
+        }
+
+        @Override
+        public void childNodeAdded(String name, NodeState after) {
+            childNodeChanged(name, MemoryNodeState.EMPTY_NODE, after);
+        }
+
+        @Override
+        public void childNodeChanged(String name, NodeState before, NodeState after) {
+            boolean matchesNodeType = after.getProperty(JcrConstants.JCR_PRIMARYTYPE).getValue(STRING).equals(nodeType);
+            boolean matchesMixin = false;
+            PropertyState mixTypes = after.getProperty(JcrConstants.JCR_MIXINTYPES);
+            if (mixTypes != null) {
+                Iterable<String> mixins = mixTypes.getValue(STRINGS);
+                for (String m : mixins) {
+                    if (m.equals(nodeType)) {
+                        matchesMixin = true;
+                        break;
+                    }
+                }
+            }
+            if (matchesNodeType || matchesMixin) {
+                processChangedNode(before, after, nodeBuilder.child(name));
+            }
+        }
+
+    }
+
+    /**
+     * Will be called on all sub-classes of the {@link NodeTypeCommitHook} class when a change is detected on a node
+     * with the specified primary type or mixin type.
+     * 
+     * @param before
+     *            the state of node before the change
+     * @param after
+     *            the state of the node after the change
+     * @param nodeBuilder
+     *            a node builder to be used in case one wants to create new states
+     */
+    protected abstract void processChangedNode(NodeState before, NodeState after, NodeBuilder nodeBuilder);
+}

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/spi/commit/NodeTypeCommitHook.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/spi/commit/NodeTypeCommitHook.java
@@ -19,13 +19,28 @@ package org.apache.jackrabbit.oak.spi.commit;
 import static org.apache.jackrabbit.oak.api.Type.STRING;
 import static org.apache.jackrabbit.oak.api.Type.STRINGS;
 
+import java.security.AccessController;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.jcr.Credentials;
+import javax.jcr.RepositoryException;
+import javax.jcr.SimpleCredentials;
+import javax.jcr.nodetype.NodeTypeIterator;
+import javax.security.auth.Subject;
+
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeState;
+import org.apache.jackrabbit.oak.plugins.nodetype.ReadOnlyNodeTypeManager;
+import org.apache.jackrabbit.oak.spi.security.authentication.ImpersonationCredentials;
 import org.apache.jackrabbit.oak.spi.state.DefaultNodeStateDiff;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This abstract class provides node-type extensible commit hooks. One can extend this class to create
@@ -34,6 +49,8 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 public abstract class NodeTypeCommitHook implements CommitHook {
 
     protected String nodeType;
+    protected Set<String> nodeTypes;
+    private static final Logger LOG = LoggerFactory.getLogger(NodeTypeCommitHook.class);
 
     /**
      * Creates a {@link NodeTypeCommitHook} for a specified node type or mixin type.
@@ -43,49 +60,7 @@ public abstract class NodeTypeCommitHook implements CommitHook {
      */
     protected NodeTypeCommitHook(String nodeType) {
         this.nodeType = nodeType;
-    }
-
-    @Override
-    public NodeState processCommit(NodeState before, NodeState after) throws CommitFailedException {
-        NodeBuilder node = after.builder();
-        after.compareAgainstBaseState(before, new ModifiedNodeStateDiff(nodeType, node));
-        return node.getNodeState();
-    }
-
-    private class ModifiedNodeStateDiff extends DefaultNodeStateDiff {
-
-        private final String nodeType;
-        private final NodeBuilder nodeBuilder;
-
-        public ModifiedNodeStateDiff(String nodeType, NodeBuilder nodeBuilder) {
-            this.nodeType = nodeType;
-            this.nodeBuilder = nodeBuilder;
-        }
-
-        @Override
-        public void childNodeAdded(String name, NodeState after) {
-            childNodeChanged(name, MemoryNodeState.EMPTY_NODE, after);
-        }
-
-        @Override
-        public void childNodeChanged(String name, NodeState before, NodeState after) {
-            boolean matchesNodeType = after.getProperty(JcrConstants.JCR_PRIMARYTYPE).getValue(STRING).equals(nodeType);
-            boolean matchesMixin = false;
-            PropertyState mixTypes = after.getProperty(JcrConstants.JCR_MIXINTYPES);
-            if (mixTypes != null) {
-                Iterable<String> mixins = mixTypes.getValue(STRINGS);
-                for (String m : mixins) {
-                    if (m.equals(nodeType)) {
-                        matchesMixin = true;
-                        break;
-                    }
-                }
-            }
-            if (matchesNodeType || matchesMixin) {
-                processChangedNode(before, after, nodeBuilder.child(name));
-            }
-        }
-
+        nodeTypes = new HashSet<String>();
     }
 
     /**
@@ -98,6 +73,90 @@ public abstract class NodeTypeCommitHook implements CommitHook {
      *            the state of the node after the change
      * @param nodeBuilder
      *            a node builder to be used in case one wants to create new states
+     * @param userID
+     *            the user who produced the change
+     * @param lastModifiedDate
+     *            the date when the change has been made
      */
-    protected abstract void processChangedNode(NodeState before, NodeState after, NodeBuilder nodeBuilder);
+    protected abstract void processChangedNode(NodeState before, NodeState after, NodeBuilder nodeBuilder,
+            String userID, Date lastModifiedDate);
+
+    @Override
+    public NodeState processCommit(NodeState before, NodeState after) throws CommitFailedException {
+        NodeBuilder node = after.builder();
+        try {
+            if (nodeTypes.size() == 0) {
+                NodeTypeIterator nti = ReadOnlyNodeTypeManager.getInstance(after).getNodeType(nodeType).getSubtypes();
+                while (nti.hasNext()) {
+                    nodeTypes.add(nti.nextNodeType().getName());
+                }
+                nodeTypes.add(nodeType);
+            }
+            after.compareAgainstBaseState(before, new ModifiedNodeStateDiff(node, getUserID(), new Date()));
+        } catch (RepositoryException e) {
+            LOG.error("Unable to determine node types", e);
+        }
+        return node.getNodeState();
+    }
+
+    private class ModifiedNodeStateDiff extends DefaultNodeStateDiff {
+
+        private final NodeBuilder nodeBuilder;
+        private final String userID;
+        private final Date lastModifiedDate;
+
+        public ModifiedNodeStateDiff(NodeBuilder nodeBuilder, String userID, Date lastModifiedDate) {
+            this.nodeBuilder = nodeBuilder;
+            this.userID = userID;
+            this.lastModifiedDate = lastModifiedDate;
+        }
+
+        @Override
+        public void childNodeAdded(String name, NodeState after) {
+            childNodeChanged(name, MemoryNodeState.EMPTY_NODE, after);
+        }
+
+        @Override
+        public void childNodeChanged(String name, NodeState before, NodeState after) {
+            after.compareAgainstBaseState(before, new ModifiedNodeStateDiff(nodeBuilder.child(name), userID,
+                    lastModifiedDate));
+            boolean matchesNodeType = nodeTypes.contains(after.getProperty(JcrConstants.JCR_PRIMARYTYPE).getValue(
+                    STRING));
+            boolean matchesMixin = false;
+            PropertyState mixTypes = after.getProperty(JcrConstants.JCR_MIXINTYPES);
+            if (mixTypes != null) {
+                Iterable<String> mixins = mixTypes.getValue(STRINGS);
+                for (String m : mixins) {
+                    if (nodeTypes.contains(m)) {
+                        matchesMixin = true;
+                        break;
+                    }
+                }
+            }
+            if (matchesNodeType || matchesMixin) {
+                processChangedNode(before, after, nodeBuilder.child(name), getUserID(), new Date());
+            }
+        }
+
+        @Override
+        public void childNodeDeleted(String name, NodeState before) {
+            NodeState after = MemoryNodeState.EMPTY_NODE;
+            after.compareAgainstBaseState(before, new ModifiedNodeStateDiff(after.builder(), userID, lastModifiedDate));
+        }
+
+    }
+
+    private String getUserID() {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        Set<Credentials> credentials = subject.getPublicCredentials(Credentials.class);
+        String userID = null;
+        for (Credentials c : credentials) {
+            if (c instanceof SimpleCredentials) {
+                userID = ((SimpleCredentials) c).getUserID();
+            } else if (c instanceof ImpersonationCredentials) {
+                userID = ((ImpersonationCredentials) c).getImpersonatorInfo().getUserID();
+            }
+        }
+        return userID;
+    }
 }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/Jcr.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/Jcr.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.mk.api.MicroKernel;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.plugins.commit.ConflictValidatorProvider;
 import org.apache.jackrabbit.oak.plugins.commit.JcrConflictHandler;
+import org.apache.jackrabbit.oak.plugins.commit.MixLastModifiedCommitHook;
 import org.apache.jackrabbit.oak.plugins.index.IndexHookProvider;
 import org.apache.jackrabbit.oak.plugins.index.nodetype.NodeTypeIndexProvider;
 import org.apache.jackrabbit.oak.plugins.index.p2.Property2IndexHookProvider;
@@ -65,6 +66,7 @@ public class Jcr {
         with(JcrConflictHandler.JCR_CONFLICT_HANDLER);
         with(new DefaultTypeEditor());
         with(new VersionHook());
+        with(new MixLastModifiedCommitHook());
 
         with(new SecurityProviderImpl());
 

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/MixLastModifiedTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/MixLastModifiedTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.jcr;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.jcr.LoginException;
+import javax.jcr.Node;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.SimpleCredentials;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.jackrabbit.oak.plugins.commit.MixLastModifiedCommitHook;
+import org.apache.jackrabbit.oak.plugins.nodetype.NodeTypeConstants;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MixLastModifiedTest {
+
+    public static final String TEST_USER_NAME = "user1";
+    public static final String TEST_USER_PASSWORD = "user1";
+
+    private static Repository repository;
+
+    private static Session adminSession;
+    private static Session session;
+    private static User user;
+
+    @BeforeClass
+    public static void beforeClass() throws LoginException, RepositoryException {
+        repository = new Jcr().
+                with(new MixLastModifiedCommitHook()).
+                createRepository();
+        adminSession = createAdminSession();
+        UserManager usrMgr = ((JackrabbitSession) adminSession).getUserManager();
+        user = usrMgr.createUser(TEST_USER_NAME, TEST_USER_PASSWORD);
+        adminSession.save();
+        session = repository.login(new SimpleCredentials(user.getID(), TEST_USER_PASSWORD.toCharArray()));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (adminSession != null) {
+            adminSession.logout();
+        }
+        if (session != null) {
+            session.logout();
+        }
+    }
+
+    @Test
+    public void testLastModifiedDate() throws LoginException, RepositoryException {
+        Node root = adminSession.getRootNode();
+        Node foo1 = root.addNode("foo1");
+        Node foo2 = root.addNode("foo2");
+        foo1.addMixin(NodeTypeConstants.MIX_LASTMODIFIED);
+        foo2.addMixin(NodeTypeConstants.MIX_LASTMODIFIED);
+
+        adminSession.save();
+        /**
+         * /foo1[jcr:mixinTypes=[mix:lastModfified]]
+         * /foo2[jcr:mixinTypes=[mix:lastModfified]]
+         */
+        
+        long foo2CreatedAt = foo2.getProperty(JcrConstants.JCR_LASTMODIFIED).getLong();
+        Node bar = foo1.addNode("bar");
+
+        adminSession.save();
+        /**
+         * /foo1/bar
+         * /foo2
+         */
+
+        Node foobar = bar.addNode("foobar");
+        foobar.addNode("node");
+        long foo1TimeBeforeLastSave = System.currentTimeMillis();
+
+        adminSession.save();
+        /**
+         * /foo1/bar/foobar/node
+         * /foo2
+         */
+
+        long foo1TimeAfterLastSave = System.currentTimeMillis();
+        session.refresh(true);
+        foo1 = session.getNode("/foo1");
+        foo2 = session.getNode("/foo2");
+        long foo1LastModifiedAt = foo1.getProperty(JcrConstants.JCR_LASTMODIFIED).getLong();
+        long foo2LastModifiedAt = foo2.getProperty(JcrConstants.JCR_LASTMODIFIED).getLong();
+        assertTrue(foo1TimeBeforeLastSave < foo1LastModifiedAt && foo1LastModifiedAt < foo1TimeAfterLastSave);
+        assertTrue(foo2CreatedAt == foo2LastModifiedAt);
+    }
+    
+    @Test
+    public void testLastModifiedBy() throws RepositoryException {
+        adminSession.refresh(true);
+        Node foo1 = adminSession.getNode("/foo1");
+        Node foobar = adminSession.getNode("/foo1/bar/foobar");
+        foobar.setProperty(NodeTypeConstants.JCR_LASTMODIFIEDBY, "h4x0r");
+        adminSession.save();
+        // TODO - once the security code allows creating nodes using other users rewrite this assertion
+        assertTrue("admin".equals(foo1.getProperty(NodeTypeConstants.JCR_LASTMODIFIEDBY).getString()));
+    }
+
+    private static Session createAdminSession() throws LoginException, RepositoryException {
+        return repository.login(new SimpleCredentials("admin", "admin".toCharArray()));
+    }
+}


### PR DESCRIPTION
I've created a node-type abstract commit hook which can be used to intercept changes to nodes having a certain primary type or mixin type.

Furthermore, I've implemented such a hook for the `mix:lastModified` mixin. For any subgraph change of a node with the mixin `mix:lastModified` (including changes to the node's own properties), the `jcr:lastModified` and `jcr:lastModifiedBy` properties are now automatically updated.
