### PR TITLE
Update README.md

### DIFF
--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -851,7 +851,7 @@ The following options are available:
     --consistency    - List all the missing blobs by doing a consistency check
     Atleast one of the above should be specified
     
-    --store          - Path to the segment store of mongo uri (Required for --ref & --consistency option above)
+    --store          - Path to the segment store or mongo uri (Required for --ref & --consistency option above)
     --dump           - Path where to dump the files (Optional). Otherwise, files will be dumped in the user tmp directory.
     --s3ds           - Path to the S3DataStore configuration file
     --fds            - Path to the FileDataStore configuration file ('path' property is mandatory)


### PR DESCRIPTION
In the docs for DS Check, it is written

 --store          - Path to the segment store o**f** mongo uri (Required for --ref & --consistency option above)

when it should be

 --store          - Path to the segment store o**r** mongo uri (Required for --ref & --consistency option above)