### PR TITLE
OAK-9483: UpgradeIT fails when noexec is set on temp folder

### DIFF
--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -126,7 +126,7 @@
                         <phase>pre-integration-test</phase>
                         <goals><goal>copy</goal></goals>
                         <configuration>
-                            <artifact>org.apache.jackrabbit:oak-run:1.6.1</artifact>
+                            <artifact>org.apache.jackrabbit:oak-run:1.6.2</artifact>
                             <outputDirectory>${project.build.directory}/upgrade-it</outputDirectory>
                             <stripVersion>true</stripVersion>
                         </configuration>


### PR DESCRIPTION
Use Oak 1.6.2 instead to get OAK-5961 fix