### PR TITLE
OAK-9158: Performance issue due to AbstractDocumentNodeState#equals

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/AbstractDocumentNodeState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/AbstractDocumentNodeState.java
@@ -83,7 +83,11 @@ public abstract class AbstractDocumentNodeState extends AbstractNodeState {
             // revision does not match: might still be equals
         } else if (that instanceof ModifiedNodeState) {
             ModifiedNodeState modified = (ModifiedNodeState) that;
-            if (modified.getBaseState() == this) {
+            NodeState baseState = modified.getBaseState();
+            if (baseState instanceof ModifiedDocumentNodeState) {
+                baseState = ((ModifiedDocumentNodeState) baseState).getBaseState();
+            }
+            if (baseState == this) {
                 return EqualsDiff.equals(this, modified);
             }
         }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ModifiedDocumentNodeState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ModifiedDocumentNodeState.java
@@ -142,6 +142,10 @@ class ModifiedDocumentNodeState extends AbstractNodeState {
         return super.compareAgainstBaseState(base, diff);
     }
 
+    NodeState getBaseState() {
+        return base;
+    }
+
     private boolean revisionEquals(AbstractDocumentNodeState a,
                                    AbstractDocumentNodeState b) {
         RevisionVector rv1 = a.getLastRevision();


### PR DESCRIPTION
Patch provided by Alexander Lüders
Added test to reproduce the problem