### PR TITLE
Add logging to DataStoreCommand.

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCommand.java
@@ -37,14 +37,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.base.Stopwatch;
-import com.google.common.collect.Lists;
-import com.google.common.io.Closeables;
-import com.google.common.io.Closer;
-import com.google.common.io.Files;
-import joptsimple.OptionParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.io.filefilter.FileFilterUtils;
@@ -85,6 +77,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closeables;
+import com.google.common.io.Closer;
+import com.google.common.io.Files;
+import joptsimple.OptionParser;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -144,8 +145,12 @@ public class DataStoreCommand implements Command {
         boolean success = false;
         try (Closer closer = Utils.createCloserWithShutdownHook()) {
             opts.setTempDirectory(dataStoreOpts.getWorkDir().getAbsolutePath());
+
+            log.info("Creating Node Store fixture");
             NodeStoreFixture fixture = NodeStoreFixtureProvider.create(opts);
+            log.info("Registering Node Store fixture");
             closer.register(fixture);
+            log.info("Node Store fixture created and registered");
 
             if (!checkParameters(dataStoreOpts, opts, fixture, parser)) {
                 return;
@@ -193,6 +198,7 @@ public class DataStoreCommand implements Command {
             metricsCloser.register(metricsExporterFixture);
 
             if (dataStoreOpts.dumpRefs()) {
+                log.info("Initiating dump of data store references");
                 final File referencesTemp = File.createTempFile("traverseref", null, new File(opts.getTempDirectory()));
                 final BufferedWriter writer = Files.newWriter(referencesTemp, UTF_8);
 
@@ -239,6 +245,7 @@ public class DataStoreCommand implements Command {
                     Closeables.close(writer, threw);
                 }
             } else if (dataStoreOpts.dumpIds()) {
+                log.info("Initiating dump of data store IDs");
                 final File blobidsTemp = File.createTempFile("blobidstemp", null, new File(opts.getTempDirectory()));
 
                 retrieveBlobIds((GarbageCollectableBlobStore) fixture.getBlobStore(), blobidsTemp);
@@ -254,6 +261,7 @@ public class DataStoreCommand implements Command {
                     FileUtils.copyFile(blobidsTemp, ids);
                 }
             } else if (dataStoreOpts.getMetadata()) {
+                log.info("Initiating dump of data store metadata");
 
                 List<String> data = getMetadata(fixture);
                 File outDir = opts.getOptionBean(DataStoreOptions.class).getOutDir();

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCommand.java
@@ -37,6 +37,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closeables;
+import com.google.common.io.Closer;
+import com.google.common.io.Files;
+import joptsimple.OptionParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.io.filefilter.FileFilterUtils;
@@ -77,15 +85,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.base.Stopwatch;
-import com.google.common.collect.Lists;
-import com.google.common.io.Closeables;
-import com.google.common.io.Closer;
-import com.google.common.io.Files;
-import joptsimple.OptionParser;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;


### PR DESCRIPTION
This PR adds logging to DataStoreCommand to help with identifying slow performance issues.  See OAK-9488.