### PR TITLE
OAK-9727 - ElasticSearch Index Function Support

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -139,7 +139,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
                         rule.getFunctionRestrictions().stream()))
                 .filter(pd -> pd.index) // keep only properties that can be indexed
                 .collect(Collectors.groupingBy(pd -> {
-                    if(pd.function != null){
+                    if (pd.function != null) {
                         return pd.function;
                     } else {
                         return pd.name;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -18,21 +18,23 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
-import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
-import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
-import org.apache.jackrabbit.oak.spi.state.NodeState;
-import org.jetbrains.annotations.NotNull;
+import static org.apache.jackrabbit.oak.plugins.index.search.util.ConfigUtil.getOptionalValue;
+import static org.apache.jackrabbit.oak.plugins.index.search.util.ConfigUtil.getOptionalValues;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.apache.jackrabbit.oak.plugins.index.search.util.ConfigUtil.getOptionalValue;
-import static org.apache.jackrabbit.oak.plugins.index.search.util.ConfigUtil.getOptionalValues;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.jetbrains.annotations.NotNull;
 
 public class ElasticIndexDefinition extends IndexDefinition {
 
@@ -133,9 +135,16 @@ public class ElasticIndexDefinition extends IndexDefinition {
 
         this.propertiesByName = getDefinedRules()
                 .stream()
-                .flatMap(rule -> StreamSupport.stream(rule.getProperties().spliterator(), false))
+                .flatMap(rule -> Stream.concat(StreamSupport.stream(rule.getProperties().spliterator(), false),
+                        rule.getFunctionRestrictions().stream()))
                 .filter(pd -> pd.index) // keep only properties that can be indexed
-                .collect(Collectors.groupingBy(pd -> pd.name));
+                .collect(Collectors.groupingBy(pd -> {
+                    if(pd.function != null){
+                        return pd.function;
+                    } else {
+                        return pd.name;
+                    }
+                }));
 
         this.dynamicBoostProperties = getDefinedRules()
                 .stream()

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
 import org.apache.jackrabbit.oak.spi.state.NodeState;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditor.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditor.java
@@ -24,7 +24,7 @@ import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexEd
  * {@link IndexEditor} implementation that is responsible for keeping the
  * corresponding Elasticsearch index up to date
  */
-class ElasticIndexEditor extends FulltextIndexEditor<ElasticDocument> {
+public class ElasticIndexEditor extends FulltextIndexEditor<ElasticDocument> {
     ElasticIndexEditor(FulltextIndexEditorContext<ElasticDocument> context) {
         super(context);
     }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndexPlanner.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndexPlanner.java
@@ -57,14 +57,12 @@ class ElasticIndexPlanner extends FulltextIndexPlanner {
                 // support for path ordering in both directions
                 orderEntries.add(o);
             }
-            // TODO: add support for function-based sorting
-//            for (PropertyDefinition functionIndex : rule.getFunctionRestrictions()) {
-//                if (functionIndex.ordered && o.getPropertyName().equals(functionIndex.function)) {
-//                    // can manage any order desc/asc
-//                    orderEntries.add(o);
-//                    result.sortedProperties.add(functionIndex);
-//                }
-//            }
+            for (PropertyDefinition functionIndex : rule.getFunctionRestrictions()) {
+                if (functionIndex.ordered && o.getPropertyName().equals(functionIndex.function)) {
+                    // can manage any order desc/asc
+                    orderEntries.add(o);
+                }
+            }
         }
 
         //TODO Should we return order entries only when all order clauses are satisfied

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFunctionIndexCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFunctionIndexCommonTest.java
@@ -16,17 +16,11 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
-import static java.util.Arrays.asList;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -40,128 +34,15 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditor;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
-import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 public class ElasticFunctionIndexCommonTest extends FunctionIndexCommonTest {
     @ClassRule
     public static final ElasticConnectionRule elasticRule = new ElasticConnectionRule(
             ElasticTestUtils.ELASTIC_CONNECTION_STRING);
 
-    @Rule
-    public TestName name = new TestName();
-
     public ElasticFunctionIndexCommonTest() {
         indexOptions = new ElasticIndexOptions();
-    }
-
-    @Before
-    public void filter() {
-        // assumeTrue(name.getMethodName().equals("lengthName"));
-    }
-
-    @Test
-    public void sameOrderableRelPropWithAndWithoutFunc_checkOrdering() throws Exception {
-
-        // Index def with same property - ordered - one with function and one without
-        Tree luceneIndex = createIndex("upper", Collections.<String>emptySet());
-        Tree nonFunc = luceneIndex.addChild(FulltextIndexConstants.INDEX_RULES)
-                .addChild("nt:base")
-                .addChild(FulltextIndexConstants.PROP_NODE)
-                .addChild("foo");
-        nonFunc.setProperty(FulltextIndexConstants.PROP_PROPERTY_INDEX, true);
-        nonFunc.setProperty(FulltextIndexConstants.PROP_ORDERED, true);
-        nonFunc.setProperty("name", "jcr:content/n/foo");
-
-        Tree func = luceneIndex.getChild(FulltextIndexConstants.INDEX_RULES)
-                .getChild("nt:base")
-                .getChild(FulltextIndexConstants.PROP_NODE)
-                .addChild("testOak");
-        func.setProperty(FulltextIndexConstants.PROP_ORDERED, true);
-        func.setProperty(FulltextIndexConstants.PROP_FUNCTION, "fn:upper-case(jcr:content/n/@foo)");
-
-        root.commit();
-
-        int i = 1;
-        // Create nodes that will be served by the index definition that follows
-        for (String node : asList("a", "c", "b", "e", "d")) {
-
-            Tree test = root.getTree("/").addChild(node);
-            test.setProperty("jcr:primaryType", "nt:unstructured", Type.NAME);
-
-            Tree a = test.addChild("jcr:content");
-            a.setProperty("jcr:primaryType", "nt:unstructured", Type.NAME);
-
-            Tree b = a.addChild("n");
-
-            b.setProperty("jcr:primaryType", "nt:unstructured", Type.NAME);
-            b.setProperty("foo", "bar" + i);
-            i++;
-        }
-
-        root.commit();
-            postCommitHook();
-
-        // Check ordering works for func and non func properties
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by upper([jcr:content/n/foo])",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by [jcr:content/n/foo]",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by upper([jcr:content/n/foo]) DESC",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by [jcr:content/n/foo] DESC",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
-
-        // Now we change the value of foo on already indexed nodes and see if changes
-        // get indexed properly.
-
-        i = 5;
-        for (String node : asList("a", "c", "b", "e", "d")) {
-
-            Tree test = root.getTree("/").getChild(node).getChild("jcr:content").getChild("n");
-
-            test.setProperty("foo", "bar" + i);
-            i--;
-        }
-        root.commit();
-        postCommitHook();
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by upper([jcr:content/n/foo])",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by [jcr:content/n/foo]",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by upper([jcr:content/n/foo]) DESC",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
-
-        assertOrderedPlanAndQuery(
-                "select * from [nt:base] order by [jcr:content/n/foo] DESC",
-                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
-
-    }
-
-    private void assertOrderedPlanAndQuery(String query, String planExpectation, List<String> paths) {
-        List<String> result = assertPlanAndQuery(query, planExpectation, paths);
-        assertEquals("Ordering doesn't match", paths, result);
-    }
-
-    private List<String> assertPlanAndQuery(String query, String planExpectation, List<String> paths) {
-        assertThat(explain(query), containsString(planExpectation));
-        return assertQuery(query, paths);
     }
 
     @Override

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFunctionIndexCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFunctionIndexCommonTest.java
@@ -16,14 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PROPERTY_NAME;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
-
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.InitialContentHelper;
 import org.apache.jackrabbit.oak.api.ContentRepository;
@@ -35,6 +27,14 @@ import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.junit.ClassRule;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
+import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
+import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PROPERTY_NAME;
+import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 
 public class ElasticFunctionIndexCommonTest extends FunctionIndexCommonTest {
     @ClassRule
@@ -66,11 +66,6 @@ public class ElasticFunctionIndexCommonTest extends FunctionIndexCommonTest {
         repositoryOptionsUtil = builder.build();
 
         return repositoryOptionsUtil.getOak().createContentRepository();
-    }
-
-    @Override
-    protected void createTestIndexNode() {
-        // setTraversalEnabled(false);
     }
 
     protected Tree createIndex(String name, Set<String> propNames) {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFunctionIndexCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFunctionIndexCommonTest.java
@@ -16,42 +16,180 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
-import org.apache.jackrabbit.JcrConstants;
-import org.apache.jackrabbit.oak.api.ContentRepository;
-import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.plugins.index.FunctionIndexCommonTest;
-import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
-import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-
-import java.util.Set;
-
+import static java.util.Arrays.asList;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
-@Ignore
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.oak.InitialContentHelper;
+import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.index.FunctionIndexCommonTest;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditor;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
+import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
+import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
 public class ElasticFunctionIndexCommonTest extends FunctionIndexCommonTest {
     @ClassRule
-    public static final ElasticConnectionRule elasticRule =
-            new ElasticConnectionRule(ElasticTestUtils.ELASTIC_CONNECTION_STRING);
+    public static final ElasticConnectionRule elasticRule = new ElasticConnectionRule(
+            ElasticTestUtils.ELASTIC_CONNECTION_STRING);
+
+    @Rule
+    public TestName name = new TestName();
 
     public ElasticFunctionIndexCommonTest() {
         indexOptions = new ElasticIndexOptions();
     }
 
+    @Before
+    public void filter() {
+        // assumeTrue(name.getMethodName().equals("lengthName"));
+    }
+
+    @Test
+    public void sameOrderableRelPropWithAndWithoutFunc_checkOrdering() throws Exception {
+
+        // Index def with same property - ordered - one with function and one without
+        Tree luceneIndex = createIndex("upper", Collections.<String>emptySet());
+        Tree nonFunc = luceneIndex.addChild(FulltextIndexConstants.INDEX_RULES)
+                .addChild("nt:base")
+                .addChild(FulltextIndexConstants.PROP_NODE)
+                .addChild("foo");
+        nonFunc.setProperty(FulltextIndexConstants.PROP_PROPERTY_INDEX, true);
+        nonFunc.setProperty(FulltextIndexConstants.PROP_ORDERED, true);
+        nonFunc.setProperty("name", "jcr:content/n/foo");
+
+        Tree func = luceneIndex.getChild(FulltextIndexConstants.INDEX_RULES)
+                .getChild("nt:base")
+                .getChild(FulltextIndexConstants.PROP_NODE)
+                .addChild("testOak");
+        func.setProperty(FulltextIndexConstants.PROP_ORDERED, true);
+        func.setProperty(FulltextIndexConstants.PROP_FUNCTION, "fn:upper-case(jcr:content/n/@foo)");
+
+        root.commit();
+
+        int i = 1;
+        // Create nodes that will be served by the index definition that follows
+        for (String node : asList("a", "c", "b", "e", "d")) {
+
+            Tree test = root.getTree("/").addChild(node);
+            test.setProperty("jcr:primaryType", "nt:unstructured", Type.NAME);
+
+            Tree a = test.addChild("jcr:content");
+            a.setProperty("jcr:primaryType", "nt:unstructured", Type.NAME);
+
+            Tree b = a.addChild("n");
+
+            b.setProperty("jcr:primaryType", "nt:unstructured", Type.NAME);
+            b.setProperty("foo", "bar" + i);
+            i++;
+        }
+
+        root.commit();
+            postCommitHook();
+
+        // Check ordering works for func and non func properties
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by upper([jcr:content/n/foo])",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by [jcr:content/n/foo]",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by upper([jcr:content/n/foo]) DESC",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by [jcr:content/n/foo] DESC",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
+
+        // Now we change the value of foo on already indexed nodes and see if changes
+        // get indexed properly.
+
+        i = 5;
+        for (String node : asList("a", "c", "b", "e", "d")) {
+
+            Tree test = root.getTree("/").getChild(node).getChild("jcr:content").getChild("n");
+
+            test.setProperty("foo", "bar" + i);
+            i--;
+        }
+        root.commit();
+        postCommitHook();
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by upper([jcr:content/n/foo])",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by [jcr:content/n/foo]",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/d", "/e", "/b", "/c", "/a"));
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by upper([jcr:content/n/foo]) DESC",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
+
+        assertOrderedPlanAndQuery(
+                "select * from [nt:base] order by [jcr:content/n/foo] DESC",
+                getIndexProvider() + "upper(/oak:index/upper)", asList("/a", "/c", "/b", "/e", "/d"));
+
+    }
+
+    private void assertOrderedPlanAndQuery(String query, String planExpectation, List<String> paths) {
+        List<String> result = assertPlanAndQuery(query, planExpectation, paths);
+        assertEquals("Ordering doesn't match", paths, result);
+    }
+
+    private List<String> assertPlanAndQuery(String query, String planExpectation, List<String> paths) {
+        assertThat(explain(query), containsString(planExpectation));
+        return assertQuery(query, paths);
+    }
+
+    @Override
+    protected String getIndexProvider() {
+        return "elasticsearch:";
+    }
+
+    @Override
+    protected void postCommitHook() {
+        try {
+            TimeUnit.SECONDS.sleep(2);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     @Override
     protected ContentRepository createRepository() {
-        repositoryOptionsUtil = new ElasticTestRepositoryBuilder(elasticRule).build();
+        ElasticTestRepositoryBuilder builder = new ElasticTestRepositoryBuilder(elasticRule);
+        builder.setNodeStore(new MemoryNodeStore(InitialContentHelper.INITIAL_CONTENT));
+        repositoryOptionsUtil = builder.build();
+
         return repositoryOptionsUtil.getOak().createContentRepository();
     }
 
     @Override
     protected void createTestIndexNode() {
-        setTraversalEnabled(false);
+        // setTraversalEnabled(false);
     }
 
     protected Tree createIndex(String name, Set<String> propNames) {
@@ -66,13 +204,14 @@ public class ElasticFunctionIndexCommonTest extends FunctionIndexCommonTest {
         def.setProperty(TYPE_PROPERTY_NAME, indexOptions.getIndexType());
         def.setProperty(REINDEX_PROPERTY_NAME, true);
         def.setProperty(FulltextIndexConstants.FULL_TEXT_ENABLED, false);
-        def.setProperty(PropertyStates.createProperty(FulltextIndexConstants.INCLUDE_PROPERTY_NAMES, propNames, Type.STRINGS));
-        //def.setProperty(LuceneIndexConstants.SAVE_DIR_LISTING, true);
+        def.setProperty(
+                PropertyStates.createProperty(FulltextIndexConstants.INCLUDE_PROPERTY_NAMES, propNames, Type.STRINGS));
+        // def.setProperty(LuceneIndexConstants.SAVE_DIR_LISTING, true);
         return index.getChild(INDEX_DEFINITIONS_NAME).getChild(name);
     }
 
     @Override
     protected String getLoggerName() {
-        return null;
+        return ElasticIndexEditor.class.getName();
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestRepositoryBuilder.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestRepositoryBuilder.java
@@ -29,7 +29,6 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorP
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticIndexProvider;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
 import org.apache.jackrabbit.oak.query.QueryEngineSettings;
-import org.apache.jackrabbit.oak.spi.commit.Observer;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -39,7 +38,7 @@ public class ElasticTestRepositoryBuilder extends TestRepositoryBuilder {
 
     private final ElasticConnection esConnection;
     private final ElasticIndexTracker indexTracker;
-    private final int asyncIndexingTimeInSeconds = 5;
+    private final int asyncIndexingTimeInSeconds = 1;
 
     public ElasticTestRepositoryBuilder(ElasticConnectionRule elasticRule) {
         this.esConnection = elasticRule.useDocker() ? elasticRule.getElasticConnectionForDocker() :

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FunctionIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FunctionIndexCommonTest.java
@@ -976,7 +976,11 @@ public abstract class FunctionIndexCommonTest extends AbstractQueryTest {
         }
 
         root.commit();
-        postCommitHook();
+        // pure paranoia, this test seems to be more suceptable to delays in indexng
+        // than others
+        for (int j = 0; j < 5; j++) {
+            postCommitHook();
+        }
 
         // Check ordering works for func and non func properties
         assertOrderedPlanAndQuery(
@@ -1007,7 +1011,11 @@ public abstract class FunctionIndexCommonTest extends AbstractQueryTest {
             i--;
         }
         root.commit();
-        postCommitHook();
+        // pure paranoia, this test seems to be more suceptable to delays in indexng
+        // than others
+        for (int j = 0; j < 5; j++) {
+            postCommitHook();
+        }
 
         assertOrderedPlanAndQuery(
                 "select * from [nt:base] order by upper([jcr:content/n/foo])",


### PR DESCRIPTION
Most of the changes are to correct issues with the tests. 

The primary changes are to introduce a delay between the test changes and test execution to ensure that the Elastic index is updated by the time the assertions are run in the [FunctionIndexCommonTest.java](https://github.com/apache/jackrabbit-oak/compare/trunk...klcodanr:elastic-function-support?expand=1#diff-2d0a75bdc45709baff8c41f725c939f9f37e9414752b37ad03e335c2d40b33c7). This was implemented as an overridden method so that the Lucene indexing does not have any delays.  (see postCommitHook) 

The other change is to ensure that the functional restrictions are translated into Document properties when creating the [ElasticIndexDefinition.java](https://github.com/apache/jackrabbit-oak/compare/trunk...klcodanr:elastic-function-support?expand=1#diff-c047e881bb3fbf15e48f90204a88d5ac9b8f10c3ac6310098e40151a111f836d) and including them in the [ElasticIndexPlanner.java](https://github.com/apache/jackrabbit-oak/compare/trunk...klcodanr:elastic-function-support?expand=1#diff-747aaeec4a6e472c51175546720cc83729ce63ee0e44af12911a36b6e35b8d4c).

I did also reduce the re-indexing delay in the [ElasticTestRepositoryBuilder.java](https://github.com/apache/jackrabbit-oak/compare/trunk...klcodanr:elastic-function-support?expand=1#diff-102e564f471507afd5abb0fb9715a26201b9a46f2f3a3d9588a1fd1e9428e4fa) to reduce the impact of waiting for the changes to be indexed.