### PR TITLE
S3 Bucket iterator stops too early

### DIFF
--- a/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
+++ b/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
@@ -993,6 +993,11 @@ public class S3Backend extends AbstractSharedBackend {
                 loadBatch();
             }
 
+            while (queue.isEmpty() && prevObjectListing.getNextMarker() != null) {
+                LOG.debug("Queue is empty, but there is more data in the S3 bucket");
+                loadBatch();
+            }
+
             if (!queue.isEmpty()) {
                 return transformer.apply(queue.remove());
             }


### PR DESCRIPTION
Fixed major bug in the S3 bucket iterator. When the queue is empty due to the fact that we get a full page of records starting with the META/ key, the iterator stops while there is still data available in the bucket. This causes problems with datastore GC, and datastore consistency checks (and possibly even more).