### PR TITLE
OAK-9672 - Adding checks to support setting null values in oak-commons JSON

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsonObject.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsonObject.java
@@ -146,15 +146,19 @@ public class JsonObject {
     }
 
     private static void toJson(JsopBuilder buf, JsonObject obj) {
-        buf.object();
-        for (String name : obj.props.keySet()) {
-            buf.key(name).encodedValue(obj.props.get(name));
+        if(obj == null){
+            buf.value(null);
+        } else {
+            buf.object();
+            for (String name : obj.props.keySet()) {
+                buf.key(name).encodedValue(obj.props.get(name));
+            }
+            for (String name : obj.children.keySet()) {
+                buf.key(name);
+                toJson(buf, obj.children.get(name));
+            }
+            buf.endObject();
         }
-        for (String name : obj.children.keySet()) {
-            buf.key(name);
-            toJson(buf, obj.children.get(name));
-        }
-        buf.endObject();
     }
 
 }

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsonObject.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsonObject.java
@@ -146,7 +146,7 @@ public class JsonObject {
     }
 
     private static void toJson(JsopBuilder buf, JsonObject obj) {
-        if(obj == null){
+        if (obj == null) {
             buf.value(null);
         } else {
             buf.object();

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
@@ -220,7 +220,7 @@ public class JsopBuilder implements JsopWriter {
         if (value != null) {
             return value.length();
         } else {
-            return 4;// null = 4 chars
+            return "null".length();
         }
     }
 

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
@@ -16,6 +16,8 @@
  */
 package org.apache.jackrabbit.oak.commons.json;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * A builder for Json and Jsop strings. It encodes string values, and knows when
  * a comma is needed. A comma is appended before '{', '[', a value, or a key;
@@ -208,10 +210,18 @@ public class JsopBuilder implements JsopWriter {
      */
     @Override
     public JsopBuilder encodedValue(String value) {
-        optionalCommaAndNewline(value.length());
+        optionalCommaAndNewline(strLength(value));
         buff.append(value);
         needComma = true;
         return this;
+    }
+
+    private int strLength(@Nullable String value) {
+        if (value != null) {
+            return value.length();
+        } else {
+            return 4;// null = 4 chars
+        }
     }
 
     private void optionalCommaAndNewline(int add) {

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/json/JsonObjectTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/json/JsonObjectTest.java
@@ -39,7 +39,7 @@ public class JsonObjectTest {
         assertEquals("{az=1, b=[2, 3], c=null}", b.getProperties().toString());
         assertEquals("{d={}}", b.getChildren().toString());
     }
-    
+
     @Test
     public void newObjectNotRespectingOrder() {
         JsonObject a = new JsonObject();
@@ -66,4 +66,30 @@ public class JsonObjectTest {
         assertEquals("{az=1, b=2}", a.getProperties().toString());
     }
 
+    @Test
+    public void handlesNullChild() {
+        JsonObject a = new JsonObject(true);
+        a.getChildren().put("test", (JsonObject) null);
+        assertEquals("{\n" +
+                "  \"test\": null\n" +
+                "}", a.toString());
+
+    }
+
+    @Test
+    public void handlesParsingNullValue() {
+        JsonObject b = JsonObject.fromJson("{\"key\": null}", true);
+        assertEquals("{\n" +
+                "  \"key\": null\n" +
+                "}", b.toString());
+    }
+
+    @Test
+    public void handlesSettingNullValue() {
+        JsonObject b = new JsonObject(true);
+        b.getProperties().put("key", null);
+        assertEquals("{\n" +
+                "  \"key\": null\n" +
+                "}", b.toString());
+    }
 }


### PR DESCRIPTION
Currently performing the following will result in a NullPointerException as null values for the properties or child objects are not checked:

```
  JsonObject a = new JsonObject(true);
  a.getChildren().put("test", (JsonObject) null);
```

This PR introduces checks to ensure null children and null properties can be set on a JsonObject without the toString method failing.