### PR TITLE
Change the method name "serialize" to "serializeReferences"

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/standby/codec/GetReferencesResponseEncoder.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/standby/codec/GetReferencesResponseEncoder.java
@@ -42,7 +42,7 @@ public class GetReferencesResponseEncoder extends MessageToByteEncoder<GetRefere
         out.writeBytes(data);
     }
 
-    private static String serialize(String segmentId, Iterable<String> references) {
+    private static String serializeReferences(String segmentId, Iterable<String> references) {
         return segmentId + ":" + Joiner.on(",").join(references);
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/standby/codec/GetReferencesResponseEncoder.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/standby/codec/GetReferencesResponseEncoder.java
@@ -36,7 +36,7 @@ public class GetReferencesResponseEncoder extends MessageToByteEncoder<GetRefere
     }
 
     private static void encode(String segmentId, Iterable<String> references, ByteBuf out) {
-        byte[] data = serialize(segmentId, references).getBytes(Charsets.UTF_8);
+        byte[] data = serializeReferences(segmentId, references).getBytes(Charsets.UTF_8);
         out.writeInt(data.length + 1);
         out.writeByte(Messages.HEADER_REFERENCES);
         out.writeBytes(data);


### PR DESCRIPTION
The function of this method is to serialize the passed references.  However, only naming it as "serialize" cannot describe it clearly.
Given that the class name (_GetReferencesResponseEncoder_) provides lots of semantic information, it would be better to change this method's name into "_serializeReferences_" for providing enough guidance.
