### PR TITLE
OAK-9049 Improve comparison of primitive numbers

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapRecord.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapRecord.java
@@ -212,7 +212,7 @@ public class MapRecord extends Record {
             assert p <= i && i <= q;
 
             long iH = segment.readInt(getRecordNumber(), 4 + i * 4) & HASH_MASK;
-            int diff = Long.valueOf(iH).compareTo(h);
+            int diff = Long.compare(iH, h);
             if (diff == 0) {
                 RecordId keyId = segment.readRecordId(getRecordNumber(), 4 + size * 4, i * 2);
                 RecordId valueId = segment.readRecordId(getRecordNumber(), 4 + size * 4, i * 2 + 1);

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentId.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentId.java
@@ -252,9 +252,9 @@ public class SegmentId implements Comparable<SegmentId> {
 
     @Override
     public int compareTo(@NotNull SegmentId that) {
-        int d = Long.valueOf(this.msb).compareTo(that.msb);
+        int d = Long.compare(this.msb, that.msb);
         if (d == 0) {
-            d = Long.valueOf(this.lsb).compareTo(that.lsb);
+            d = Long.compare(this.lsb, that.lsb);
         }
         return d;
     }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeState.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeState.java
@@ -535,8 +535,7 @@ public class SegmentNodeState extends Record implements NodeState {
                 afterTemplate.getPropertyTemplates();
         while (beforeIndex < beforeProperties.length
                 && afterIndex < afterProperties.length) {
-            int d = Integer.valueOf(afterProperties[afterIndex].hashCode())
-                    .compareTo(beforeProperties[beforeIndex].hashCode());
+            int d = Integer.compare(afterProperties[afterIndex].hashCode(), beforeProperties[beforeIndex].hashCode());
             if (d == 0) {
                 d = afterProperties[afterIndex].getName().compareTo(
                         beforeProperties[beforeIndex].getName());

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/index/IndexEntry.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/index/IndexEntry.java
@@ -75,16 +75,5 @@ public interface IndexEntry extends SegmentArchiveEntry {
      */
     boolean isCompacted();
 
-    Comparator<IndexEntry> POSITION_ORDER = new Comparator<IndexEntry>() {
-        @Override
-        public int compare(IndexEntry a, IndexEntry b) {
-            if (a.getPosition() > b.getPosition()) {
-                return 1;
-            } else if (a.getPosition() < b.getPosition()) {
-                return -1;
-            } else {
-                return 0;
-            }
-        }
-    };
+    Comparator<IndexEntry> POSITION_ORDER = Comparator.comparingInt(IndexEntry::getPosition);
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/index/IndexWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/index/IndexWriter.java
@@ -117,13 +117,7 @@ public class IndexWriter {
             if (a.msb > b.msb) {
                 return 1;
             }
-            if (a.lsb < b.lsb) {
-                return -1;
-            }
-            if (a.lsb > b.lsb) {
-                return 1;
-            }
-            return 0;
+            return Long.compare(a.lsb, b.lsb);
         });
 
         for (Entry entry : entries) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Revision.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Revision.java
@@ -116,9 +116,9 @@ public final class Revision implements CacheValue {
                     "Trying to compare revisions of different cluster ids: " +
                             this + " and " + other);
         }
-        int comp = timestamp < other.timestamp ? -1 : timestamp > other.timestamp ? 1 : 0;
+        int comp = Long.compare(timestamp, other.timestamp);
         if (comp == 0) {
-            comp = counter < other.counter ? -1 : counter > other.counter ? 1 : 0;
+            comp = Integer.compare(counter, other.counter);
         }
         return comp;
     }
@@ -132,9 +132,9 @@ public final class Revision implements CacheValue {
      * @return -1 if this revision occurred earlier, 1 if later, 0 if equal
      */
     int compareRevisionTimeThenClusterId(Revision other) {
-        int comp = timestamp < other.timestamp ? -1 : timestamp > other.timestamp ? 1 : 0;
+        int comp = Long.compare(timestamp, other.timestamp);
         if (comp == 0) {
-            comp = counter < other.counter ? -1 : counter > other.counter ? 1 : 0;
+            comp = Integer.compare(counter, other.counter);
         }
         if (comp == 0) {
             comp = compareClusterId(other);
@@ -165,7 +165,7 @@ public final class Revision implements CacheValue {
      * @return -1 if this revision occurred earlier, 1 if later, 0 if equal
      */
     int compareClusterId(Revision other) {
-        return clusterId < other.clusterId ? -1 : clusterId > other.clusterId ? 1 : 0;
+        return Integer.compare(clusterId, other.clusterId);
     }
 
     /**


### PR DESCRIPTION
This change avoids some redundant (un-)boxing
and makes the code more readable.

See #203
See OAK-9026
See OAK-9049