### PR TITLE
OAK-9208 - Log unexpected writes to the paths designated as part of a non-default mount

### DIFF
--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/impl/NonDefaultMountWriteReportingObserver.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/impl/NonDefaultMountWriteReportingObserver.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.composite.impl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.Observer;
+import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
+import org.apache.jackrabbit.oak.spi.state.DefaultNodeStateDiff;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.composite.impl.NonDefaultMountWriteReportingObserver.Config;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reports writes to non-default mounts
+ * 
+ * <p>This is a <em>diagnostic observer</em> and is expected to be used in scenarios where the
+ * <tt>CompositeNodeStore</tt> is configured in a 'seed' mode, where the non-default
+ * mounts are write-enabled.<p>
+ * 
+ * <p>In such scenarios it is useful to report writes to non-default mounts from components
+ * that are unexpected. For instance, it can report all writes that do not originate
+ * from the FileVault package installer.</p>
+ * 
+ * <p>Performance note: the overhead of this observer has not been measured, but as it is
+ * designed to be used only for initial setups the performance impact should not
+ * matter.</p>
+ *
+ */
+@Component(service =  Observer.class, configurationPolicy =  ConfigurationPolicy.REQUIRE)
+@Designate(ocd = Config.class)
+public class NonDefaultMountWriteReportingObserver implements Observer {
+
+    @ObjectClassDefinition
+    public @interface Config {
+        @AttributeDefinition(description = "Class name fragments that, when found in the stack trace, cause the writes to not be reported. Examples: org.apache.jackrabbit.vault.packaging.impl.JcrPackageImpl, org.apache.jackrabbit.vault.packaging.impl.JcrPackageImpl,org.apache.sling.jcr.repoinit")
+        String[] ignoredClassNameFragments();
+    }
+    
+    @Reference
+    private MountInfoProvider mountInfoProvider;
+    private Config cfg;
+    
+    private ChangeReporter reporter = new ChangeReporter();
+    private NodeState oldState = null;
+
+    protected void activate(Config cfg) {
+        this.cfg = cfg;
+    }
+
+    // method copied from DiffObserver since we need to report at the end, when all the changes
+    // have been accumulated
+    @Override
+    public final synchronized void contentChanged(NodeState root, CommitInfo info) {
+        checkNotNull(root);
+        if (oldState != null) {
+            CountingDiff diff = new CountingDiff("/", new LinkedHashMap<>());
+            root.compareAgainstBaseState(oldState, diff);
+            diff.report();
+        }
+        oldState = root;
+    }    
+    
+    class CountingDiff extends DefaultNodeStateDiff {
+        private final String path;
+        private final Map<String, String> changes;
+        
+        private CountingDiff(String path, Map<String, String> changes) {
+            this.path = path;
+            this.changes = changes;
+        }
+        
+        public void report() {
+            if ( changes.isEmpty() )
+                return;
+            
+            RuntimeException location = new RuntimeException();
+            for ( StackTraceElement element : location.getStackTrace() )
+                for ( String acceptedClassName : cfg.ignoredClassNameFragments() )
+                    if ( element.getClassName().contains(acceptedClassName ))
+                        return;
+            
+            reporter.reportChanges(changes, location);
+        }
+
+        @Override
+        public boolean childNodeDeleted(String name, NodeState before) {
+            return onChange(name, before, EmptyNodeState.MISSING_NODE, "Deleted");
+        }
+        
+        private boolean onChange(String name, NodeState before, NodeState after, String changeType) {
+            String childPath = PathUtils.concat(path, name);
+
+            boolean isCovered = mountInfoProvider.getNonDefaultMounts().stream()
+                    .anyMatch( m -> m.isMounted(childPath)) ;
+            
+            if ( isCovered )
+                changes.put(childPath, changeType);
+            
+            return after.compareAgainstBaseState(before, new CountingDiff(childPath, changes));            
+        }
+        
+        @Override
+        public boolean childNodeChanged(String name, NodeState before, NodeState after) {
+            
+            return onChange(name, before, after, "Changed");
+        }
+        
+        @Override
+        public boolean childNodeAdded(String name, NodeState after) {
+            
+            return onChange(name, EmptyNodeState.MISSING_NODE, after, "Added");
+        }
+    }
+    
+    // visible for testing
+    void setReporter(ChangeReporter reporter) {
+        this.reporter = reporter;
+    }
+    
+    static class ChangeReporter {
+        
+        private static final int LOG_OUTPUT_MAX_ITEMS = 50;
+        
+        private final Logger logger = LoggerFactory.getLogger(getClass());
+        
+        void reportChanges(Map<String, String> changes, RuntimeException location) {
+            
+            if ( !logger.isWarnEnabled() )
+                return;
+            
+            StringBuilder out = new StringBuilder();
+            out.append("Unexpected changes (")
+                .append(changes.size())
+                .append(") performed on a non-default mount. Printing at most ")
+                .append(LOG_OUTPUT_MAX_ITEMS);
+            
+            changes.entrySet().stream()
+                .limit(LOG_OUTPUT_MAX_ITEMS)
+                .forEach( e -> 
+                    out.append("\n- ").append(e.getKey()).append(" : ").append(e.getValue())
+            );
+
+            logger.warn(out.toString(), location);
+        }
+    }
+}

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/impl/NonDefaultMountWriteReportingObserverTest.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/impl/NonDefaultMountWriteReportingObserverTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.composite.impl;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.composite.MountInfoProviderService;
+import org.apache.jackrabbit.oak.composite.impl.NonDefaultMountWriteReportingObserver.ChangeReporter;
+import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class NonDefaultMountWriteReportingObserverTest {
+    
+    @Rule
+    public final OsgiContext context = new OsgiContext();
+
+    private SpyChangeReporter reporter;
+    private NonDefaultMountWriteReportingObserver observer;
+    
+    @Before
+    public void prepare() {
+
+        context.registerInjectActivateService(new MountInfoProviderService(), "mountedPaths", new String[] { "/foo/bar"});
+        observer = context.registerInjectActivateService(new NonDefaultMountWriteReportingObserver(), "ignoredClassNameFragments", "MarkerToBeIgnored");
+        reporter = new SpyChangeReporter();
+        observer.setReporter(reporter);
+    }
+
+    @Test
+    public void pathAddedUnderNonDefaultMount() throws CommitFailedException {
+        
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("foo")
+            .child("bar")
+            .child("baz");
+        
+        nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        assertThat(reporter.changes, equalTo(Arrays.asList("Added|/foo/bar", "Added|/foo/bar/baz") ) );
+    }
+
+    @Test
+    public void subPathAddedUnderNonDefaultMount() throws CommitFailedException {
+        
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("foo")
+            .child("bar");
+        
+        nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        reporter.changes.clear();
+
+        NodeBuilder builder2 = nodeStore.getRoot().builder();
+        builder2
+            .child("foo")
+            .child("bar")
+            .child("baz");
+
+        nodeStore.merge(builder2, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        
+        assertThat(reporter.changes, equalTo(Arrays.asList("Changed|/foo/bar", "Added|/foo/bar/baz") ) );
+    }
+    
+    @Test
+    public void propertyChangedUnderNonDefaultMount() throws CommitFailedException {
+        
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("foo")
+            .child("bar")
+            .child("baz");
+        
+        nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        reporter.changes.clear();
+
+        NodeBuilder builder2 = nodeStore.getRoot().builder();
+        builder2
+            .child("foo")
+            .child("bar")
+            .child("baz")
+            .setProperty("prop", "val");
+
+        nodeStore.merge(builder2, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        
+        assertThat(reporter.changes, equalTo(Arrays.asList("Changed|/foo/bar", "Changed|/foo/bar/baz")));
+    }    
+    
+    @Test
+    public void subPathAddedUnderDefaultMount() throws CommitFailedException {
+        
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("baz");
+        
+        nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+
+        assertThat(reporter.changes, equalTo(Arrays.asList() ) );
+    }
+    
+    @Test
+    public void subPathUnderNonDefaultMountButWithExpectedComponent() throws Exception {
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("foo")
+            .child("bar");
+        
+        MarkerToBeIgnored.call( () -> nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY));
+        
+        assertThat(reporter.changes, equalTo(Arrays.asList() ) );
+    }
+    
+    @Test
+    public void commitWithMixedDefaultAndNonDefaultMounts() throws CommitFailedException {
+
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("foo")
+            .child("bar");
+
+        builder
+            .child("outside");
+
+        nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+
+        assertThat(reporter.changes, equalTo(Arrays.asList("Added|/foo/bar")));
+    }
+    
+    @Test
+    public void commitWithDeletedNodeUnderNonDefaultMount() throws CommitFailedException {
+
+        MemoryNodeStore nodeStore = new MemoryNodeStore();
+        nodeStore.addObserver(observer);
+        
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        builder
+            .child("foo")
+            .child("bar")
+            .child("baz");
+        
+        nodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        reporter.changes.clear();
+
+        NodeBuilder builder2 = nodeStore.getRoot().builder();
+        builder2
+            .child("foo")
+            .child("bar")
+            .child("baz")
+            .remove();
+
+        nodeStore.merge(builder2, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        
+        assertThat(reporter.changes, equalTo(Arrays.asList("Changed|/foo/bar", "Deleted|/foo/bar/baz")));        
+    }
+    
+    static class SpyChangeReporter extends ChangeReporter {
+        List<String> changes = new ArrayList<>();
+        
+        @Override
+        void reportChanges(Map<String, String> changes, RuntimeException ignored) {
+            changes.forEach( (path, type) -> this.changes.add(type + "|" + path) );
+        }
+    }
+    
+    static class MarkerToBeIgnored {
+        
+        static <T> void call(Callable<T> callable) throws Exception {
+            callable.call();
+        }
+    }
+    
+}


### PR DESCRIPTION
OAK-9208 - Log unexpected writes to the paths designated as part of a non-default mount