### PR TITLE
OAK-9548 changed the blockId parameter to match blockid parameter in azure Put Block API spec

### DIFF
--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -967,9 +967,10 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
 
             EnumSet<SharedAccessBlobPermissions> perms = EnumSet.of(SharedAccessBlobPermissions.WRITE);
             Map<String, String> presignedURIRequestParams = Maps.newHashMap();
+            // see https://docs.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
             presignedURIRequestParams.put("comp", "block");
             for (long blockId = 1; blockId <= numParts; ++blockId) {
-                presignedURIRequestParams.put("blockId",
+                presignedURIRequestParams.put("blockid",
                         Base64.encode(String.format("%06d", blockId)));
                 uploadPartURIs.add(
                         createPresignedURI(key,


### PR DESCRIPTION
Azurite, the local nodejs-based Azure Storage Simulator, uses case-sensitive parameter matching when performing lookups based on autogen OpenAPI specs. This change will make it possible to use Azurite as a near fully-functional, fully-local replacement for a real Azure storage account for development and testing of Direct Binary Access related features.