### PR TITLE
OAK-9211: elastic dynamic boost

### DIFF
--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/AbstractQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/AbstractQueryTest.java
@@ -272,9 +272,7 @@ public abstract class AbstractQueryTest {
             if (!query.contains("order by") && !skipSort) {
                 Collections.sort(lines);
             }
-        } catch (ParseException e) {
-            lines.add(e.toString());
-        } catch (IllegalArgumentException e) {
+        } catch (ParseException | IllegalArgumentException e) {
             lines.add(e.toString());
         }
         time = System.currentTimeMillis() - time;

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/dynamicBoost/DynamicBoostTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/dynamicBoost/DynamicBoostTest.java
@@ -152,10 +152,10 @@ public class DynamicBoostTest extends AbstractQueryTest {
             Tree node = createNodeWithType(test, "item", "dam:Asset");
             Tree predicted =
                     createNodeWithType(
-                    createNodeWithType(
-                    createNodeWithType(node, JcrConstants.JCR_CONTENT, UNSTRUCTURED),
-                    "metadata", UNSTRUCTURED),
-                    "predictedTags", UNSTRUCTURED);
+                            createNodeWithType(
+                                    createNodeWithType(node, JcrConstants.JCR_CONTENT, UNSTRUCTURED),
+                                    "metadata", UNSTRUCTURED),
+                            "predictedTags", UNSTRUCTURED);
             Tree t = createNodeWithType(predicted, "a", UNSTRUCTURED);
             if (nameProperty) {
                 t.setProperty("name", "my:a");

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -84,6 +84,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
     private final String remoteAlias;
 
     private final Map<String, List<PropertyDefinition>> propertiesByName;
+    private final List<PropertyDefinition> dynamicBoostProperties;
 
     public ElasticIndexDefinition(NodeState root, NodeState defn, String indexPath, String indexPrefix) {
         super(root, defn, determineIndexFormatVersion(defn), determineUniqueId(defn), indexPath);
@@ -93,12 +94,18 @@ public class ElasticIndexDefinition extends IndexDefinition {
         this.bulkFlushIntervalMs = getOptionalValue(defn, BULK_FLUSH_INTERVAL_MS, BULK_FLUSH_INTERVAL_MS_DEFAULT);
         this.bulkRetries = getOptionalValue(defn, BULK_RETRIES, BULK_RETRIES_DEFAULT);
         this.bulkRetriesBackoff = getOptionalValue(defn, BULK_RETRIES_BACKOFF, BULK_RETRIES_BACKOFF_DEFAULT);
-
+        
         this.propertiesByName = getDefinedRules()
                 .stream()
                 .flatMap(rule -> StreamSupport.stream(rule.getProperties().spliterator(), false))
                 .filter(pd -> pd.index) // keep only properties that can be indexed
                 .collect(Collectors.groupingBy(pd -> pd.name));
+
+        this.dynamicBoostProperties = getDefinedRules()
+                .stream()
+                .flatMap(IndexingRule::getNamePattersProperties)
+                .filter(pd -> pd.dynamicBoost)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -112,6 +119,10 @@ public class ElasticIndexDefinition extends IndexDefinition {
 
     public Map<String, List<PropertyDefinition>> getPropertiesByName() {
         return propertiesByName;
+    }
+
+    public List<PropertyDefinition> getDynamicBoostProperties() {
+        return dynamicBoostProperties;
     }
 
     /**

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
@@ -195,9 +195,11 @@ class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument> {
     }
 
     @Override
-    protected boolean indexDynamicBoost(ElasticDocument doc, PropertyDefinition pd, NodeState nodeState,
-                                        String propertyName) {
-        // TODO : not implemented
+    protected boolean indexDynamicBoost(ElasticDocument doc, String parent, String nodeName, String token, double boost) {
+        if (token.length() > 0) {
+            doc.addDynamicBoostField(nodeName, token, boost);
+            return true;
+        }
         return false;
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -44,6 +44,7 @@ class ElasticIndexHelper {
         final XContentBuilder mappingBuilder = XContentFactory.jsonBuilder();
         mappingBuilder.startObject();
         {
+            //mappingBuilder.field("dynamic", false);
             mappingBuilder.startObject("properties");
             {
                 mapInternalProperties(mappingBuilder);
@@ -217,6 +218,26 @@ class ElasticIndexHelper {
                     mappingBuilder.startObject("suggestion")
                             .field("type", "text")
                             .field("analyzer", "oak_analyzer")
+                            .endObject();
+                }
+                mappingBuilder.endObject();
+            }
+            mappingBuilder.endObject();
+        }
+
+        for (PropertyDefinition pd : indexDefinition.getDynamicBoostProperties()) {
+            mappingBuilder.startObject(pd.nodeName);
+            {
+                mappingBuilder.field("type", "nested");
+                mappingBuilder.startObject("properties");
+                {
+                    mappingBuilder.startObject("token")
+                            .field("type", "keyword")
+                            .field("ignore_above", 256)
+                            .field("doc_values", false)
+                            .endObject();
+                    mappingBuilder.startObject("boost")
+                            .field("type", "double")
                             .endObject();
                 }
                 mappingBuilder.endObject();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -229,9 +229,8 @@ class ElasticIndexHelper {
                 mappingBuilder.startObject("properties");
                 {
                     mappingBuilder.startObject("token")
-                            .field("type", "keyword")
-                            .field("ignore_above", 256)
-                            .field("doc_values", false)
+                            .field("type", "text")
+                            .field("analyzer", "oak_analyzer")
                             .endObject();
                     mappingBuilder.startObject("boost")
                             .field("type", "double")

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -448,7 +448,7 @@ public class ElasticRequestHandler {
 
     private Stream<QueryBuilder> dynamicScoreQueries(String text) {
         return elasticIndexDefinition.getDynamicBoostProperties().stream()
-                .map(pd -> nestedQuery(pd.nodeName, functionScoreQuery(termQuery(pd.nodeName + ".token", text),
+                .map(pd -> nestedQuery(pd.nodeName, functionScoreQuery(matchQuery(pd.nodeName + ".token", text),
                         ScoreFunctionBuilders.fieldValueFactorFunction(pd.nodeName + ".boost")), ScoreMode.Avg));
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -50,12 +50,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition.BULK_FLUSH_INTERVAL_MS_DEFAULT;
+import static org.junit.Assert.assertEquals;
 
 public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
 
@@ -241,6 +243,11 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
                 nodeStore.getRoot().getChildNode(INDEX_DEFINITIONS_NAME).getChildNode(index.getName()),
                 index.getPath(),
                 esConnection.getIndexPrefix());
+    }
+
+    protected void assertOrderedQuery(String sql, List<String> paths) {
+        List<String> result = executeQuery(sql, AbstractQueryTest.SQL2, true, true);
+        assertEquals(paths, result);
     }
 
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -176,15 +176,15 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
     }
 
     protected IndexDefinitionBuilder createIndex(String... propNames) {
-        return createIndex(true, propNames);
+        return createIndex(true, "nt:base", propNames);
     }
 
-    protected IndexDefinitionBuilder createIndex(boolean isPropertyIndex, String... propNames) {
+    protected IndexDefinitionBuilder createIndex(boolean isPropertyIndex, String nodeType, String... propNames) {
         IndexDefinitionBuilder builder = new ElasticIndexDefinitionBuilder();
         if (!useAsyncIndexing()) {
             builder = builder.noAsync();
         }
-        IndexDefinitionBuilder.IndexRule indexRule = builder.indexRule("nt:base");
+        IndexDefinitionBuilder.IndexRule indexRule = builder.indexRule(nodeType);
         if (isPropertyIndex) {
             for (String propName : propNames) {
                 indexRule.property(propName).propertyIndex();

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticDynamicBoostQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticDynamicBoostQueryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.plugins.nodetype.write.NodeTypeRegistry;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+public class ElasticDynamicBoostQueryTest extends ElasticAbstractQueryTest {
+
+    public static final String ASSET_NODE_TYPE =
+            "[dam:Asset]\n" +
+                    " - * (UNDEFINED) multiple\n" +
+                    " - * (UNDEFINED)\n" +
+                    " + * (nt:base) = oak:TestNode VERSION";
+
+    private static final String UNSTRUCTURED = "nt:unstructured";
+
+    @Test
+    public void dynamicBoost() throws CommitFailedException {
+        NodeTypeRegistry.register(root, toInputStream(ASSET_NODE_TYPE), "test nodeType");
+        IndexDefinitionBuilder builder = createIndex(true, "dam:Asset", "title", "dynamicBoost");
+        IndexDefinitionBuilder.PropertyRule title = builder.indexRule("dam:Asset")
+                .property("title")
+                .analyzed();
+        title.getBuilderTree().setProperty(JcrConstants.JCR_PRIMARYTYPE, UNSTRUCTURED, Type.NAME);
+        IndexDefinitionBuilder.PropertyRule db = builder.indexRule("dam:Asset").property("dynamicBoost");
+        Tree dbTree = db.getBuilderTree();
+        dbTree.setProperty(JcrConstants.JCR_PRIMARYTYPE, UNSTRUCTURED, Type.NAME);
+        dbTree.setProperty("name", "jcr:content/metadata/.*");
+        dbTree.setProperty("isRegexp", true);
+        dbTree.setProperty("dynamicBoost", true);
+        setIndex("damAsset_" + UUID.randomUUID(), builder);
+        root.commit();
+
+        Tree test = createNodeWithType(root.getTree("/"), "test", UNSTRUCTURED);
+        Tree item1 = createNodeWithType(test, "item1", "dam:Asset");
+        item1.setProperty("title", "flower with a lot of red and a bit of blue");
+
+        Tree item1Metadata = createNodeWithType(
+                createNodeWithType(item1, JcrConstants.JCR_CONTENT, UNSTRUCTURED),
+                "metadata", UNSTRUCTURED);
+        Tree item1Color1 = createNodeWithType(item1Metadata,"color1", UNSTRUCTURED);
+        item1Color1.setProperty("name", "red");
+        item1Color1.setProperty("confidence", 9.0);
+        Tree item1Color2 = createNodeWithType(item1Metadata,"color2", UNSTRUCTURED);
+        item1Color2.setProperty("name", "blue");
+        item1Color2.setProperty("confidence", 1.0);
+
+        Tree item2 = createNodeWithType(test, "item2", "dam:Asset");
+        item2.setProperty("title", "flower with a lot of blue and a bit of red");
+        Tree item2Metadata = createNodeWithType(
+                createNodeWithType(item2, JcrConstants.JCR_CONTENT, UNSTRUCTURED),
+                "metadata", UNSTRUCTURED);
+        Tree item2Color1 = createNodeWithType(item1Metadata,"color1", UNSTRUCTURED);
+        item2Color1.setProperty("name", "blue");
+        item2Color1.setProperty("confidence", 9.0);
+        Tree item2Color2 = createNodeWithType(item1Metadata,"color2", UNSTRUCTURED);
+        item2Color2.setProperty("name", "red");
+        item2Color2.setProperty("confidence", 1.0);
+        root.commit();
+
+        assertEventually(() -> {
+            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'flower')] ",
+                    XPATH, Arrays.asList("/test/item1", "/test/item2"));
+            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'red flower')] ",
+                    XPATH, Arrays.asList("/test/item1", "/test/item2"), true);
+            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'blue flower')] ",
+                    XPATH, Arrays.asList("/test/item2", "/test/item1"), true);
+        });
+    }
+
+    private static Tree createNodeWithType(Tree t, String nodeName, String typeName){
+        t = t.addChild(nodeName);
+        t.setProperty(JcrConstants.JCR_PRIMARYTYPE, typeName, Type.NAME);
+        return t;
+    }
+
+    private static InputStream toInputStream(String x) {
+        return new ByteArrayInputStream(x.getBytes());
+    }
+}

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticDynamicBoostQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticDynamicBoostQueryTest.java
@@ -87,12 +87,12 @@ public class ElasticDynamicBoostQueryTest extends ElasticAbstractQueryTest {
         root.commit();
 
         assertEventually(() -> {
-            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'flower')] ",
+            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'flower')]",
                     XPATH, Arrays.asList("/test/item1", "/test/item2"));
-            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'red flower')] ",
-                    XPATH, Arrays.asList("/test/item1", "/test/item2"), true);
-            assertQuery("//element(*, dam:Asset)[jcr:contains(@title, 'blue flower')] ",
-                    XPATH, Arrays.asList("/test/item2", "/test/item1"), true);
+            assertOrderedQuery("select [jcr:path] from [dam:Asset] where contains(title, 'red flower')",
+                    Arrays.asList("/test/item1", "/test/item2"));
+            assertOrderedQuery("select [jcr:path] from [dam:Asset] where contains(title, 'blue flower')",
+                    Arrays.asList("/test/item2", "/test/item1"));
         });
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAsyncTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAsyncTest.java
@@ -118,7 +118,7 @@ public class ElasticFullTextAsyncTest extends ElasticAbstractQueryTest {
      */
     @Test
     public void onlyNodeScopeIndexedQuery() throws Exception {
-        IndexDefinitionBuilder builder = createIndex(false, "a", "b").async("async");
+        IndexDefinitionBuilder builder = createIndex(false, "nt:base", "a", "b").async("async");
         builder.indexRule("nt:base").property("a").nodeScopeIndex();
         builder.indexRule("nt:base").property("b").nodeScopeIndex();
 
@@ -176,7 +176,7 @@ public class ElasticFullTextAsyncTest extends ElasticAbstractQueryTest {
      */
     @Test
     public void onlyAnalyzedPropertyShouldNotBeReturnedForNodeScopeIndexedQuery() throws Exception {
-        IndexDefinitionBuilder builder = createIndex(false, "a", "b").async("async");
+        IndexDefinitionBuilder builder = createIndex(false, "nt:base", "a", "b").async("async");
         builder.indexRule("nt:base").property("a").nodeScopeIndex();
         builder.indexRule("nt:base").property("b").analyzed();
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticOrderByTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticOrderByTest.java
@@ -167,9 +167,4 @@ public class ElasticOrderByTest extends ElasticAbstractQueryTest {
         assertOrderedQuery("select [jcr:path] from [nt:base] order by @bar DESC, @foo DESC",
                 asList("/test/b", "/test/a2", "/test/a1"));
     }
-
-    private void assertOrderedQuery(String sql, List<String> paths) {
-        List<String> result = executeQuery(sql, AbstractQueryTest.SQL2, true, true);
-        assertEquals(paths, result);
-    }
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
@@ -1063,6 +1064,10 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
 
         public List<PropertyDefinition> getSimilarityProperties() {
             return similarityProperties;
+        }
+
+        public Stream<PropertyDefinition> getNamePattersProperties() {
+            return namePatterns.stream().map(NamePattern::getConfig);
         }
 
         @Override

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/PropertyDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/PropertyDefinition.java
@@ -61,6 +61,8 @@ public class PropertyDefinition {
      */
     public final String name;
 
+    public final String nodeName;
+
     private final int propertyType;
 
     /**
@@ -133,6 +135,7 @@ public class PropertyDefinition {
     public final boolean similarityTags;
 
     public PropertyDefinition(IndexingRule idxDefn, String nodeName, NodeState defn) {
+        this.nodeName = nodeName;
         this.isRegexp = getOptionalValue(defn, PROP_IS_REGEX, false);
         this.name = getName(defn, nodeName);
         this.relative = isRelativeProperty(name);


### PR DESCRIPTION
This PR introduces dynamic boost for Elastic. Although some logic used in Lucene has been refactored and moved in `FulltextDocumentMaker`, the elastic version differs on the following aspects:

* the boosting is performed at query time
* structurally the docs are stored as nested docs

```
(lucene)
dynamicBoost.red=1 (boost=9)
dynamicBoost.blue=1 (boost=2)

(elastic)
dynamicBoost [
  {
    token="red"
    boost=9
  },
  {
    token="blue"
    boost=2
  }
]
```
The main differences are: the tokens are stored as analyzed values (instead of field names) and the boost is a value. This value is used at query time with a script score query.

The benefits of this implementation are:
* less sparse documents leading to better disk space usage (https://issues.apache.org/jira/browse/LUCENE-6863)
* better relevance since the boost query is not an exact match anymore but full-text analyzed