### PR TITLE
OAK-9644 Fix 4 flaky tests by using LinkedHashSet

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterView.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterView.java
@@ -18,6 +18,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -130,7 +131,7 @@ class ClusterView {
      */
     static ClusterView fromDocument(int localInstanceId, String clusterId, ClusterViewDocument clusterViewDoc, Set<Integer> backlogIds) {
         Set<Integer> activeIds = clusterViewDoc.getActiveIds();
-        Set<Integer> deactivatingIds = new HashSet<Integer>();
+        Set<Integer> deactivatingIds = new LinkedHashSet<Integer>();
         deactivatingIds.addAll(clusterViewDoc.getRecoveringIds());
         deactivatingIds.addAll(backlogIds);
         Set<Integer> inactiveIds = new HashSet<Integer>();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterView.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterView.java
@@ -134,7 +134,7 @@ class ClusterView {
         Set<Integer> deactivatingIds = new LinkedHashSet<Integer>();
         deactivatingIds.addAll(clusterViewDoc.getRecoveringIds());
         deactivatingIds.addAll(backlogIds);
-        Set<Integer> inactiveIds = new HashSet<Integer>();
+        Set<Integer> inactiveIds = new LinkedHashSet<Integer>();
         inactiveIds.addAll(clusterViewDoc.getInactiveIds());
         if (!inactiveIds.removeAll(backlogIds) && backlogIds.size() > 0) {
             // then not all backlogIds were listed is inactive - which is

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewDocument.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -470,12 +471,12 @@ class ClusterViewDocument {
 
     /** Returns the set of active ids of this cluster view **/
     Set<Integer> getActiveIds() {
-        return new HashSet<Integer>(Arrays.asList(activeIds));
+        return new LinkedHashSet<Integer>(Arrays.asList(activeIds));
     }
 
     /** Returns the set of recovering ids of this cluster view **/
     Set<Integer> getRecoveringIds() {
-        return new HashSet<Integer>(Arrays.asList(recoveringIds));
+        return new LinkedHashSet<Integer>(Arrays.asList(recoveringIds));
     }
 
     /** Returns the set of inactive ids of this cluster view **/

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewDocument.java
@@ -481,7 +481,7 @@ class ClusterViewDocument {
 
     /** Returns the set of inactive ids of this cluster view **/
     Set<Integer> getInactiveIds() {
-        return new HashSet<Integer>(Arrays.asList(inactiveIds));
+        return new LinkedHashSet<Integer>(Arrays.asList(inactiveIds));
     }
 
     /** Returns the history map **/

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewBuilder.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,9 +26,9 @@ import java.util.Set;
  **/
 class ClusterViewBuilder {
 
-    private final Set<Integer> activeIds = new HashSet<Integer>();
-    private final Set<Integer> recoveringIds = new HashSet<Integer>();
-    private final Set<Integer> backlogIds = new HashSet<Integer>();
+    private final Set<Integer> activeIds = new LinkedHashSet<Integer>();
+    private final Set<Integer> recoveringIds = new LinkedHashSet<Integer>();
+    private final Set<Integer> backlogIds = new LinkedHashSet<Integer>();
     private final Set<Integer> inactiveIds = new HashSet<Integer>();
     private final long viewSeqNum;
     private final int myId;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewBuilder.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterViewBuilder.java
@@ -29,7 +29,7 @@ class ClusterViewBuilder {
     private final Set<Integer> activeIds = new LinkedHashSet<Integer>();
     private final Set<Integer> recoveringIds = new LinkedHashSet<Integer>();
     private final Set<Integer> backlogIds = new LinkedHashSet<Integer>();
-    private final Set<Integer> inactiveIds = new HashSet<Integer>();
+    private final Set<Integer> inactiveIds = new LinkedHashSet<Integer>();
     private final long viewSeqNum;
     private final int myId;
 


### PR DESCRIPTION
- Related 4 flaky tests:
  - org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testOneActiveSeveralInactive
 
  - org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testSeveralActiveOneInactive
 
  - org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testWithRecoveringAndBacklog
 
  - org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testWithRecoveringOnly
 
- The flakiness is due to the nondeterministic iterative order of ```HashSet```

- This proposed method is changing ```HashSet``` to ```LinkedHashSet``` to keep the order deterministic.    

More Information
- Version of ```jackrabbit-oak```
  SHA: 08eab301c869c227d8721da0e9b9bd3d2029d458

- JVM version
  > openjdk version "1.8.0_292"
OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~18.04-b10)
OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)

- The way to reproduce the flaky test failure (using the test ```org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testOneActiveSeveralInactive``` as example)
  - 0.Environment setup: Maven 3.6.0 and Java 1.8.0_292
  - 1.clone the repo:
  ```
  git clone https://github.com/apache/jackrabbit-oak
  cd jackrabbit-oak
  git checkout 08eab301c869c227d8721da0e9b9bd3d2029d458
  ```
  - 2.run with [Nondex tool](https://github.com/TestingResearchIllinois/NonDex) (which explores different behaviors of under-determined APIs and reports test failures)
  ```
  mvn install -pl core -am -DskipTests
  mvn -pl core edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testOneActiveSeveralInactive
  ```
  - 3.And we can get the test failure screenshot:
![image](https://user-images.githubusercontent.com/46290389/145200735-32b51ff6-d5f4-408a-961e-4e186796ac15.png)

  - 4.about the code trace:
  ```
  mvn -pl core edu.illinois:nondex-maven-plugin:1.1.2:debug -Dtest=org.apache.jackrabbit.oak.plugins.document.ClusterViewTest#testOneActiveSeveralInactive
  ```
  we can get the code trace result
![image](https://user-images.githubusercontent.com/46290389/145200761-17bfed55-59c5-4f83-8ab8-dd99cae8cc12.png)
