### PR TITLE
OAK-9584 add failing test when accessing rep:authorizableId via expanded

### DIFF
--- a/oak-jcr/pom.xml
+++ b/oak-jcr/pom.xml
@@ -52,6 +52,7 @@
       org.apache.jackrabbit.test.api.WorkspaceCopyTest#testCopyNodesLocked                             <!-- OAK-118 -->
       org.apache.jackrabbit.test.api.WorkspaceMoveSameNameSibsTest#testMoveNodesOrderingSupportedByParent <!-- OAK-118 -->
       org.apache.jackrabbit.test.api.WorkspaceMoveTest#testMoveNodesLocked                             <!-- OAK-118 -->
+      org.apache.jackrabbit.oak.jcr.ValidNamesTest#testRepNamespaceUri                                 <!-- OAK-74 -->
 
       <!-- Locking : not fully implemented -->
       org.apache.jackrabbit.test.api.lock.LockTest#testNodeLocked <!-- OAK-3482 -->

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/PropertyTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/PropertyTest.java
@@ -20,7 +20,6 @@ import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
 import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.jcr.nodetype.NodeTypeManager;
@@ -30,10 +29,6 @@ import javax.jcr.nodetype.PropertyDefinitionTemplate;
 
 import com.google.common.collect.Iterators;
 import org.apache.jackrabbit.JcrConstants;
-import org.apache.jackrabbit.api.JackrabbitSession;
-import org.apache.jackrabbit.api.security.user.User;
-import org.apache.jackrabbit.api.security.user.UserManager;
-import org.apache.jackrabbit.spi.Name;
 import org.apache.jackrabbit.test.AbstractJCRTest;
 
 public class PropertyTest extends AbstractJCRTest {
@@ -278,24 +273,5 @@ public class PropertyTest extends AbstractJCRTest {
         pitr = n.getProperties(new String[] {"foo*", "cat*"});
         assertEquals(3, pitr.getSize());
         assertEquals(3, Iterators.size(pitr));
-    }
-
-    public void testHasPropertyWithExpandedNames() throws RepositoryException {
-        Node n = testRootNode.addNode("unstructured", JcrConstants.NT_UNSTRUCTURED);
-        n.setProperty("jcr:custom", "test");
-        superuser.save();
-
-        assertTrue(n.hasProperty("jcr:custom"));
-        assertTrue(n.hasProperty("{"+Name.NS_JCR_URI+"}custom"));
-
-        JackrabbitSession jrSession = (JackrabbitSession)superuser;
-        UserManager userManager = jrSession.getUserManager();
-        User user = userManager.createUser("test", "test");
-
-        superuser.save();
-        n = superuser.getNode(user.getPath());
-
-        assertTrue(n.hasProperty("rep:authorizableId"));
-        assertTrue(n.hasProperty("{internal}authorizableId"));
     }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/PropertyTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/PropertyTest.java
@@ -20,6 +20,7 @@ import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
 import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.jcr.nodetype.NodeTypeManager;
@@ -29,6 +30,10 @@ import javax.jcr.nodetype.PropertyDefinitionTemplate;
 
 import com.google.common.collect.Iterators;
 import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.jackrabbit.spi.Name;
 import org.apache.jackrabbit.test.AbstractJCRTest;
 
 public class PropertyTest extends AbstractJCRTest {
@@ -273,5 +278,24 @@ public class PropertyTest extends AbstractJCRTest {
         pitr = n.getProperties(new String[] {"foo*", "cat*"});
         assertEquals(3, pitr.getSize());
         assertEquals(3, Iterators.size(pitr));
+    }
+
+    public void testHasPropertyWithExpandedNames() throws RepositoryException {
+        Node n = testRootNode.addNode("unstructured", JcrConstants.NT_UNSTRUCTURED);
+        n.setProperty("jcr:custom", "test");
+        superuser.save();
+
+        assertTrue(n.hasProperty("jcr:custom"));
+        assertTrue(n.hasProperty("{"+Name.NS_JCR_URI+"}custom"));
+
+        JackrabbitSession jrSession = (JackrabbitSession)superuser;
+        UserManager userManager = jrSession.getUserManager();
+        User user = userManager.createUser("test", "test");
+
+        superuser.save();
+        n = superuser.getNode(user.getPath());
+
+        assertTrue(n.hasProperty("rep:authorizableId"));
+        assertTrue(n.hasProperty("{internal}authorizableId"));
     }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ValidNamesTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ValidNamesTest.java
@@ -32,6 +32,9 @@ import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.junit.After;
@@ -235,6 +238,21 @@ public class ValidNamesTest extends AbstractRepositoryTest {
         assertEquals(testPrefix + ":foo", n.getName());
     }
 
+    // OAK-74 and OAK-9584
+    @Test
+    public void testRepNamespaceUri() throws RepositoryException {
+        JackrabbitSession jrSession = (JackrabbitSession)session;
+        UserManager userManager = jrSession.getUserManager();
+        User user = userManager.createUser("test", "test");
+
+        session.save();
+        Node n = session.getNode(user.getPath());
+
+        String repNamespaceUri = session.getNamespaceURI("rep");
+        assertTrue(n.hasProperty("rep:authorizableId"));
+        assertTrue(n.hasProperty("{"+repNamespaceUri+"}authorizableId"));
+    }
+ 
     // TODO: questionable exception
     @Test
     public void testValidNamespaceUriInCurlysWrongPlace() {

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ValidNamesTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ValidNamesTest.java
@@ -36,16 +36,21 @@ import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
+import org.apache.jackrabbit.oak.jcr.util.KnownIssuesIgnoreRule;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
 
 public class ValidNamesTest extends AbstractRepositoryTest {
 
+    @Rule
+    public KnownIssuesIgnoreRule customIgnoreRule = new KnownIssuesIgnoreRule();
+    
     private static final String TEST_NODE = "test_node";
     private static final String TEST_PATH = '/' + TEST_NODE;
     private static final Map<NodeStoreFixture, NodeStore> STORES = Maps.newConcurrentMap();

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/util/KnownIssuesIgnoreRule.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/util/KnownIssuesIgnoreRule.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.jcr.util;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.apache.jackrabbit.test.AbstractJCRTest;
+import org.apache.jackrabbit.test.JCRTestResult;
+import org.junit.Assume;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * Evaluates the system properties "known.issues" and "known.issues.override" to skip failing for certain test method failures.
+ * This is the JUnit4 equivalent of {@link JCRTestResult} which is used by the JUnit3 base class {@link AbstractJCRTest}.
+ */
+public class KnownIssuesIgnoreRule implements MethodRule {
+
+    /**
+     * Set of Strings that identify the test methods that currently fails but
+     * are recognized as known issues. Those will not be reported as errors.
+     */
+    private static final Set<String> KNOWN_ISSUES = tokenize("known.issues");
+    private static final Set<String> KNOWN_ISSUES_OVERRIDE = tokenize("known.issues.override");
+
+    // copied from https://github.com/apache/jackrabbit/blob/ed3124e5fe223dada33ce6ddf53bc666063c3f2f/jackrabbit-jcr-tests/src/main/java/org/apache/jackrabbit/test/JCRTestResult.java#L161-L177
+    /**
+     * Takes the named system property and returns the set of string tokens
+     * in the property value. Returns an empty set if the named property does
+     * not exist.
+     *
+     * @param name name of the system property
+     * @return set of string tokens
+     */
+    private static Set<String> tokenize(String name) {
+        Set<String> tokens = new HashSet<String>();
+        StringTokenizer tokenizer =
+            new StringTokenizer(System.getProperty(name, ""));
+        while (tokenizer.hasMoreTokens()) {
+            tokens.add(tokenizer.nextToken());
+        }
+        return tokens;
+    }
+    
+    // similar to https://github.com/apache/jackrabbit/blob/ed3124e5fe223dada33ce6ddf53bc666063c3f2f/jackrabbit-jcr-tests/src/main/java/org/apache/jackrabbit/test/JCRTestResult.java#L179-L215
+    /**
+     * Checks if a variation of the name of the given test case is included
+     * in the given set of token. The tested variations are:
+     * <ul>
+     *   <li>package name</li>
+     *   <li>non-qualified class name</li>
+     *   <li>fully qualified class name</li>
+     *   <li>non-qualified method name</li>
+     *   <li>class-qualified method name</li>
+     *   <li>fully-qualified method name</li>
+     * </ul>
+     *
+     * @param tokens set of string tokens
+     * @param className the fully qualified class name
+     * @param methodName the method name
+     * @return <code>true</code> if the test case name is included,
+     *         <code>false</code> otherwise
+     */
+    private static boolean contains(Set<String> tokens, String className, String methodName) {
+        int i = className.lastIndexOf('.');
+        if (i >= 0) {
+            String packageName = className.substring(0, i);
+            String shortName = className.substring(i + 1);
+            return tokens.contains(packageName)
+                || tokens.contains(shortName)
+                || tokens.contains(className)
+                || tokens.contains(methodName)
+                || tokens.contains(shortName + "#" + methodName)
+                || tokens.contains(className + "#" + methodName);
+        } else {
+            return tokens.contains(className)
+                || tokens.contains(methodName)
+                || tokens.contains(className + "#" + methodName);
+        }
+    }
+   
+    // similar to https://github.com/apache/jackrabbit/blob/ed3124e5fe223dada33ce6ddf53bc666063c3f2f/jackrabbit-jcr-tests/src/main/java/org/apache/jackrabbit/test/JCRTestResult.java#L217-L231
+    private static boolean isKnownIssue(String className, String methodName) {
+        return contains(KNOWN_ISSUES, className, methodName)
+                && !contains(KNOWN_ISSUES_OVERRIDE, className, methodName);
+    }
+
+
+    @Override
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        return new IgnorableStatement(base, method.getDeclaringClass().getName(), method.getName());
+    }
+
+    private class IgnorableStatement extends Statement {
+
+        private final Statement base;
+        private final String className;
+        private final String methodName;
+
+        public IgnorableStatement(Statement base, String className, String methodName) {
+            this.base = base;
+            this.className = className;
+            this.methodName = methodName;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            Assume.assumeTrue("Test is ignored through system property 'known.issues'!", !isKnownIssue(className, methodName));
+            base.evaluate();
+        }
+    }
+
+}

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -296,6 +296,9 @@
             <argLine>${test.opts}</argLine>
             <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
+              <!-- evaluated in oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/util/KnownIssuesIgnoreRule.java (JUnit4) and
+                   https://github.com/apache/jackrabbit/blob/ed3124e5fe223dada33ce6ddf53bc666063c3f2f/jackrabbit-jcr-tests/src/main/java/org/apache/jackrabbit/test/AbstractJCRTest.java#L476 (JUnit3)
+               -->
               <known.issues>${known.issues}</known.issues>
               <mongo.host>${mongo.host}</mongo.host>
               <mongo.port>${mongo.port}</mongo.port>
@@ -316,6 +319,9 @@
             <argLine>${test.opts}</argLine>
             <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
+              <!-- evaluated in oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/util/KnownIssuesIgnoreRule.java (JUnit4) and
+                   https://github.com/apache/jackrabbit/blob/ed3124e5fe223dada33ce6ddf53bc666063c3f2f/jackrabbit-jcr-tests/src/main/java/org/apache/jackrabbit/test/AbstractJCRTest.java#L476 (JUnit3)
+               -->
               <known.issues>${known.issues}</known.issues>
               <mongo.host>${mongo.host}</mongo.host>
               <mongo.port>${mongo.port}</mongo.port>


### PR DESCRIPTION
name

@anchela @mreutegg Any idea why this is failing for the namespace prefix "rep"?