### PR TITLE
OAK-9737 : Avoid duplicate tree resolution by using ResultRow.getTree

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlManagerImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlManagerImpl.java
@@ -375,10 +375,11 @@ public class AccessControlManagerImpl extends AbstractAccessControlManager imple
         Set<String> processed = Sets.newHashSet();
         Predicate<Tree> predicate = new PrincipalPredicate(principals);
         for (ResultRow row : aceResult.getRows()) {
-            String acePath = row.getPath();
+            Tree aceTree = row.getTree(null);
+            String acePath = aceTree.getPath();
             String aclName = Text.getName(Text.getRelativeParent(acePath, 1));
 
-            Tree accessControlledTree = r.getTree(Text.getRelativeParent(acePath, 2));
+            Tree accessControlledTree = aceTree.getParent().getParent();
             if (!POLICY_NODE_NAMES.contains(aclName) || !accessControlledTree.exists()) {
                 log.debug("Isolated access control entry -> ignore query result at {}", acePath);
                 continue;
@@ -488,7 +489,7 @@ public class AccessControlManagerImpl extends AbstractAccessControlManager imple
         List<ACE> entries = new ArrayList<>();
         Map<String, Principal> principalMap = new HashMap<>();
         for (ResultRow row : aceResult.getRows()) {
-            Tree aceTree = root.getTree(row.getPath());
+            Tree aceTree = row.getTree(null);
             if (Util.isACE(aceTree, ntMgr)) {
                 String aclPath = Text.getRelativeParent(aceTree.getPath(), 1);
                 String path;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserProvider.java
@@ -240,8 +240,7 @@ class UserProvider extends AuthorizableBaseProvider {
 
             Iterator<? extends ResultRow> rows = result.getRows().iterator();
             if (rows.hasNext()) {
-                String path = rows.next().getPath();
-                return root.getTree(path);
+                return rows.next().getTree(null);
             }
         } catch (ParseException ex) {
             log.error("Failed to retrieve authorizable by principal", ex);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManager.java
@@ -273,7 +273,7 @@ public class UserQueryManager {
                     statement, javax.jcr.query.Query.XPATH, limit, offset,
                     NO_BINDINGS, namePathMapper.getSessionLocalMappings());
             Iterable<? extends ResultRow> resultRows = query.getRows();
-            Iterator<Authorizable> authorizables = Iterators.transform(resultRows.iterator(), new ResultRowToAuthorizable(userManager, root, type));
+            Iterator<Authorizable> authorizables = Iterators.transform(resultRows.iterator(), new ResultRowToAuthorizable(userManager, root, type, query.getSelectorNames()));
             return Iterators.filter(authorizables, new UniqueResultPredicate());
         } catch (ParseException e) {
             throw new RepositoryException("Invalid user query "+statement, e);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlManagerImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlManagerImplTest.java
@@ -1745,12 +1745,7 @@ public class AccessControlManagerImplTest extends AbstractAccessControlTest impl
         ace.setProperty(REP_PRINCIPAL_NAME, testPrincipal.getName());
         ace.setProperty(REP_PRIVILEGES, ImmutableList.of(JCR_READ), Type.NAMES);
 
-        ResultRow row = when(mock(ResultRow.class).getPath()).thenReturn(ace.getPath()).getMock();
-        Iterable rows = ImmutableList.of(row);
-        Result res = mock(Result.class);
-        when(res.getRows()).thenReturn(rows).getMock();
-        QueryEngine qe = mock(QueryEngine.class);
-        when(qe.executeQuery(anyString(), anyString(), any(Map.class), any(Map.class))).thenReturn(res);
+        QueryEngine qe = mockQueryEngine(ace);
         when(r.getQueryEngine()).thenReturn(qe);
 
         AccessControlManagerImpl mgr = createAccessControlManager(r, getNamePathMapper());
@@ -1770,17 +1765,22 @@ public class AccessControlManagerImplTest extends AbstractAccessControlTest impl
         ace.setProperty(REP_PRINCIPAL_NAME, testPrincipal.getName());
         ace.setProperty(REP_PRIVILEGES, ImmutableList.of(JCR_READ), Type.NAMES);
 
-        ResultRow row = when(mock(ResultRow.class).getPath()).thenReturn(ace.getPath()).getMock();
-        Iterable rows = ImmutableList.of(row);
-        Result res = mock(Result.class);
-        when(res.getRows()).thenReturn(rows).getMock();
-        QueryEngine qe = mock(QueryEngine.class);
-        when(qe.executeQuery(anyString(), anyString(), any(Map.class), any(Map.class))).thenReturn(res);
+        QueryEngine qe = mockQueryEngine(ace);
         when(r.getQueryEngine()).thenReturn(qe);
 
         AccessControlManagerImpl mgr = createAccessControlManager(r, getNamePathMapper());
         AccessControlPolicy[] policies = mgr.getEffectivePolicies(ImmutableSet.of(testPrincipal));
         assertPolicies(policies, 0);
+    }
+    
+    private static QueryEngine mockQueryEngine(@NotNull Tree aceTree) throws Exception {
+        ResultRow row = when(mock(ResultRow.class).getTree(null)).thenReturn(aceTree).getMock();
+        Iterable rows = ImmutableList.of(row);
+        Result res = mock(Result.class);
+        when(res.getRows()).thenReturn(rows).getMock();
+        QueryEngine qe = mock(QueryEngine.class);
+        when(qe.executeQuery(anyString(), anyString(), any(Map.class), any(Map.class))).thenReturn(res);
+        return qe;
     }
 
     @Test(expected = RepositoryException.class)


### PR DESCRIPTION
hi @thomasmueller , i would appreciate if you had time to review the proposed changes.

in particular i would like to get your input on usage of 'seletorname' in ResultRowToAuthorizable. is it correct to use the first one in case the passed selectornames are not empty? i didn't try to understand if using a differen selector name would make a difference (in UserQueryManagerTest.testFindWithRelPathMultipleSelectorNames) and got the same tree back for all selectornames... but maybe that was a coincidence? how would i else know which selectorname to use?

thanks for taking the time to review. much appreciated.