### PR TITLE
add jib plugin to build an official oak run image, run command "mvn c…

### DIFF
--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -198,6 +198,19 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <to>
+            <image>docker.io/apache/jackrabbit-oak-run</image>
+          </to>
+          <container>
+            <mainClass>org.apache.jackrabbit.oak.run.Main</mainClass>
+          </container>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
…ompile jib:build" will build and push docker image