### PR TITLE
OAK-9553: Add config support for multiple mounts in CompositeNodeStore

### DIFF
--- a/oak-it-osgi/pom.xml
+++ b/oak-it-osgi/pom.xml
@@ -246,7 +246,6 @@
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-junit4</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -256,50 +255,38 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-atinject_1.0_spec</artifactId>
-      <version>1.0</version>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-container-forked</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>6.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.jaas</artifactId>
-      <version>1.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-link-mvn</artifactId>
-      <version>${pax.exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-aether</artifactId>
-      <version>2.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-wrap</artifactId>
-      <version>2.6.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -68,6 +68,7 @@
          When upgrading jackson, try to align them to the same version -->
     <jackson.databind.version>2.10.5.1</jackson.databind.version>
     <testcontainers.version>1.16.2</testcontainers.version>
+    <pax-exam.version>4.13.4</pax-exam.version>
     <java.version>1.8</java.version>
     <java.version.signature>java18</java.version.signature>
     
@@ -752,6 +753,67 @@
         <version>1.2.2</version>
       </dependency>
 
+      <!-- Pax Exam Integration Test Dependencies -->
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.testing.paxexam</artifactId>
+        <version>3.1.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-junit4</artifactId>
+        <version>${pax-exam.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-link-mvn</artifactId>
+        <version>${pax-exam.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-cm</artifactId>
+        <version>${pax-exam.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam</artifactId>
+        <version>${pax-exam.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-container-forked</artifactId>
+        <version>${pax-exam.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-aether</artifactId>
+        <version>2.6.9</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-wrap</artifactId>
+        <version>2.6.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>org.apache.felix.framework</artifactId>
+        <version>7.0.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/oak-store-composite/pom.xml
+++ b/oak-store-composite/pom.xml
@@ -31,6 +31,10 @@
   <name>Oak Composite Store</name>
   <packaging>bundle</packaging>
 
+  <properties>
+    <pax-exam.version>4.13.4</pax-exam.version>
+  </properties>
+  
   <build>
     <plugins>
       <plugin>
@@ -46,16 +50,42 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
-            <java.util.logging.config.file>
-              src/test/resources/logging.properties
-            </java.util.logging.config.file>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <systemPropertyVariables combine.children="append">
+            <bundle.filename>${basedir}/target/${project.build.finalName}.jar</bundle.filename>
           </systemPropertyVariables>
         </configuration>
       </plugin>
-   </plugins>
+      <plugin>
+        <groupId>org.apache.servicemix.tooling</groupId>
+        <artifactId>depends-maven-plugin</artifactId>
+        <version>1.4.0</version>
+        <executions>
+          <!-- Generate dependency file used by Pax Exam -->
+          <execution>
+            <id>generate-depends-file</id>
+            <goals>
+              <goal>generate-depends-file</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <outputFile>${project.build.directory}/test-classes/META-INF/maven/dependencies.properties</outputFile>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/it/*/*.config</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencies>
@@ -174,6 +204,73 @@
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
       <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Integration Test Dependencies -->
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.paxexam</artifactId>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-mvn</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-cm</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.url</groupId>
+      <artifactId>pax-url-aether</artifactId>
+      <version>2.6.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <version>7.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-forked</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-segment-tar</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/oak-store-composite/pom.xml
+++ b/oak-store-composite/pom.xml
@@ -31,10 +31,6 @@
   <name>Oak Composite Store</name>
   <packaging>bundle</packaging>
 
-  <properties>
-    <pax-exam.version>4.13.4</pax-exam.version>
-  </properties>
-  
   <build>
     <plugins>
       <plugin>
@@ -211,55 +207,46 @@
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.testing.paxexam</artifactId>
-      <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-junit4</artifactId>
-      <version>${pax-exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-link-mvn</artifactId>
-      <version>${pax-exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-cm</artifactId>
-      <version>${pax-exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-aether</artifactId>
-      <version>2.6.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>7.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
-      <version>1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam</artifactId>
-      <version>${pax-exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-container-forked</artifactId>
-      <version>${pax-exam.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/CompositeNodeStore.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/CompositeNodeStore.java
@@ -405,7 +405,7 @@ public class CompositeNodeStore implements NodeStore, Observable {
             checkNotNull(store, "store");
             checkNotNull(mountName, "mountName");
 
-            Mount mount = checkNotNull(mip.getMountByName(mountName), "No mount with name %s found in %s", mountName, mip);
+            Mount mount = checkNotNull(mip.getMountByName(mountName), "No mount with name '%s' found in %s", mountName, mip.getNonDefaultMounts());
             nonDefaultStores.add(new MountedNodeStore(mount, store));
             return this;
         }

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoConfig.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoConfig.java
@@ -20,57 +20,53 @@ package org.apache.jackrabbit.oak.composite;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.PropertyUnbounded;
-import org.apache.felix.scr.annotations.Service;
-import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import static java.util.stream.Collectors.toList;
 
-@Component(label = "Apache Jackrabbit Oak MountInfo Config", configurationFactory = true, metatype = true)
-@Service(MountInfoConfig.class)
+@Component(service = MountInfoConfig.class)
+@Designate(ocd = MountInfoConfig.Props.class, factory = true)
 public class MountInfoConfig {
 
-    private static final String[] PROP_MOUNTED_PATHS_DEFAULT = {};
+    @ObjectClassDefinition(name = "MountInfoConfig Properties")
+    public @interface Props {
 
-    @Property(label = "Mounted paths",
-        unbounded = PropertyUnbounded.ARRAY,
-        description = "Paths which are part of private mount"
-    )
-    private static final String PROP_MOUNT_PATHS = "mountedPaths";
+        String DEFAULT_MOUNT_NAME = "private";
+
+        @AttributeDefinition(
+            name = "Mounted paths",
+            description = "Paths which are part of private mount"
+        )
+        String[] mountedPaths() default {};
+
+        @AttributeDefinition(
+            name = "Mount name",
+            description = "Name of the mount"
+        )
+        String mountName() default DEFAULT_MOUNT_NAME;
+
+        @AttributeDefinition(
+            name = "Readonly",
+            description = "If enabled then mount would be considered as readonly"
+        )
+        boolean readOnlyMount() default true;
+
+        @AttributeDefinition(
+            name = "Paths supporting fragments",
+            description = "oak:mount-* under this paths will be included to mounts"
+        )
+        String[] pathsSupportingFragments() default {"/"};
+
+    }
+    
     private List<String> paths;
-
-    static final String PROP_MOUNT_NAME_DEFAULT = "private";
-
-    @Property(label = "Mount name",
-        description = "Name of the mount",
-        value = PROP_MOUNT_NAME_DEFAULT
-    )
-    private static final String PROP_MOUNT_NAME = "mountName";
     private String mountName;
-
-    private static final String[] PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT = {"/"};
-
-    @Property(label = "Paths supporting fragments",
-        unbounded = PropertyUnbounded.ARRAY,
-        description = "oak:mount-* under this paths will be included to mounts",
-        value = {"/"}
-    )
-    private static final String PROP_PATHS_SUPPORTING_FRAGMENTS = "pathsSupportingFragments";
     private List<String> pathsSupportingFragments;
-
-    private static final boolean PROP_MOUNT_READONLY_DEFAULT = true;
-
-    @Property(label = "Readonly",
-        description = "If enabled then mount would be considered as readonly",
-        boolValue = PROP_MOUNT_READONLY_DEFAULT
-    )
-    private static final String PROP_MOUNT_READONLY = "readOnlyMount";
-
     private boolean readOnly;
 
     public MountInfoConfig() {
@@ -84,11 +80,11 @@ public class MountInfoConfig {
     }
 
     @Activate
-    private void activate(BundleContext bundleContext, Map<String, ?> config) {
-        paths = trimAll(Arrays.asList(PropertiesUtil.toStringArray(config.get(PROP_MOUNT_PATHS), PROP_MOUNTED_PATHS_DEFAULT)));
-        mountName = PropertiesUtil.toString(config.get(PROP_MOUNT_NAME), PROP_MOUNT_NAME_DEFAULT).trim();
-        pathsSupportingFragments = trimAll(Arrays.asList(PropertiesUtil.toStringArray(config.get(PROP_PATHS_SUPPORTING_FRAGMENTS), PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT)));
-        readOnly = PropertiesUtil.toBoolean(config.get(PROP_MOUNT_READONLY), PROP_MOUNT_READONLY_DEFAULT);
+    void activate(BundleContext bundleContext, Props props) {
+        paths = trimAll(Arrays.asList(props.mountedPaths()));
+        mountName = props.mountName().trim();
+        pathsSupportingFragments = trimAll(Arrays.asList(props.pathsSupportingFragments()));
+        readOnly = props.readOnlyMount();
     }
 
     public List<String> getPaths() {

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoConfig.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.composite;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.PropertyUnbounded;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.jackrabbit.oak.commons.PropertiesUtil;
+import org.osgi.framework.BundleContext;
+
+import static java.util.stream.Collectors.toList;
+
+@Component(label = "Apache Jackrabbit Oak MountInfo Config", configurationFactory = true, metatype = true)
+@Service(MountInfoConfig.class)
+public class MountInfoConfig {
+
+    private static final String[] PROP_MOUNTED_PATHS_DEFAULT = {};
+
+    @Property(label = "Mounted paths",
+        unbounded = PropertyUnbounded.ARRAY,
+        description = "Paths which are part of private mount"
+    )
+    private static final String PROP_MOUNT_PATHS = "mountedPaths";
+    private List<String> paths;
+
+    static final String PROP_MOUNT_NAME_DEFAULT = "private";
+
+    @Property(label = "Mount name",
+        description = "Name of the mount",
+        value = PROP_MOUNT_NAME_DEFAULT
+    )
+    private static final String PROP_MOUNT_NAME = "mountName";
+    private String mountName;
+
+    private static final String[] PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT = {"/"};
+
+    @Property(label = "Paths supporting fragments",
+        unbounded = PropertyUnbounded.ARRAY,
+        description = "oak:mount-* under this paths will be included to mounts",
+        value = {"/"}
+    )
+    private static final String PROP_PATHS_SUPPORTING_FRAGMENTS = "pathsSupportingFragments";
+    private List<String> pathsSupportingFragments;
+
+    private static final boolean PROP_MOUNT_READONLY_DEFAULT = true;
+
+    @Property(label = "Readonly",
+        description = "If enabled then mount would be considered as readonly",
+        boolValue = PROP_MOUNT_READONLY_DEFAULT
+    )
+    private static final String PROP_MOUNT_READONLY = "readOnlyMount";
+
+    private boolean readOnly;
+
+    public MountInfoConfig() {
+    }
+
+    MountInfoConfig(String mountName, List<String> paths, List<String> pathsSupportingFragments, boolean readOnly) {
+        this.mountName = mountName;
+        this.paths = trimAll(paths);
+        this.pathsSupportingFragments = trimAll(pathsSupportingFragments);
+        this.readOnly = readOnly;
+    }
+
+    @Activate
+    private void activate(BundleContext bundleContext, Map<String, ?> config) {
+        paths = trimAll(Arrays.asList(PropertiesUtil.toStringArray(config.get(PROP_MOUNT_PATHS), PROP_MOUNTED_PATHS_DEFAULT)));
+        mountName = PropertiesUtil.toString(config.get(PROP_MOUNT_NAME), PROP_MOUNT_NAME_DEFAULT).trim();
+        pathsSupportingFragments = trimAll(Arrays.asList(PropertiesUtil.toStringArray(config.get(PROP_PATHS_SUPPORTING_FRAGMENTS), PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT)));
+        readOnly = PropertiesUtil.toBoolean(config.get(PROP_MOUNT_READONLY), PROP_MOUNT_READONLY_DEFAULT);
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public String getMountName() {
+        return mountName;
+    }
+
+    public List<String> getPathsSupportingFragments() {
+        return pathsSupportingFragments;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    private static List<String> trimAll(List<String> strings) {
+        return strings.stream()
+            .map(String::trim)
+            .collect(toList());
+    }
+}

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
@@ -19,15 +19,20 @@
 
 package org.apache.jackrabbit.oak.composite;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
 
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Deactivate;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.PropertyUnbounded;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.ReferenceCardinality;
+import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.mount.Mounts;
@@ -36,70 +41,141 @@ import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Component(metatype = false, label = "Apache Jackrabbit Oak MountInfoProvider")
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+@Component(label = "Apache Jackrabbit Oak MountInfoProviderService")
 public class MountInfoProviderService {
+    private final static Logger LOG = LoggerFactory.getLogger(MountInfoProviderService.class);
+
+    @Reference(
+        cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE,
+        policy = ReferencePolicy.STATIC,
+        bind = "bindMountInfoConfig",
+        unbind = "unbindMountInfoConfig",
+        referenceInterface = MountInfoConfig.class)
+    private List<MountInfoConfig> mountInfoConfigs = new CopyOnWriteArrayList<>();
+
+    private static final String[] PROP_EXPECTED_MOUNTS_DEFAULT = {};
+    
+    @Property(
+        label = "Expected mounts",
+        description = "List of all expected read-only mount names",
+        unbounded = PropertyUnbounded.ARRAY
+    )
+    private static final String PROP_EXPECTED_MOUNTS = "expectedMounts";
+    private List<String> expectedMounts;
 
     @Property(label = "Mounted paths",
-            unbounded = PropertyUnbounded.ARRAY,
-            description = "Paths which are part of private mount"
+        unbounded = PropertyUnbounded.ARRAY,
+        description = "Paths which are part of private mount"
     )
+    @Deprecated
     private static final String PROP_MOUNT_PATHS = "mountedPaths";
 
-    static final String PROP_MOUNT_NAME_DEFAULT = "private";
+    @Deprecated
+    private static final String PROP_MOUNT_NAME_DEFAULT = "private";
 
     @Property(label = "Mount name",
-            description = "Name of the mount",
-            value = PROP_MOUNT_NAME_DEFAULT
+        description = "Name of the mount",
+        value = PROP_MOUNT_NAME_DEFAULT
     )
+    @Deprecated
     private static final String PROP_MOUNT_NAME = "mountName";
 
+    @Deprecated
     private static final boolean PROP_MOUNT_READONLY_DEFAULT = false;
 
     @Property(label = "Readonly",
-            description = "If enabled then mount would be considered as readonly",
-            boolValue = PROP_MOUNT_READONLY_DEFAULT
+        description = "If enabled then mount would be considered as readonly",
+        boolValue = PROP_MOUNT_READONLY_DEFAULT
     )
+    @Deprecated
     private static final String PROP_MOUNT_READONLY = "readOnlyMount";
 
+    @Deprecated
     private static final String[] PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT = new String[] {"/"};
 
     @Property(label = "Paths supporting fragments",
-            unbounded = PropertyUnbounded.ARRAY,
-            description = "oak:mount-* under this paths will be included to mounts",
-            value = {"/"}
+        unbounded = PropertyUnbounded.ARRAY,
+        description = "oak:mount-* under this paths will be included to mounts",
+        value = {"/"}
     )
+    @Deprecated
     private static final String PROP_PATHS_SUPPORTING_FRAGMENTS = "pathsSupportingFragments";
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private ServiceRegistration reg;
+    private BundleContext context;
 
     @Activate
     private void activate(BundleContext bundleContext, Map<String, ?> config) {
+        expectedMounts = Stream.of(PropertiesUtil.toStringArray(config.get(PROP_EXPECTED_MOUNTS), PROP_EXPECTED_MOUNTS_DEFAULT))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(toList());
+        context = bundleContext;
+        addMountInfoConfigFromProperties(config);
+        registerMountInfoProvider();
+    }
+
+    /**
+     * @deprecated only used for backward-compatibility. Now mount configurations should be provided with the {@code MountInfoConfig} class.
+     */
+    @Deprecated
+    private void addMountInfoConfigFromProperties(Map<String, ?> config) {
         String[] paths = PropertiesUtil.toStringArray(config.get(PROP_MOUNT_PATHS));
         String mountName = PropertiesUtil.toString(config.get(PROP_MOUNT_NAME), PROP_MOUNT_NAME_DEFAULT);
         boolean readOnly = PropertiesUtil.toBoolean(config.get(PROP_MOUNT_READONLY), PROP_MOUNT_READONLY_DEFAULT);
         String[] pathsSupportingFragments = PropertiesUtil.toStringArray(config.get(PROP_PATHS_SUPPORTING_FRAGMENTS), PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT);
-
-        MountInfoProvider mip = Mounts.defaultMountInfoProvider();
         if (paths != null) {
-            mip = Mounts.newBuilder()
-                    .mount(mountName.trim(), readOnly, trim(pathsSupportingFragments), trim(paths))
-                    .build();
-            log.info("Enabling mount for {}", mip);
-        } else {
-            log.info("No mount config provided. Mounting would be disabled");
+            mountInfoConfigs.add(new MountInfoConfig(mountName, Arrays.asList(paths), Arrays.asList(pathsSupportingFragments), readOnly));
+            expectedMounts.add(mountName);
         }
-
-        reg = bundleContext.registerService(MountInfoProvider.class.getName(), mip, null);
     }
 
-    private static List<String> trim(String[] array) {
-        List<String> result = new ArrayList<>(array.length);
-        for (String s : array) {
-            result.add(s.trim());
+    @SuppressWarnings("unused")
+    protected void bindMountInfoConfig(MountInfoConfig config) {
+        if (!config.getPaths().isEmpty()) { // Ignore empty configs
+            mountInfoConfigs.add(config);
         }
-        return result;
+        registerMountInfoProvider();
+    }
+
+    private void registerMountInfoProvider() {
+        if (context == null || reg != null) {
+            return;
+        }
+        if (!mountInfoConfigs.stream().allMatch(mountInfo -> expectedMounts.contains(mountInfo.getMountName()))) {
+            LOG.info("Not all expected mounts are present yet (expected: {}, current: {}). Postponing configuration...",
+                expectedMounts, mountInfoConfigs.stream().map(MountInfoConfig::getMountName).collect(joining(",", "[", "]")));
+            return;
+        }
+
+        MountInfoProvider mip;
+
+        boolean hasPaths = mountInfoConfigs.stream().anyMatch(conf -> !conf.getPaths().isEmpty());
+        if (hasPaths) {
+            Mounts.Builder builder = Mounts.newBuilder();
+
+            for (MountInfoConfig mountInfoConfig : mountInfoConfigs) {
+                if (!mountInfoConfig.getPaths().isEmpty()) {
+                    builder.mount(
+                        mountInfoConfig.getMountName(),
+                        mountInfoConfig.isReadOnly(), // read-only
+                        mountInfoConfig.getPathsSupportingFragments(),
+                        mountInfoConfig.getPaths());
+
+                    LOG.info("Enabling mount for {}", mountInfoConfig.getMountName());
+                }
+            }
+            mip = builder.build();
+        } else {
+            mip = Mounts.defaultMountInfoProvider();
+            LOG.info("No mount config provided. Mounting would be disabled");
+        }
+
+        reg = context.registerService(MountInfoProvider.class.getName(), mip, null);
     }
 
     @Deactivate
@@ -108,5 +184,10 @@ public class MountInfoProviderService {
             reg.unregister();
             reg = null;
         }
+    }
+
+    @SuppressWarnings("unused")
+    protected void unbindMountInfoConfig(MountInfoConfig config) {
+        LOG.warn("Dynamic removal of MountInfoConfig is unsupported");
     }
 }

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
@@ -19,103 +19,94 @@
 
 package org.apache.jackrabbit.oak.composite;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
-
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.PropertyUnbounded;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.mount.Mounts;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
-@Component(label = "Apache Jackrabbit Oak MountInfoProviderService")
+@Component
+@Designate(ocd = MountInfoProviderService.Props.class)
 public class MountInfoProviderService {
     private final static Logger LOG = LoggerFactory.getLogger(MountInfoProviderService.class);
 
-    @Reference(
-        cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE,
-        policy = ReferencePolicy.STATIC,
-        bind = "bindMountInfoConfig",
-        unbind = "unbindMountInfoConfig",
-        referenceInterface = MountInfoConfig.class)
-    private List<MountInfoConfig> mountInfoConfigs = new CopyOnWriteArrayList<>();
+    @ObjectClassDefinition(name = "MountInfoProviderService Properties")
+    @interface Props {
 
-    private static final String[] PROP_EXPECTED_MOUNTS_DEFAULT = {};
-    
-    @Property(
-        label = "Expected mounts",
-        description = "List of all expected read-only mount names",
-        unbounded = PropertyUnbounded.ARRAY
-    )
-    private static final String PROP_EXPECTED_MOUNTS = "expectedMounts";
+        String DEFAULT_MOUNT_NAME = "private";
+
+        @AttributeDefinition(
+            name = "Expected mounts",
+            description = "List of all expected read-only mount names"
+        )
+        String[] expectedMounts() default {};
+
+        @AttributeDefinition(
+            name = "Mounted paths",
+            description = "Paths which are part of private mount"
+        )
+        @Deprecated
+        String[] mountedPaths() default {};
+
+        @AttributeDefinition(
+            name = "Mount name",
+            description = "Name of the mount"
+        )
+        @Deprecated
+        String mountName() default DEFAULT_MOUNT_NAME;
+
+        @AttributeDefinition(
+            name = "Readonly",
+            description = "If enabled then mount would be considered as readonly"
+        )
+        @Deprecated
+        boolean readOnlyMount() default true;
+
+        @AttributeDefinition(
+            name = "Paths supporting fragments",
+            description = "oak:mount-* under this paths will be included to mounts"
+        )
+        @Deprecated
+        String[] pathsSupportingFragments() default {"/"};
+
+    }
+
+    private final List<MountInfoConfig> mountInfoConfigs = new CopyOnWriteArrayList<>();
+
     private List<String> expectedMounts;
-
-    @Property(label = "Mounted paths",
-        unbounded = PropertyUnbounded.ARRAY,
-        description = "Paths which are part of private mount"
-    )
-    @Deprecated
-    private static final String PROP_MOUNT_PATHS = "mountedPaths";
-
-    @Deprecated
-    private static final String PROP_MOUNT_NAME_DEFAULT = "private";
-
-    @Property(label = "Mount name",
-        description = "Name of the mount",
-        value = PROP_MOUNT_NAME_DEFAULT
-    )
-    @Deprecated
-    private static final String PROP_MOUNT_NAME = "mountName";
-
-    @Deprecated
-    private static final boolean PROP_MOUNT_READONLY_DEFAULT = false;
-
-    @Property(label = "Readonly",
-        description = "If enabled then mount would be considered as readonly",
-        boolValue = PROP_MOUNT_READONLY_DEFAULT
-    )
-    @Deprecated
-    private static final String PROP_MOUNT_READONLY = "readOnlyMount";
-
-    @Deprecated
-    private static final String[] PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT = new String[] {"/"};
-
-    @Property(label = "Paths supporting fragments",
-        unbounded = PropertyUnbounded.ARRAY,
-        description = "oak:mount-* under this paths will be included to mounts",
-        value = {"/"}
-    )
-    @Deprecated
-    private static final String PROP_PATHS_SUPPORTING_FRAGMENTS = "pathsSupportingFragments";
-
-
     private ServiceRegistration reg;
     private BundleContext context;
 
     @Activate
-    private void activate(BundleContext bundleContext, Map<String, ?> config) {
-        expectedMounts = Stream.of(PropertiesUtil.toStringArray(config.get(PROP_EXPECTED_MOUNTS), PROP_EXPECTED_MOUNTS_DEFAULT))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .collect(toList());
+    public void activate(BundleContext bundleContext, Props props) {
+        String[] expectedMounts = props.expectedMounts();
+        if (expectedMounts != null) {
+            this.expectedMounts = Stream.of(expectedMounts)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(toList());
+        } else {
+            this.expectedMounts = new ArrayList<>();
+        }
         context = bundleContext;
-        addMountInfoConfigFromProperties(config);
+        addMountInfoConfigFromProperties(props);
         registerMountInfoProvider();
     }
 
@@ -123,18 +114,18 @@ public class MountInfoProviderService {
      * @deprecated only used for backward-compatibility. Now mount configurations should be provided with the {@code MountInfoConfig} class.
      */
     @Deprecated
-    private void addMountInfoConfigFromProperties(Map<String, ?> config) {
-        String[] paths = PropertiesUtil.toStringArray(config.get(PROP_MOUNT_PATHS));
-        String mountName = PropertiesUtil.toString(config.get(PROP_MOUNT_NAME), PROP_MOUNT_NAME_DEFAULT);
-        boolean readOnly = PropertiesUtil.toBoolean(config.get(PROP_MOUNT_READONLY), PROP_MOUNT_READONLY_DEFAULT);
-        String[] pathsSupportingFragments = PropertiesUtil.toStringArray(config.get(PROP_PATHS_SUPPORTING_FRAGMENTS), PROP_PATHS_SUPPORTING_FRAGMENTS_DEFAULT);
-        if (paths != null) {
+    private void addMountInfoConfigFromProperties(Props mountInfoProps) {
+        String[] paths = mountInfoProps.mountedPaths();
+        String mountName = mountInfoProps.mountName();
+        boolean readOnly = mountInfoProps.readOnlyMount();
+        String[] pathsSupportingFragments = mountInfoProps.pathsSupportingFragments();
+        if (paths != null && paths.length > 0) {
             mountInfoConfigs.add(new MountInfoConfig(mountName, Arrays.asList(paths), Arrays.asList(pathsSupportingFragments), readOnly));
             expectedMounts.add(mountName);
         }
     }
 
-    @SuppressWarnings("unused")
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE)
     protected void bindMountInfoConfig(MountInfoConfig config) {
         if (!config.getPaths().isEmpty()) { // Ignore empty configs
             mountInfoConfigs.add(config);
@@ -184,10 +175,5 @@ public class MountInfoProviderService {
             reg.unregister();
             reg = null;
         }
-    }
-
-    @SuppressWarnings("unused")
-    protected void unbindMountInfoConfig(MountInfoConfig config) {
-        LOG.warn("Dynamic removal of MountInfoConfig is unsupported");
     }
 }

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
@@ -157,7 +157,7 @@ public class MountInfoProviderService {
                         mountInfoConfig.getPathsSupportingFragments(),
                         mountInfoConfig.getPaths());
 
-                    LOG.info("Enabling mount for {}", mountInfoConfig.getMountName());
+                    LOG.info("Enabling mount for {} with paths: {}", mountInfoConfig.getMountName(), mountInfoConfig.getPaths());
                 }
             }
             mip = builder.build();

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/package-info.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/package-info.java
@@ -55,7 +55,7 @@
  *  This is obviously correct but may be slow.
  *  {@link org.apache.jackrabbit.oak.composite.CompositionContext#getContributingStores(java.lang.String, java.util.function.Function)}
  */
-@Version("0.3.0")
+@Version("0.4.0")
 package org.apache.jackrabbit.oak.composite;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreServiceTest.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreServiceTest.java
@@ -50,7 +50,12 @@ public class CompositeNodeStoreServiceTest {
 		// Create node stores
 		MemoryNodeStore nodeStoreLibs = new MemoryNodeStore();
 		MemoryNodeStore nodeStoreApps = new MemoryNodeStore();
-		MemoryNodeStore global = new MemoryNodeStore();
+		MemoryNodeStore globalStore = new MemoryNodeStore();
+		NodeBuilder globalRoot = globalStore.getRoot().builder();
+		NodeBuilder global = globalRoot.child("content");
+		global.child("content1");
+		global.child("content2");
+		globalStore.merge(globalRoot, EmptyHook.INSTANCE, CommitInfo.EMPTY);
 
 		// Initialise node stores
 		NodeBuilder appsRoot = nodeStoreApps.getRoot().builder();
@@ -73,7 +78,7 @@ public class CompositeNodeStoreServiceTest {
         
 		// Register node stores
 		ctx.registerService(StatisticsProvider.class, StatisticsProvider.NOOP);
-		ctx.registerService(NodeStoreProvider.class, new SimpleNodeStoreProvider(global), ImmutableMap.of("role", "composite-global", "registerDescriptors", Boolean.TRUE));
+		ctx.registerService(NodeStoreProvider.class, new SimpleNodeStoreProvider(globalStore), ImmutableMap.of("role", "composite-global", "registerDescriptors", Boolean.TRUE));
 		ctx.registerService(NodeStoreProvider.class, new SimpleNodeStoreProvider(nodeStoreLibs), ImmutableMap.of("role", "composite-mount-libs"));
 		ctx.registerService(NodeStoreProvider.class, new SimpleNodeStoreProvider(nodeStoreApps), ImmutableMap.of("role", "composite-mount-apps"));
 		ctx.registerInjectActivateService(new NodeStoreChecksService());
@@ -82,6 +87,7 @@ public class CompositeNodeStoreServiceTest {
 
 
 		NodeStore nodeStore = ctx.getService(NodeStore.class);
+		assertNotNull(nodeStore.getRoot().getChildNode("content").getChildNode("content1"));
 		assertNotNull(nodeStore.getRoot().getChildNode("apps").getChildNode("app1"));
 		assertNotNull(nodeStore.getRoot().getChildNode("libs").getChildNode("lib1"));
 	}

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/MountInfoPropsBuilder.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/MountInfoPropsBuilder.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.composite;
+
+import java.lang.annotation.Annotation;
+
+public class MountInfoPropsBuilder {
+    private String[] expectedMounts;
+    private String[] mountPaths;
+    private String mountName;
+    private boolean readonly = true;
+    private String[] pathsSupportingFragments;
+
+    public MountInfoPropsBuilder withExpectedMounts(String... expectedMounts) {
+        this.expectedMounts = expectedMounts;
+        return this;
+    }
+
+    public MountInfoPropsBuilder withMountPaths(String... mountPaths) {
+        this.mountPaths = mountPaths;
+        return this;
+    }
+
+    public MountInfoPropsBuilder withMountName(String mountName) {
+        this.mountName = mountName;
+        return this;
+    }
+
+    public MountInfoPropsBuilder withReadonly(boolean readonly) {
+        this.readonly = readonly;
+        return this;
+    }
+
+    public MountInfoPropsBuilder withPathsSupportingFragments(String... pathsSupportingFragments) {
+        this.pathsSupportingFragments = pathsSupportingFragments;
+        return this;
+    }
+
+    public MountInfoConfig.Props buildMountInfoProps() {
+        return new MountInfoConfig.Props() {
+            @Override
+            public String[] mountedPaths() {
+                return mountPaths == null ? new String[0] : mountPaths;
+            }
+
+            @Override
+            public String mountName() {
+                return mountName == null ? MountInfoConfig.Props.DEFAULT_MOUNT_NAME : mountName;
+            }
+
+            @Override
+            public boolean readOnlyMount() {
+                return readonly;
+            }
+
+            @Override
+            public String[] pathsSupportingFragments() {
+                return pathsSupportingFragments == null ? new String[0] : pathsSupportingFragments;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return MountInfoConfig.Props.class;
+            }
+        };
+    }
+
+    public MountInfoProviderService.Props buildProviderServiceProps() {
+        return new MountInfoProviderService.Props() {
+            @Override
+            public String[] expectedMounts() {
+                return expectedMounts == null ? new String[0] : expectedMounts;
+            }
+
+            @Override
+            public String[] mountedPaths() {
+                return mountPaths == null ? new String[0] : mountPaths;
+            }
+
+            @Override
+            public String mountName() {
+                return mountName == null ? MountInfoProviderService.Props.DEFAULT_MOUNT_NAME : mountName;
+            }
+
+            @Override
+            public boolean readOnlyMount() {
+                return readonly;
+            }
+
+            @Override
+            public String[] pathsSupportingFragments() {
+                return pathsSupportingFragments == null ? new String[0] : pathsSupportingFragments;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return MountInfoProviderService.Props.class;
+            }
+        };
+    }
+}

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/MountInfoProviderServiceTest.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/MountInfoProviderServiceTest.java
@@ -19,10 +19,12 @@
 
 package org.apache.jackrabbit.oak.composite;
 
-import java.util.Collections;
-
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import org.apache.jackrabbit.oak.spi.mount.Mount;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
@@ -32,7 +34,7 @@ import org.junit.Test;
 
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -41,11 +43,11 @@ public class MountInfoProviderServiceTest {
     @Rule
     public final OsgiContext context = new OsgiContext();
 
-    private MountInfoProviderService service = new MountInfoProviderService();
+    private final MountInfoProviderService service = new MountInfoProviderService();
 
     @Test
-    public void defaultSetup() throws Exception{
-        MockOsgi.activate(service, context.bundleContext(), Collections.<String, Object>emptyMap());
+    public void defaultSetup() {
+        MockOsgi.activate(service, context.bundleContext(), Collections.emptyMap());
 
         MountInfoProvider provider = context.getService(MountInfoProvider.class);
         assertNotNull(provider);
@@ -56,43 +58,140 @@ public class MountInfoProviderServiceTest {
     }
 
     @Test
-    public void mountWithConfig_Paths() throws Exception{
-        MockOsgi.activate(service, context.bundleContext(),
-                ImmutableMap.<String, Object>of("mountedPaths", new String[] {"/a", "/b"}));
+    public void mountWithDefaultMountInfoConfig() {
+        registerActivateMountInfoConfig(Collections.emptyMap());
+
+        MockOsgi.injectServices(service, context.bundleContext());
+        MockOsgi.activate(service, context.bundleContext());
+
+        MountInfoProvider provider = context.getService(MountInfoProvider.class);
+        assertNotNull(provider);
+        assertEquals(defaultMountInfoProvider(), provider);
+    }
+
+    @Test
+    public void mountWithConfig_Paths() {
+        registerActivateMountInfoConfig(ImmutableList.of("/a", "/b"));
+
+        MockOsgi.injectServices(service, context.bundleContext());
+        MockOsgi.activate(service, context.bundleContext(), ImmutableMap.of("expectedMounts", new String[]{MountInfoConfig.PROP_MOUNT_NAME_DEFAULT}));
 
         MountInfoProvider provider = context.getService(MountInfoProvider.class);
         assertEquals(1, provider.getNonDefaultMounts().size());
 
-        Mount m = provider.getMountByName(MountInfoProviderService.PROP_MOUNT_NAME_DEFAULT);
+        Mount m = provider.getMountByName(MountInfoConfig.PROP_MOUNT_NAME_DEFAULT);
         assertNotNull(m);
         Mount defMount = provider.getDefaultMount();
         assertNotNull(defMount);
-        assertFalse(m.isReadOnly());
+        assertTrue(m.isReadOnly());
         assertEquals(m, provider.getMountByPath("/a"));
         assertEquals(defMount, provider.getMountByPath("/x"));
     }
 
     @Test
-    public void mountWithConfig_Name() throws Exception{
-        MockOsgi.activate(service, context.bundleContext(),
-                ImmutableMap.<String, Object>of(
-                        "mountedPaths", new String[] {"/a", "/b"},
-                        "mountName", "foo",
-                        "readOnlyMount", true
-                ));
+    public void mountWithConfig_Multiple() {
+        registerActivateMountInfoConfig("foo", "/a");
+        registerActivateMountInfoConfig("bar", "/b");
+        registerActivateMountInfoConfig("baz", "/c");
+
+        MockOsgi.injectServices(service, context.bundleContext());
+        MockOsgi.activate(service, context.bundleContext(), ImmutableMap.of("expectedMounts", new String[]{"foo", "bar", "baz"}));
 
         MountInfoProvider provider = context.getService(MountInfoProvider.class);
-        assertEquals(1, provider.getNonDefaultMounts().size());
+        assertEquals(3, provider.getNonDefaultMounts().size());
 
-        Mount m = provider.getMountByName(MountInfoProviderService.PROP_MOUNT_NAME_DEFAULT);
+        Mount m = provider.getMountByName(MountInfoConfig.PROP_MOUNT_NAME_DEFAULT);
         assertNull(m);
         Mount defMount = provider.getDefaultMount();
         assertNotNull(defMount);
 
         m = provider.getMountByName("foo");
+        assertNotNull(m);
         assertEquals(m, provider.getMountByPath("/a"));
+        assertNotEquals(m, provider.getMountByPath("/b"));
+        assertNotEquals(m, provider.getMountByPath("/c"));
+
+        m = provider.getMountByName("bar");
+        assertNotNull(m);
+        assertNotEquals(m, provider.getMountByPath("/a"));
+        assertEquals(m, provider.getMountByPath("/b"));
+        assertNotEquals(m, provider.getMountByPath("/c"));
+
+        m = provider.getMountByName("baz");
+        assertNotNull(m);
+        assertNotEquals(m, provider.getMountByPath("/a"));
+        assertNotEquals(m, provider.getMountByPath("/b"));
+        assertEquals(m, provider.getMountByPath("/c"));
+    }
+
+    @Test
+    public void mountWithConfig_Name() {
+        registerActivateMountInfoConfig("foo", ImmutableList.of("/a", "/b"));
+
+        MockOsgi.injectServices(service, context.bundleContext());
+        MockOsgi.activate(service, context.bundleContext(), ImmutableMap.of("expectedMounts", "foo"));
+
+        MountInfoProvider provider = context.getService(MountInfoProvider.class);
+        assertEquals(1, provider.getNonDefaultMounts().size());
+
+        Mount m = provider.getMountByName(MountInfoConfig.PROP_MOUNT_NAME_DEFAULT);
+        assertNull(m);
+        Mount defMount = provider.getDefaultMount();
+        assertNotNull(defMount);
+
+        m = provider.getMountByName("foo");
+        assertNotNull(m);
+        assertEquals(m, provider.getMountByPath("/a"));
+        assertEquals(m, provider.getMountByPath("/b"));
         assertEquals(defMount, provider.getMountByPath("/x"));
         assertTrue(m.isReadOnly());
+    }
+
+    @Test
+    public void mountWithConfig_BackwardCompatible() {
+        MockOsgi.activate(service, context.bundleContext(), ImmutableMap.of(
+            "mountedPaths", new String[] {"/a", "/b"},
+            "mountName", "foo",
+            "readOnlyMount", true,
+            "pathsSupportingFragments", new String[] {"/test/*$"}
+        ));
+
+        MountInfoProvider provider = context.getService(MountInfoProvider.class);
+        assertEquals(1, provider.getNonDefaultMounts().size());
+
+        Mount m = provider.getMountByName(MountInfoConfig.PROP_MOUNT_NAME_DEFAULT);
+        assertNull(m);
+        Mount defMount = provider.getDefaultMount();
+        assertNotNull(defMount);
+
+        m = provider.getMountByName("foo");
+        assertNotNull(m);
+        assertEquals(m, provider.getMountByPath("/a"));
+        assertEquals(m, provider.getMountByPath("/b"));
+        assertEquals(defMount, provider.getMountByPath("/x"));
+        assertTrue(m.isReadOnly());
+        assertTrue(m.isSupportFragmentUnder("/test"));
+    }
+
+    private void registerActivateMountInfoConfig(Map<String, Object> mountProperties) {
+        MountInfoConfig mountInfoConfig = new MountInfoConfig();
+        context.bundleContext().registerService(MountInfoConfig.class.getName(), mountInfoConfig, new Properties());
+        MockOsgi.activate(mountInfoConfig, context.bundleContext(), mountProperties);
+    }
+
+    private void registerActivateMountInfoConfig(String mountName, List<String> mountedPaths) {
+        registerActivateMountInfoConfig(ImmutableMap.of(
+            "mountedPaths", mountedPaths.toArray(),
+            "mountName", mountName
+        ));
+    }
+
+    private void registerActivateMountInfoConfig(String mountName, String mountedPath) {
+        registerActivateMountInfoConfig(mountName, ImmutableList.of(mountedPath));
+    }
+
+    private void registerActivateMountInfoConfig(List<String> mountedPaths) {
+        registerActivateMountInfoConfig(MountInfoConfig.PROP_MOUNT_NAME_DEFAULT, mountedPaths);
     }
 
 }

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/BackwardCompatibleMountCompositeIT.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/BackwardCompatibleMountCompositeIT.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.composite.it;
+
+import com.google.common.collect.ImmutableSet;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.inject.Inject;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+/**
+ * Ensures previous composite configuration using {@link org.apache.jackrabbit.oak.composite.MountInfoProviderService} still works.
+ * This test should be removed once the deprecated properties in  {@link org.apache.jackrabbit.oak.composite.MountInfoProviderService} are 
+ * removed.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class BackwardCompatibleMountCompositeIT extends CompositeTestSupport {
+
+    @Configuration
+    public Option[] configuration() {
+        NodeStoresInitializer.initTestStores();
+        
+        return options(baseConfiguration());
+    }
+
+    @Override
+    protected Path getConfigDir() {
+        return Paths.get("src", "test", "resources", "it", "compat");
+    }
+
+    @Inject
+    private NodeStore store;
+
+    @Test
+    public void compositeNodeStoreCreatedFromDeprecatedConfiguration() {
+        assertEquals("Node store should be a CompositeNodeStore", "CompositeNodeStore", store.getClass().getSimpleName());
+        
+        NodeState root = store.getRoot();
+        ImmutableSet<String> expectedNodes = ImmutableSet.of("content", "apps", "libs");
+        ImmutableSet<String> actualNodes = ImmutableSet.copyOf(root.getChildNodeNames());
+        assertTrue("Expected nodes " + expectedNodes + ", but was " + actualNodes, actualNodes.containsAll(expectedNodes));
+
+        assertTrue("'libs' path should be mounted", root.getChildNode("libs").getChildNode("libsMount").exists());
+        assertTrue("'apps' mount should be mounted", root.getChildNode("apps").getChildNode("libsMount").exists());
+        assertTrue("'global' mount should be mounted", root.getChildNode("content").getChildNode("globalMount").exists());
+    }
+}

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/CompositeTestSupport.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/CompositeTestSupport.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.composite.it;
+
+import java.nio.file.Path;
+import org.apache.sling.testing.paxexam.TestSupport;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.ModifiableCompositeOption;
+
+import static org.apache.sling.testing.paxexam.SlingOptions.scr;
+import static org.apache.sling.testing.paxexam.SlingOptions.slingCommonsMetrics;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.frameworkProperty;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.CoreOptions.vmOption;
+
+/**
+ * PaxExam support for oak-store-composite integration tests.
+ * 
+ * WARNING: when running the integration tests in an IDE, make sure to generate the oak-store-composite JAR first, otherwise your latest
+ * code changes will be ignored. Just run `mvn package` to generate the JAR.
+ */
+public abstract class CompositeTestSupport extends TestSupport {
+
+    private static final String JACKRABBIT_GROUP_ID = "org.apache.jackrabbit";
+
+    protected abstract Path getConfigDir();
+
+    @Override
+    protected ModifiableCompositeOption baseConfiguration() {
+        return composite(
+            super.baseConfiguration(),
+            logging("INFO"),
+            junitBundles(),
+            felixFileInstall(),
+            oak(),
+            testBundle("bundle.filename"),
+            frameworkProperty("repository.home").value("target")
+        );
+    }
+
+    public static Option oak() {
+        return composite(
+            scr(),
+            slingCommonsMetrics(),
+            jackrabbit(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-commons").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-api").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-blob").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-blob-plugins").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-core").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-core-spi").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-jackrabbit-api").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-query-spi").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-security-spi").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-segment-tar").versionAsInProject(),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("oak-store-spi").versionAsInProject(),
+            mavenBundle().groupId("com.google.guava").artifactId("guava").versionAsInProject()
+        );
+    }
+
+    public static Option jackrabbit() {
+        return composite(
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("jackrabbit-data").version("2.20.4"),
+            mavenBundle().groupId(JACKRABBIT_GROUP_ID).artifactId("jackrabbit-jcr-commons").version("2.20.4"),
+            mavenBundle().groupId("javax.jcr").artifactId("jcr").versionAsInProject(),
+            mavenBundle().groupId("commons-codec").artifactId("commons-codec").versionAsInProject(),
+            mavenBundle().groupId("commons-io").artifactId("commons-io").versionAsInProject()
+        );
+    }
+
+    protected static Option logging(String level) {
+        return composite(
+            mavenBundle("org.ops4j.pax.logging", "pax-logging-api", "1.11.13"),
+            systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value(level)
+        );
+    }
+
+    protected Option felixFileInstall() {
+        return composite(
+            mavenBundle("org.apache.felix", "org.apache.felix.configadmin", "1.9.22"),
+            mavenBundle("org.apache.felix", "org.apache.felix.fileinstall", "3.7.4"),
+            systemProperty("felix.fileinstall.dir").value(getConfigDir().toAbsolutePath().toString()),
+            systemProperty("felix.fileinstall.enableConfigSave").value("false"),
+            systemProperty("felix.fileinstall.noInitialDelay").value("true")
+        );
+    }
+
+    /**
+     * to debug a test, add this configuration and "run" the test which would block due to suspend="y"
+     * then run remote debugger with specified port
+     */
+    protected static Option debugConfiguration() {
+        return vmOption("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005");
+    }
+}

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/MultiMountCompositeIT.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/MultiMountCompositeIT.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.composite.it;
+
+import com.google.common.collect.ImmutableSet;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.inject.Inject;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+/**
+ * Validates composite multi-mount configuration using {@link org.apache.jackrabbit.oak.composite.MountInfoConfig}.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class MultiMountCompositeIT extends CompositeTestSupport {
+
+    @Configuration
+    public Option[] configuration() {
+        NodeStoresInitializer.initTestStores();
+
+        return options(baseConfiguration());
+    }
+
+    protected Path getConfigDir() {
+        return Paths.get("src", "test", "resources", "it", "multi-mounts");
+    }
+
+    @Inject
+    private NodeStore store;
+
+    @Test
+    public void compositeNodeStoreWithMultipleReadOnlyMounts() {
+        assertEquals("Node store should be a CompositeNodeStore", "CompositeNodeStore", store.getClass().getSimpleName());
+
+        NodeState root = store.getRoot();
+        ImmutableSet<String> expectedNodes = ImmutableSet.of("content", "apps", "libs");
+        ImmutableSet<String> actualNodes = ImmutableSet.copyOf(root.getChildNodeNames());
+        assertTrue("Expected nodes " + expectedNodes + ", but was " + actualNodes, actualNodes.containsAll(expectedNodes));
+
+        assertTrue("'apps' mount should be mounted", root.getChildNode("apps").getChildNode("appsMount").exists());
+        assertTrue("'libs' path should be mounted", root.getChildNode("libs").getChildNode("libsMount").exists());
+        assertTrue("'global' mount should be mounted", root.getChildNode("content").getChildNode("globalMount").exists());
+    }
+}

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/NodeStoresInitializer.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/NodeStoresInitializer.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.composite.it;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Consumer;
+import org.apache.commons.io.FileUtils;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.segment.SegmentNodeStore;
+import org.apache.jackrabbit.oak.segment.SegmentNodeStoreBuilders;
+import org.apache.jackrabbit.oak.segment.file.FileStore;
+import org.apache.jackrabbit.oak.segment.file.FileStoreBuilder;
+import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+
+/**
+ * Initializes the NodeStores used by the Integration Tests. Executed by Maven in the pre-integration-test phase.
+ */
+public class NodeStoresInitializer {
+
+    public static final String GLOBAL_STORE = "segmentstore-composite-global";
+    public static final String LIBS_STORE = "segmentstore-composite-mount-libs";
+    public static final String APPS_STORE = "segmentstore-composite-mount-apps";
+    
+    private static boolean alreadyInitialized;
+
+    public static void initTestStores() {
+        if (alreadyInitialized) {
+            return;
+        }
+        try {
+            Path targetPath = Paths.get("target", "it", "nodestores").toAbsolutePath();
+            initRepo(targetPath, GLOBAL_STORE, builder -> {
+                builder.child("content").child("globalMount");
+                builder.child("libs").child("globalMount");
+                builder.child("apps").child("globalMount");
+            });
+            initRepo(targetPath, LIBS_STORE, builder -> {
+                builder.child("libs").child("libsMount");
+                builder.child("apps").child("libsMount");
+            });
+            initRepo(targetPath, APPS_STORE, builder -> {
+                builder.child("apps").child("appsMount");
+                builder.child("libs").child("appsMount");
+            });
+            alreadyInitialized = true;
+        } catch (IOException | CommitFailedException e) {
+            throw new RuntimeException("Error while initializing test node stores", e);
+        }
+    }
+
+    private static void initRepo(Path targetPath, String store, Consumer<NodeBuilder> consumer) throws IOException, CommitFailedException {
+        Path path = targetPath.resolve(store);
+        FileUtils.deleteDirectory(path.toFile());
+        FileStore filestore = getFileStore(path);
+        SegmentNodeStore segmentNodeStore = SegmentNodeStoreBuilders.builder(filestore).build();
+        NodeBuilder builder = segmentNodeStore.getRoot().builder();
+        consumer.accept(builder);
+        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, new CommitInfo("1", "user"));
+        filestore.flush();
+        filestore.close();
+    }
+
+    private static FileStore getFileStore(Path path) {
+        try {
+            return FileStoreBuilder.fileStoreBuilder(path.toFile()).build();
+        } catch (InvalidFileStoreVersionException | IOException e) {
+            throw new RuntimeException("Failed to build FileStore at path " + path, e);
+        }
+    }
+}

--- a/oak-store-composite/src/test/resources/exam.properties
+++ b/oak-store-composite/src/test/resources/exam.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#Disable the default bundles provisioned under pax logging
+pax.exam.logging=none

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.CompositeNodeStoreService.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.CompositeNodeStoreService.config
@@ -1,0 +1,4 @@
+partialReadOnly="true"
+seedMount="seed"
+enableChecks="true"
+enabled="true"

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.CrossMountReferenceValidatorProvider.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.CrossMountReferenceValidatorProvider.config
@@ -1,0 +1,1 @@
+failOnDetection="true"

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.MountInfoProviderService.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.MountInfoProviderService.config
@@ -1,0 +1,3 @@
+mountName="libs"
+mountedPaths=["/libs", "/apps", "/jcr:system/rep:permissionStore/oak:mount-libs-default"]
+pathsSupportingFragments=["/oak:index/*$"]

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-referenceable.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-referenceable.config
@@ -1,0 +1,3 @@
+invalidNodeType="mix:referenceable"
+excludedNodeTypes=["nt:resource"]
+errorLabel="referenceable node"

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-versionable.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-versionable.config
@@ -1,0 +1,2 @@
+invalidNodeType="mix:versionable"
+errorLabel="versionable node"

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-global.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-global.config
@@ -1,0 +1,4 @@
+role="composite-global"
+registerDescriptors="true"
+repository.home="target/it/nodestores"
+dispatchChanges="true"

--- a/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-libs.config
+++ b/oak-store-composite/src/test/resources/it/compat/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-libs.config
@@ -1,0 +1,3 @@
+role="composite-mount-libs"
+customBlobStore="false"
+repository.home="target/it/nodestores"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.CompositeNodeStoreService.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.CompositeNodeStoreService.config
@@ -1,0 +1,4 @@
+partialReadOnly="true"
+seedMount="seed"
+enableChecks="true"
+enabled="true"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.CrossMountReferenceValidatorProvider.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.CrossMountReferenceValidatorProvider.config
@@ -1,0 +1,1 @@
+failOnDetection="true"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.MountInfoConfig-apps.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.MountInfoConfig-apps.config
@@ -1,0 +1,3 @@
+mountName="apps"
+mountedPaths=["/apps", "/jcr:system/rep:permissionStore/oak:mount-apps-default"]
+pathsSupportingFragments=["/oak:index/*$"]

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.MountInfoConfig-libs.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.MountInfoConfig-libs.config
@@ -1,0 +1,3 @@
+mountName="libs"
+mountedPaths=["/libs"]
+pathsSupportingFragments=["/oak:index/*$"]

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.MountInfoProviderService.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.MountInfoProviderService.config
@@ -1,0 +1,1 @@
+expectedMounts=["apps","libs"]

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-referenceable.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-referenceable.config
@@ -1,0 +1,3 @@
+invalidNodeType="mix:referenceable"
+excludedNodeTypes=["nt:resource"]
+errorLabel="referenceable node"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-versionable.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.composite.checks.NodeTypeMountedNodeStoreChecker-versionable.config
@@ -1,0 +1,2 @@
+invalidNodeType="mix:versionable"
+errorLabel="versionable node"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-apps.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-apps.config
@@ -1,0 +1,3 @@
+role="composite-mount-apps"
+customBlobStore="false"
+repository.home="target/it/nodestores"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-global.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-global.config
@@ -1,0 +1,4 @@
+role="composite-global"
+registerDescriptors="true"
+repository.home="target/it/nodestores"
+dispatchChanges="true"

--- a/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-libs.config
+++ b/oak-store-composite/src/test/resources/it/multi-mounts/org.apache.jackrabbit.oak.segment.SegmentNodeStoreFactory-libs.config
@@ -1,0 +1,3 @@
+role="composite-mount-libs"
+customBlobStore="false"
+repository.home="target/it/nodestores"

--- a/oak-store-composite/src/test/resources/logback-test.xml
+++ b/oak-store-composite/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+<configuration>
+
+<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+        <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+    </encoder>
+</appender>
+
+<appender name="file" class="ch.qos.logback.core.FileAppender">
+    <file>target/unit-tests.log</file>
+    <encoder>
+        <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+    </encoder>
+</appender>
+
+<root level="INFO">
+    <!--
+    <appender-ref ref="console"/>
+    -->
+    <appender-ref ref="file"/>
+</root>
+
+</configuration>


### PR DESCRIPTION
Add MountInfoConfig configuration factory, which can be used to
configure multiple read-only mounts.
MountInfoProviderService can now be configured with the list of expected
mounts, so it can wait for all of them before registering a
MountInfoProvider.
For backward-compatibility, MountInfoProviderService can still be used
to configure a single read-only mount, but all such properties are now
marked as deprecated.