### PR TITLE
OAK-9676 Mounted paths are not ignored anymore

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/mount/MountInfo.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/mount/MountInfo.java
@@ -79,8 +79,12 @@ public final class MountInfo implements Mount {
     @Override
     public boolean isDirectlyUnder(String path) {
         path = SANITIZE_PATH.apply(path);
-        String nextPath = includedPaths.higher(path);
-        return nextPath != null && path.equals(getParentPath(nextPath));
+        for (String nextPath : includedPaths) {
+            if (path.equals(getParentPath(nextPath))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
All mount paths should be considered when checking for mounts directly
under a path for composite node stores.