### PR TITLE
OAK-9384: AzureBlobStoreBackend may return incorrect download URI

### DIFF
--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -19,6 +19,7 @@
 
 package org.apache.jackrabbit.oak.blob.cloud.azure.blobstorage;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.Thread.currentThread;
 
 import java.io.BufferedInputStream;
@@ -822,8 +823,12 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
                 throw new NullPointerException("Could not determine domain for direct download");
             }
 
+            String cacheKey = identifier.toString()
+                    + domain
+                    + nullToEmpty(downloadOptions.getContentTypeHeader())
+                    + nullToEmpty(downloadOptions.getContentDispositionHeader());
             if (null != httpDownloadURICache) {
-                uri = httpDownloadURICache.getIfPresent(identifier.toString() + domain);
+                uri = httpDownloadURICache.getIfPresent(cacheKey);
             }
             if (null == uri) {
                 if (presignedDownloadURIVerifyExists) {
@@ -861,8 +866,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
                         headers,
                         domain);
                 if (uri != null && httpDownloadURICache != null) {
-                    httpDownloadURICache.put(identifier.toString() + domain,
-                            uri);
+                    httpDownloadURICache.put(cacheKey, uri);
                 }
             }
         }

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataRecordAccessProviderTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataRecordAccessProviderTest.java
@@ -48,7 +48,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -158,7 +157,6 @@ public class AzureDataRecordAccessProviderTest extends AbstractDataRecordAccessP
         assertEquals(expectedNumURIs, upload.getUploadURIs().size());
     }
 
-    @Ignore("OAK-9384")
     @Test
     public void downloadURIsWithVaryingOptions() throws Exception {
         ConfigurableDataRecordAccessProvider dataStore = this.getDataStore();


### PR DESCRIPTION
Construct cache key from identifier, domain, content type and content disposition header.
Enable test