### PR TITLE
OAK-7427: Inconsistent method name.

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/standby/codec/GetReferencesResponseEncoder.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/standby/codec/GetReferencesResponseEncoder.java
@@ -36,13 +36,13 @@ public class GetReferencesResponseEncoder extends MessageToByteEncoder<GetRefere
     }
 
     private static void encode(String segmentId, Iterable<String> references, ByteBuf out) {
-        byte[] data = serialize(segmentId, references).getBytes(Charsets.UTF_8);
+        byte[] data = format(segmentId, references).getBytes(Charsets.UTF_8);
         out.writeInt(data.length + 1);
         out.writeByte(Messages.HEADER_REFERENCES);
         out.writeBytes(data);
     }
 
-    private static String serialize(String segmentId, Iterable<String> references) {
+    private static String format(String segmentId, Iterable<String> references) {
         return segmentId + ":" + Joiner.on(",").join(references);
     }
 


### PR DESCRIPTION
Change the method name "serialize" to "format".

The method is named as "serialize", but the method seems like to format the data.
The method name "format" should be more clear than "serialize".