### PR TITLE
OAK-9704 AzureBlobStoreBackend: empty string as null in boolean property

### DIFF
--- a/oak-blob-cloud-azure/pom.xml
+++ b/oak-blob-cloud-azure/pom.xml
@@ -174,6 +174,13 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.arakelian</groupId>
+            <artifactId>docker-junit-rule</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -164,12 +164,13 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
 
             try {
                 Utils.setProxyIfNeeded(properties);
-                containerName = (String) properties.get(AzureConstants.AZURE_BLOB_CONTAINER_NAME);
-                createBlobContainer = PropertiesUtil.toBoolean(properties.getProperty(AzureConstants.AZURE_CREATE_CONTAINER), true);
+                containerName = properties.getProperty(AzureConstants.AZURE_BLOB_CONTAINER_NAME);
+                createBlobContainer = PropertiesUtil.toBoolean(
+                    Strings.emptyToNull(properties.getProperty(AzureConstants.AZURE_CREATE_CONTAINER)), true);
                 connectionString = Utils.getConnectionStringFromProperties(properties);
 
                 concurrentRequestCount = PropertiesUtil.toInteger(
-                        properties.get(AzureConstants.AZURE_BLOB_CONCURRENT_REQUESTS_PER_OPERATION),
+                        properties.getProperty(AzureConstants.AZURE_BLOB_CONCURRENT_REQUESTS_PER_OPERATION),
                         DEFAULT_CONCURRENT_REQUEST_COUNT);
                 if (concurrentRequestCount < DEFAULT_CONCURRENT_REQUEST_COUNT) {
                     LOG.warn("Invalid setting [{}] for concurrentRequestsPerOperation (too low); resetting to {}",
@@ -184,12 +185,12 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
                 }
                 LOG.info("Using concurrentRequestsPerOperation={}", concurrentRequestCount);
 
-                retryPolicy = Utils.getRetryPolicy((String)properties.get(AzureConstants.AZURE_BLOB_MAX_REQUEST_RETRY));
+                retryPolicy = Utils.getRetryPolicy(properties.getProperty(AzureConstants.AZURE_BLOB_MAX_REQUEST_RETRY));
                 if (properties.getProperty(AzureConstants.AZURE_BLOB_REQUEST_TIMEOUT) != null) {
                     requestTimeout = PropertiesUtil.toInteger(properties.getProperty(AzureConstants.AZURE_BLOB_REQUEST_TIMEOUT), RetryPolicy.DEFAULT_CLIENT_RETRY_COUNT);
                 }
-                presignedDownloadURIVerifyExists =
-                        PropertiesUtil.toBoolean(properties.get(AzureConstants.PRESIGNED_HTTP_DOWNLOAD_URI_VERIFY_EXISTS), true);
+                presignedDownloadURIVerifyExists = PropertiesUtil.toBoolean(
+                    Strings.emptyToNull(properties.getProperty(AzureConstants.PRESIGNED_HTTP_DOWNLOAD_URI_VERIFY_EXISTS)), true);
 
                 CloudBlobContainer azureContainer = getAzureContainer();
 
@@ -253,11 +254,11 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
             return is;
         }
         catch (StorageException e) {
-            LOG.info("Error reading blob. identifier=%s", key);
+            LOG.info("Error reading blob. identifier={}", key);
             throw new DataStoreException(String.format("Cannot read blob. identifier=%s", key), e);
         }
         catch (URISyntaxException e) {
-            LOG.debug("Error reading blob. identifier=%s", key);
+            LOG.debug("Error reading blob. identifier={}", key);
             throw new DataStoreException(String.format("Cannot read blob. identifier=%s", key), e);
         } finally {
             if (contextClassLoader != null) {

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/Utils.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/Utils.java
@@ -141,7 +141,8 @@ public final class Utils {
 
         return getConnectionString(
                 accountName,
-                accountKey);
+                accountKey, 
+                blobEndpoint);
     }
 
     private static String getConnectionStringForSas(String sasUri, String blobEndpoint, String accountName) {
@@ -152,12 +153,15 @@ public final class Utils {
         }
     }
 
-    public static String getConnectionString(final String accountName, final String accountKey) {
-        return String.format(
-            "DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s",
-            accountName,
-            accountKey
-        );
+    public static String getConnectionString(final String accountName, final String accountKey, String blobEndpoint) {
+        StringBuilder connString = new StringBuilder("DefaultEndpointsProtocol=https");
+        connString.append(";AccountName=").append(accountName);
+        connString.append(";AccountKey=").append(accountKey);
+        
+        if (!Strings.isNullOrEmpty(blobEndpoint)) {
+            connString.append(";BlobEndpoint=").append(blobEndpoint);
+        }
+        return connString.toString();
     }
 
     /**

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.blob.cloud.azure.blobstorage;
+
+import com.google.common.collect.ImmutableSet;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.SharedAccessBlobPermissions;
+import com.microsoft.azure.storage.blob.SharedAccessBlobPolicy;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.ADD;
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.CREATE;
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.LIST;
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.READ;
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.WRITE;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class AzureBlobStoreBackendTest {
+    @ClassRule
+    public static AzuriteDockerRule azurite = new AzuriteDockerRule();
+    
+    private static final String CONTAINER_NAME = "blobstore";
+    private static final EnumSet<SharedAccessBlobPermissions> READ_ONLY = EnumSet.of(READ, LIST);
+    private static final EnumSet<SharedAccessBlobPermissions> READ_WRITE = EnumSet.of(READ, LIST, CREATE, WRITE, ADD);
+    private static final ImmutableSet<String> BLOBS = ImmutableSet.of("blob1", "blob2");
+
+    private CloudBlobContainer container;
+    
+    @After
+    public void tearDown() throws Exception {
+        if (container != null) {
+            container.deleteIfExists();
+        }
+    }
+
+    @Test
+    public void initWithSharedAccessSignature_readOnly() throws Exception {
+        CloudBlobContainer container = createBlobContainer();
+        String sasToken = container.generateSharedAccessSignature(policy(READ_ONLY), null);
+
+        AzureBlobStoreBackend azureBlobStoreBackend = new AzureBlobStoreBackend();
+        azureBlobStoreBackend.setProperties(getConfigurationWithSasToken(sasToken));
+        
+        azureBlobStoreBackend.init();
+        
+        assertWriteAccessNotGranted(azureBlobStoreBackend);
+        assertReadAccessGranted(azureBlobStoreBackend, BLOBS);
+    }
+
+    @Test
+    public void initWithSharedAccessSignature_readWrite() throws Exception {
+        CloudBlobContainer container = createBlobContainer();
+        String sasToken = container.generateSharedAccessSignature(policy(READ_WRITE), null);
+
+        AzureBlobStoreBackend azureBlobStoreBackend = new AzureBlobStoreBackend();
+        azureBlobStoreBackend.setProperties(getConfigurationWithSasToken(sasToken));
+        
+        azureBlobStoreBackend.init();
+
+        assertWriteAccessGranted(azureBlobStoreBackend, "file");
+        assertReadAccessGranted(azureBlobStoreBackend, concat(BLOBS, "file"));
+    }
+
+    @Test
+    public void connectWithSharedAccessSignatureURL_expired() throws Exception {
+        CloudBlobContainer container = createBlobContainer();
+        SharedAccessBlobPolicy expiredPolicy = policy(READ_WRITE, yesterday());
+        String sasToken = container.generateSharedAccessSignature(expiredPolicy, null);
+
+        AzureBlobStoreBackend azureBlobStoreBackend = new AzureBlobStoreBackend();
+        azureBlobStoreBackend.setProperties(getConfigurationWithSasToken(sasToken));
+
+        azureBlobStoreBackend.init();
+        
+        assertWriteAccessNotGranted(azureBlobStoreBackend);
+        assertReadAccessNotGranted(azureBlobStoreBackend);
+    }
+
+    @Test
+    public void initWithAccessKey() throws Exception {
+        AzureBlobStoreBackend azureBlobStoreBackend = new AzureBlobStoreBackend();
+        azureBlobStoreBackend.setProperties(getConfigurationWithAccessKey());
+
+        azureBlobStoreBackend.init();
+        
+        assertWriteAccessGranted(azureBlobStoreBackend, "file");
+        assertReadAccessGranted(azureBlobStoreBackend, ImmutableSet.of("file"));
+    }
+
+    @Test
+    public void initWithConnectionURL() throws Exception {
+        AzureBlobStoreBackend azureBlobStoreBackend = new AzureBlobStoreBackend();
+        azureBlobStoreBackend.setProperties(getConfigurationWithConnectionString());
+
+        azureBlobStoreBackend.init();
+
+        assertWriteAccessGranted(azureBlobStoreBackend, "file");
+        assertReadAccessGranted(azureBlobStoreBackend, ImmutableSet.of("file"));
+    }
+
+    private CloudBlobContainer createBlobContainer() throws Exception {
+        container = azurite.getContainer("blobstore");
+        for (String blob : BLOBS) {
+            container.getBlockBlobReference(blob + ".txt").uploadText(blob);
+        }
+        return container;
+    }
+    
+    private static Properties getConfigurationWithSasToken(String sasToken) {
+        Properties properties = getBasicConfiguration();
+        properties.setProperty(AzureConstants.AZURE_SAS, sasToken);
+        properties.setProperty(AzureConstants.AZURE_CREATE_CONTAINER, "false");
+        return properties;
+    }
+    
+    private static Properties getConfigurationWithAccessKey() {
+        Properties properties = getBasicConfiguration();
+        properties.setProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, AzuriteDockerRule.ACCOUNT_KEY);
+        return properties;
+    }
+
+    @NotNull
+    private static Properties getConfigurationWithConnectionString() {
+        Properties properties = getBasicConfiguration();
+        properties.setProperty(AzureConstants.AZURE_CONNECTION_STRING, getConnectionString());
+        return properties;
+    }
+    
+    @NotNull
+    private static Properties getBasicConfiguration() {
+        Properties properties = new Properties();
+        properties.setProperty(AzureConstants.AZURE_BLOB_CONTAINER_NAME, CONTAINER_NAME);
+        properties.setProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, AzuriteDockerRule.ACCOUNT_NAME);
+        properties.setProperty(AzureConstants.AZURE_BLOB_ENDPOINT, azurite.getBlobEndpoint());
+        properties.setProperty(AzureConstants.AZURE_CREATE_CONTAINER, "");
+        return properties;
+    }
+
+    @NotNull
+    private static SharedAccessBlobPolicy policy(EnumSet<SharedAccessBlobPermissions> permissions, Instant expirationTime) {
+        SharedAccessBlobPolicy sharedAccessBlobPolicy = new SharedAccessBlobPolicy();
+        sharedAccessBlobPolicy.setPermissions(permissions);
+        sharedAccessBlobPolicy.setSharedAccessExpiryTime(Date.from(expirationTime));
+        return sharedAccessBlobPolicy;
+    }
+
+    @NotNull
+    private static SharedAccessBlobPolicy policy(EnumSet<SharedAccessBlobPermissions> permissions) {
+        return policy(permissions, Instant.now().plus(Duration.ofDays(7)));
+    }
+
+    private static void assertReadAccessGranted(AzureBlobStoreBackend backend, Set<String> expectedBlobs) throws Exception {
+        CloudBlobContainer container = backend.getAzureContainer();
+        Set<String> actualBlobNames = StreamSupport.stream(container.listBlobs().spliterator(), false)
+            .map(blob -> blob.getUri().getPath())
+            .map(path -> path.substring(path.lastIndexOf('/') + 1))
+            .collect(toSet());
+        Set<String> expectedBlobNames = expectedBlobs.stream().map(name -> name + ".txt").collect(toSet());
+
+        assertEquals(expectedBlobNames, actualBlobNames);
+
+        Set<String> actualBlobContent = actualBlobNames.stream()
+            .map(name -> {
+                try {
+                    return container.getBlockBlobReference(name).downloadText();
+                } catch (StorageException | IOException | URISyntaxException e) {
+                    throw new RuntimeException("Error while reading blob " + name, e);
+                }
+            })
+            .collect(toSet());
+        assertEquals(expectedBlobs, actualBlobContent);
+    }
+
+    private static void assertWriteAccessGranted(AzureBlobStoreBackend backend, String blob) throws Exception {
+        backend.getAzureContainer()
+            .getBlockBlobReference(blob + ".txt").uploadText(blob);
+    }
+   
+    private static void assertWriteAccessNotGranted(AzureBlobStoreBackend backend) {
+        try {
+            assertWriteAccessGranted(backend, "test.txt");
+            fail("Write access should not be granted, but writing to the storage succeeded.");
+        } catch (Exception e) {
+            // successful
+        }
+    }
+
+    private static void assertReadAccessNotGranted(AzureBlobStoreBackend backend) {
+        try {
+            assertReadAccessGranted(backend, BLOBS);
+            fail("Read access should not be granted, but reading from the storage succeeded.");
+        } catch (Exception e) {
+            // successful
+        }
+    }
+
+    private static Instant yesterday() {
+        return Instant.now().minus(Duration.ofDays(1));
+    }
+    
+    private static ImmutableSet<String> concat(ImmutableSet<String> set, String element) {
+        return ImmutableSet.<String>builder().addAll(set).add(element).build();
+    }
+   
+    private static String getConnectionString() {
+        return Utils.getConnectionString(AzuriteDockerRule.ACCOUNT_NAME, AzuriteDockerRule.ACCOUNT_KEY, azurite.getBlobEndpoint());
+    }
+}

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzuriteDockerRule.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzuriteDockerRule.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.blob.cloud.azure.blobstorage;
+
+import com.arakelian.docker.junit.DockerRule;
+import com.arakelian.docker.junit.model.ImmutableDockerConfig;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.auth.FixedRegistryAuthSupplier;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class AzuriteDockerRule implements TestRule {
+
+    private static final String IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.15.0";
+    
+    public static final String ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    public static final String ACCOUNT_NAME = "devstoreaccount1";
+
+    private final DockerRule wrappedRule;
+
+    public AzuriteDockerRule() {
+        wrappedRule = new DockerRule(ImmutableDockerConfig.builder()
+            .image(IMAGE)
+            .name("oak-test-azurite")
+            .ports("10000")
+            .addStartedListener(container -> {
+                container.waitForPort("10000/tcp");
+                container.waitForLog("Azurite Blob service is successfully listening at http://0.0.0.0:10000");
+            })
+            .addContainerConfigurer(builder -> builder.env("executable=blob"))
+            .alwaysRemoveContainer(true)
+            .build());
+    }
+
+    public CloudBlobContainer getContainer(String name) throws URISyntaxException, StorageException, InvalidKeyException {
+        CloudStorageAccount cloud = getCloudStorageAccount();
+        CloudBlobClient cloudBlobClient = cloud.createCloudBlobClient();
+        CloudBlobContainer container = cloudBlobClient.getContainerReference(name);
+        container.deleteIfExists();
+        container.create();
+        return container;
+    }
+
+    public CloudStorageAccount getCloudStorageAccount() throws URISyntaxException, InvalidKeyException {
+        String blobEndpoint = "BlobEndpoint=" + getBlobEndpoint();
+        String accountName = "AccountName=" + ACCOUNT_NAME;
+        String accountKey = "AccountKey=" + ACCOUNT_KEY;
+        return CloudStorageAccount.parse("DefaultEndpointsProtocol=http;" + ";" + accountName + ";" + accountKey + ";" + blobEndpoint);
+    }
+
+    @NotNull
+    public String getBlobEndpoint() {
+        int mappedPort = getMappedPort();
+        return "http://127.0.0.1:" + mappedPort + "/devstoreaccount1";
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        try {
+            DefaultDockerClient client = DefaultDockerClient.fromEnv()
+                .connectTimeoutMillis(5000L)
+                .readTimeoutMillis(20000L)
+                .registryAuthSupplier(new FixedRegistryAuthSupplier())
+                .build();
+            client.ping();
+            client.pull(IMAGE);
+            client.close();
+        } catch (Throwable t) {
+            Assume.assumeNoException(t);
+        }
+
+        return wrappedRule.apply(statement, description);
+    }
+
+    public int getMappedPort() {
+        return wrappedRule.getContainer().getPortBinding("10000/tcp").getPort();
+    }
+}


### PR DESCRIPTION
When configured from OSGi using interpolation, an unset property can
default to an empty string. The empty string is interpreted as null, so
that the correct default is selected.