### PR TITLE
OAK-9744 Add check for StackOverflowError

### DIFF
--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java
@@ -245,9 +245,9 @@ public class IndexName implements Comparable<IndexName> {
             }
             return isIndexActiveMerged(indexNode, rootState);
         } catch (StackOverflowError e) {
-            LOG.error("Fail to check index activeness for {} with error {}", indexPath, e);
+            LOG.error("Fail to check index activeness for {} due to StackOverflowError", indexPath, e);
+            return true;
         }
-        return true;
     }
 
     private static boolean isIndexActiveMerged(NodeState indexNode, NodeState rootState) {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java
@@ -233,16 +233,21 @@ public class IndexName implements Comparable<IndexName> {
     private static boolean isIndexActive(String indexPath, NodeState rootState) {
         // An index is active if it has a hidden child node that starts with ":oak:mount-",
         // OR if it is an active merged index
-        NodeState indexNode = rootState;
-        for(String e : PathUtils.elements(indexPath)) {
-            indexNode = indexNode.getChildNode(e);
-        }
-        for(String c : indexNode.getChildNodeNames()) {
-            if (c.startsWith(":oak:mount-")) {
-                return true;
+        try {
+            NodeState indexNode = rootState;
+            for (String e : PathUtils.elements(indexPath)) {
+                indexNode = indexNode.getChildNode(e);
             }
+            for (String c : indexNode.getChildNodeNames()) {
+                if (c.startsWith(":oak:mount-")) {
+                    return true;
+                }
+            }
+            return isIndexActiveMerged(indexNode, rootState);
+        } catch (StackOverflowError e) {
+            LOG.error("Fail to check index activeness for {} with error {}", indexPath, e);
         }
-        return isIndexActiveMerged(indexNode, rootState);
+        return true;
     }
 
     private static boolean isIndexActiveMerged(NodeState indexNode, NodeState rootState) {

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexNameTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexNameTest.java
@@ -20,8 +20,15 @@ package org.apache.jackrabbit.oak.plugins.index.search.spi.query;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.junit.Test;
+import org.slf4j.event.Level;
+import java.util.ArrayList;
 
 /**
  * Test the IndexName class
@@ -30,22 +37,22 @@ public class IndexNameTest {
 
     @Test
     public void parse() {
-        assertEquals("/lucene base=/lucene product=0 custom=0", 
+        assertEquals("/lucene base=/lucene product=0 custom=0",
                 IndexName.parse("/lucene").toString());
-        assertEquals("/lucene-1 base=/lucene versioned product=1 custom=0", 
+        assertEquals("/lucene-1 base=/lucene versioned product=1 custom=0",
                 IndexName.parse("/lucene-1").toString());
-        assertEquals("/lucene-2 base=/lucene versioned product=2 custom=0", 
+        assertEquals("/lucene-2 base=/lucene versioned product=2 custom=0",
                 IndexName.parse("/lucene-2").toString());
-        assertEquals("/lucene-custom-3 base=/lucene versioned product=0 custom=3", 
+        assertEquals("/lucene-custom-3 base=/lucene versioned product=0 custom=3",
                 IndexName.parse("/lucene-custom-3").toString());
-        assertEquals("/lucene-4-custom-5 base=/lucene versioned product=4 custom=5", 
+        assertEquals("/lucene-4-custom-5 base=/lucene versioned product=4 custom=5",
                 IndexName.parse("/lucene-4-custom-5").toString());
-        assertEquals("/lucene-12-custom-34 base=/lucene versioned product=12 custom=34", 
+        assertEquals("/lucene-12-custom-34 base=/lucene versioned product=12 custom=34",
                 IndexName.parse("/lucene-12-custom-34").toString());
         // illegal
-        assertEquals("/lucene-abc base=/lucene-abc product=0 custom=0 illegal", 
+        assertEquals("/lucene-abc base=/lucene-abc product=0 custom=0 illegal",
                 IndexName.parse("/lucene-abc").toString());
-        assertEquals("/lucene-abc-custom-2 base=/lucene-abc-custom-2 product=0 custom=0 illegal", 
+        assertEquals("/lucene-abc-custom-2 base=/lucene-abc-custom-2 product=0 custom=0 illegal",
                 IndexName.parse("/lucene-abc-custom-2").toString());
     }
 
@@ -59,23 +66,49 @@ public class IndexNameTest {
         IndexName p1 = IndexName.parse("/lucene-1");
         IndexName p1c1 = IndexName.parse("/lucene-1-custom-1");
         IndexName p1c2 = IndexName.parse("/lucene-1-custom-2");
-        
+
         assertTrue(p0.compareTo(p0a) == 0);
         assertTrue(p0.compareTo(p0b) == 0);
         assertTrue(p0a.compareTo(p0b) == 0);
         assertTrue(p0c1.compareTo(p0c1a) == 0);
-        
+
         assertTrue(p0.compareTo(p0c1) < 0);
         assertTrue(p0c1.compareTo(p1) < 0);
         assertTrue(p1.compareTo(p1c1) < 0);
         assertTrue(p1c1.compareTo(p1c2) < 0);
-        
+
         IndexName a = IndexName.parse("/luceneA");
         IndexName b = IndexName.parse("/luceneB");
         IndexName c = IndexName.parse("/luceneC");
         assertTrue(a.compareTo(b) < 0);
         assertTrue(b.compareTo(c) < 0);
-        
+
     }
 
+    @Test
+    public void recursiveActive() {
+        LogCustomizer lc = LogCustomizer.forLogger(IndexName.class)
+                .enable(Level.ERROR)
+                .filter(Level.ERROR)
+                .create();
+
+        NodeBuilder builder = EMPTY_NODE.builder();
+        NodeBuilder luceneOneBuilder = builder.child("lucene-1");
+        NodeBuilder luceneTwoBuilder = builder.child("lucene-2");
+        luceneOneBuilder.setProperty("merges", "lucene-1");
+        luceneTwoBuilder.setProperty("merges", "lucene-2");
+        NodeState base = builder.getNodeState();
+        ArrayList<String> indexPaths = new ArrayList<>();
+        indexPaths.add("lucene-1");
+
+        try {
+            lc.starting();
+            IndexName.filterReplacedIndexes(indexPaths, base, true);
+            assertTrue("StackOverflowError should be caught", lc.getLogs().contains("Fail to check index activeness for lucene-1 due to StackOverflowError"));
+        } catch (StackOverflowError e) {
+            fail("should not run into StackOverflowError exception");
+        } finally {
+            lc.finished();
+        }
+    }
 }

--- a/oak-search/src/test/resources/logback-test.xml
+++ b/oak-search/src/test/resources/logback-test.xml
@@ -29,15 +29,9 @@
         </encoder>
     </appender>
 
-    <!--
-    <logger name="org.apache.jackrabbit.oak.index.IndexerSupport" level="TRACE"/>
-    -->
     <logger name="org.apache.jackrabbit.oak.plugins.index.search.spi.query" level="TRACE"/>
 
     <root level="INFO">
-        <!--
-        <appender-ref ref="console"/>
-        -->
         <appender-ref ref="file"/>
     </root>
 

--- a/oak-search/src/test/resources/logback-test.xml
+++ b/oak-search/src/test/resources/logback-test.xml
@@ -1,0 +1,44 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.FileAppender">
+        <file>target/unit-tests.log</file>
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!--
+    <logger name="org.apache.jackrabbit.oak.index.IndexerSupport" level="TRACE"/>
+    -->
+    <logger name="org.apache.jackrabbit.oak.plugins.index.search.spi.query" level="TRACE"/>
+
+    <root level="INFO">
+        <!--
+        <appender-ref ref="console"/>
+        -->
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This PR prevent `StackOverflowError` for recursive call between function `isIndexActive` and `isIndexActiveMerged`.
It returns `true` by default if error is catched.