### PR TITLE
OAK-9145: Swap order of default filters

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/OakAnalyzer.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/OakAnalyzer.java
@@ -62,12 +62,12 @@ public class OakAnalyzer extends Analyzer {
     protected TokenStreamComponents createComponents(final String fieldName,
             final Reader reader) {
         StandardTokenizer src = new StandardTokenizer(matchVersion, reader);
-        TokenStream tok = new LowerCaseFilter(matchVersion, src);
-        tok = new WordDelimiterFilter(tok,
+        TokenStream tok = new WordDelimiterFilter(src,
                 WordDelimiterFilter.GENERATE_WORD_PARTS
                         | WordDelimiterFilter.STEM_ENGLISH_POSSESSIVE
                         | this.INDEX_ORIGINAL_TERM
                         | WordDelimiterFilter.GENERATE_NUMBER_PARTS, null);
+        tok = new LowerCaseFilter(matchVersion, tok);
         return new TokenStreamComponents(src, tok);
     }
 }


### PR DESCRIPTION
WordDelimiterFilter is invoked with the GENERATE_WORD_PARTS flag, which splits camelCase/PascalCase into multiple terms.  But since the LowerCaseFilter is applied first, the mixed-case is lost and the terms can't be split by WordDelimiterFilter.  Reversing filters so that behaviour occurs as expected.

I would have liked to add unit tests, but there didn't seem to be any around this class.  I *may* come back to add some.