### PR TITLE
OAK-9624 print the name of the calling class invoking a query in some cases

### DIFF
--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/QueryEngineSettingsMBean.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.api.jmx;
 
+import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
@@ -140,4 +141,21 @@ public interface QueryEngineSettingsMBean {
     @Description("Get the query validator data as a JSON string.")
     String getQueryValidatorJson();
 
+    /**
+     * Set or remove java package/class names which are ignored from finding the 
+     * invoking class for queries.
+     * 
+     * It can be either Java package names or fully-qualified class names (package + class name).
+     * 
+     * @param classNames the class names to be ignored.
+     */
+    @Description("Set or remove Java package / fully qualified class names to ignore in Call Trace analysis")
+    void setIgnoredClassNamesInCallTrace(
+            @Description("package or fully qualified class names")
+            @Name("class names")
+            @NotNull String[] classNames);
+    
+//    @Description("Get the Java package / fully qualified class names to ignore when finding the caller of query")
+    @NotNull
+    String[] getIgnoredClassNamesInCallTrace();
 }

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/package-info.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-@Version("4.10.0")
+@Version("4.11.0")
 package org.apache.jackrabbit.oak.api.jmx;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -974,6 +974,14 @@ public class Oak {
         void setFullTextComparisonWithoutIndex(boolean fullTextComparisonWithoutIndex) {
             this.settings.setFullTextComparisonWithoutIndex(fullTextComparisonWithoutIndex);
         }
+
+        public void setIgnoredClassNamesInCallTrace(@NotNull String[] packageNames) {
+            settings.setIgnoredClassNamesInCallTrace(packageNames);
+        }
+
+        public @NotNull String[] getIgnoredClassNamesInCallTrace() {
+            return settings.getIgnoredClassNamesInCallTrace();
+        }
     }
 
     public static class OakDefaultComponents {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/Cursors.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/Cursors.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index;
 
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -339,7 +340,9 @@ public class Cursors {
                     readCount++;
                     if (readCount % 1000 == 0) {
                         FilterIterators.checkReadLimit(readCount, settings);
-                        LOG.warn("Traversed " + readCount + " nodes with filter " + filter + "; consider creating an index or changing the query");
+                        String caller = IndexUtils.getCaller(this.settings.getIgnoredClassNamesInCallTrace());
+                        LOG.warn("Traversed {} nodes with filter {} called by {}; consider creating an index or changing the query" , 
+                                new Object[] {readCount, filter, caller});
                     }
 
                     NodeState node = entry.getNodeState();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/Cursors.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/Cursors.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index;
 
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -342,7 +341,7 @@ public class Cursors {
                         FilterIterators.checkReadLimit(readCount, settings);
                         String caller = IndexUtils.getCaller(this.settings.getIgnoredClassNamesInCallTrace());
                         LOG.warn("Traversed {} nodes with filter {} called by {}; consider creating an index or changing the query" , 
-                                new Object[] {readCount, filter, caller});
+                                readCount, filter, caller);
                     }
 
                     NodeState node = entry.getNodeState();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
@@ -30,9 +30,11 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PRO
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.UNIQUE_PROPERTY_NAME;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.jcr.RepositoryException;
 
@@ -40,6 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.QueryEngine;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexEditorProvider;
@@ -240,5 +243,38 @@ public final class IndexUtils {
             return Iterables.getOnlyElement(asyncNames);
         }
         return null;
+    }
+
+    /**
+     * Retrieves the calling class and method from the call stack; this is determined by unwinding
+     * the stack until it finds a combination of full qualified classname + method (separated by ".") which
+     * do not start with any of the values provided by the ignoredJavaPackages parameters. If the provided
+     * parameters cover all stack frames, the whole query is considered to be internal, where the 
+     * actual caller doesn't matter (or cannot be determined clearly). In this case a short message
+     * indicating this is returned.
+     *
+     * If the ingoredJavaPackages parameter is null or empty, the caller is not looked up, but
+     * instead it is assumed, that the feature is not configured; in that case a short messages
+     * is returned indicating that the feature is not configured.
+     *
+     * @param ignoredJavaPackages the java packages or class names
+     * @return the calling class or another non-null value
+     */
+    @NotNull
+    public static String getCaller(@Nullable String[] ignoredJavaPackages) {
+        if (ignoredJavaPackages == null || ignoredJavaPackages.length == 0) {
+            return "(<function not configured>)";
+        }
+
+        // With java9 we would use https://docs.oracle.com/javase/9/docs/api/java/lang/StackWalker.html
+        final StackTraceElement[] callStack = Thread.currentThread().getStackTrace();
+        for (StackTraceElement stackFrame : callStack) {
+            final String classAndMethod = stackFrame.getClassName() + "." + stackFrame.getMethodName();
+            if (Stream.of(ignoredJavaPackages).noneMatch(pkg -> classAndMethod.startsWith(pkg))) {
+                return classAndMethod;
+            }
+        }
+        // if every element is ignored, we assume it's an internal request
+        return "(internal)";
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
@@ -30,7 +30,6 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PRO
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.UNIQUE_PROPERTY_NAME;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +41,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.jackrabbit.oak.api.PropertyState;
-import org.apache.jackrabbit.oak.api.QueryEngine;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexEditorProvider;
@@ -253,7 +251,7 @@ public final class IndexUtils {
      * actual caller doesn't matter (or cannot be determined clearly). In this case a short message
      * indicating this is returned.
      *
-     * If the ingoredJavaPackages parameter is null or empty, the caller is not looked up, but
+     * If the ignoredJavaPackages parameter is null or empty, the caller is not looked up, but
      * instead it is assumed, that the feature is not configured; in that case a short messages
      * is returned indicating that the feature is not configured.
      *
@@ -270,7 +268,7 @@ public final class IndexUtils {
         final StackTraceElement[] callStack = Thread.currentThread().getStackTrace();
         for (StackTraceElement stackFrame : callStack) {
             final String classAndMethod = stackFrame.getClassName() + "." + stackFrame.getMethodName();
-            if (Stream.of(ignoredJavaPackages).noneMatch(pkg -> classAndMethod.startsWith(pkg))) {
+            if (Stream.of(ignoredJavaPackages).noneMatch(classAndMethod::startsWith)) {
                 return classAndMethod;
             }
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexPlan.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexPlan.java
@@ -24,7 +24,6 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.DECLARING_N
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_CONTENT_NODE_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.PROPERTY_NAMES;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexPlan.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexPlan.java
@@ -24,12 +24,14 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.DECLARING_N
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_CONTENT_NODE_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.PROPERTY_NAMES;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.Cursors;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.IndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.property.strategy.IndexStoreStrategy;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
@@ -205,11 +207,12 @@ public class PropertyIndexPlan {
     }
 
     Cursor execute() {
-        if (deprecated) {
-            LOG.warn("This index is deprecated: {}; it is used for query {}. " + 
-                    "Please change the query or the index definitions.", name, filter);
-        }
         QueryLimits settings = filter.getQueryLimits();
+        if (deprecated) {
+            final String caller = IndexUtils.getCaller(settings.getIgnoredClassNamesInCallTrace());
+            LOG.warn("This index is deprecated: {}; it is used for query {} called by {}. " +
+                    "Please change the query or the index definitions.", name, filter, caller);
+        }
         List<Iterable<String>> iterables = Lists.newArrayList();
         for (IndexStoreStrategy s : strategies) {
             iterables.add(s.query(filter, name, definition, values));

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/strategy/ContentMirrorStoreStrategy.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/strategy/ContentMirrorStoreStrategy.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.index.IndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.counter.ApproximateCounter;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditor;
 import org.apache.jackrabbit.oak.plugins.index.counter.jmx.NodeCounter;
@@ -456,7 +457,9 @@ public class ContentMirrorStoreStrategy implements IndexStoreStrategy {
                         readCount++;
                         if (readCount % TRAVERSING_WARN == 0) {
                             FilterIterators.checkReadLimit(readCount, settings);
-                            LOG.warn("Index-Traversed {} nodes ({} index entries) using index {} with filter {}", readCount, intermediateNodeReadCount, indexName, filter);
+                            String caller = IndexUtils.getCaller(settings.getIgnoredClassNamesInCallTrace());
+                            LOG.warn("Index-Traversed {} nodes ({} index entries) using index {} with filter {}, caller {}", 
+                                    readCount, intermediateNodeReadCount, indexName, filter, caller);
                         }
                         return;
                     } else {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -18,6 +18,8 @@
  */
 package org.apache.jackrabbit.oak.query;
 
+import java.util.Arrays;
+
 import org.apache.jackrabbit.oak.api.StrictPathRestriction;
 import org.apache.jackrabbit.oak.api.jmx.QueryEngineSettingsMBean;
 import org.apache.jackrabbit.oak.query.stats.QueryStatsMBean;
@@ -25,6 +27,7 @@ import org.apache.jackrabbit.oak.query.stats.QueryStatsMBeanImpl;
 import org.apache.jackrabbit.oak.query.stats.QueryStatsReporter;
 import org.apache.jackrabbit.oak.spi.query.QueryLimits;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Settings of the query engine.
@@ -87,6 +90,8 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private final StatisticsProvider statisticsProvider;
 
     private final QueryValidator queryValidator = new QueryValidator();
+
+    private String[] classNamesIgnoredInCallTrace = new String[] {};
 
     public QueryEngineSettings() {
         statisticsProvider = StatisticsProvider.NOOP;
@@ -182,6 +187,14 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     public QueryValidator getQueryValidator() {
         return queryValidator;
     }
+    
+    public void setIgnoredClassNamesInCallTrace(@NotNull String[] packageNames) {
+        classNamesIgnoredInCallTrace = packageNames;
+    }
+    
+    public @NotNull String[] getIgnoredClassNamesInCallTrace() {
+        return classNamesIgnoredInCallTrace;
+    }
 
     @Override
     public String toString() {
@@ -192,6 +205,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
                 ", fullTextComparisonWithoutIndex=" + fullTextComparisonWithoutIndex +
                 ", sql2Optimisation=" + sql2Optimisation +
                 ", fastQuerySize=" + fastQuerySize +
+                ", classNamesIgnoredInCallTrace=" + Arrays.toString(classNamesIgnoredInCallTrace) +
                 '}';
     }
     

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
@@ -82,7 +82,7 @@ public class QueryEngineSettingsService {
                 name="Fully qualified class names to ignore when finding caller",
                 description="If non-empty the query engine logs the query statement plus the java package "
                         + "which executed this query. This java package is the first package in the call trace"
-                        + "which does not not start with the any of the provided fully qualfied class names (packagename + classname)"
+                        + "which does not  start with any of the provided fully qualified class names (packagename + classname)"
                 )
         String[] ignoredClassNamesinCallTrace() default {};
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
@@ -81,10 +81,10 @@ public class QueryEngineSettingsService {
         @AttributeDefinition(
                 name="Fully qualified class names to ignore when finding caller",
                 description="If non-empty the query engine logs the query statement plus the java package "
-                        + "which executed this query. This java package is the first package in the call trace"
+                        + "which executed this query. This java package is the first package in the call trace "
                         + "which does not  start with any of the provided fully qualified class names (packagename + classname)"
                 )
-        String[] ignoredClassNamesinCallTrace() default {};
+        String[] ignoredClassNamesInCallTrace() default {};
 
     }
 
@@ -130,7 +130,7 @@ public class QueryEngineSettingsService {
             logMsg(QUERY_FAIL_TRAVERSAL, QueryEngineSettings.OAK_QUERY_FAIL_TRAVERSAL);
         }
 
-        queryEngineSettings.setIgnoredClassNamesInCallTrace(config.ignoredClassNamesinCallTrace());
+        queryEngineSettings.setIgnoredClassNamesInCallTrace(config.ignoredClassNamesInCallTrace());
 
         boolean fastQuerySizeSysProp = QueryEngineSettings.DEFAULT_FAST_QUERY_SIZE;
         boolean fastQuerySizeFromConfig = config.fastQuerySize();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsService.java
@@ -77,6 +77,14 @@ public class QueryEngineSettingsService {
                         "the queryPaths of the index is taken into account."
         )
         String getStrictPathRestrictionsForIndexes() default DISABLED_STRICT_PATH_RESTRICTION;
+        
+        @AttributeDefinition(
+                name="Fully qualified class names to ignore when finding caller",
+                description="If non-empty the query engine logs the query statement plus the java package "
+                        + "which executed this query. This java package is the first package in the call trace"
+                        + "which does not not start with the any of the provided fully qualfied class names (packagename + classname)"
+                )
+        String[] ignoredClassNamesinCallTrace() default {};
 
     }
 
@@ -121,6 +129,8 @@ public class QueryEngineSettingsService {
         } else {
             logMsg(QUERY_FAIL_TRAVERSAL, QueryEngineSettings.OAK_QUERY_FAIL_TRAVERSAL);
         }
+
+        queryEngineSettings.setIgnoredClassNamesInCallTrace(config.ignoredClassNamesinCallTrace());
 
         boolean fastQuerySizeSysProp = QueryEngineSettings.DEFAULT_FAST_QUERY_SIZE;
         boolean fastQuerySizeFromConfig = config.fastQuerySize();

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexUtilsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexUtilsTest.java
@@ -28,6 +28,12 @@ import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE
 import static org.junit.Assert.*;
 
 public class IndexUtilsTest {
+    
+    // all relevant package TLDs
+    private static final String[] ALL_CLASSES_IGNORED = new String[] {"org", "com", "sun", "jdk", "java"};
+    
+    // all packages used with Oak
+    private static final String[] OAK_CLASSES_IGNORED = new String[] {"org.apache.jackrabbit", "java.lang", "sun.reflect", "jdk"};
 
     @Test
     public void asyncName() throws Exception {
@@ -41,4 +47,14 @@ public class IndexUtilsTest {
         assertEquals("async3", IndexUtils.getAsyncLaneName(builder.getNodeState(), "/fooIndex"));
     }
 
+    @Test
+    public void getCaller() {
+        assertNotNull(IndexUtils.getCaller(null));
+        assertNotNull(IndexUtils.getCaller(new String[0]));
+        
+        assertEquals("(internal)",IndexUtils.getCaller(ALL_CLASSES_IGNORED));
+        
+        String caller = IndexUtils.getCaller(OAK_CLASSES_IGNORED);
+        assertTrue(caller.startsWith("org.junit.runners"));
+    }  
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexDeprecatedTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexDeprecatedTest.java
@@ -106,7 +106,7 @@ public class PropertyIndexDeprecatedTest {
         propertyIndex.query(f, root);
         assertEquals("[[WARN] This index is deprecated: foo; " + 
                 "it is used for query Filter(query=" + 
-                "SELECT * FROM [nt:base], path=*, property=[foo=[x10]]). " + 
+                "SELECT * FROM [nt:base], path=*, property=[foo=[x10]]) called by (<function not configured>). " + 
                 "Please change the query or the index definitions.]", appender.list.toString());
         
         index = rootBuilder.child(INDEX_DEFINITIONS_NAME).child("foo");

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryLimits.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryLimits.java
@@ -19,6 +19,7 @@
 package org.apache.jackrabbit.oak.spi.query;
 
 import org.apache.jackrabbit.oak.api.StrictPathRestriction;
+import org.jetbrains.annotations.NotNull;
 
 public interface QueryLimits {
 
@@ -33,5 +34,13 @@ public interface QueryLimits {
     default String getStrictPathRestriction() {
         return StrictPathRestriction.DISABLE.name();
     }
-
+    
+    /**
+     * Retrieve the java package names / full qualified class names which should be
+     * ignored when finding the class starting a query
+     * @return the name of the packages / full qualified class names
+     */
+    default @NotNull String[] getIgnoredClassNamesInCallTrace() {
+        return new String[] {};
+    }
 }

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/package-info.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/package-info.java
@@ -18,7 +18,7 @@
 /**
  * This package contains oak query index related classes.
  */
-@Version("1.4.0")
+@Version("1.5.0")
 package org.apache.jackrabbit.oak.spi.query;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Print the name of the calling class invoking a query in some cases:
* on traversals and index-traversals
* when using a deprecated index

