### PR TITLE
OAK-9181 Fix PersistentRedisCache connection timeout configuration

### DIFF
--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/Configuration.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/Configuration.java
@@ -88,9 +88,9 @@ public @interface Configuration {
 
     @AttributeDefinition(
             name = "Redis connection timeout",
-            description = "Number of seconds to wait for redis connection to be established"
+            description = "Number of milliseconds to wait for redis connection to be established"
     )
-    int redisConnectionTimeout() default 50;
+    int redisConnectionTimeout() default 5000;
 
     @AttributeDefinition(
             name = "Redis Minimum Connections",

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCache.java
@@ -49,8 +49,8 @@ public class PersistentRedisCache extends AbstractPersistentCache {
 
     private static final String REDIS_PREFIX = "SEGMENT";
     private final IOMonitor redisCacheIOMonitor;
-    private JedisPool redisPool;
-    private SetParams setParamsWithExpire;
+    private final JedisPool redisPool;
+    private final SetParams setParamsWithExpire;
 
     public PersistentRedisCache(String redisHost, int redisPort, int redisExpireSeconds, int redisSocketTimeout,
             int redisConnectionTimeout, int redisMinConnections, int redisMaxConnections, int redisMaxTotalConnections,

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/package-info.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("0.0.1")
+@Version("1.0.0")
 package org.apache.jackrabbit.oak.segment.remote.persistentcache;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/package-info.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Version("0.0.1")
+package org.apache.jackrabbit.oak.segment.remote.persistentcache;
+
+import org.osgi.annotation.versioning.Version;

--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCacheTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCacheTest.java
@@ -64,7 +64,7 @@ public class PersistentRedisCacheTest extends AbstractPersistentCacheTest {
                 port,
                 -1,
                 10000,
-                50,
+                1000,
                 10,
                 2000,
                 200000,


### PR DESCRIPTION
Change incorrect default redisConnectionTimeout configuration, from
seconds to millis, as it's interpreted in millis by jedisPool. Fix
the flaky tests as well.