### PR TITLE
upgrading netty dependency to 4.1.66.final jira OAK-9539

### DIFF
--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -33,7 +33,7 @@
     <name>Oak Segment Tar</name>
 
     <properties>
-        <netty.version>4.1.52.Final</netty.version>
+        <netty.version>4.1.66.Final</netty.version>
         <concurrentlinkedhashmap.version>1.4.2</concurrentlinkedhashmap.version>
     </properties>
 

--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -93,6 +93,12 @@
                             sun.security.ssl;resolution:=optional,
                             sun.security.util;resolution:=optional,
                             sun.security.x509;resolution:=optional,
+                            com.aayushatharva.brotli4j;version="[1.4,2)";resolution:=optional,
+                            com.aayushatharva.brotli4j.decoder;version="[1.4,2)";resolution:=optional,
+                            com.aayushatharva.brotli4j.encoder;version="[1.4,2)";resolution:=optional,
+                            com.github.luben.zstd;version="[1.5,2)";resolution:=optional,
+                            org.bouncycastle.jsse;version="[1.6,2)";resolution:=optional,
+                            org.bouncycastle.jsse.provider;version="[1.6,2)";resolution:=optional,
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
upgrading netty dependency to 4.1.66.final version jira OAK-9539