### PR TITLE
OAK-8603: counter index fix to allow re-indexing of composite stores

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/counter/NodeCounterEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/counter/NodeCounterEditor.java
@@ -154,28 +154,29 @@ public class NodeCounterEditor implements Editor {
     }
 
     private void leaveNew(NodeState before, NodeState after) throws CommitFailedException {
-        if (!countOffsets.isEmpty()) {
+        if (countOffsets.isEmpty()) {
+            return;
+        }
+        root.callback.indexUpdate();
+        for (Map.Entry<Mount, Integer> e : countOffsets.entrySet()) {
+            Mount mount = e.getKey();
+            if (mount.isReadOnly()) {
+                continue;
+            }
+            NodeBuilder builder = getBuilder(mount);
+            int countOffset = e.getValue();
 
-            root.callback.indexUpdate();
-            for (Map.Entry<Mount, Integer> e : countOffsets.entrySet()) {
-                Mount mount = e.getKey();
-                if (!mount.isReadOnly()) {
-                    NodeBuilder builder = getBuilder(mount);
-                    int countOffset = e.getValue();
-
-                    PropertyState p = builder.getProperty(COUNT_HASH_PROPERTY_NAME);
-                    long count = p == null ? 0 : p.getValue(Type.LONG);
-                    count += countOffset;
-                    if (count <= 0) {
-                        if (builder.getChildNodeCount(1) >= 0) {
-                            builder.removeProperty(COUNT_HASH_PROPERTY_NAME);
-                        } else {
-                            builder.remove();
-                        }
-                    } else {
-                        builder.setProperty(COUNT_HASH_PROPERTY_NAME, count);
-                    }
+            PropertyState p = builder.getProperty(COUNT_HASH_PROPERTY_NAME);
+            long count = p == null ? 0 : p.getValue(Type.LONG);
+            count += countOffset;
+            if (count <= 0) {
+                if (builder.getChildNodeCount(1) >= 0) {
+                    builder.removeProperty(COUNT_HASH_PROPERTY_NAME);
+                } else {
+                    builder.remove();
                 }
+            } else {
+                builder.setProperty(COUNT_HASH_PROPERTY_NAME, count);
             }
         }
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/counter/NodeCounterEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/counter/NodeCounterEditor.java
@@ -153,26 +153,29 @@ public class NodeCounterEditor implements Editor {
         }
     }
 
-    public void leaveNew(NodeState before, NodeState after) throws CommitFailedException {
-        if (countOffsets.isEmpty()) {
-            return;
-        }
-        root.callback.indexUpdate();
-        for (Map.Entry<Mount, Integer> e : countOffsets.entrySet()) {
-            NodeBuilder builder = getBuilder(e.getKey());
-            int countOffset = e.getValue();
+    private void leaveNew(NodeState before, NodeState after) throws CommitFailedException {
+        if (!countOffsets.isEmpty()) {
 
-            PropertyState p = builder.getProperty(COUNT_HASH_PROPERTY_NAME);
-            long count = p == null ? 0 : p.getValue(Type.LONG);
-            count += countOffset;
-            if (count <= 0) {
-                if (builder.getChildNodeCount(1) >= 0) {
-                    builder.removeProperty(COUNT_HASH_PROPERTY_NAME);
-                } else {
-                    builder.remove();
+            root.callback.indexUpdate();
+            for (Map.Entry<Mount, Integer> e : countOffsets.entrySet()) {
+                Mount mount = e.getKey();
+                if (!mount.isReadOnly()) {
+                    NodeBuilder builder = getBuilder(mount);
+                    int countOffset = e.getValue();
+
+                    PropertyState p = builder.getProperty(COUNT_HASH_PROPERTY_NAME);
+                    long count = p == null ? 0 : p.getValue(Type.LONG);
+                    count += countOffset;
+                    if (count <= 0) {
+                        if (builder.getChildNodeCount(1) >= 0) {
+                            builder.removeProperty(COUNT_HASH_PROPERTY_NAME);
+                        } else {
+                            builder.remove();
+                        }
+                    } else {
+                        builder.setProperty(COUNT_HASH_PROPERTY_NAME, count);
+                    }
                 }
-            } else {
-                builder.setProperty(COUNT_HASH_PROPERTY_NAME, count);
             }
         }
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/NameValidator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/NameValidator.java
@@ -30,6 +30,7 @@ import org.apache.jackrabbit.oak.spi.commit.DefaultValidator;
 import org.apache.jackrabbit.oak.spi.commit.Validator;
 import org.apache.jackrabbit.oak.spi.lifecycle.RepositoryInitializer;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,7 +173,9 @@ class NameValidator extends DefaultValidator {
     @Override
     public Validator childNodeAdded(String name, NodeState after)
             throws CommitFailedException {
-        checkValidName(name);
+        if (!NodeStateUtils.isHidden(name)) {
+            checkValidName(name);
+        }
         return this;
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
@@ -475,6 +475,9 @@ public class TypeEditor extends DefaultEditor {
         }
         if (!names.isEmpty()) {
             for (String name : names) {
+                if (NodeStateUtils.isHidden(name)) {
+                    continue;
+                }
                 NodeState child = after.getChildNode(name);
                 String primary = child.getName(JCR_PRIMARYTYPE);
                 Iterable<String> mixins = child.getNames(JCR_MIXINTYPES);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
@@ -78,7 +78,7 @@ public class TypeEditor extends DefaultEditor {
      * Extension point that allows pluggable handling of constraint violations
      */
     @ConsumerType
-    public static interface ConstraintViolationCallback {
+    public interface ConstraintViolationCallback {
         /**
          * Invoked whenever a constraint violation is detected.
          * 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreLuceneIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreLuceneIndexTest.java
@@ -30,8 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -48,9 +46,7 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFIN
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.TestUtil.shutdown;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @SuppressWarnings("ConstantConditions")
 public class CompositeNodeStoreLuceneIndexTest extends CompositeNodeStoreQueryTestBase {
@@ -123,44 +119,18 @@ public class CompositeNodeStoreLuceneIndexTest extends CompositeNodeStoreQueryTe
         } catch (Exception e) {
             Session s = repoV1.getSession();
             Node c = s.getRootNode().getNode(INDEX_DEFINITIONS_NAME).getNode("counter");
-            System.out.println("type " + c.getProperty("type").getString());
-            System.out.println("async " + c.getProperty("async").getString());
 
-            // maybe disable async (speedup)
-            // c.setProperty("async", (String) null);
-
+            c.setProperty("async", (String) null);
             c.setProperty("resolution", 1);
             c.setProperty("reindex", true);
             s.save();
 
-            // restart repository (maybe not needed)
-            repoV1.restartRepo();
-            s = repoV1.getSession();
+            // retrieve counter again (maybe not needed)
             c = s.getRootNode().getNode(INDEX_DEFINITIONS_NAME).getNode("counter");
 
-            for (int i = 0; i < 1000; i++) {
-                if (!c.getProperty("reindex").getBoolean()) {
-                    break;
-                }
-                Thread.sleep(1000);
-                s.refresh(false);
-                c = s.getRootNode().getNode(INDEX_DEFINITIONS_NAME).getNode("counter");
-                PropertyIterator it = c.getProperties();
-                while (it.hasNext()) {
-                    Property p = it.nextProperty();
-                    System.out.println("  " + p.getName() + ": " + p.getString());
-                }
-                if (i > 100) {
-                    throw new AssertionError();
-                }
-            }
+            assertFalse(c.getProperty("reindex").getBoolean());
         } finally {
             repoV1.cleanup();
-        }
-        try {
-            repoV1.setupIndexAndContentInRepo("luceneTest", "foo", true, VERSION_1);
-        } catch (Exception e) {
-            assertTrue(true);
         }
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTestBase.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTestBase.java
@@ -461,13 +461,12 @@ public class CompositeNodeStoreQueryTestBase {
                             throw new IllegalStateException("instance already created");
                         }
 
-                        // TODO - don't use Unix directory separators
                         String directoryName = name != null ? "segment-" + name : "segment";
-                        storePath = new File("target/classes/" + directoryName);
+                        storePath = new File("target/compositeTest/" + directoryName);
 
                         //String blobStoreDirectoryName = name != null ? "blob-" + name : "blob";
                         String blobStoreDirectoryName = "blob" ;
-                        blobStorePath = "target/classes/" + blobStoreDirectoryName;
+                        blobStorePath = "target/compositeTest/" + blobStoreDirectoryName;
 
                         BlobStore blobStore = new FileBlobStore(blobStorePath);
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTestBase.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTestBase.java
@@ -308,7 +308,8 @@ public class CompositeNodeStoreQueryTestBase {
                     .with((Observer) luceneIndexProvider)
                     .with(new NodeTypeIndexProvider().with(mip))
                     .with(new ReferenceEditorProvider().with(mip))
-                    .with(new ReferenceIndexProvider().with(mip));
+                    .with(new ReferenceIndexProvider().with(mip))
+                    .withAsyncIndexing("async", 1);
         }
 
     }
@@ -501,7 +502,7 @@ public class CompositeNodeStoreQueryTestBase {
                     @Override
                     public NodeStore get() throws Exception {
                         RDBOptions options = new RDBOptions().dropTablesOnClose(true);
-                        String jdbcUrl = "jdbc:h2:file:./target/classes/document";
+                        String jdbcUrl = "jdbc:h2:file:./target/compositeTest/document";
                         if ( name != null ) {
                             jdbcUrl += "-" + name;
                         }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTestBase.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTestBase.java
@@ -89,7 +89,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -134,8 +134,8 @@ public class CompositeNodeStoreQueryTestBase {
     protected IndexCopier indexCopier;
     protected Oak oak;
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder(new File("target"));
+    @ClassRule
+    public final static TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder(new File("target"));
 
     @Parameters(name="Root: {0}, Mounts: {1}")
     public static Collection<Object[]> data() {
@@ -242,7 +242,7 @@ public class CompositeNodeStoreQueryTestBase {
             return oak;
         }
         try {
-            indexCopier = new IndexCopier(executorService, temporaryFolder.getRoot());
+            indexCopier = new IndexCopier(executorService, TEMPORARY_FOLDER.getRoot());
         } catch (IOException e) {
             throw new RuntimeException();
         }
@@ -278,7 +278,7 @@ public class CompositeNodeStoreQueryTestBase {
     Oak getOakRepo(NodeStore store, MountInfoProvider mip) {
 
         try {
-            indexCopier = new IndexCopier(executorService, temporaryFolder.getRoot());
+            indexCopier = new IndexCopier(executorService, TEMPORARY_FOLDER.getRoot());
         } catch (IOException e) {
             throw new RuntimeException();
         }
@@ -308,8 +308,7 @@ public class CompositeNodeStoreQueryTestBase {
                     .with((Observer) luceneIndexProvider)
                     .with(new NodeTypeIndexProvider().with(mip))
                     .with(new ReferenceEditorProvider().with(mip))
-                    .with(new ReferenceIndexProvider().with(mip))
-                    .withAsyncIndexing("async", 1);
+                    .with(new ReferenceIndexProvider().with(mip));
         }
 
     }
@@ -413,7 +412,7 @@ public class CompositeNodeStoreQueryTestBase {
         }
     }
 
-    static enum NodeStoreKind {
+    enum NodeStoreKind {
         MEMORY {
             @Override
             public NodeStoreRegistration create(String name) {
@@ -462,11 +461,11 @@ public class CompositeNodeStoreQueryTestBase {
                         }
 
                         String directoryName = name != null ? "segment-" + name : "segment";
-                        storePath = new File("target/compositeTest/" + directoryName);
+                        storePath = TEMPORARY_FOLDER.newFolder(directoryName);
 
                         //String blobStoreDirectoryName = name != null ? "blob-" + name : "blob";
                         String blobStoreDirectoryName = "blob" ;
-                        blobStorePath = "target/compositeTest/" + blobStoreDirectoryName;
+                        blobStorePath = TEMPORARY_FOLDER.getRoot().getAbsolutePath() + blobStoreDirectoryName;
 
                         BlobStore blobStore = new FileBlobStore(blobStorePath);
 
@@ -501,7 +500,7 @@ public class CompositeNodeStoreQueryTestBase {
                     @Override
                     public NodeStore get() throws Exception {
                         RDBOptions options = new RDBOptions().dropTablesOnClose(true);
-                        String jdbcUrl = "jdbc:h2:file:./target/compositeTest/document";
+                        String jdbcUrl = "jdbc:h2:file:" + TEMPORARY_FOLDER.getRoot().getAbsolutePath() + "/document";
                         if ( name != null ) {
                             jdbcUrl += "-" + name;
                         }


### PR DESCRIPTION
It includes:

* Patch in [OAK-8603](https://issues.apache.org/jira/browse/OAK-8603) but instead of catching the  `UnsupportedOperationException` checks if the mount is not read-only.
* Patch in [OAK-8579](https://issues.apache.org/jira/browse/OAK-8579) to allow index creation in read-only repo first.