### PR TITLE
OAK-9401: Avoid calling getLeaseTime on inactive cluster.

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLock.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLock.java
@@ -177,11 +177,14 @@ class RecoveryLock {
             // cannot determine current lock owner
             return false;
         }
-        long now = clock.getTime();
-        long leaseEnd = recovering.getLeaseEndTime();
-        if (recovering.isActive() && leaseEnd > now) {
-            // still active, cannot break lock
-            return false;
+        // OAK-9401: leaseEndTime can be null when the cluster is not active
+        if (recovering.isActive()) {
+            long now = clock.getTime();
+            long leaseEnd = recovering.getLeaseEndTime();
+            if (leaseEnd > now) {
+                // still active, cannot break lock
+                return false;
+            }
         }
         // try to break the lock
         try {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLockTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLockTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 
+import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.stats.Clock;
 import org.junit.After;
@@ -56,7 +57,6 @@ public class RecoveryLockTest {
     private RecoveryLock lock2 = new RecoveryLock(store, clock, 2);
 
     private ClusterNodeInfo info1;
-    private ClusterNodeInfo info2;
 
     @Before
     public void before() throws Exception {
@@ -69,6 +69,7 @@ public class RecoveryLockTest {
     @After
     public void after() {
         ClusterNodeInfo.resetClockToDefault();
+        new ExecutorCloser(executor).close();
     }
 
     @Test

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLockTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLockTest.java
@@ -223,7 +223,7 @@ public class RecoveryLockTest {
         doReturn(false).when(mockClusterInfo).isActive();
         when(store.find(CLUSTER_NODES, String.valueOf(1))).thenCallRealMethod().thenReturn(mockClusterInfo);
 
-        // clusterId 2 should be able to acquire (break) the recovery lock, instead of
+        // clusterId 2 should be able to acquire (break) the recovery lock, instead of 
         // throwing "java.lang.NullPointerException: Lease End Time not set"
         assertTrue(recLock.acquireRecoveryLock(2));
     }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLockTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLockTest.java
@@ -197,12 +197,11 @@ public class RecoveryLockTest {
 
         // expire clusterId 1
         clock.waitUntil(info1.getLeaseEndTime() + DEFAULT_LEASE_UPDATE_INTERVAL_MILLIS);
-        MissingLastRevSeeker seeker = new MissingLastRevSeeker(store, clock);
 
         Semaphore recovering = new Semaphore(0);
         Semaphore recovered = new Semaphore(0);
         // simulate new startup and get info again
-        Future<ClusterNodeInfo> infoFuture = executor.submit(() ->
+        executor.submit(() ->
                 ClusterNodeInfo.getInstance(store, clusterId -> {
                     assertTrue(recLock.acquireRecoveryLock(1));
                     recovering.release();
@@ -226,6 +225,9 @@ public class RecoveryLockTest {
         // clusterId 2 should be able to acquire (break) the recovery lock, instead of 
         // throwing "java.lang.NullPointerException: Lease End Time not set"
         assertTrue(recLock.acquireRecoveryLock(2));
+
+        // let submitted task complete
+        recovered.release();
     }
 
     private ClusterNodeInfoDocument infoDocument(int clusterId) {


### PR DESCRIPTION
Implemented a fix to avoid calling getLeaseTime in the method tryBreakRecoveryLock when the cluster is not active, as it could be null and this throw a NullPointerException.