### PR TITLE
OAK-9595 XPath queries don't support bind variables

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Expression.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Expression.java
@@ -180,6 +180,10 @@ abstract class Expression {
         static Literal newString(String s) {
             return new Literal(SQL2Parser.escapeStringLiteral(s), s);
         }
+
+        static Literal newBindVariable(String s) {
+            return new Literal("@" + s, s);
+        }
     
         @Override
         public String toString() {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
@@ -624,6 +624,8 @@ public class XPathToSQL2Converter {
                 read(")");
             }
             return Expression.Literal.newBoolean(false);
+        } else if (readIf("$")) {
+            return Expression.Literal.newBindVariable(readIdentifier());
         } else if (currentTokenType == VALUE_NUMBER) {
             Expression.Literal l = Expression.Literal.newNumber(currentToken);
             read();

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/xpath.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/xpath.txt
@@ -26,6 +26,14 @@
 
 #
 
+xpath2sql /jcr:root/content//element(*, nt:base)[@jcr:lastModified >= $lastModified] order by @jcr:lastModified, @jcr:path
+select [jcr:path], [jcr:score], *
+  from [nt:base] as a
+  where [jcr:lastModified] >= @lastModified
+  and isdescendantnode(a, '/content')
+  order by [jcr:lastModified], [jcr:path]
+  /* xpath ... */
+
 xpath2sql /jcr:root//element(*, nt:base)[jcr:contains(., 'hello')]/rep:excerpt()
 select [jcr:path], [jcr:score], [rep:excerpt]
   from [nt:base] as a
@@ -1755,13 +1763,13 @@ xpath2sql //element(*, my:type)[@my:value = +'x']
 invalid: Query: //element(*, my:type)[@my:value = +'x'(*)]
 
 xpath2sql //element(*, my:type)[@my:value = ['x']
-invalid: Query: //element(*, my:type)[@my:value = [(*)'x']; expected: @, true, false, -, +, *, ., @, (
+invalid: Query: //element(*, my:type)[@my:value = [(*)'x']; expected: @, true, false, $, -, +, *, ., @, (
 
 xpath2sql //element(*, my:type)[jcr:strike(@title,'%Java%')]
 invalid: Query: //element(*, my:type)[jcr:strike(@(*)title,'%Java%')]; expected: jcr:like | jcr:contains | jcr:score | xs:dateTime | fn:lower-case | fn:upper-case | fn:name | rep:similar | rep:spellcheck | rep:suggest
 
 xpath2sql //element(*, my:type)[
-invalid: Query: //element(*, my:type)(*)[; expected: fn:not, not, (, @, true, false, -, +, *, ., @, (
+invalid: Query: //element(*, my:type)(*)[; expected: fn:not, not, (, @, true, false, $, -, +, *, ., @, (
 
 xpath2sql //element(*, my:type)[@my:value >= %]
-invalid: Query: //element(*, my:type)[@my:value >= %(*)]; expected: @, true, false, -, +, *, ., @, (
+invalid: Query: //element(*, my:type)[@my:value >= %(*)]; expected: @, true, false, $, -, +, *, ., @, (


### PR DESCRIPTION
Found while testing the documentation for keyset pagination at https://jackrabbit.apache.org/oak/docs/query/query-engine.html#Keyset_Pagination