### PR TITLE
OAK-9149: Use batch calls in backgroundSplit

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentSplitTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentSplitTest.java
@@ -140,9 +140,10 @@ public class DocumentSplitTest extends BaseDocumentMKTest {
         MemoryDocumentStore delegateStore = new MemoryDocumentStore();
         CountingDocumentStore store = new CountingDocumentStore(delegateStore);
         mkBuilder.setDocumentStore(store);
+        // disable automatic background operations
+        mkBuilder.setAsyncDelay(0);
         mk = mkBuilder.open();
         DocumentNodeStore ns = mk.getNodeStore();
-        assertTrue(ns.stopBackgroundUpdateThread(10000));
         assertEquals(batchSize, ns.getCreateOrUpdateBatchSize());
 
         NodeBuilder builder = ns.getRoot().builder();


### PR DESCRIPTION
Set asyncDelay to zero to disable automatic background operations in test.
Fix some typos and revert test method changes introduced earlier in DocumentNodeStore