### PR TITLE
OAK-8903: Support for removing repository markers for transient repositories

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/SharedDataStore.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/SharedDataStore.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStoreException;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Interface to be implemented by a shared data store.
@@ -115,5 +116,21 @@ public interface SharedDataStore {
      * @return the type
      */
     Type getType();
+
+    /**
+     * Returns the repository id (identifier for the repository in the DataStore)
+     * @return repository id
+     */
+    @Nullable
+    default String getRepositoryId() {
+        return null;
+    }
+
+    /**
+     * Sets the repository id to identify repository in the DataStore
+     * @param repositoryId
+     * @throws DataStoreException
+     */
+    default void setRepositoryId(String repositoryId) throws DataStoreException {}
 }
 

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/AbstractBlobGCRegistrationTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/AbstractBlobGCRegistrationTest.java
@@ -68,6 +68,10 @@ public abstract class AbstractBlobGCRegistrationTest {
         BlobGCMBean mbean = context.getService(BlobGCMBean.class);
         assertNotNull(mbean);
 
+        // Check repository id present
+        BlobStore store = context.getService(BlobStore.class);
+        assertNotNull(((DataStoreBlobStore) store).getRepositoryId());
+
         unregisterNodeStoreService();
         unregisterBlobStore();
     }

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/BlobGCTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/BlobGCTest.java
@@ -188,9 +188,7 @@ public class BlobGCTest {
             this.blobStore = blobStore;
             if (SharedDataStoreUtils.isShared(blobStore)) {
                 repoId = ClusterRepositoryInfo.getOrCreateId(nodeStore);
-                ((SharedDataStore) blobStore).addMetadataRecord(
-                    new ByteArrayInputStream(new byte[0]),
-                    REPOSITORY.getNameFromId(repoId));
+                ((SharedDataStore) blobStore).setRepositoryId(repoId);
             }
             referenceRetriever = ((MemoryBlobStoreNodeStore) nodeStore).getBlobReferenceRetriever();
             startReferenceTime = clock.getTime();

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStoreTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStoreTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -225,6 +226,18 @@ public class DataStoreBlobStoreTest extends AbstractBlobStoreTest {
 
         String id = ds.writeBlob(new ByteArrayInputStream(data));
         assertTrue(IOUtils.contentEquals(new ByteArrayInputStream(data), ds.getInputStream(id)));
+    }
+
+    @Test
+    public void testAddRepositoryId() throws DataStoreException {
+        String repoId = UUID.randomUUID().toString();
+        ((DataStoreBlobStore) store).setRepositoryId(repoId);
+        assertEquals(repoId, ((DataStoreBlobStore) store).getRepositoryId());
+        DataRecord metadataRecord = ((DataStoreBlobStore) store)
+            .getMetadataRecord(SharedDataStoreUtils.SharedStoreRecordType.REPOSITORY.getNameFromId(repoId));
+
+        assertEquals(repoId, SharedDataStoreUtils.SharedStoreRecordType.REPOSITORY
+            .getIdFromName(metadataRecord.getIdentifier().toString()));
     }
 
     @Override

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreTrackerGCTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreTrackerGCTest.java
@@ -76,8 +76,6 @@ import static org.apache.jackrabbit.oak.commons.FileIOUtils.readStringsAsSet;
 import static org.apache.jackrabbit.oak.commons.FileIOUtils.writeStrings;
 import static org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreUtils.createFDS;
 import static org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreUtils.getBlobStore;
-import static org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils
-    .SharedStoreRecordType.REPOSITORY;
 import static org.apache.jackrabbit.oak.plugins.document.Revision.getCurrentTimestamp;
 import static org.apache.jackrabbit.oak.spi.commit.CommitInfo.EMPTY;
 import static org.apache.jackrabbit.oak.spi.commit.EmptyHook.INSTANCE;
@@ -633,9 +631,7 @@ public class DataStoreTrackerGCTest {
             repoId = ClusterRepositoryInfo.getOrCreateId(nodeStore);
             nodeStore.runBackgroundOperations();
 
-            ((SharedDataStore) blobStore).addMetadataRecord(
-                new ByteArrayInputStream(new byte[0]),
-                REPOSITORY.getNameFromId(repoId));
+            ((SharedDataStore) blobStore).setRepositoryId(repoId);
 
             String trackerRoot = folder.newFolder(clusterName).getAbsolutePath();
             tracker = BlobIdTracker.build(trackerRoot,

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/binary/BinaryAccessDSGCIT.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/binary/BinaryAccessDSGCIT.java
@@ -24,13 +24,11 @@ import static org.apache.jackrabbit.oak.jcr.binary.util.BinaryAccessTestUtils.ht
 import static org.apache.jackrabbit.oak.jcr.binary.util.BinaryAccessTestUtils.isSuccessfulHttpPut;
 import static org.apache.jackrabbit.oak.jcr.binary.util.BinaryAccessTestUtils.putBinary;
 import static org.apache.jackrabbit.oak.jcr.binary.util.BinaryAccessTestUtils.storeBinaryAndRetrieve;
-import static org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils.SharedStoreRecordType.REPOSITORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -208,8 +206,7 @@ public class BinaryAccessDSGCIT extends AbstractBinaryAccessIT {
         
         if (null == garbageCollector) {
             String repoId = ClusterRepositoryInfo.getOrCreateId(getNodeStore());
-            blobStore.addMetadataRecord(new ByteArrayInputStream(new byte[0]),
-                    REPOSITORY.getNameFromId(repoId));
+            blobStore.setRepositoryId(repoId);
             if (null == executor) {
                 executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(10);
             }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStoreRegistrar.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStoreRegistrar.java
@@ -25,7 +25,6 @@ import static org.apache.jackrabbit.oak.segment.compaction.SegmentGCOptions.RETA
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
 import static org.apache.jackrabbit.oak.spi.cluster.ClusterRepositoryInfo.getOrCreateId;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +47,6 @@ import org.apache.jackrabbit.oak.plugins.blob.BlobTrackingStore;
 import org.apache.jackrabbit.oak.plugins.blob.MarkSweepGarbageCollector;
 import org.apache.jackrabbit.oak.plugins.blob.SharedDataStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.BlobIdTracker;
-import org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils;
 import org.apache.jackrabbit.oak.segment.compaction.SegmentGCOptions;
 import org.apache.jackrabbit.oak.segment.compaction.SegmentRevisionGC;
 import org.apache.jackrabbit.oak.segment.compaction.SegmentRevisionGCMBean;
@@ -403,7 +401,7 @@ class SegmentNodeStoreRegistrar {
         if (!cfg.isSecondarySegmentStore() && cfg.hasCustomBlobStore() && isShared(cfg.getBlobStore())) {
             SharedDataStore sharedDataStore = (SharedDataStore) cfg.getBlobStore();
             try {
-                sharedDataStore.addMetadataRecord(new ByteArrayInputStream(new byte[0]), SharedDataStoreUtils.SharedStoreRecordType.REPOSITORY.getNameFromId(getOrCreateId(segmentNodeStore)));
+                sharedDataStore.setRepositoryId(getOrCreateId(segmentNodeStore));
             } catch (Exception e) {
                 throw new IOException("Could not register a unique repositoryId", e);
             }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentDataStoreBlobGCIT.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentDataStoreBlobGCIT.java
@@ -20,7 +20,6 @@
 package org.apache.jackrabbit.oak.segment;
 
 import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
-import static org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils.SharedStoreRecordType.REPOSITORY;
 import static org.apache.jackrabbit.oak.segment.compaction.SegmentGCOptions.defaultGCOptions;
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
 import static org.junit.Assert.assertEquals;
@@ -362,9 +361,7 @@ public class SegmentDataStoreBlobGCIT {
         String repoId = null;
         if (SharedDataStoreUtils.isShared(store.getBlobStore())) {
             repoId = ClusterRepositoryInfo.getOrCreateId(nodeStore);
-            ((SharedDataStore) store.getBlobStore()).addMetadataRecord(
-                new ByteArrayInputStream(new byte[0]),
-                REPOSITORY.getNameFromId(repoId));
+            ((SharedDataStore) store.getBlobStore()).setRepositoryId(repoId);
         }
         TestGarbageCollector gc = new TestGarbageCollector(
             new SegmentBlobReferenceRetriever(store),
@@ -439,9 +436,7 @@ public class SegmentDataStoreBlobGCIT {
         String repoId = null;
         if (SharedDataStoreUtils.isShared(store.getBlobStore())) {
             repoId = ClusterRepositoryInfo.getOrCreateId(nodeStore);
-            ((SharedDataStore) store.getBlobStore()).addMetadataRecord(
-                new ByteArrayInputStream(new byte[0]), 
-                REPOSITORY.getNameFromId(repoId));
+            ((SharedDataStore) store.getBlobStore()).setRepositoryId(repoId);
         }
         MarkSweepGarbageCollector gc =
             new MarkSweepGarbageCollector(new SegmentBlobReferenceRetriever(store),

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -30,7 +30,6 @@ import static org.apache.jackrabbit.oak.spi.blob.osgi.SplitBlobStoreService.ONLY
 import static org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils.registerMBean;
 import static org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils.scheduleWithFixedDelay;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.text.ParseException;
@@ -340,8 +339,7 @@ public class DocumentNodeStoreService {
             String repoId = null;
             try {
                 repoId = ClusterRepositoryInfo.getOrCreateId(nodeStore);
-                ((SharedDataStore) blobStore).addMetadataRecord(new ByteArrayInputStream(new byte[0]),
-                    SharedDataStoreUtils.SharedStoreRecordType.REPOSITORY.getNameFromId(repoId));
+                ((SharedDataStore) blobStore).setRepositoryId(repoId);
             } catch (Exception e) {
                 throw new IOException("Could not register a unique repositoryId", e);
             }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoBlobGCTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoBlobGCTest.java
@@ -69,8 +69,6 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils
-    .SharedStoreRecordType.REPOSITORY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -347,9 +345,7 @@ public class MongoBlobGCTest extends AbstractMongoConnectionTest {
         String repoId = null;
         if (SharedDataStoreUtils.isShared(store.getBlobStore())) {
             repoId = ClusterRepositoryInfo.getOrCreateId(store);
-            ((SharedDataStore) store.getBlobStore()).addMetadataRecord(
-                new ByteArrayInputStream(new byte[0]),
-                REPOSITORY.getNameFromId(repoId));
+            ((SharedDataStore) store.getBlobStore()).setRepositoryId(repoId);
         }
         TestGarbageCollector gc =
             new TestGarbageCollector(new DocumentBlobReferenceRetriever(store),
@@ -456,9 +452,7 @@ public class MongoBlobGCTest extends AbstractMongoConnectionTest {
         String repoId = null;
         if (SharedDataStoreUtils.isShared(store.getBlobStore())) {
             repoId = ClusterRepositoryInfo.getOrCreateId(store);
-            ((SharedDataStore) store.getBlobStore()).addMetadataRecord(
-                new ByteArrayInputStream(new byte[0]),
-                REPOSITORY.getNameFromId(repoId));
+            ((SharedDataStore) store.getBlobStore()).setRepositoryId(repoId);
         }
         if (Strings.isNullOrEmpty(root)) {
             root = folder.newFolder().getAbsolutePath();

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/SharedBlobStoreGCTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/SharedBlobStoreGCTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.jackrabbit.oak.plugins.document;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
@@ -41,7 +40,6 @@ import org.apache.jackrabbit.oak.plugins.blob.MarkSweepGarbageCollector;
 import org.apache.jackrabbit.oak.plugins.blob.SharedDataStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreBlobStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreUtils;
-import org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils.SharedStoreRecordType;
 import org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollector.VersionGCStats;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
@@ -96,8 +94,7 @@ public class SharedBlobStoreGCTest {
                 .getNodeStore();
         String repoId1 = ClusterRepositoryInfo.getOrCreateId(ds1);
         // Register the unique repository id in the data store
-        ((SharedDataStore) blobeStore1).addMetadataRecord(new ByteArrayInputStream(new byte[0]),
-            SharedStoreRecordType.REPOSITORY.getNameFromId(repoId1));
+        ((SharedDataStore) blobeStore1).setRepositoryId(repoId1);
 
         BlobStore blobeStore2 = getBlobStore(rootFolder);
         DocumentNodeStore ds2 = new DocumentMK.Builder()
@@ -108,8 +105,7 @@ public class SharedBlobStoreGCTest {
                 .getNodeStore();
         String repoId2 = ClusterRepositoryInfo.getOrCreateId(ds2);
         // Register the unique repository id in the data store
-        ((SharedDataStore) blobeStore2).addMetadataRecord(new ByteArrayInputStream(new byte[0]),
-            SharedStoreRecordType.REPOSITORY.getNameFromId(repoId2));
+        ((SharedDataStore) blobeStore2).setRepositoryId(repoId2);
 
         cluster1 = new Cluster(ds1, repoId1, 20);
         cluster1.init();


### PR DESCRIPTION
- System flag `oak.datastore.sharedTransient` which if set to true will force deletion of the repository marker from the datastore on close()
- Added 2 new default setter/getter methods for repository ids in the SharedDataStore interface with the only implementation needed in the DataStoreBlobStore (which is the glue between BlobStore & DataStore)
- The construction code (*NodeStoreService & tests) don't need to add the metadata file to the DataStore directly and can simply call the setRepositoryId() on the DataStoreBlobStore. 
- Additional tests and changes to existing test to change the call above in 3.