### PR TITLE
OAK-9562: Missing _bin when node is recreated after revision GC

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
@@ -250,14 +250,8 @@ public class Commit {
      * Update the binary status in the update op.
      */
     private void updateBinaryStatus() {
-        DocumentStore store = this.nodeStore.getDocumentStore();
-
         for (Path path : this.nodesWithBinaries) {
-            NodeDocument nd = store.getIfCached(Collection.NODES, Utils.getIdFromPath(path));
-            if ((nd == null) || !nd.hasBinary()) {
-                UpdateOp updateParentOp = getUpdateOperationForNode(path);
-                NodeDocument.setHasBinary(updateParentOp);
-            }
+            NodeDocument.setHasBinary(getUpdateOperationForNode(path));
         }
     }
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BlobReferenceIteratorTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BlobReferenceIteratorTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.jackrabbit.oak.plugins.document;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -29,24 +29,41 @@ import com.mongodb.ReadPreference;
 
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.plugins.blob.ReferencedBlob;
+import org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollector.VersionGCStats;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoTestUtils;
+import org.apache.jackrabbit.oak.plugins.document.rdb.RDBOptions;
+import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.stats.Clock;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.apache.jackrabbit.oak.plugins.document.MongoBlobGCTest.randomStream;
+import static org.apache.jackrabbit.oak.plugins.document.TestUtils.merge;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(Parameterized.class)
 public class BlobReferenceIteratorTest {
-    private DocumentStoreFixture fixture;
+
+    private final DocumentStoreFixture fixture;
+
+    private Clock clock;
 
     private DocumentNodeStore store;
+
+    private DocumentNodeStore store2;
 
     public BlobReferenceIteratorTest(DocumentStoreFixture fixture) {
         this.fixture = fixture;
@@ -70,20 +87,38 @@ public class BlobReferenceIteratorTest {
     }
 
     @Before
-    public void setUp() {
-        store = new DocumentMK.Builder()
-                .setDocumentStore(fixture.createDocumentStore())
-                .setAsyncDelay(0)
-                .getNodeStore();
+    public void setUp() throws Exception {
+        if (fixture instanceof DocumentStoreFixture.RDBFixture) {
+            ((DocumentStoreFixture.RDBFixture) fixture).setRDBOptions(
+                    new RDBOptions().tablePrefix("T" + Long.toHexString(System.currentTimeMillis())).dropTablesOnClose(true));
+        }
+        clock = new Clock.Virtual();
+        clock.waitUntil(System.currentTimeMillis());
+        Revision.setClock(clock);
+        store = newDocumentNodeStore(1);
         // enforce primary read preference, otherwise test fails on a replica
         // set with a read preference configured to secondary.
         MongoTestUtils.setReadPreference(store, ReadPreference.primary());
     }
 
+    private DocumentNodeStore newDocumentNodeStore(int clusterId) {
+        return new DocumentMK.Builder()
+                .setLeaseCheckMode(LeaseCheckMode.DISABLED)
+                .clock(clock)
+                .setDocumentStore(fixture.createDocumentStore(clusterId))
+                .setClusterId(clusterId)
+                .setAsyncDelay(0)
+                .getNodeStore();
+    }
+
     @After
     public void tearDown() throws Exception {
         store.dispose();
+        if (store2 != null) {
+            store2.dispose();
+        }
         fixture.dispose();
+        Revision.resetClockToDefault();
     }
 
     @Test
@@ -102,5 +137,46 @@ public class BlobReferenceIteratorTest {
         List<ReferencedBlob> collectedBlobs = ImmutableList.copyOf(store.getReferencedBlobsIterator());
         assertEquals(blobs.size(), collectedBlobs.size());
         assertEquals(new HashSet<>(blobs), new HashSet<>(collectedBlobs));
+    }
+
+    @Test
+    @Ignore("OAK-9562")
+    public void recreateNodeAfterRevisionGC() throws Exception {
+        assumeTrue(fixture.hasSinglePersistence());
+
+        String id = Utils.getIdFromPath("/test");
+
+        NodeBuilder builder = store.getRoot().builder();
+        Blob b = builder.createBlob(new RandomStream(100, 42));
+        builder.child("test").setProperty("binary", b);
+        merge(store, builder);
+
+        builder = store.getRoot().builder();
+        builder.child("test").remove();
+        merge(store, builder);
+
+        // create a second node store
+        store2 = newDocumentNodeStore(2);
+        assertFalse(store2.getRoot().hasChildNode("test"));
+        NodeDocument doc = store2.getDocumentStore().find(Collection.NODES, id);
+        assertNotNull(doc);
+
+        // wait 60 minutes
+        clock.waitUntil(clock.getTime() + TimeUnit.MINUTES.toMillis(60));
+
+        // clean up garbage docs older than 30 minutes
+        VersionGarbageCollector gc = store.getVersionGarbageCollector();
+        VersionGCStats stats = gc.gc(30, TimeUnit.MINUTES);
+        assertThat(stats.deletedDocGCCount, Matchers.equalTo(1));
+
+        // recreate node via store2
+        builder = store2.getRoot().builder();
+        builder.child("test").setProperty("binary", b);
+        merge(store2, builder);
+
+        // make sure we do not fetch from cache
+        doc = store2.getDocumentStore().find(Collection.NODES, id, 0);
+        assertNotNull(doc);
+        assertTrue(doc.hasBinary());
     }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BlobReferenceIteratorTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BlobReferenceIteratorTest.java
@@ -40,7 +40,6 @@ import org.apache.jackrabbit.oak.stats.Clock;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -140,7 +139,6 @@ public class BlobReferenceIteratorTest {
     }
 
     @Test
-    @Ignore("OAK-9562")
     public void recreateNodeAfterRevisionGC() throws Exception {
         assumeTrue(fixture.hasSinglePersistence());
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BlobReferenceIteratorTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BlobReferenceIteratorTest.java
@@ -105,7 +105,7 @@ public class BlobReferenceIteratorTest {
         return new DocumentMK.Builder()
                 .setLeaseCheckMode(LeaseCheckMode.DISABLED)
                 .clock(clock)
-                .setDocumentStore(fixture.createDocumentStore(clusterId))
+                .setDocumentStore(wrap(fixture.createDocumentStore(clusterId)))
                 .setClusterId(clusterId)
                 .setAsyncDelay(0)
                 .getNodeStore();
@@ -178,5 +178,21 @@ public class BlobReferenceIteratorTest {
         doc = store2.getDocumentStore().find(Collection.NODES, id, 0);
         assertNotNull(doc);
         assertTrue(doc.hasBinary());
+    }
+
+    private static DocumentStore wrap(DocumentStore ds) {
+        return new DocumentStoreTestWrapper(ds);
+    }
+
+    private static class DocumentStoreTestWrapper extends DocumentStoreWrapper {
+
+        private DocumentStoreTestWrapper(DocumentStore store) {
+            super(store);
+        }
+
+        @Override
+        public void dispose() {
+            // ignore
+        }
     }
 }


### PR DESCRIPTION
Add ignored test that reproduces the issue