### PR TITLE
OAK-9624 add query caller logging

### DIFF
--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
@@ -139,5 +139,14 @@ public interface QueryEngineSettingsMBean {
 
     @Description("Get the query validator data as a JSON string.")
     String getQueryValidatorJson();
-
+    
+    
+//    @Description("Set or remove Java Package Name to ignore in Call Trace analysis")
+    void setIgnoredPackageNamesinCallTrace(
+            @Description("package names")
+            @Name("package names")
+            String[] packageNames);
+    
+//    @Description("Get the Java package Names to ignore in Call trace analysis")
+    String[] getIgnoredPackageNamesinCallTrace();
 }

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
@@ -141,16 +141,14 @@ public interface QueryEngineSettingsMBean {
     @Description("Get the query validator data as a JSON string.")
     String getQueryValidatorJson();
     
-    
     /**
      * Set or remove java package/class names which are ignored from finding the 
      * invoking class for queries.
      * 
-     * it can be either Java package names or fully-qualified class names (package + class name).
+     * It can be either Java package names or fully-qualified class names (package + class name).
      * 
      * @param classNames the class names to be ignored.
      */
-    
     @Description("Set or remove Java Package Name to ignore in Call Trace analysis")
     void setIgnoredClassNamesinCallTrace(
             @Description("package or fully qualified class names")

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.api.jmx;
 
+import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
@@ -141,12 +142,21 @@ public interface QueryEngineSettingsMBean {
     String getQueryValidatorJson();
     
     
-//    @Description("Set or remove Java Package Name to ignore in Call Trace analysis")
-    void setIgnoredClassNamesinCallTrace(
-            @Description("package names")
-            @Name("package names")
-            String[] packageNames);
+    /**
+     * Set or remove java package/class names which are ignored from finding the 
+     * invoking class for queries.
+     * 
+     * it can be either Java package names or fully-qualified class names (package + class name).
+     * 
+     * @param classNames the class names to be ignored.
+     */
     
-//    @Description("Get the Java package Names to ignore in Call trace analysis")
-    String[] getIgnoredClassNamesinCallTrace();
+    @Description("Set or remove Java Package Name to ignore in Call Trace analysis")
+    void setIgnoredClassNamesinCallTrace(
+            @Description("package or fully qualified class names")
+            @Name("class names")
+            @NotNull String[] classNames);
+    
+    @Description("Get the Java package / fully qualified class names to ignore when finding the caller of query")
+    @NotNull String[] getIgnoredClassNamesinCallTrace();
 }

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
@@ -142,11 +142,11 @@ public interface QueryEngineSettingsMBean {
     
     
 //    @Description("Set or remove Java Package Name to ignore in Call Trace analysis")
-    void setIgnoredPackageNamesinCallTrace(
+    void setIgnoredClassNamesinCallTrace(
             @Description("package names")
             @Name("package names")
             String[] packageNames);
     
 //    @Description("Get the Java package Names to ignore in Call trace analysis")
-    String[] getIgnoredPackageNamesinCallTrace();
+    String[] getIgnoredClassNamesinCallTrace();
 }

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/package-info.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-@Version("4.10.0")
+@Version("4.11.0")
 package org.apache.jackrabbit.oak.api.jmx;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -60,6 +60,8 @@ import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.api.ContentSession;
 import org.apache.jackrabbit.oak.api.Descriptors;
 import org.apache.jackrabbit.oak.api.Root;
+import org.apache.jackrabbit.oak.api.jmx.Description;
+import org.apache.jackrabbit.oak.api.jmx.Name;
 import org.apache.jackrabbit.oak.api.jmx.QueryEngineSettingsMBean;
 import org.apache.jackrabbit.oak.api.jmx.RepositoryManagementMBean;
 import org.apache.jackrabbit.oak.commons.IOUtils;
@@ -974,6 +976,15 @@ public class Oak {
         void setFullTextComparisonWithoutIndex(boolean fullTextComparisonWithoutIndex) {
             this.settings.setFullTextComparisonWithoutIndex(fullTextComparisonWithoutIndex);
         }
+        
+        public void setIgnoredPackageNamesinCallTrace(String[] packageNames) {
+            settings.setIgnoredPackageNamesinCallTrace(packageNames);
+        }
+        
+        public String[] getIgnoredPackageNamesinCallTrace() {
+            return settings.getIgnoredPackageNamesinCallTrace();
+        }
+        
     }
 
     public static class OakDefaultComponents {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -60,8 +60,6 @@ import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.api.ContentSession;
 import org.apache.jackrabbit.oak.api.Descriptors;
 import org.apache.jackrabbit.oak.api.Root;
-import org.apache.jackrabbit.oak.api.jmx.Description;
-import org.apache.jackrabbit.oak.api.jmx.Name;
 import org.apache.jackrabbit.oak.api.jmx.QueryEngineSettingsMBean;
 import org.apache.jackrabbit.oak.api.jmx.RepositoryManagementMBean;
 import org.apache.jackrabbit.oak.commons.IOUtils;
@@ -977,11 +975,11 @@ public class Oak {
             this.settings.setFullTextComparisonWithoutIndex(fullTextComparisonWithoutIndex);
         }
         
-        public void setIgnoredClassNamesinCallTrace(String[] packageNames) {
+        public void setIgnoredClassNamesinCallTrace(@NotNull String[] packageNames) {
             settings.setIgnoredClassNamesinCallTrace(packageNames);
         }
         
-        public String[] getIgnoredClassNamesinCallTrace() {
+        public @NotNull String[] getIgnoredClassNamesinCallTrace() {
             return settings.getIgnoredClassNamesinCallTrace();
         }
         

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -977,12 +977,12 @@ public class Oak {
             this.settings.setFullTextComparisonWithoutIndex(fullTextComparisonWithoutIndex);
         }
         
-        public void setIgnoredPackageNamesinCallTrace(String[] packageNames) {
-            settings.setIgnoredPackageNamesinCallTrace(packageNames);
+        public void setIgnoredClassNamesinCallTrace(String[] packageNames) {
+            settings.setIgnoredClassNamesinCallTrace(packageNames);
         }
         
-        public String[] getIgnoredPackageNamesinCallTrace() {
-            return settings.getIgnoredPackageNamesinCallTrace();
+        public String[] getIgnoredClassNamesinCallTrace() {
+            return settings.getIgnoredClassNamesinCallTrace();
         }
         
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
@@ -259,7 +259,7 @@ public abstract class QueryEngineImpl implements QueryEngine {
 
         ExecutionContext context = getExecutionContext();
         
-        QueryInformationLogger.logCaller(statement, context.getSettings().getIgnoredPackageNamesinCallTrace());
+        QueryInformationLogger.logCaller(statement, context.getSettings().getIgnoredClassNamesinCallTrace());
         
         List<Query> queries = parseQuery(statement, language, context, mappings);
         

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
@@ -258,6 +258,9 @@ public abstract class QueryEngineImpl implements QueryEngine {
         }
 
         ExecutionContext context = getExecutionContext();
+        
+        QueryInformationLogger.logCaller(statement, context.getSettings().getIgnoredPackageNamesinCallTrace());
+        
         List<Query> queries = parseQuery(statement, language, context, mappings);
         
         for (Query q : queries) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -27,6 +27,7 @@ import org.apache.jackrabbit.oak.query.stats.QueryStatsMBeanImpl;
 import org.apache.jackrabbit.oak.query.stats.QueryStatsReporter;
 import org.apache.jackrabbit.oak.spi.query.QueryLimits;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Settings of the query engine.
@@ -187,11 +188,11 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
         return queryValidator;
     }
     
-    public void setIgnoredClassNamesinCallTrace(String[] packageNames) {
+    public void setIgnoredClassNamesinCallTrace(@NotNull String[] packageNames) {
         classNamesIgnoredInCallTrace = packageNames;
     }
     
-    public String[] getIgnoredClassNamesinCallTrace() {
+    public @NotNull String[] getIgnoredClassNamesinCallTrace() {
         return classNamesIgnoredInCallTrace;
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -18,6 +18,8 @@
  */
 package org.apache.jackrabbit.oak.query;
 
+import java.util.Arrays;
+
 import org.apache.jackrabbit.oak.api.StrictPathRestriction;
 import org.apache.jackrabbit.oak.api.jmx.QueryEngineSettingsMBean;
 import org.apache.jackrabbit.oak.query.stats.QueryStatsMBean;
@@ -81,7 +83,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     private final QueryStatsMBeanImpl queryStats = new QueryStatsMBeanImpl(this);
     
-    private String[] javaPackagesIgnoredInCallTrace = new String[0];
+    private String[] classNamesIgnoredInCallTrace = new String[0];
 
     /**
      * StatisticsProvider used to record query side metrics.
@@ -185,12 +187,12 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
         return queryValidator;
     }
     
-    public void setIgnoredPackageNamesinCallTrace(String[] packageNames) {
-        javaPackagesIgnoredInCallTrace = packageNames;
+    public void setIgnoredClassNamesinCallTrace(String[] packageNames) {
+        classNamesIgnoredInCallTrace = packageNames;
     }
     
-    public String[] getIgnoredPackageNamesinCallTrace() {
-        return javaPackagesIgnoredInCallTrace;
+    public String[] getIgnoredClassNamesinCallTrace() {
+        return classNamesIgnoredInCallTrace;
     }
 
     @Override
@@ -202,6 +204,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
                 ", fullTextComparisonWithoutIndex=" + fullTextComparisonWithoutIndex +
                 ", sql2Optimisation=" + sql2Optimisation +
                 ", fastQuerySize=" + fastQuerySize +
+                ", classNamesIgnoredInCallTrace=" + Arrays.toString(classNamesIgnoredInCallTrace) +
                 '}';
     }
     

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -80,6 +80,8 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private StrictPathRestriction strictPathRestriction = StrictPathRestriction.DISABLE;
 
     private final QueryStatsMBeanImpl queryStats = new QueryStatsMBeanImpl(this);
+    
+    private String[] javaPackagesIgnoredInCallTrace = new String[0];
 
     /**
      * StatisticsProvider used to record query side metrics.
@@ -181,6 +183,14 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public QueryValidator getQueryValidator() {
         return queryValidator;
+    }
+    
+    public void setIgnoredPackageNamesinCallTrace(String[] packageNames) {
+        javaPackagesIgnoredInCallTrace = packageNames;
+    }
+    
+    public String[] getIgnoredPackageNamesinCallTrace() {
+        return javaPackagesIgnoredInCallTrace;
     }
 
     @Override

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
@@ -84,7 +84,7 @@ public class QueryEngineSettingsService {
                         + "which executed this query. This java package is the first package in the call trace"
                         + "which does not not start with the any of the provided fully qualfied class names (packagename + classname)"
                 )
-        String[] ignoredClassNamesinCallTrace();
+        String[] ignoredClassNamesinCallTrace() default {};
 
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
@@ -79,12 +79,12 @@ public class QueryEngineSettingsService {
         String getStrictPathRestrictionsForIndexes() default DISABLED_STRICT_PATH_RESTRICTION;
         
         @AttributeDefinition(
-                name="Java package names to ignore when finding caller",
+                name="Fully qualified class names to ignore when finding caller",
                 description="If non-empty the query engine logs the query statement plus the java package "
                         + "which executed this query. This java package is the first package in the call trace"
-                        + "which does not not start with the any of the provided package names"
+                        + "which does not not start with the any of the provided fully qualfied class names (packagename + classname)"
                 )
-        String[] ignoredPackageNamesinCallTrace();
+        String[] ignoredClassNamesinCallTrace();
 
     }
 
@@ -130,7 +130,7 @@ public class QueryEngineSettingsService {
             logMsg(QUERY_FAIL_TRAVERSAL, QueryEngineSettings.OAK_QUERY_FAIL_TRAVERSAL);
         }
 
-        queryEngineSettings.setIgnoredPackageNamesinCallTrace(config.ignoredPackageNamesinCallTrace());
+        queryEngineSettings.setIgnoredClassNamesinCallTrace(config.ignoredClassNamesinCallTrace());
 
         boolean fastQuerySizeSysProp = QueryEngineSettings.DEFAULT_FAST_QUERY_SIZE;
         boolean fastQuerySizeFromConfig = config.fastQuerySize();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
@@ -77,6 +77,14 @@ public class QueryEngineSettingsService {
                         "the queryPaths of the index is taken into account."
         )
         String getStrictPathRestrictionsForIndexes() default DISABLED_STRICT_PATH_RESTRICTION;
+        
+        @AttributeDefinition(
+                name="Java package names to ignore when finding caller",
+                description="If non-empty the query engine logs the query statement plus the java package "
+                        + "which executed this query. This java package is the first package in the call trace"
+                        + "which does not not start with the any of the provided package names"
+                )
+        String[] ignoredPackageNamesinCallTrace();
 
     }
 
@@ -121,6 +129,8 @@ public class QueryEngineSettingsService {
         } else {
             logMsg(QUERY_FAIL_TRAVERSAL, QueryEngineSettings.OAK_QUERY_FAIL_TRAVERSAL);
         }
+
+        queryEngineSettings.setIgnoredPackageNamesinCallTrace(config.ignoredPackageNamesinCallTrace());
 
         boolean fastQuerySizeSysProp = QueryEngineSettings.DEFAULT_FAST_QUERY_SIZE;
         boolean fastQuerySizeFromConfig = config.fastQuerySize();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryInformationLogger.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryInformationLogger.java
@@ -37,7 +37,6 @@ public class QueryInformationLogger {
      * @param ignoredClassNames entries to be ignored. If empty, the method is a no-op.
      */
     public static void logCaller(@NotNull String statement, @NotNull String[] ignoredClassNames) {
-        
         if (ignoredClassNames.length == 0) {
             return;
         }
@@ -80,8 +79,8 @@ public class QueryInformationLogger {
      * @return the calling class; if all classes of the call trace are in packages which are ignored,
      *   an empty string is returned.
      */
-    private static String getInvokingClass(String[] ignoredJavaPackages) {
-        
+    @NotNull
+    private static  String getInvokingClass(@NotNull String[] ignoredJavaPackages) {
         // With java9 we would use https://docs.oracle.com/javase/9/docs/api/java/lang/StackWalker.html
         final StackTraceElement[] callStack = Thread.currentThread().getStackTrace();
         
@@ -101,7 +100,6 @@ public class QueryInformationLogger {
         return ""; 
     }
     
-    
     /**
      * Check if statement is explicitly marked to be internal
      * @param statement the JCR query statement to check
@@ -110,11 +108,4 @@ public class QueryInformationLogger {
     private static boolean isOakInternalQuery(@NotNull String statement) {
         return statement.endsWith(QueryEngine.INTERNAL_SQL2_QUERY);
     }
-    
-    
-    
-    
-    
-    
-
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryInformationLogger.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryInformationLogger.java
@@ -24,15 +24,26 @@ public class QueryInformationLogger {
     
     protected static final String OAK_INTERNAL_MARKER = "/* oak-internal */";
     
-    
-    public static void logCaller (String statement, String[] ignoredJavaPackages) {
+    /**
+     * Logs the caller of the query based on the callstack. To refine the result, all stack frames
+     * are ignored, for which the entry (consisting of package name, classname and method name) starts
+     * with one of the entries provided by ignoredClassNames.
+     * 
+     * @param statement the query statement
+     * @param ignoredClassNames entries to be ignored. If empty, the method is a no-op.
+     */
+    public static void logCaller (String statement, String[] ignoredClassNames) {
+        
+        if (ignoredClassNames.length == 0) {
+            return;
+        }
         
         if (isOakInternalQuery(statement)) {
             INTERNAL_QUERIES_LOG.debug("Oak-internal query, query=[{}]", statement);
             return;
         }
         
-        String callingClass = getInvokingClass (ignoredJavaPackages);
+        String callingClass = getInvokingClass (ignoredClassNames);
         if (callingClass.isEmpty()) {
             INTERNAL_QUERIES_LOG.debug("Oak-internal query, query=[{}]", statement);
             if (INTERNAL_QUERIES_LOG.isTraceEnabled()) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryInformationLogger.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryInformationLogger.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.apache.jackrabbit.oak.query;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueryInformationLogger {
+    
+    private static final Logger INTERNAL_QUERIES_LOG = LoggerFactory.getLogger(QueryInformationLogger.class.getName() + ".internalQuery");
+    private static final Logger EXTERNAL_QUERIES_LOG = LoggerFactory.getLogger(QueryInformationLogger.class.getName() + ".externalQuery");
+    
+    protected static final String OAK_INTERNAL_MARKER = "/* oak-internal */";
+    
+    
+    public static void logCaller (String statement, String[] ignoredJavaPackages) {
+        
+        if (isOakInternalQuery(statement)) {
+            INTERNAL_QUERIES_LOG.debug("Oak-internal query, query=[{}]", statement);
+            return;
+        }
+        
+        String callingClass = getInvokingClass (ignoredJavaPackages);
+        if (callingClass.isEmpty()) {
+            INTERNAL_QUERIES_LOG.debug("Oak-internal query, query=[{}]", statement);
+            if (INTERNAL_QUERIES_LOG.isTraceEnabled()) {
+                try {
+                    throw new RuntimeException("requested stacktrace");
+                } catch (RuntimeException e) {
+                    INTERNAL_QUERIES_LOG.trace("providing requested stacktrace", e);
+                }
+            }
+        } else {
+            EXTERNAL_QUERIES_LOG.info("query=[{}], caller=[{}]",statement, callingClass);
+            if (EXTERNAL_QUERIES_LOG.isDebugEnabled()) {
+                try {
+                    throw new RuntimeException("requested stacktrace");
+                } catch (RuntimeException e) {
+                    EXTERNAL_QUERIES_LOG.debug("providing requested stacktrace", e);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Retrieves the calling class and method from the call stack; this is determined by unwinding
+     * the stack until it finds a combination of full qualified classname + method (separated by ".") which
+     * do not start with any of the values provided by the ignoredJavaPackages parameters.
+     * 
+     * @param ignoredJavaPackages
+     * @return the calling class; if all classes of the call trace are in packages which are ignored,
+     *   an empty string is returned.
+     */
+    private static String getInvokingClass (String[] ignoredJavaPackages) {
+        
+        // With java9 we would use https://docs.oracle.com/javase/9/docs/api/java/lang/StackWalker.html
+        final StackTraceElement[] callStack = Thread.currentThread().getStackTrace();
+        
+        for (StackTraceElement stackFrame : callStack) {
+            boolean foundMatch = false;
+            for (String packageName : ignoredJavaPackages) {
+                final String classMethod = stackFrame.getClassName() + "." + stackFrame.getMethodName();
+                if (classMethod.startsWith(packageName)) {
+                    foundMatch = true;
+                    continue;
+                }
+            }
+            if (!foundMatch) {
+                return stackFrame.getClassName() + "." + stackFrame.getMethodName();
+            }
+        }
+        return ""; 
+    }
+    
+    
+    
+    private static boolean isOakInternalQuery (String statement) {
+        return statement.endsWith(OAK_INTERNAL_MARKER);
+    }
+    
+    
+    
+    
+    
+    
+
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
@@ -1,5 +1,18 @@
-package org.apache.jackrabbit.oak.query;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
+package org.apache.jackrabbit.oak.query;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -23,10 +36,8 @@ public class QueryInformationLoggerTest {
     // it might be required to adjust if the CI/CD solution uses different package names (e.g. "com")
     String[] allClassesIgnored = new String[] {"java","org","net","sun","jdk"};
     
-    
     @Test
     public void regularQueryTest() {
-        
         LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.INFO).create();
         LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.TRACE).create();
         try {
@@ -46,7 +57,6 @@ public class QueryInformationLoggerTest {
     
     @Test
     public void withStacktrace() {
-        
         LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
         LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.TRACE).create();
         try {
@@ -99,7 +109,6 @@ public class QueryInformationLoggerTest {
         }     
     }  
     
-    
     @Test
     public void testWithAllStackEntriesIgnored_DEBUG() {
         LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
@@ -136,6 +145,4 @@ public class QueryInformationLoggerTest {
             internal.finished();
         }     
     }  
-    
-    
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
@@ -4,6 +4,7 @@ package org.apache.jackrabbit.oak.query;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.jackrabbit.oak.api.QueryEngine;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -11,13 +12,15 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 public class QueryInformationLoggerTest {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(QueryInformationLoggerTest.class);
 
     private static final String EXTERNAL_LOG = QueryInformationLogger.class.getName() + ".externalQuery";
     private static final String INTERNAL_LOG = QueryInformationLogger.class.getName() + ".internalQuery";
     
+    // these package names should ignore all Oak-internal code
     String[] ignoredClasses = new String[] {"org.apache.jackrabbit.oak","java.lang","sun.reflect", "jdk"};
+    
+    // these package names should cover all class names which appear in the stack trace.
+    // it might be required to adjust if the CI/CD solution uses different package names (e.g. "com")
     String[] allClassesIgnored = new String[] {"java","org","net","sun","jdk"};
     
     
@@ -66,7 +69,7 @@ public class QueryInformationLoggerTest {
         try {
             external.starting();
             internal.starting();
-            String query = "SELECT * FROM [cq:Page] " + QueryInformationLogger.OAK_INTERNAL_MARKER;
+            String query = "SELECT * FROM [cq:Page] " + QueryEngine.INTERNAL_SQL2_QUERY;
             QueryInformationLogger.logCaller(query, ignoredClasses);
             
             // On INFO no logs are written

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
@@ -1,0 +1,143 @@
+package org.apache.jackrabbit.oak.query;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+public class QueryInformationLoggerTest {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(QueryInformationLoggerTest.class);
+
+    private static final String EXTERNAL_LOG = QueryInformationLogger.class.getName() + ".externalQuery";
+    private static final String INTERNAL_LOG = QueryInformationLogger.class.getName() + ".internalQuery";
+    
+    String[] ignoredClasses = new String[] {"org.apache.jackrabbit.oak","java.lang","sun.reflect", "jdk"};
+    String[] allClassesIgnored = new String[] {"java","org","net","sun","jdk"};
+    
+    
+    @Test
+    public void regularQueryTest() {
+        
+        LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.INFO).create();
+        LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.TRACE).create();
+        try {
+            external.starting();
+            internal.starting();
+            String query = "SELECT * FROM [cq:Page]";
+            QueryInformationLogger.logCaller(query, ignoredClasses);
+            assertEquals("Exactly 1 entry must be written",1,external.getLogs().size());
+            String logEntry = external.getLogs().get(0);
+            assertTrue(logEntry.contains("org.junit.runners.model")); // org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
+            assertEquals(0,internal.getLogs().size());
+        } finally {
+            external.finished();
+            internal.finished();
+        }      
+    }
+    
+    @Test
+    public void withStacktrace() {
+        
+        LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
+        LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.TRACE).create();
+        try {
+            external.starting();
+            internal.starting();
+            String query = "SELECT * FROM [cq:Page]";
+            QueryInformationLogger.logCaller(query, ignoredClasses);
+            assertEquals("Exactly 2 entries must be written",2,external.getLogs().size()); //     
+            assertEquals(0,internal.getLogs().size());
+        } finally {
+            external.finished();
+            internal.finished();
+        }      
+    }
+    
+    @Test
+    public void testOakInternalStatement() {
+        LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
+        LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.INFO).create();
+        try {
+            external.starting();
+            internal.starting();
+            String query = "SELECT * FROM [cq:Page] " + QueryInformationLogger.OAK_INTERNAL_MARKER;
+            QueryInformationLogger.logCaller(query, ignoredClasses);
+            
+            // On INFO no logs are written
+            assertEquals(0,external.getLogs().size()); //     
+            assertEquals(0,internal.getLogs().size());
+        } finally {
+            external.finished();
+            internal.finished();
+        }     
+    }
+    
+    @Test
+    public void testWithAllStackEntriesIgnored_INFO() {
+        LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
+        LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.INFO).create();
+        try {
+            external.starting();
+            internal.starting();
+            String query = "SELECT * FROM [cq:Page]";
+            QueryInformationLogger.logCaller(query, allClassesIgnored);
+            try {
+                throw new AssertionError();
+            } catch (AssertionError e) {
+                e.printStackTrace();
+            }
+            
+            assertEquals(0,external.getLogs().size());    
+            assertEquals(0,internal.getLogs().size()); // would require DEBUG
+        } finally {
+            external.finished();
+            internal.finished();
+        }     
+    }  
+    
+    
+    @Test
+    public void testWithAllStackEntriesIgnored_DEBUG() {
+        LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
+        LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.DEBUG).create();
+        try {
+            external.starting();
+            internal.starting();
+            String query = "SELECT * FROM [cq:Page]";
+            QueryInformationLogger.logCaller(query, allClassesIgnored);
+            
+            assertEquals(0,external.getLogs().size());    
+            assertEquals(1,internal.getLogs().size()); // query statement
+        } finally {
+            external.finished();
+            internal.finished();
+        }     
+    } 
+    
+    @Test
+    public void testWithAllStackEntriesIgnored_TRACE() {
+        LogCustomizer external = LogCustomizer.forLogger(EXTERNAL_LOG).enable(Level.DEBUG).create();
+        LogCustomizer internal = LogCustomizer.forLogger(INTERNAL_LOG).enable(Level.TRACE).create();
+        try {
+            external.starting();
+            internal.starting();
+            String query = "SELECT * FROM [cq:Page]";
+            QueryInformationLogger.logCaller(query, allClassesIgnored);
+            
+            // On INFO no logs are written
+            assertEquals(0,external.getLogs().size());    
+            assertEquals(2,internal.getLogs().size()); // query statement + Stacktrace
+        } finally {
+            external.finished();
+            internal.finished();
+        }     
+    }  
+    
+    
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
@@ -34,7 +34,7 @@ public class QueryInformationLoggerTest {
             internal.starting();
             String query = "SELECT * FROM [cq:Page]";
             QueryInformationLogger.logCaller(query, ignoredClasses);
-            assertEquals("Exactly 1 entry must be written",1,external.getLogs().size());
+            assertEquals("Exactly 1 entry must be written", 1, external.getLogs().size());
             String logEntry = external.getLogs().get(0);
             assertTrue(logEntry.contains("org.junit.runners.model")); // org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
             assertEquals(0,internal.getLogs().size());
@@ -54,8 +54,8 @@ public class QueryInformationLoggerTest {
             internal.starting();
             String query = "SELECT * FROM [cq:Page]";
             QueryInformationLogger.logCaller(query, ignoredClasses);
-            assertEquals("Exactly 2 entries must be written",2,external.getLogs().size()); //     
-            assertEquals(0,internal.getLogs().size());
+            assertEquals("Exactly 2 entries must be written", 2, external.getLogs().size()); //     
+            assertEquals(0, internal.getLogs().size());
         } finally {
             external.finished();
             internal.finished();
@@ -73,8 +73,8 @@ public class QueryInformationLoggerTest {
             QueryInformationLogger.logCaller(query, ignoredClasses);
             
             // On INFO no logs are written
-            assertEquals(0,external.getLogs().size()); //     
-            assertEquals(0,internal.getLogs().size());
+            assertEquals(0, external.getLogs().size()); //     
+            assertEquals(0, internal.getLogs().size());
         } finally {
             external.finished();
             internal.finished();
@@ -115,8 +115,8 @@ public class QueryInformationLoggerTest {
             String query = "SELECT * FROM [cq:Page]";
             QueryInformationLogger.logCaller(query, allClassesIgnored);
             
-            assertEquals(0,external.getLogs().size());    
-            assertEquals(1,internal.getLogs().size()); // query statement
+            assertEquals(0, external.getLogs().size());    
+            assertEquals(1, internal.getLogs().size()); // query statement
         } finally {
             external.finished();
             internal.finished();
@@ -134,8 +134,8 @@ public class QueryInformationLoggerTest {
             QueryInformationLogger.logCaller(query, allClassesIgnored);
             
             // On INFO no logs are written
-            assertEquals(0,external.getLogs().size());    
-            assertEquals(2,internal.getLogs().size()); // query statement + Stacktrace
+            assertEquals(0, external.getLogs().size());    
+            assertEquals(2, internal.getLogs().size()); // query statement + Stacktrace
         } finally {
             external.finished();
             internal.finished();

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryInformationLoggerTest.java
@@ -37,7 +37,7 @@ public class QueryInformationLoggerTest {
             assertEquals("Exactly 1 entry must be written", 1, external.getLogs().size());
             String logEntry = external.getLogs().get(0);
             assertTrue(logEntry.contains("org.junit.runners.model")); // org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
-            assertEquals(0,internal.getLogs().size());
+            assertEquals(0, internal.getLogs().size());
         } finally {
             external.finished();
             internal.finished();
@@ -73,7 +73,7 @@ public class QueryInformationLoggerTest {
             QueryInformationLogger.logCaller(query, ignoredClasses);
             
             // On INFO no logs are written
-            assertEquals(0, external.getLogs().size()); //     
+            assertEquals(0, external.getLogs().size());    
             assertEquals(0, internal.getLogs().size());
         } finally {
             external.finished();
@@ -90,14 +90,9 @@ public class QueryInformationLoggerTest {
             internal.starting();
             String query = "SELECT * FROM [cq:Page]";
             QueryInformationLogger.logCaller(query, allClassesIgnored);
-            try {
-                throw new AssertionError();
-            } catch (AssertionError e) {
-                e.printStackTrace();
-            }
             
-            assertEquals(0,external.getLogs().size());    
-            assertEquals(0,internal.getLogs().size()); // would require DEBUG
+            assertEquals(0, external.getLogs().size());    
+            assertEquals(0, internal.getLogs().size()); // would require DEBUG
         } finally {
             external.finished();
             internal.finished();


### PR DESCRIPTION
Add fucntionality which is able to log the class which is issuing a JCR query. The detection is based on an analysis of the callstack with the ability to ignore a defined set of packages/names.

* the configuration of an ignoreList is done via the OSGI configuration (QueryEngineSettingsService)
* if the ignoreList is empty (non-configured), nothing is done, and there is no overhead.
* If configured it displays the caller based on the callstack, ignoring stackframes which start with the classnames on the ignoreList.
* If a more verbose loglevel is used, also full stacktraces are logged (helps to refine the configuration)
* Dedicated loggers are created for internal queries (which either are completely matched by elements of the ignoreList or which have the ``/* oak-internal */`` as annotation) or external queries (everything else).
* For external queries a single log line is logged on INFO (stacktrace on DEBUG), for internal queries the single log line is logged on DEBUG (stacktrace on TRACE).

There might be a small overhead in execution time (getting the stack isn't that cheap), but for the frequent and time-critical queries (the ones marked with ``/* oak-internal */`` this isn't done.

When these elements are put onto the ignoreList:
```
org.apache.jackrabbit.oak
java.lang
org.apache.sling.jcr.resource.internal.helper.JcrResourceUtil.query
org.apache.sling.jcr.resource.internal.helper.jcr.BasicQueryLanguageProvider
org.apache.sling.resourceresolver.impl.providers.stateful.AuthenticatedResourceProvider.findResources
org.apache.sling.resourceresolver.impl.helper.ResourceResolverControl.findResources
org.apache.sling.resourceresolver.impl.ResourceResolverImpl.findResources
```

The correct calling classes of JCR Queries and Sling's ``ResourceResolver.findResource`` are logged.