### PR TITLE
OAK-9670 : log at WARN level for fulltext query without index 

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -1201,9 +1201,9 @@ public class QueryImpl implements Query {
         }
 
         if (potentiallySlowTraversalQuery || bestIndex == null) {
-            // Log error for fulltext queries without index, since these cannot return results
+            // Log warning for fulltext queries without index, since these cannot return results
             if(!filter.getFulltextConditions().isEmpty()) { 
-                LOG.error("Fulltext query without index for filter {}; no results will be returned", filter);
+                LOG.warn("Fulltext query without index for filter {}; no results will be returned", filter);
             } else {
                 LOG.debug("no proper index was found for filter {}", filter);      
             }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -1202,10 +1202,10 @@ public class QueryImpl implements Query {
 
         if (potentiallySlowTraversalQuery || bestIndex == null) {
             // Log error for fulltext queries without index, since these cannot return results
-        	if(!filter.getFulltextConditions().isEmpty()) { 
-        		LOG.error("Fulltext query without index for filter {}; no results will be returned", filter);
-        	} else {
-	            LOG.debug("no proper index was found for filter {}", filter);      
+            if(!filter.getFulltextConditions().isEmpty()) { 
+                LOG.error("Fulltext query without index for filter {}; no results will be returned", filter);
+            } else {
+                LOG.debug("no proper index was found for filter {}", filter);      
             }
             
             StatisticsProvider statisticsProvider = getSettings().getStatisticsProvider();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -1201,7 +1201,13 @@ public class QueryImpl implements Query {
         }
 
         if (potentiallySlowTraversalQuery || bestIndex == null) {
-            LOG.debug("no proper index was found for filter {}", filter);
+            // Log error for fulltext queries without index, since these cannot return results
+        	if(!filter.getFulltextConditions().isEmpty()) { 
+        		LOG.error("Fulltext query without index for filter {}; no results will be returned", filter);
+        	} else {
+	            LOG.debug("no proper index was found for filter {}", filter);      
+            }
+            
             StatisticsProvider statisticsProvider = getSettings().getStatisticsProvider();
             if (statisticsProvider != null) {
                 HistogramStats histogram = statisticsProvider.getHistogram(INDEX_UNAVAILABLE, StatsOptions.METRICS_ONLY);


### PR DESCRIPTION
Fulltext queries cannot be handled by traversal, so we need to highlight prominently when a fulltext query has been issues but no appropriate index can be found.