### PR TITLE
OAK-9541 javax.jcr.ItemExistsException with wrong message

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
@@ -417,14 +417,13 @@ public class ImporterImpl implements Importer {
                     // this node has already been auto-created, no need to create it
                     tree = existing;
                 } else {
-                    // edge case: colliding node does have same uuid
+                    // edge case: colliding node with same uuid should not trigger an exception for certain uuidBehaviors
                     // (see http://issues.apache.org/jira/browse/JCR-1128)
                     String existingIdentifier = IdentifierManager.getIdentifier(existing);
                     if (!(existingIdentifier.equals(id)
                             && (uuidBehavior == ImportUUIDBehavior.IMPORT_UUID_COLLISION_REMOVE_EXISTING
                             || uuidBehavior == ImportUUIDBehavior.IMPORT_UUID_COLLISION_REPLACE_EXISTING))) {
-                        throw new ItemExistsException(
-                                "Node with the same UUID exists:" + existing);
+                        throw new ItemExistsException("Node with name " + nodeName + " already exists at this path.");
                     }
                     // fall through
                 }


### PR DESCRIPTION
According to https://github.com/apache/jackrabbit/blob/ed3124e5fe223dada33ce6ddf53bc666063c3f2f/jackrabbit-jcr-tests/src/main/java/org/apache/jackrabbit/test/api/SerializationTest.java#L397 and https://docs.adobe.com/content/docs/en/spec/jsr170/javadocs/jcr-2.0/javax/jcr/Session.html#importXML(java.lang.String,%20java.io.InputStream,%20int) the `ItemExistsException` is actually correct. But that should IMHO be independent of the UUID behaviour (whether it conflicts or not) so the message "Node with the same UUID exists:" is definitely wrong here. So the question is rather: Under which circumstances should it not(!) throw an IEE (in case a node with the same name does already exist).