### PR TITLE
OAK-9564 (Bugfixed): Make the renewLease mechanism a bit more tolerant against unexpected updates

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfo.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfo.java
@@ -650,19 +650,24 @@ public class ClusterNodeInfo {
 
         String machineInfo = clusterNode.machineId;
         String instanceInfo = clusterNode.instanceId;
+        String runtimeInfo = clusterNode.runtimeId;
         if (before != null) {
             // machineId or instanceId may have changed
             String beforeMachineId = String.valueOf(before.get(MACHINE_ID_KEY));
             String beforeInstanceId = String.valueOf(before.get(INSTANCE_ID_KEY));
+            String beforeRuntimeId = String.valueOf(before.get(RUNTIME_ID_KEY));
             if (!clusterNode.machineId.equals(beforeMachineId)) {
                 machineInfo = "(changed) " + beforeMachineId + " -> " + machineInfo;
             }
             if (!clusterNode.instanceId.equals(beforeInstanceId)) {
                 instanceInfo = "(changed) " + beforeInstanceId + " -> " + instanceInfo;
             }
+            if (!clusterNode.runtimeId.equals(beforeRuntimeId)) {
+                runtimeInfo = "(changed) " + beforeRuntimeId + " -> " + runtimeInfo;
+            }
         }
-        LOG.info("Acquired ({}) clusterId {}. MachineId {}, InstanceId {}",
-                type, clusterNode.getId(), machineInfo, instanceInfo);
+        LOG.info("Acquired ({}) clusterId {}. MachineId {}, InstanceId {}, RuntimeId {}",
+                type, clusterNode.getId(), machineInfo, instanceInfo, runtimeInfo);
 
     }
 
@@ -1149,6 +1154,7 @@ public class ClusterNodeInfo {
                 "startTime: " + startTime + ",\n" +
                 "machineId: " + machineId + ",\n" +
                 "instanceId: " + instanceId + ",\n" +
+                "runtimeId: " + runtimeId + ",\n" +
                 "pid: " + PROCESS_ID + ",\n" +
                 "uuid: " + uuid + ",\n" +
                 "readWriteMode: " + readWriteMode + ",\n" +

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfo.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfo.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.base.Stopwatch;
 
 import org.apache.jackrabbit.oak.commons.StringUtils;
+import org.apache.jackrabbit.oak.commons.UUIDUtils;
 import org.apache.jackrabbit.oak.plugins.document.spi.lease.LeaseFailureHandler;
 import org.apache.jackrabbit.oak.plugins.document.util.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.stats.Clock;
@@ -175,6 +176,11 @@ public class ClusterNodeInfo {
     public static final String INVISIBLE = "invisible";
 
     /**
+     * Runtime UUID (generated unique ID for this instance)
+     */
+    public static final String RUNTIME_ID_KEY = "runtime_id";
+
+    /**
      * The unique machine id (the MAC address if available).
      */
     private static final String MACHINE_ID = getHardwareMachineId();
@@ -291,20 +297,6 @@ public class ClusterNodeInfo {
     private volatile long leaseEndTime;
 
     /**
-     * The value of leaseEnd last updated towards DocumentStore -
-     * this one is used to compare against (for OAK-3398) when checking
-     * if any other instance updated the lease or if the lease is unchanged.
-     * (This is kind of a duplication of the leaseEndTime field, yes - but the semantics
-     * are that previousLeaseEndTime exactly only serves the purpose of
-     * keeping the value of what was stored in the previous lease update.
-     * leaseEndTime on the other hand serves the purpose of *defining the lease end*,
-     * these are two different concerns, thus justify two different fields.
-     * the leaseEndTime for example can be manipulated during tests therefore,
-     * without interfering with previousLeaseEndTime)
-     */
-    private long previousLeaseEndTime;
-
-    /**
      * The read/write mode.
      */
     private String readWriteMode;
@@ -347,18 +339,22 @@ public class ClusterNodeInfo {
      */
     private boolean invisible;
 
+    /**
+     * Unique ID generated at Runtime.
+     */
+    private final String runtimeId;
 
     private ClusterNodeInfo(int id, DocumentStore store, String machineId,
                             String instanceId, boolean newEntry, boolean invisible) {
         this.id = id;
         this.startTime = getCurrentTime();
         this.leaseEndTime = this.startTime +leaseTime;
-        this.previousLeaseEndTime = this.leaseEndTime;
         this.store = store;
         this.machineId = machineId;
         this.instanceId = instanceId;
         this.newEntry = newEntry;
         this.invisible = invisible;
+        this.runtimeId = UUIDUtils.generateUUID();
     }
 
     void setLeaseCheckMode(@NotNull LeaseCheckMode mode) {
@@ -379,6 +375,10 @@ public class ClusterNodeInfo {
 
     String getInstanceId() {
         return instanceId;
+    }
+
+    String getRuntimeId() {
+        return runtimeId;
     }
 
     boolean isInvisible() {
@@ -482,6 +482,7 @@ public class ClusterNodeInfo {
             update.set(STATE, ACTIVE.name());
             update.set(OAK_VERSION_KEY, OAK_VERSION);
             update.set(INVISIBLE, invisible);
+            update.set(RUNTIME_ID_KEY, clusterNode.runtimeId);
 
             ClusterNodeInfoDocument before = null;
             final boolean success;
@@ -502,6 +503,8 @@ public class ClusterNodeInfo {
                 update.notEquals(STATE, ACTIVE.name());
                 // 2) must not have a recovery lock
                 update.notEquals(REV_RECOVERY_LOCK, ACQUIRED.name());
+                // 3) must not be assigned to a different node
+                update.equals(RUNTIME_ID_KEY, null);
 
                 success = store.findAndUpdate(Collection.CLUSTER_NODES, update) != null;
             }
@@ -944,7 +947,8 @@ public class ClusterNodeInfo {
         }
 
         UpdateOp update = new UpdateOp("" + id, false);
-        update.set(LEASE_END_KEY, updatedLeaseEndTime);
+        // Update the field only if the newer value is higher (or doesn't exist)
+        update.max(LEASE_END_KEY, updatedLeaseEndTime);
 
         if (leaseCheckMode != LeaseCheckMode.DISABLED) {
             // if leaseCheckDisabled, then we just update the lease without
@@ -955,16 +959,13 @@ public class ClusterNodeInfo {
             // then we can now make an assertion that the lease is unchanged
             // and the incremental update must only succeed if no-one else
             // did a recover/inactivation in the meantime
-            // make three assertions: the leaseEnd must match ..
-            update.equals(LEASE_END_KEY, null, previousLeaseEndTime);
-            // plus it must still be active ..
+            // make three assertions: it must still be active
             update.equals(STATE, null, ACTIVE.name());
             // plus it must not have a recovery lock on it
             update.notEquals(REV_RECOVERY_LOCK, ACQUIRED.name());
-            // @TODO: to make it 100% failure proof we could introduce
-            // yet another field to clusterNodes: a runtimeId that we
-            // create (UUID) at startup each time - and against that
-            // we could also check here - but that goes a bit far IMO
+            // and the runtimeId that we create at startup each time
+            // should be the same
+            update.equals(RUNTIME_ID_KEY, null, runtimeId);
         }
 
         if (LOG.isDebugEnabled()) {
@@ -1020,7 +1021,6 @@ public class ClusterNodeInfo {
                 return false;
             }
             leaseEndTime = updatedLeaseEndTime;
-            previousLeaseEndTime = leaseEndTime; // store previousLeaseEndTime for reference for next time
             String mode = (String) doc.get(READ_WRITE_MODE_KEY);
             if (mode != null && !mode.equals(readWriteMode)) {
                 readWriteMode = mode;
@@ -1042,8 +1042,8 @@ public class ClusterNodeInfo {
             }
         }
         // if we get here, the update failed with an exception, try to read the
-        // current cluster node info document and update leaseEndTime &
-        // previousLeaseEndTime accordingly until leaseEndTime is reached
+        // current cluster node info document and update leaseEndTime
+        // accordingly until leaseEndTime is reached
         while (getCurrentTime() < updatedLeaseEndTime) {
             synchronized (this) {
                 if (leaseCheckFailed) {
@@ -1071,10 +1071,9 @@ public class ClusterNodeInfo {
                             "anymore. {}", id, doc);
                     // break here and let the next lease update attempt fail
                     break;
-                } else if (doc.getLeaseEndTime() == previousLeaseEndTime
-                        || doc.getLeaseEndTime() == updatedLeaseEndTime) {
-                    // set lease end times to current values
-                    previousLeaseEndTime = doc.getLeaseEndTime();
+                } else if (runtimeId.equals(doc.getRuntimeId())) {
+                    // set lease end time to current value, as they belong
+                    // to this same cluster node
                     leaseEndTime = doc.getLeaseEndTime();
                     break;
                 } else {
@@ -1144,6 +1143,7 @@ public class ClusterNodeInfo {
         update.set(LEASE_END_KEY, null);
         update.set(STATE, null);
         update.set(INVISIBLE, false);
+        update.set(RUNTIME_ID_KEY, null);
         store.createOrUpdate(Collection.CLUSTER_NODES, update);
         state = NONE;
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfo.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfo.java
@@ -503,8 +503,6 @@ public class ClusterNodeInfo {
                 update.notEquals(STATE, ACTIVE.name());
                 // 2) must not have a recovery lock
                 update.notEquals(REV_RECOVERY_LOCK, ACQUIRED.name());
-                // 3) must not be assigned to a different node
-                update.equals(RUNTIME_ID_KEY, null);
 
                 success = store.findAndUpdate(Collection.CLUSTER_NODES, update) != null;
             }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfoDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfoDocument.java
@@ -69,6 +69,14 @@ public class ClusterNodeInfoDocument extends Document {
         return startTime;
     }
 
+    /**
+     * @return the Runtime ID for this cluster node.
+     */
+    @Nullable
+    public String getRuntimeId() {
+        return (String) get(ClusterNodeInfo.RUNTIME_ID_KEY);
+    }
+
     public boolean isActive(){
         return getState() == ClusterNodeState.ACTIVE;
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLock.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/RecoveryLock.java
@@ -25,6 +25,7 @@ import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.DEFAULT
 import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.LEASE_END_KEY;
 import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.REV_RECOVERY_BY;
 import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.REV_RECOVERY_LOCK;
+import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.RUNTIME_ID_KEY;
 import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.RecoverLockState.ACQUIRED;
 import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.STATE;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.CLUSTER_NODES;
@@ -102,6 +103,7 @@ class RecoveryLock {
             if (success) {
                 update.set(STATE, null);
                 update.set(LEASE_END_KEY, null);
+                update.set(RUNTIME_ID_KEY, null);
             } else {
                 // make sure lease is expired
                 update.set(LEASE_END_KEY, clock.getTime() - 1);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfoTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfoTest.java
@@ -418,6 +418,84 @@ public class ClusterNodeInfoTest {
         info2.dispose();
     }
 
+    // OAK-9564
+    @Test
+    public void canGetDisposedClusterWithDifferentRuntimeId() {
+        ClusterNodeInfo info = newClusterNodeInfo(0);
+        int id = info.getId();
+        assertEquals(1, id);
+        // shut it down
+        info.dispose();
+
+        // edit the runtime ID
+        UpdateOp op = new UpdateOp(String.valueOf(id), false);
+        op.set(ClusterNodeInfo.RUNTIME_ID_KEY, "some-different-uuid");
+        assertNotNull(store.findAndUpdate(Collection.CLUSTER_NODES, op));
+
+        try {
+            info = newClusterNodeInfo(id);
+            assertEquals(info.getId(), id);
+        } catch(DocumentStoreException e) {
+            // should be able to acquire it again, because it was properly disposed
+            fail("Must be able to acquire the cluster again after disposal");
+        }
+    }
+
+    // OAK-9564
+    @Test
+    public void canGetRecoveredClusterWithDifferentRuntimeId() {
+        ClusterNodeInfo info = newClusterNodeInfo(0);
+        int id = info.getId();
+        assertEquals(1, id);
+        // shut it down
+        info.dispose();
+
+        // edit the data artificially to reproduce the bug where a cluster can't be acquired
+        // after it was recovered by a different node
+        UpdateOp op = new UpdateOp(String.valueOf(id), false);
+        op.set(ClusterNodeInfo.RUNTIME_ID_KEY, "some-different-uuid");
+        op.set(ClusterNodeInfo.REV_RECOVERY_BY, "");
+        op.set(ClusterNodeInfo.REV_RECOVERY_LOCK, "NONE");
+        op.set(ClusterNodeInfo.STATE, null);
+        op.set(ClusterNodeInfo.LEASE_END_KEY, null);
+        assertNotNull(store.findAndUpdate(Collection.CLUSTER_NODES, op));
+
+        // should be able to acquire it
+        try {
+            info = newClusterNodeInfo(id);
+            assertEquals(info.getId(), id);
+        } catch(DocumentStoreException e) {
+            fail("Must be able to acquire the cluster");
+        }
+    }
+
+    // OAK-9564
+    @Test
+    public void cannotGetActiveClusterWithDifferentRuntimeIdUntilExpires() {
+        ClusterNodeInfo info = newClusterNodeInfo(0);
+        int id = info.getId();
+        assertEquals(1, id);
+
+        // edit the runtime ID
+        UpdateOp op = new UpdateOp(String.valueOf(id), false);
+        op.set(ClusterNodeInfo.RUNTIME_ID_KEY, "some-different-uuid");
+        assertNotNull(store.findAndUpdate(Collection.CLUSTER_NODES, op));
+
+        // should be able to acquire it, but it should wait until the lease expire
+        ClusterNodeInfo infoNew = newClusterNodeInfo(id);
+        assertEquals(infoNew.getId(), id);
+        assertTrue(infoNew.getLeaseEndTime() > info.getLeaseEndTime());
+        assertNotEquals(infoNew.getRuntimeId(), info.getRuntimeId());
+        try {
+            info.performLeaseCheck();
+            fail("Must fail here, and not get cluster node info");
+        } catch(DocumentStoreException e) {
+            // expected exception
+            assertTrue(e.getMessage().startsWith("This oak instance failed to update the lease in"));
+        }
+        infoNew.performLeaseCheck();
+    }
+
     @Test
     public void acquireExpiredClusterIdStatic() throws Exception {
         String instanceId1 = "node1";

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfoTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ClusterNodeInfoTest.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.plugins.document;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -38,13 +39,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -269,6 +271,110 @@ public class ClusterNodeInfoTest {
         }
     }
 
+    // OAK-9564
+    @Test
+    public void renewLeaseSameRuntimeId() throws Exception {
+        ClusterNodeInfo info = newClusterNodeInfo(1);
+        String runtimeId = info.getRuntimeId();
+        long leaseEnd = info.getLeaseEndTime();
+        waitLeaseUpdateInterval();
+        assertTrue(info.renewLease());
+        assertTrue(info.getLeaseEndTime() > leaseEnd);
+        // The Runtime UUID should remain the same
+        assertEquals(info.getRuntimeId(), runtimeId);
+        assertFalse(handler.isLeaseFailure());
+    }
+
+    // OAK-9564
+    @Test
+    public void renewLeaseDifferentRuntimeId() throws Exception {
+        ClusterNodeInfo info = newClusterNodeInfo(1);
+        waitLeaseUpdateInterval();
+        long leaseEndTimeBeforeRenew = info.getLeaseEndTime();
+
+        // Modify the UUID to mock it belongs to a different node
+        UpdateOp update = new UpdateOp("1", false);
+        update.set(ClusterNodeInfo.RUNTIME_ID_KEY, "different-uuid");
+        store.findAndUpdate(Collection.CLUSTER_NODES, update);
+
+        try {
+            info.renewLease();
+            fail("Should not update lease anymore");
+        } catch(DocumentStoreException e) {
+            // expected
+        }
+
+        // Lease end time shouldn't be different
+        assertEquals(leaseEndTimeBeforeRenew, info.getLeaseEndTime());
+    }
+
+    // OAK-9564
+    @Test
+    public void renewLeaseTakingLongerThanTimeout() throws Exception {
+        ClusterNodeInfo info = newClusterNodeInfo(1);
+        waitLeaseUpdateInterval();
+        final long leaseEndTimeBeforeRenew = info.getLeaseEndTime();
+        final String runtimeId = info.getRuntimeId();
+
+        Map<String, Long> unexpectedLeaseEnd = new HashMap<>();
+        long unexpectedLeaseEndTime = info.getLeaseEndTime() + 133333;
+        unexpectedLeaseEnd.put(ClusterNodeInfo.LEASE_END_KEY, unexpectedLeaseEndTime);
+
+        // The update will fail after 30 seconds. Simulating a Mongo timeout.
+        store.setFailAfterUpdate(1);
+        store.setDelayMillisOnce(30000);
+        store.setDelayMillis(10000);
+        store.setFindShouldAlterReturnDocument(true);
+        // However, the following find after the update will return an
+        // unexpected lease time (but still within a valid time).
+        // This unexpected update could come from a previous but very slow update
+        // executed in Mongo. So it's still a valid one, but not the new one
+        // that is expected.
+        store.setMapAlterReturnDocument(unexpectedLeaseEnd);
+
+        // However, the current behaviour is that as the lease end time doesn't
+        // match the expected one, the lease will fail and the nodeStore becomes
+        // unusable.
+        try {
+            info.renewLease();
+        } catch(DocumentStoreException e) {
+            // expected
+        }
+
+        // The new leaseEndTime coming from Mongo is not reflected in the
+        // ClusterNodeInfo. Meaning it will eventually be treated as 'expired'
+        // by the DocumentNodeStore, even when in Mongo it was set.
+        assertThat(leaseEndTimeBeforeRenew, lessThan(info.getLeaseEndTime()));
+        assertEquals(unexpectedLeaseEndTime, info.getLeaseEndTime());
+        // Runtime ID is the same
+        assertEquals(runtimeId, info.getRuntimeId());
+    }
+
+    // OAK-9564: This is a someway artificial test. The idea behind is to try to reproduce
+    // a case where a renewLease fails because of a timeout. Then the following renewLease
+    // occurs faster, but during that time the previous update is executed in Mongo.
+    // That 'older' update shouldn't go through now, reducing the effective lease end time.
+    @Test
+    public void renewLeaseShouldNotGoBackInTime() throws Exception {
+        ClusterNodeInfo info = newClusterNodeInfo(1);
+        waitLeaseUpdateInterval();
+
+        long newerLeaseEndTime = clock.getTime() + ClusterNodeInfo.DEFAULT_LEASE_DURATION_MILLIS +
+                ClusterNodeInfo.DEFAULT_LEASE_UPDATE_INTERVAL_MILLIS;
+        // simulate a newer renew lease took place
+        UpdateOp update = new UpdateOp("1", false);
+        update.set(ClusterNodeInfo.LEASE_END_KEY, newerLeaseEndTime);
+        store.findAndUpdate(Collection.CLUSTER_NODES, update);
+
+        // now another renew happens, which will try to set a lesser lease end
+        info.renewLease();
+
+        ClusterNodeInfoDocument info2 = store.find(Collection.CLUSTER_NODES, "1");
+        assertNotNull(info2);
+        // the lease end time should remain the same
+        assertEquals(newerLeaseEndTime, info2.getLeaseEndTime());
+    }
+
     @Test
     public void readOnlyClusterNodeInfo() {
         ClusterNodeInfo info = ClusterNodeInfo.getReadOnlyInstance(store);
@@ -416,84 +522,6 @@ public class ClusterNodeInfoTest {
         assertEquals(2, info2.getId());
         assertEquals(instanceId2, info2.getInstanceId());
         info2.dispose();
-    }
-
-    // OAK-9564
-    @Test
-    public void canGetDisposedClusterWithDifferentRuntimeId() {
-        ClusterNodeInfo info = newClusterNodeInfo(0);
-        int id = info.getId();
-        assertEquals(1, id);
-        // shut it down
-        info.dispose();
-
-        // edit the runtime ID
-        UpdateOp op = new UpdateOp(String.valueOf(id), false);
-        op.set(ClusterNodeInfo.RUNTIME_ID_KEY, "some-different-uuid");
-        assertNotNull(store.findAndUpdate(Collection.CLUSTER_NODES, op));
-
-        try {
-            info = newClusterNodeInfo(id);
-            assertEquals(info.getId(), id);
-        } catch(DocumentStoreException e) {
-            // should be able to acquire it again, because it was properly disposed
-            fail("Must be able to acquire the cluster again after disposal");
-        }
-    }
-
-    // OAK-9564
-    @Test
-    public void canGetRecoveredClusterWithDifferentRuntimeId() {
-        ClusterNodeInfo info = newClusterNodeInfo(0);
-        int id = info.getId();
-        assertEquals(1, id);
-        // shut it down
-        info.dispose();
-
-        // edit the data artificially to reproduce the bug where a cluster can't be acquired
-        // after it was recovered by a different node
-        UpdateOp op = new UpdateOp(String.valueOf(id), false);
-        op.set(ClusterNodeInfo.RUNTIME_ID_KEY, "some-different-uuid");
-        op.set(ClusterNodeInfo.REV_RECOVERY_BY, "");
-        op.set(ClusterNodeInfo.REV_RECOVERY_LOCK, "NONE");
-        op.set(ClusterNodeInfo.STATE, null);
-        op.set(ClusterNodeInfo.LEASE_END_KEY, null);
-        assertNotNull(store.findAndUpdate(Collection.CLUSTER_NODES, op));
-
-        // should be able to acquire it
-        try {
-            info = newClusterNodeInfo(id);
-            assertEquals(info.getId(), id);
-        } catch(DocumentStoreException e) {
-            fail("Must be able to acquire the cluster");
-        }
-    }
-
-    // OAK-9564
-    @Test
-    public void cannotGetActiveClusterWithDifferentRuntimeIdUntilExpires() {
-        ClusterNodeInfo info = newClusterNodeInfo(0);
-        int id = info.getId();
-        assertEquals(1, id);
-
-        // edit the runtime ID
-        UpdateOp op = new UpdateOp(String.valueOf(id), false);
-        op.set(ClusterNodeInfo.RUNTIME_ID_KEY, "some-different-uuid");
-        assertNotNull(store.findAndUpdate(Collection.CLUSTER_NODES, op));
-
-        // should be able to acquire it, but it should wait until the lease expire
-        ClusterNodeInfo infoNew = newClusterNodeInfo(id);
-        assertEquals(infoNew.getId(), id);
-        assertTrue(infoNew.getLeaseEndTime() > info.getLeaseEndTime());
-        assertNotEquals(infoNew.getRuntimeId(), info.getRuntimeId());
-        try {
-            info.performLeaseCheck();
-            fail("Must fail here, and not get cluster node info");
-        } catch(DocumentStoreException e) {
-            // expected exception
-            assertTrue(e.getMessage().startsWith("This oak instance failed to update the lease in"));
-        }
-        infoNew.performLeaseCheck();
     }
 
     @Test
@@ -669,10 +697,14 @@ public class ClusterNodeInfoTest {
 
     final class TestStore extends DocumentStoreWrapper {
 
+        private final AtomicBoolean findShouldAlterReturnDocument = new AtomicBoolean();
+        private final AtomicBoolean findAndUpdateShouldAlterReturnDocument = new AtomicBoolean();
+        private Map mapAlterReturnDocument;
         private final AtomicInteger failBeforeUpdate = new AtomicInteger();
         private final AtomicInteger failAfterUpdate = new AtomicInteger();
         private final AtomicInteger failFind = new AtomicInteger();
         private long delayMillis;
+        private long delayMillisOnce;
 
         TestStore() {
             super(new MemoryDocumentStore());
@@ -686,10 +718,18 @@ public class ClusterNodeInfoTest {
         public <T extends Document> T findAndUpdate(Collection<T> collection,
                                                     UpdateOp update) {
             maybeDelay();
+            maybeDelayOnce();
             maybeThrow(failBeforeUpdate, "update failed before");
             T doc = super.findAndUpdate(collection, update);
             maybeThrow(failAfterUpdate, "update failed after");
-            return doc;
+            if (getFindAndUpdateShouldAlterReturnDocument()) {
+                ClusterNodeInfoDocument cdoc = new ClusterNodeInfoDocument();
+                cdoc.data.putAll(getMapAlterReturnDocument());
+                cdoc.seal();
+                return (T)cdoc;
+            } else {
+                return doc;
+            }
         }
 
         @Override
@@ -697,7 +737,16 @@ public class ClusterNodeInfoTest {
                                            String key) {
             maybeDelay();
             maybeThrow(failFind, "find failed");
-            return super.find(collection, key);
+            T doc = super.find(collection, key);
+            if (getFindShouldAlterReturnDocument()) {
+                ClusterNodeInfoDocument cdoc = new ClusterNodeInfoDocument();
+                doc.deepCopy(cdoc);
+                cdoc.data.putAll(getMapAlterReturnDocument());
+                cdoc.seal();
+                return (T)cdoc;
+            } else {
+                return doc;
+            }
         }
 
         private void maybeDelay() {
@@ -708,11 +757,44 @@ public class ClusterNodeInfoTest {
             }
         }
 
+        private void maybeDelayOnce() {
+            try {
+                clock.waitUntil(clock.getTime() + delayMillisOnce);
+                delayMillisOnce = 0;
+            } catch (InterruptedException e) {
+                throw new DocumentStoreException(e);
+            }
+        }
+
         private void maybeThrow(AtomicInteger num, String msg) {
             if (num.get() > 0) {
                 num.decrementAndGet();
                 throw new DocumentStoreException(msg);
             }
+        }
+
+        public Map getMapAlterReturnDocument() {
+            return mapAlterReturnDocument;
+        }
+
+        public void setMapAlterReturnDocument(Map mapAlterReturnDocument) {
+            this.mapAlterReturnDocument = mapAlterReturnDocument;
+        }
+
+        public boolean getFindShouldAlterReturnDocument() {
+            return findShouldAlterReturnDocument.get();
+        }
+
+        public void setFindShouldAlterReturnDocument(boolean findShouldAlterReturnDocument) {
+            this.findShouldAlterReturnDocument.set(findShouldAlterReturnDocument);
+        }
+
+        public boolean getFindAndUpdateShouldAlterReturnDocument() {
+            return findAndUpdateShouldAlterReturnDocument.get();
+        }
+
+        public void setFindAndUpdateShouldAlterReturnDocument(boolean findAndUpdateShouldAlterReturnDocument) {
+            this.findAndUpdateShouldAlterReturnDocument.set(findAndUpdateShouldAlterReturnDocument);
         }
 
         public int getFailBeforeUpdate() {
@@ -737,6 +819,14 @@ public class ClusterNodeInfoTest {
 
         public void setDelayMillis(long delayMillis) {
             this.delayMillis = delayMillis;
+        }
+
+        public long getDelayMillisOnce() {
+            return delayMillisOnce;
+        }
+
+        public void setDelayMillisOnce(long delayMillisOnce) {
+            this.delayMillisOnce = delayMillisOnce;
         }
 
         public int getFailFind() {


### PR DESCRIPTION
This PR #455, which is a revert of #359 because of a discovered bug after it was merged.
The new commit resolves the bug, improves the logging of the newly added field "Runtime_id", and adds new tests to reproduce and cover the detected bug to allow to acquire recovered and disposed clusters properly.