### PR TITLE
OAK-9580 Fix Azure secret keys leaked in logs

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureSegmentStoreService.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureSegmentStoreService.java
@@ -76,8 +76,8 @@ public class AzureSegmentStoreService {
             } else {
                 connectionString.append(configuration.connectionURL());
             }
-            log.info("Connection string: '{}'", connectionString.toString());
             CloudStorageAccount cloud = CloudStorageAccount.parse(connectionString.toString());
+            log.info("Connection string: '{}'", cloud.toString());
             CloudBlobContainer container = cloud.createCloudBlobClient().getContainerReference(configuration.containerName());
             container.createIfNotExists();
 


### PR DESCRIPTION
Using CloudStorageAccount.ToString method to print the connection string. This will hide the sensitive data.
https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.cloudstorageaccount.tostring?view=azure-dotnet#Microsoft_Azure_Storage_CloudStorageAccount_ToString