### PR TITLE
OAK-9578: Duplicate logs in oak run indexing output

### DIFF
--- a/oak-run/src/main/resources/logback-indexing.xml
+++ b/oak-run/src/main/resources/logback-indexing.xml
@@ -18,6 +18,7 @@
   ~ under the License.
   -->
 <configuration scan="true" scanPeriod="1 second">
+
   <appender name="index" class="ch.qos.logback.core.FileAppender">
     <file>${oak.workDir}/indexing.log</file>
     <encoder>
@@ -28,25 +29,22 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <target>System.out</target>
     <encoder>
-      <pattern>%d %-5level [%thread] %logger{30} %marker- %msg %n</pattern>
+      <pattern>%d{HH:mm:ss} - %msg%n</pattern>
     </encoder>
   </appender>
 
   <!-- For index tooling -->
   <logger name="org.apache.jackrabbit.oak.index" level="INFO">
-    <appender-ref ref="index" />
-  </logger>
-  <logger name="org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate" level="DEBUG">
-    <appender-ref ref="index" />
+    <appender-ref ref="STDOUT" />
   </logger>
   <logger name="org.apache.jackrabbit.oak.plugins.index.importer" level="INFO">
-    <appender-ref ref="index" />
+    <appender-ref ref="STDOUT" />
   </logger>
   <logger name="org.apache.jackrabbit.oak.plugins.index.IndexUpdate" level="INFO">
-    <appender-ref ref="index" />
+    <appender-ref ref="STDOUT" />
   </logger>
   <logger name="org.apache.jackrabbit.oak.plugins.index.progress" level="INFO">
-    <appender-ref ref="index" />
+    <appender-ref ref="STDOUT" />
   </logger>
 
   <root level="INFO">


### PR DESCRIPTION
Reverting logging changes done for OAK-9536