### PR TITLE
OAK-9141: fix assertEventually logic with async indexing

### DIFF
--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -177,7 +177,7 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
 
     protected void assertEventually(Runnable r) {
         ElasticTestUtils.assertEventually(r,
-                ((useAsyncIndexing() ? DEFAULT_ASYNC_INDEXING_TIME_IN_SECONDS : 0) + BULK_FLUSH_INTERVAL_MS_DEFAULT) * 5);
+                ((useAsyncIndexing() ? DEFAULT_ASYNC_INDEXING_TIME_IN_SECONDS * 1000L : 0) + BULK_FLUSH_INTERVAL_MS_DEFAULT) * 5);
     }
 
     protected IndexDefinitionBuilder createIndex(String... propNames) {


### PR DESCRIPTION
The `assertEventually` logic wrongly mixes seconds and milliseconds. We have never had issues so far but this could result in flaky tests when async indexing is enabled.