### PR TITLE
OAK-8951: Improve performance of RepositoryStatistics$Type.getType

### DIFF
--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/stats/RepositoryStatistics.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/stats/RepositoryStatistics.java
@@ -129,11 +129,12 @@ public interface RepositoryStatistics {
         }
 
         public static Type getType(String type) {
-            Type realType = null;
-            try {
-                realType = valueOf(type);
-            } catch (IllegalArgumentException ignore) {}
-            return realType;
+            for (Type realType : values()) {
+                if (realType.name().equals(type)) {
+                    return realType;
+                }
+            }
+            return null;
         }
 
         public boolean isResetValueEachSecond() {


### PR DESCRIPTION
This changes avoids the expensive creation of the IllegalArgumentException
thrown by Enum.valueOf()

fixes OAK-8951