### PR TITLE
OAK-9060: override ColumnImpl#copyOf() in in FacetColumnImpl

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/ColumnImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/ColumnImpl.java
@@ -27,7 +27,7 @@ import org.apache.jackrabbit.oak.api.PropertyValue;
  */
 public class ColumnImpl extends AstElement {
 
-    private final String selectorName, propertyName, columnName;
+    protected final String selectorName, propertyName, columnName;
     private SelectorImpl selector;
 
     public ColumnImpl(String selectorName, String propertyName, String columnName) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/FacetColumnImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/FacetColumnImpl.java
@@ -33,4 +33,8 @@ public class FacetColumnImpl extends ColumnImpl {
         return this.getSelector().currentOakProperty(getPropertyName());
     }
 
+    @Override
+    public AstElement copyOf() {
+        return new FacetColumnImpl(selectorName, propertyName, columnName);
+    }
 }


### PR DESCRIPTION
In order to retain the state properly when doing a QueryImpl#copyOf() the FacetColumnImpl should copy itself as FacetColumnImpl, not as ColumnImpl.