### PR TITLE
OAK-9392: Improve resilience when primary becomes unavailable

### DIFF
--- a/oak-store-document/pom.xml
+++ b/oak-store-document/pom.xml
@@ -332,5 +332,23 @@
       <artifactId>docker-junit-rule</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.15.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+      <version>1.15.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
+      <version>1.15.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -72,7 +72,7 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreBuilde
             description = "Socket timeout for lease update operations in " +
                     "milliseconds. Note that this value can be " +
                     "overridden via framework property 'oak.mongo.leaseSocketTimeout'")
-    int leaseSocketTimeout() default DocumentNodeStoreService.DEFAULT_LEASE_SO_TIMEOUT_MILLIS;
+    int mongoLeaseSocketTimeout() default DocumentNodeStoreService.DEFAULT_MONGO_LEASE_SO_TIMEOUT_MILLIS;
 
     @AttributeDefinition(
             name = "Cache Size (in MB)",

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -68,6 +68,13 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreBuilde
     boolean socketKeepAlive() default DocumentNodeStoreService.DEFAULT_SO_KEEP_ALIVE;
 
     @AttributeDefinition(
+            name = "MongoDB socket timeout for lease update operations",
+            description = "Socket timeout for lease update operations in " +
+                    "milliseconds. Note that this value can be " +
+                    "overridden via framework property 'oak.mongo.leaseSocketTimeout'")
+    int leaseSocketTimeout() default DocumentNodeStoreService.DEFAULT_LEASE_SO_TIMEOUT_MILLIS;
+
+    @AttributeDefinition(
             name = "Cache Size (in MB)",
             description = "Cache size in MB. This is distributed among various caches used in DocumentNodeStore")
     int cache() default DocumentNodeStoreService.DEFAULT_CACHE;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -293,6 +293,7 @@ public class DocumentNodeStoreService {
             configureBuilder(builder);
             builder.setMaxReplicationLag(config.maxReplicationLagInSecs(), TimeUnit.SECONDS);
             builder.setSocketKeepAlive(soKeepAlive);
+            builder.setLeaseSocketTimeout(config.leaseSocketTimeout());
             builder.setMongoDB(uri, db, config.blobCacheSize());
             mkBuilder = builder;
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -133,7 +133,7 @@ public class DocumentNodeStoreService {
     static final int DEFAULT_BLOB_CACHE_SIZE = 16;
     static final String DEFAULT_DB = "oak";
     static final boolean DEFAULT_SO_KEEP_ALIVE = true;
-    static final int DEFAULT_LEASE_SO_TIMEOUT_MILLIS = 30000;
+    static final int DEFAULT_MONGO_LEASE_SO_TIMEOUT_MILLIS = 30000;
     static final String DEFAULT_PERSISTENT_CACHE = "cache";
     static final String DEFAULT_JOURNAL_CACHE = "diff-cache";
     static final boolean DEFAULT_CUSTOM_BLOB_STORE = false;
@@ -293,7 +293,7 @@ public class DocumentNodeStoreService {
             configureBuilder(builder);
             builder.setMaxReplicationLag(config.maxReplicationLagInSecs(), TimeUnit.SECONDS);
             builder.setSocketKeepAlive(soKeepAlive);
-            builder.setLeaseSocketTimeout(config.leaseSocketTimeout());
+            builder.setLeaseSocketTimeout(config.mongoLeaseSocketTimeout());
             builder.setMongoDB(uri, db, config.blobCacheSize());
             mkBuilder = builder;
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -133,6 +133,7 @@ public class DocumentNodeStoreService {
     static final int DEFAULT_BLOB_CACHE_SIZE = 16;
     static final String DEFAULT_DB = "oak";
     static final boolean DEFAULT_SO_KEEP_ALIVE = true;
+    static final int DEFAULT_LEASE_SO_TIMEOUT_MILLIS = 30000;
     static final String DEFAULT_PERSISTENT_CACHE = "cache";
     static final String DEFAULT_JOURNAL_CACHE = "diff-cache";
     static final boolean DEFAULT_CUSTOM_BLOB_STORE = false;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfiguration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfiguration.java
@@ -77,7 +77,7 @@ final class DocumentNodeStoreServiceConfiguration {
      * Name of framework property to configure socket timeout for lease update
      * operations on MongoDB.
      */
-    private static final String FWK_PROP_LEASE_SO_TIMEOUT = "oak.mongo.leaseSocketTimeout";
+    private static final String FWK_PROP_MONGO_LEASE_SO_TIMEOUT = "oak.mongo.leaseSocketTimeout";
 
     /**
      * Name of the framework property to configure the update limit.
@@ -101,7 +101,7 @@ final class DocumentNodeStoreServiceConfiguration {
             .put(PROP_URI, FWK_PROP_URI)
             .put(PROP_HOME, PROP_HOME)
             .put(PROP_SO_KEEP_ALIVE, FWK_PROP_SO_KEEP_ALIVE)
-            .put(PROP_LEASE_SO_TIMEOUT, FWK_PROP_LEASE_SO_TIMEOUT)
+            .put(PROP_LEASE_SO_TIMEOUT, FWK_PROP_MONGO_LEASE_SO_TIMEOUT)
             .put(PROP_UPDATE_LIMIT, FWK_PROP_UPDATE_LIMIT)
             .build();
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfiguration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfiguration.java
@@ -74,6 +74,12 @@ final class DocumentNodeStoreServiceConfiguration {
     private static final String FWK_PROP_SO_KEEP_ALIVE = "oak.mongo.socketKeepAlive";
 
     /**
+     * Name of framework property to configure socket timeout for lease update
+     * operations on MongoDB.
+     */
+    private static final String FWK_PROP_LEASE_SO_TIMEOUT = "oak.mongo.leaseSocketTimeout";
+
+    /**
      * Name of the framework property to configure the update limit.
      */
     private static final String FWK_PROP_UPDATE_LIMIT = "update.limit";
@@ -82,6 +88,7 @@ final class DocumentNodeStoreServiceConfiguration {
     private static final String PROP_URI = "mongouri";
     private static final String PROP_HOME = "repository.home";
     static final String PROP_SO_KEEP_ALIVE = "socketKeepAlive";
+    static final String PROP_LEASE_SO_TIMEOUT = "leaseSocketTimeout";
     static final String PROP_UPDATE_LIMIT = "updateLimit";
 
     /**
@@ -89,13 +96,14 @@ final class DocumentNodeStoreServiceConfiguration {
      * property names are mapped to framework properties by prefixing them with
      * {@link #DEFAULT_FWK_PREFIX}.
      */
-    private static final Map<String, String> FWK_PROP_MAPPING = ImmutableMap.of(
-            PROP_DB, FWK_PROP_DB,
-            PROP_URI, FWK_PROP_URI,
-            PROP_HOME, PROP_HOME,
-            PROP_SO_KEEP_ALIVE, FWK_PROP_SO_KEEP_ALIVE,
-            PROP_UPDATE_LIMIT, FWK_PROP_UPDATE_LIMIT
-    );
+    private static final Map<String, String> FWK_PROP_MAPPING = new ImmutableMap.Builder<String, String>()
+            .put(PROP_DB, FWK_PROP_DB)
+            .put(PROP_URI, FWK_PROP_URI)
+            .put(PROP_HOME, PROP_HOME)
+            .put(PROP_SO_KEEP_ALIVE, FWK_PROP_SO_KEEP_ALIVE)
+            .put(PROP_LEASE_SO_TIMEOUT, FWK_PROP_LEASE_SO_TIMEOUT)
+            .put(PROP_UPDATE_LIMIT, FWK_PROP_UPDATE_LIMIT)
+            .build();
 
     private DocumentNodeStoreServiceConfiguration() {
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoClock.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoClock.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.mongo;
+
+import com.mongodb.client.ClientSession;
+
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+/**
+ * <code>MongoClock</code> keeps track of the most recent cluster and operation
+ * time.
+ */
+final class MongoClock {
+
+    private BsonDocument clusterTime;
+
+    private BsonTimestamp operationTime;
+
+    synchronized void advanceSession(ClientSession session) {
+        session.advanceClusterTime(clusterTime);
+        session.advanceOperationTime(operationTime);
+    }
+
+    synchronized void advanceSessionAndClock(ClientSession session) {
+        session.advanceClusterTime(clusterTime);
+        clusterTime = session.getClusterTime();
+        session.advanceOperationTime(operationTime);
+        operationTime = session.getOperationTime();
+    }
+}

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBClient.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBClient.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.mongo;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import com.mongodb.ReadConcernLevel;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.jackrabbit.oak.plugins.document.util.MongoConnection.readConcernLevel;
+
+/**
+ * Simple struct that contains {@code MongoClient}, {@code MongoDatabase} and
+ * {@code MongoStatus}.
+ */
+final class MongoDBClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBClient.class);
+
+    private final MongoClient client;
+    private final MongoDatabase db;
+    private final MongoStatus status;
+    private final MongoClock clock;
+    private final MongoSessionFactory sessionFactory;
+
+    MongoDBClient(@NotNull MongoClient client,
+                  @NotNull MongoDatabase database,
+                  @NotNull MongoStatus status,
+                  @NotNull MongoClock clock) {
+        this.client = checkNotNull(client);
+        this.db = checkNotNull(database);
+        this.status = checkNotNull(status);
+        this.clock = checkNotNull(clock);
+        this.sessionFactory = new MongoSessionFactory(client, clock);
+    }
+
+    static MongoDBClient newMongoDBClient(@NotNull String uri,
+                                          @NotNull String name,
+                                          @NotNull MongoClock clock,
+                                          int socketTimeout,
+                                          boolean socketKeepAlive) {
+        CompositeServerMonitorListener serverMonitorListener = new CompositeServerMonitorListener();
+        MongoClientOptions.Builder options = MongoConnection.getDefaultBuilder();
+        options.addServerMonitorListener(serverMonitorListener);
+        options.socketKeepAlive(socketKeepAlive);
+        if (socketTimeout > 0) {
+            options.socketTimeout(socketTimeout);
+        }
+        MongoClient client = new MongoClient(new MongoClientURI(uri, options));
+        MongoStatus status = new MongoStatus(client, name);
+        serverMonitorListener.addListener(status);
+        MongoDatabase db = client.getDatabase(name);
+        if (!MongoConnection.hasWriteConcern(uri)) {
+            db = db.withWriteConcern(MongoConnection.getDefaultWriteConcern(client));
+        }
+        if (status.isMajorityReadConcernSupported()
+                && status.isMajorityReadConcernEnabled()
+                && !MongoConnection.hasReadConcern(uri)) {
+            db = db.withReadConcern(MongoConnection.getDefaultReadConcern(client, db));
+        }
+        return new MongoDBClient(client, db, status, clock);
+    }
+
+    @NotNull
+    MongoClient getClient() {
+        return client;
+    }
+
+    @NotNull
+    MongoDatabase getDatabase() {
+        return db;
+    }
+
+    @NotNull
+    MongoStatus getStatus() {
+        return status;
+    }
+
+    @NotNull
+    MongoClock getClock() {
+        return clock;
+    }
+
+    @NotNull
+    MongoCollection<BasicDBObject> getCollection(@NotNull String name) {
+        return db.getCollection(name, BasicDBObject.class);
+    }
+
+    @NotNull
+    ClientSession createClientSession() {
+        return sessionFactory.createClientSession();
+    }
+
+    void close() {
+        client.close();
+    }
+
+    /**
+     * Checks read and write concern on the {@code MongoDatabase} and logs warn
+     * messages when they differ from the recommended values.
+     */
+    void checkReadWriteConcern() {
+        if (!MongoConnection.isSufficientWriteConcern(client, db.getWriteConcern())) {
+            LOG.warn("Insufficient write concern: {} At least {} is recommended.",
+                    db.getWriteConcern(), MongoConnection.getDefaultWriteConcern(client));
+        }
+        if (status.isMajorityReadConcernSupported() && !status.isMajorityReadConcernEnabled()) {
+            LOG.warn("The read concern should be enabled on mongod using --enableMajorityReadConcern");
+        } else if (status.isMajorityReadConcernSupported() && !MongoConnection.isSufficientReadConcern(client, db.getReadConcern())) {
+            ReadConcernLevel currentLevel = readConcernLevel(db.getReadConcern());
+            ReadConcernLevel recommendedLevel = readConcernLevel(MongoConnection.getDefaultReadConcern(client, db));
+            if (currentLevel == null) {
+                LOG.warn("Read concern hasn't been set. At least {} is recommended.",
+                        recommendedLevel);
+            } else {
+                LOG.warn("Insufficient read concern: {}}. At least {} is recommended.",
+                        currentLevel, recommendedLevel);
+            }
+        }
+    }
+}

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConnection.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConnection.java
@@ -37,9 +37,9 @@ import static org.apache.jackrabbit.oak.plugins.document.util.MongoConnection.re
  * Simple struct that contains {@code MongoClient}, {@code MongoDatabase} and
  * {@code MongoStatus}.
  */
-final class MongoDBClient {
+final class MongoDBConnection {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MongoDBClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBConnection.class);
 
     private final MongoClient client;
     private final MongoDatabase db;
@@ -47,10 +47,10 @@ final class MongoDBClient {
     private final MongoClock clock;
     private final MongoSessionFactory sessionFactory;
 
-    MongoDBClient(@NotNull MongoClient client,
-                  @NotNull MongoDatabase database,
-                  @NotNull MongoStatus status,
-                  @NotNull MongoClock clock) {
+    MongoDBConnection(@NotNull MongoClient client,
+                      @NotNull MongoDatabase database,
+                      @NotNull MongoStatus status,
+                      @NotNull MongoClock clock) {
         this.client = checkNotNull(client);
         this.db = checkNotNull(database);
         this.status = checkNotNull(status);
@@ -58,11 +58,11 @@ final class MongoDBClient {
         this.sessionFactory = new MongoSessionFactory(client, clock);
     }
 
-    static MongoDBClient newMongoDBClient(@NotNull String uri,
-                                          @NotNull String name,
-                                          @NotNull MongoClock clock,
-                                          int socketTimeout,
-                                          boolean socketKeepAlive) {
+    static MongoDBConnection newMongoDBConnection(@NotNull String uri,
+                                                  @NotNull String name,
+                                                  @NotNull MongoClock clock,
+                                                  int socketTimeout,
+                                                  boolean socketKeepAlive) {
         CompositeServerMonitorListener serverMonitorListener = new CompositeServerMonitorListener();
         MongoClientOptions.Builder options = MongoConnection.getDefaultBuilder();
         options.addServerMonitorListener(serverMonitorListener);
@@ -82,7 +82,7 @@ final class MongoDBClient {
                 && !MongoConnection.hasReadConcern(uri)) {
             db = db.withReadConcern(MongoConnection.getDefaultReadConcern(client, db));
         }
-        return new MongoDBClient(client, db, status, clock);
+        return new MongoDBConnection(client, db, status, clock);
     }
 
     @NotNull

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -19,10 +19,6 @@ package org.apache.jackrabbit.oak.plugins.document.mongo;
 import java.util.concurrent.TimeUnit;
 
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientURI;
-import com.mongodb.ReadConcernLevel;
-import com.mongodb.client.MongoDatabase;
 
 import org.apache.jackrabbit.oak.plugins.blob.ReferencedBlob;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
@@ -30,13 +26,10 @@ import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreBuilder;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.MissingLastRevSeeker;
 import org.apache.jackrabbit.oak.plugins.document.VersionGCSupport;
-import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Suppliers.memoize;
-import static org.apache.jackrabbit.oak.plugins.document.util.MongoConnection.readConcernLevel;
+import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBClient.newMongoDBClient;
 
 /**
  * A base builder implementation for a {@link DocumentNodeStore} backed by
@@ -45,12 +38,14 @@ import static org.apache.jackrabbit.oak.plugins.document.util.MongoConnection.re
 public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentNodeStoreBuilderBase<T>>
         extends DocumentNodeStoreBuilder<T> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MongoDocumentNodeStoreBuilder.class);
-
+    private final MongoClock mongoClock = new MongoClock();
     private boolean socketKeepAlive = true;
     private MongoStatus mongoStatus;
     private long maxReplicationLagMillis = TimeUnit.HOURS.toMillis(6);
     private boolean clientSessionDisabled = false;
+    private int leaseSocketTimeout = 0;
+    private String uri;
+    private String name;
 
     /**
      * Uses the given information to connect to to MongoDB as backend
@@ -69,23 +64,9 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     public T setMongoDB(@NotNull String uri,
                         @NotNull String name,
                         int blobCacheSizeMB) {
-        CompositeServerMonitorListener serverMonitorListener = new CompositeServerMonitorListener();
-        MongoClientOptions.Builder options = MongoConnection.getDefaultBuilder();
-        options.addServerMonitorListener(serverMonitorListener);
-        options.socketKeepAlive(socketKeepAlive);
-        MongoClient client = new MongoClient(new MongoClientURI(uri, options));
-        MongoStatus status = new MongoStatus(client, name);
-        serverMonitorListener.addListener(status);
-        MongoDatabase db = client.getDatabase(name);
-        if (!MongoConnection.hasWriteConcern(uri)) {
-            db = db.withWriteConcern(MongoConnection.getDefaultWriteConcern(client));
-        }
-        if (status.isMajorityReadConcernSupported()
-                && status.isMajorityReadConcernEnabled()
-                && !MongoConnection.hasReadConcern(uri)) {
-            db = db.withReadConcern(MongoConnection.getDefaultReadConcern(client, db));
-        }
-        setMongoDB(client, db, status, blobCacheSizeMB);
+        this.uri = uri;
+        this.name = name;
+        setMongoDB(createMongoDBClient(0), blobCacheSizeMB);
         return thisBuilder();
     }
 
@@ -100,8 +81,8 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     public T setMongoDB(@NotNull MongoClient client,
                         @NotNull String dbName,
                         int blobCacheSizeMB) {
-        return setMongoDB(client, client.getDatabase(dbName),
-                new MongoStatus(client, dbName), blobCacheSizeMB);
+        return setMongoDB(new MongoDBClient(client, client.getDatabase(dbName),
+                new MongoStatus(client, dbName), mongoClock), blobCacheSizeMB);
     }
 
     /**
@@ -155,11 +136,32 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         return clientSessionDisabled;
     }
 
+    /**
+     * Sets a socket timeout for lease update operations.
+     *
+     * @param timeoutMillis the socket timeout in milliseconds.
+     * @return this builder.
+     */
+    public T setLeaseSocketTimeout(int timeoutMillis) {
+
+        this.leaseSocketTimeout = timeoutMillis;
+        return thisBuilder();
+    }
+
+    /**
+     * @return the lease socket timeout in milliseconds. If none is set, then
+     *      zero is returned.
+     */
+    int getLeaseSocketTimeout() {
+        return leaseSocketTimeout;
+    }
+
     public T setMaxReplicationLag(long duration, TimeUnit unit){
         maxReplicationLagMillis = unit.toMillis(duration);
         return thisBuilder();
     }
 
+    @Override
     public VersionGCSupport createVersionGCSupport() {
         DocumentStore store = getDocumentStore();
         if (store instanceof MongoDocumentStore) {
@@ -169,6 +171,7 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         }
     }
 
+    @Override
     public Iterable<ReferencedBlob> createReferencedBlobs(DocumentNodeStore ns) {
         final DocumentStore store = getDocumentStore();
         if (store instanceof MongoDocumentStore) {
@@ -178,6 +181,7 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         }
     }
 
+    @Override
     public MissingLastRevSeeker createMissingLastRevSeeker() {
         final DocumentStore store = getDocumentStore();
         if (store instanceof MongoDocumentStore) {
@@ -201,33 +205,27 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         return maxReplicationLagMillis;
     }
 
-    private T setMongoDB(@NotNull MongoClient client,
-                         @NotNull MongoDatabase db,
-                         MongoStatus status,
-                         int blobCacheSizeMB) {
-        if (!MongoConnection.isSufficientWriteConcern(client, db.getWriteConcern())) {
-            LOG.warn("Insufficient write concern: " + db.getWriteConcern()
-                    + " At least " + MongoConnection.getDefaultWriteConcern(client) + " is recommended.");
-        }
-        if (status.isMajorityReadConcernSupported() && !status.isMajorityReadConcernEnabled()) {
-            LOG.warn("The read concern should be enabled on mongod using --enableMajorityReadConcern");
-        } else if (status.isMajorityReadConcernSupported() && !MongoConnection.isSufficientReadConcern(client, db.getReadConcern())) {
-            ReadConcernLevel currentLevel = readConcernLevel(db.getReadConcern());
-            ReadConcernLevel recommendedLevel = readConcernLevel(MongoConnection.getDefaultReadConcern(client, db));
-            if (currentLevel == null) {
-                LOG.warn("Read concern hasn't been set. At least " + recommendedLevel + " is recommended.");
-            } else {
-                LOG.warn("Insufficient read concern: " + currentLevel + ". At least " + recommendedLevel + " is recommended.");
-            }
-        }
+    MongoClock getMongoClock() {
+        return mongoClock;
+    }
 
-        this.mongoStatus = status;
+    MongoDBClient createMongoDBClient(int socketTimeout) {
+        if (uri == null || name == null) {
+            throw new IllegalStateException("Cannot create MongoDB client without 'uri' or 'name'");
+        }
+        return newMongoDBClient(uri, name, mongoClock, socketTimeout, socketKeepAlive);
+    }
+
+    private T setMongoDB(@NotNull MongoDBClient client,
+                         int blobCacheSizeMB) {
+        client.checkReadWriteConcern();
+        this.mongoStatus = client.getStatus();
         this.documentStoreSupplier = memoize(() -> new MongoDocumentStore(
-                client, db, MongoDocumentNodeStoreBuilderBase.this));
+                client.getClient(), client.getDatabase(), MongoDocumentNodeStoreBuilderBase.this));
 
         if (this.blobStoreSupplier == null) {
             this.blobStoreSupplier = memoize(
-                    () -> new MongoBlobStore(db, blobCacheSizeMB * 1024 * 1024L, MongoDocumentNodeStoreBuilderBase.this));
+                    () -> new MongoBlobStore(client.getDatabase(), blobCacheSizeMB * 1024 * 1024L, MongoDocumentNodeStoreBuilderBase.this));
         }
 
         return thisBuilder();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -29,7 +29,7 @@ import org.apache.jackrabbit.oak.plugins.document.VersionGCSupport;
 import org.jetbrains.annotations.NotNull;
 
 import static com.google.common.base.Suppliers.memoize;
-import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBClient.newMongoDBClient;
+import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBConnection.newMongoDBConnection;
 
 /**
  * A base builder implementation for a {@link DocumentNodeStore} backed by
@@ -81,7 +81,7 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     public T setMongoDB(@NotNull MongoClient client,
                         @NotNull String dbName,
                         int blobCacheSizeMB) {
-        return setMongoDB(new MongoDBClient(client, client.getDatabase(dbName),
+        return setMongoDB(new MongoDBConnection(client, client.getDatabase(dbName),
                 new MongoStatus(client, dbName), mongoClock), blobCacheSizeMB);
     }
 
@@ -209,14 +209,14 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         return mongoClock;
     }
 
-    MongoDBClient createMongoDBClient(int socketTimeout) {
+    MongoDBConnection createMongoDBClient(int socketTimeout) {
         if (uri == null || name == null) {
             throw new IllegalStateException("Cannot create MongoDB client without 'uri' or 'name'");
         }
-        return newMongoDBClient(uri, name, mongoClock, socketTimeout, socketKeepAlive);
+        return newMongoDBConnection(uri, name, mongoClock, socketTimeout, socketKeepAlive);
     }
 
-    private T setMongoDB(@NotNull MongoDBClient client,
+    private T setMongoDB(@NotNull MongoDBConnection client,
                          int blobCacheSizeMB) {
         client.checkReadWriteConcern();
         this.mongoStatus = client.getStatus();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -279,10 +279,11 @@ public class MongoDocumentStore implements DocumentStore {
 
         LOG.info("Connected to MongoDB {} with maxReplicationLagMillis {}, " +
                 "maxDeltaForModTimeIdxSecs {}, disableIndexHint {}, " +
-                "clientSessionSupported {}, clientSessionInUse {}, {}, " +
-                "serverStatus {}",
+                "leaseSocketTimeout {}, clientSessionSupported {}, " +
+                "clientSessionInUse {}, {}, serverStatus {}",
                 status.getVersion(), maxReplicationLagMillis,
                 maxDeltaForModTimeIdxSecs, disableIndexHint,
+                builder.getLeaseSocketTimeout(),
                 status.isClientSessionSupported(), useClientSession,
                 db.getWriteConcern(), status.getServerDetails());
     }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
@@ -50,6 +50,7 @@ public class DocumentNodeStoreServiceConfigurationTest {
         assertEquals(DocumentNodeStoreService.DEFAULT_URI, config.mongouri());
         assertEquals(DocumentNodeStoreService.DEFAULT_DB, config.db());
         assertEquals(DocumentNodeStoreService.DEFAULT_SO_KEEP_ALIVE, config.socketKeepAlive());
+        assertEquals(DocumentNodeStoreService.DEFAULT_LEASE_SO_TIMEOUT_MILLIS, config.leaseSocketTimeout());
         assertEquals(DocumentNodeStoreService.DEFAULT_CACHE, config.cache());
         assertEquals(DocumentMK.Builder.DEFAULT_NODE_CACHE_PERCENTAGE, config.nodeCachePercentage());
         assertEquals(DocumentMK.Builder.DEFAULT_PREV_DOC_CACHE_PERCENTAGE, config.prevDocCachePercentage());
@@ -109,6 +110,14 @@ public class DocumentNodeStoreServiceConfigurationTest {
         addConfigurationEntry(preset, "persistentCacheIncludes", includes);
         Configuration config = createConfiguration();
         assertTrue(Arrays.equals(includes, config.persistentCacheIncludes()));
+    }
+
+    @Test
+    public void presetLeaseSocketTimeout() throws Exception {
+        int timeout = DocumentNodeStoreService.DEFAULT_LEASE_SO_TIMEOUT_MILLIS / 2;
+        addConfigurationEntry(preset, "leaseSocketTimeout", timeout);
+        Configuration config = createConfiguration();
+        assertEquals(timeout, config.leaseSocketTimeout());
     }
 
     @Test

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
@@ -115,7 +115,7 @@ public class DocumentNodeStoreServiceConfigurationTest {
     @Test
     public void presetLeaseSocketTimeout() throws Exception {
         int timeout = DocumentNodeStoreService.DEFAULT_MONGO_LEASE_SO_TIMEOUT_MILLIS / 2;
-        addConfigurationEntry(preset, "leaseSocketTimeout", timeout);
+        addConfigurationEntry(preset, "mongoLeaseSocketTimeout", timeout);
         Configuration config = createConfiguration();
         assertEquals(timeout, config.mongoLeaseSocketTimeout());
     }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
@@ -50,7 +50,7 @@ public class DocumentNodeStoreServiceConfigurationTest {
         assertEquals(DocumentNodeStoreService.DEFAULT_URI, config.mongouri());
         assertEquals(DocumentNodeStoreService.DEFAULT_DB, config.db());
         assertEquals(DocumentNodeStoreService.DEFAULT_SO_KEEP_ALIVE, config.socketKeepAlive());
-        assertEquals(DocumentNodeStoreService.DEFAULT_LEASE_SO_TIMEOUT_MILLIS, config.leaseSocketTimeout());
+        assertEquals(DocumentNodeStoreService.DEFAULT_MONGO_LEASE_SO_TIMEOUT_MILLIS, config.mongoLeaseSocketTimeout());
         assertEquals(DocumentNodeStoreService.DEFAULT_CACHE, config.cache());
         assertEquals(DocumentMK.Builder.DEFAULT_NODE_CACHE_PERCENTAGE, config.nodeCachePercentage());
         assertEquals(DocumentMK.Builder.DEFAULT_PREV_DOC_CACHE_PERCENTAGE, config.prevDocCachePercentage());
@@ -114,10 +114,10 @@ public class DocumentNodeStoreServiceConfigurationTest {
 
     @Test
     public void presetLeaseSocketTimeout() throws Exception {
-        int timeout = DocumentNodeStoreService.DEFAULT_LEASE_SO_TIMEOUT_MILLIS / 2;
+        int timeout = DocumentNodeStoreService.DEFAULT_MONGO_LEASE_SO_TIMEOUT_MILLIS / 2;
         addConfigurationEntry(preset, "leaseSocketTimeout", timeout);
         Configuration config = createConfiguration();
-        assertEquals(timeout, config.leaseSocketTimeout());
+        assertEquals(timeout, config.mongoLeaseSocketTimeout());
     }
 
     @Test

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/TestUtils.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/TestUtils.java
@@ -103,6 +103,14 @@ public class TestUtils {
         Revision.resetClockToDefault();
     }
 
+    public static void setClusterNodeInfoClock(Clock c) {
+        ClusterNodeInfo.setClock(c);
+    }
+
+    public static void resetClusterNodeInfoClockToDefault() {
+        ClusterNodeInfo.resetClockToDefault();
+    }
+
     public static void persistToBranch(NodeBuilder builder) {
         if (builder instanceof DocumentRootBuilder) {
             ((DocumentRootBuilder) builder).persist();

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/LeaseUpdateSocketTimeoutIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/LeaseUpdateSocketTimeoutIT.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.mongo;
+
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo;
+import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.DocumentStoreException;
+import org.apache.jackrabbit.oak.plugins.document.LeaseFailureHandler;
+import org.apache.jackrabbit.oak.plugins.document.SimpleRecoveryHandler;
+import org.apache.jackrabbit.oak.plugins.document.TestUtils;
+import org.apache.jackrabbit.oak.stats.Clock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.containers.ToxiproxyContainer.ContainerProxy;
+import org.testcontainers.utility.DockerImageName;
+
+import static eu.rekawek.toxiproxy.model.ToxicDirection.DOWNSTREAM;
+import static org.apache.jackrabbit.oak.plugins.document.TestUtils.setClusterNodeInfoClock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+public class LeaseUpdateSocketTimeoutIT {
+
+    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("shopify/toxiproxy:2.1.4");
+
+    private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:4.2");
+
+    private static final int MONGODB_DEFAULT_PORT = 27017;
+
+    private static final int LEASE_SO_TIMEOUT = 50;
+
+    @Rule
+    public Network network = Network.newNetwork();
+
+    @Rule
+    public MongoDBContainer mongoDBContainer = new MongoDBContainer(MONGODB_IMAGE)
+            .withNetwork(network)
+            .withExposedPorts(MONGODB_DEFAULT_PORT);
+
+    @Rule
+    public ToxiproxyContainer tp = new ToxiproxyContainer(TOXIPROXY_IMAGE)
+            .withNetwork(network);
+
+    private ContainerProxy proxy;
+
+    private Clock clock;
+
+    private DocumentStore store;
+
+    private final FailureHandler handler = new FailureHandler();
+
+    @BeforeClass
+    public static void dockerAvailable() {
+        assumeTrue(MongoDockerRule.isDockerAvailable());
+    }
+
+    @Before
+    public void before() throws Exception {
+        clock = new Clock.Virtual();
+        clock.waitUntil(System.currentTimeMillis());
+        setClusterNodeInfoClock(clock);
+        proxy = tp.getProxy(mongoDBContainer, MONGODB_DEFAULT_PORT);
+        String uri = "mongodb://" + proxy.getContainerIpAddress() + ":" + proxy.getProxyPort();
+        store = new MongoDocumentNodeStoreBuilder()
+                .setMongoDB(uri, "oak", 0)
+                .setLeaseSocketTimeout(LEASE_SO_TIMEOUT)
+                .getDocumentStore();
+    }
+
+    @After
+    public void after() {
+        store.dispose();
+        TestUtils.resetClusterNodeInfoClockToDefault();
+    }
+
+    @Test
+    public void leaseUpdateFailureOnSocketTimeout() throws Exception {
+        ClusterNodeInfo info = newClusterNodeInfo();
+        waitLeaseUpdateInterval();
+        CountDownLatch latch = new CountDownLatch(1);
+        List<Exception> exceptions = new ArrayList<>();
+        Thread t = new Thread(() -> {
+            try {
+                proxy.toxics().latency("latency", DOWNSTREAM, LEASE_SO_TIMEOUT * 2);
+                latch.countDown();
+                Thread.sleep(1000);
+                proxy.toxics().get("latency").remove();
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        });
+        t.start();
+        latch.await();
+        try {
+            info.renewLease();
+            fail("must fail with DocumentStoreException");
+        } catch (DocumentStoreException e) {
+            // expected
+            assertRootException(e, SocketTimeoutException.class);
+        }
+        t.join();
+
+        for (Exception e : exceptions) {
+            fail(e.getMessage());
+        }
+
+        long leaseEnd = info.getLeaseEndTime();
+        // must succeed next time
+        waitLeaseUpdateInterval();
+        assertTrue(info.renewLease());
+        assertTrue(info.getLeaseEndTime() > leaseEnd);
+        assertFalse(handler.isLeaseFailure());
+    }
+
+    private void assertRootException(Throwable t,
+                                     Class<?> clazz) {
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        assertEquals(clazz, t.getClass());
+    }
+
+    private ClusterNodeInfo newClusterNodeInfo() {
+        ClusterNodeInfo info = ClusterNodeInfo.getInstance(store,
+                new SimpleRecoveryHandler(store, clock), null, null, 1);
+        info.setLeaseFailureHandler(handler);
+        return info;
+    }
+
+    private void waitLeaseUpdateInterval() throws Exception {
+        clock.waitUntil(clock.getTime() + ClusterNodeInfo.DEFAULT_LEASE_UPDATE_INTERVAL_MILLIS + 1);
+    }
+
+    static final class FailureHandler implements LeaseFailureHandler {
+
+        private final AtomicBoolean leaseFailure = new AtomicBoolean();
+
+        @Override
+        public void handleLeaseFailure() {
+            leaseFailure.set(true);
+        }
+
+        public boolean isLeaseFailure() {
+            return leaseFailure.get();
+        }
+    }
+}

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoClockTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoClockTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.mongo;
+
+import com.mongodb.client.ClientSession;
+
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class MongoClockTest {
+
+    private final MongoClock clock = new MongoClock();
+
+    @Test
+    public void advanceSessionAndClock() {
+        BsonTimestamp opT1 = new BsonTimestamp(42, 1);
+        BsonDocument cT1 = new BsonDocument("clusterTime", opT1);
+        ClientSession s1 = Mockito.mock(ClientSession.class);
+        Mockito.when(s1.getClusterTime()).thenReturn(cT1);
+        Mockito.when(s1.getOperationTime()).thenReturn(opT1);
+
+        clock.advanceSessionAndClock(s1);
+
+        ClientSession s2 = Mockito.mock(ClientSession.class);
+        clock.advanceSession(s2);
+        Mockito.verify(s2, Mockito.times(1)).advanceOperationTime(opT1);
+        Mockito.verify(s2, Mockito.times(1)).advanceClusterTime(cT1);
+
+        ClientSession s3 = Mockito.mock(ClientSession.class);
+        BsonTimestamp opT2 = new BsonTimestamp(42, 2);
+        Mockito.when(s3.getClusterTime()).thenReturn(cT1);
+        Mockito.when(s3.getOperationTime()).thenReturn(opT2);
+        clock.advanceSessionAndClock(s3);
+
+        ClientSession s4 = Mockito.mock(ClientSession.class);
+        clock.advanceSession(s4);
+        Mockito.verify(s4, Mockito.times(1)).advanceOperationTime(opT2);
+        Mockito.verify(s4, Mockito.times(1)).advanceClusterTime(cT1);
+    }
+
+}


### PR DESCRIPTION
Introduces a new configuration that sets a socket timeout for operations on the clusterNodes collection.

Default is up for discussion. Initially I set it to 30 seconds.