### PR TITLE
OAK-9552: Don't index except if it's oak:QueryIndexDefinitio

### DIFF
--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -2107,7 +2107,8 @@ public class AsyncIndexUpdateTest {
 
         // Make index
         NodeBuilder builder = store.getRoot().builder();
-        builder.child("oak:index").child("fooIndex").setProperty("async", "async").setProperty("type", "foo");
+        builder.child("oak:index").child("fooIndex").setProperty("async", "async").setProperty("type", "foo")
+                .setProperty("jcr:primaryType", "oak:QueryIndexDefinition", Type.NAME);
         store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
 
         // reset stats


### PR DESCRIPTION
Resolve failing test AsyncIndexUpdateTest.indexCommitCallback