### PR TITLE
OAK-9740 - Offset / Limit Option

### DIFF
--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/QueryEngine.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/QueryEngine.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyMap;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -89,6 +90,24 @@ public interface QueryEngine {
      */
     Result executeQuery(
             String statement, String language, long limit, long offset,
+            Map<String, ? extends PropertyValue> bindings,
+            Map<String, String> mappings) throws ParseException;
+
+    /**
+     * Execute a query and get the result.
+     *
+     * @param statement the query statement
+     * @param language the language
+     * @param limit the maximum result set size (may not be negative but may be empty)
+     * @param offset the number of rows to skip (may not be negative but may be empty)
+     * @param bindings the bind variable value bindings
+     * @param mappings namespace prefix mappings
+     * @return the result
+     * @throws ParseException if the statement could not be parsed
+     * @throws IllegalArgumentException if there was an error executing the query
+     */
+    Result executeQuery(
+            String statement, String language, Optional<Long> limit, Optional<Long> offset,
             Map<String, ? extends PropertyValue> bindings,
             Map<String, String> mappings) throws ParseException;
     

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/package-info.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/package-info.java
@@ -18,7 +18,7 @@
 /**
  * Oak repository API
  */
-@Version("3.3.0")
+@Version("3.4.0")
 package org.apache.jackrabbit.oak.api;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/Query.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/Query.java
@@ -43,6 +43,10 @@ public interface Query {
 
     void setOffset(long offset);
 
+    long getLimit();
+
+    long getOffset();
+
     void bindValue(String key, PropertyValue value);
 
     void setTraversalEnabled(boolean traversalEnabled);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/Query.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/Query.java
@@ -15,10 +15,7 @@ package org.apache.jackrabbit.oak.query;
 
 import java.util.Iterator;
 import java.util.List;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.osgi.annotation.versioning.ProviderType;
+import java.util.Optional;
 
 import org.apache.jackrabbit.oak.api.PropertyValue;
 import org.apache.jackrabbit.oak.api.Result;
@@ -26,6 +23,9 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.query.ast.ColumnImpl;
 import org.apache.jackrabbit.oak.query.ast.OrderingImpl;
 import org.apache.jackrabbit.oak.query.stats.QueryStatsData.QueryExecutionStats;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * A "select" or "union" query.
@@ -43,9 +43,9 @@ public interface Query {
 
     void setOffset(long offset);
 
-    long getLimit();
+    Optional<Long> getLimit();
 
-    long getOffset();
+    Optional<Long> getOffset();
 
     void bindValue(String key, PropertyValue value);
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
@@ -264,7 +264,7 @@ public abstract class QueryEngineImpl implements QueryEngine {
         List<Query> queries = parseQuery(statement, language, context, mappings);
 
         long actualLimit = getValue(queries, limit, Query::getLimit, Long.MAX_VALUE);
-        long actualOffset = getValue(queries, limit, Query::getOffset, 0L);
+        long actualOffset = getValue(queries, offset, Query::getOffset, 0L);
 
         for (Query q : queries) {
             q.setExecutionContext(context);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
@@ -302,7 +302,7 @@ public abstract class QueryEngineImpl implements QueryEngine {
 
     private long getOffset(List<Query> queries, Optional<Long> passedOffset) {
         if (!passedOffset.isPresent()) {
-            return queries.stream().filter(q -> q.getOffset() >= 0).findFirst().map(Query::getOffset)
+            return queries.stream().map(Query::getOffset).filter(Optional::isPresent).map(Optional::get).findFirst()
                     .orElse(0L);
         }
         if (passedOffset.get() < 0) {
@@ -313,7 +313,7 @@ public abstract class QueryEngineImpl implements QueryEngine {
 
     private long getLimit(List<Query> queries, Optional<Long> passedLimit) {
         if (!passedLimit.isPresent()) {
-            return queries.stream().filter(q -> q.getLimit() > 0).findFirst().map(Query::getLimit)
+            return queries.stream().map(Query::getLimit).filter(Optional::isPresent).map(Optional::get).findFirst()
                     .orElse(Long.MAX_VALUE);
         }
         if (passedLimit.get() < 0) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
@@ -300,7 +300,7 @@ public abstract class QueryEngineImpl implements QueryEngine {
 
     }
 
-    private long getOffset(List<Query> queries, Optional<Long> passedOffset) {
+    private static long getOffset(List<Query> queries, Optional<Long> passedOffset) {
         if (!passedOffset.isPresent()) {
             return queries.stream().map(Query::getOffset).filter(Optional::isPresent).map(Optional::get).findFirst()
                     .orElse(0L);
@@ -311,7 +311,7 @@ public abstract class QueryEngineImpl implements QueryEngine {
         return passedOffset.get();
     }
 
-    private long getLimit(List<Query> queries, Optional<Long> passedLimit) {
+    private static long getLimit(List<Query> queries, Optional<Long> passedLimit) {
         if (!passedLimit.isPresent()) {
             return queries.stream().map(Query::getLimit).filter(Optional::isPresent).map(Optional::get).findFirst()
                     .orElse(Long.MAX_VALUE);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineImpl.java
@@ -316,10 +316,11 @@ public abstract class QueryEngineImpl implements QueryEngine {
             return queries.stream().map(Query::getLimit).filter(Optional::isPresent).map(Optional::get).findFirst()
                     .orElse(Long.MAX_VALUE);
         }
-        if (passedLimit.get() < 0) {
+        long limit = passedLimit.get();
+        if (limit < 0) {
             throw new IllegalArgumentException("Limit may not be negative, is: " + passedLimit.get());
         }
-        return passedLimit.get();
+        return limit;
     }
 
     /**

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -1089,6 +1089,8 @@ public class QueryImpl implements Query {
         double almostBestCost = Double.POSITIVE_INFINITY;
         IndexPlan almostBestPlan = null;
 
+        long maxEntryCount = saturatedAdd(offset.orElse(0L), limit.orElse(Long.MAX_VALUE));
+
         // Sort the indexes according to their minimum cost to be able to skip the remaining indexes if the cost of the
         // current index is below the minimum cost of the next index.
         List<? extends QueryIndex> queryIndexes = MINIMAL_COST_ORDERING
@@ -1114,17 +1116,6 @@ public class QueryImpl implements Query {
             if (index instanceof AdvancedQueryIndex) {
                 AdvancedQueryIndex advIndex = (AdvancedQueryIndex) index;
 
-                long localLimit = limit.orElse(Long.MAX_VALUE);
-                long localOffset = offset.orElse(0L);
-                long maxEntryCount = localLimit;
-                if (localOffset > 0) {
-                    if (localOffset + localLimit < 0) {
-                        // long overflow
-                        maxEntryCount = Long.MAX_VALUE;
-                    } else {
-                        maxEntryCount = localOffset + localLimit;
-                    }
-                }
                 List<IndexPlan> ipList = advIndex.getPlans(
                         filter, sortOrder, rootState);
                 cost = Double.POSITIVE_INFINITY;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -474,6 +474,14 @@ public class QueryImpl implements Query {
         return constraint;
     }
 
+    public long getLimit() {
+        return limit;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
     public OrderingImpl[] getOrderings() {
         return orderings;
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryOptions.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryOptions.java
@@ -21,6 +21,8 @@ public class QueryOptions {
     public Traversal traversal = Traversal.DEFAULT;
     public String indexName;
     public String indexTag;
+    public long limit = -1;
+    public long offset = -1;
     
     public enum Traversal {
         // traversing without index is OK for this query, and does not fail or log a warning

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryOptions.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryOptions.java
@@ -13,6 +13,8 @@
  */
 package org.apache.jackrabbit.oak.query;
 
+import java.util.Optional;
+
 /**
  * A query options (or "hints") that are used to customize the way the query is processed.
  */
@@ -21,8 +23,8 @@ public class QueryOptions {
     public Traversal traversal = Traversal.DEFAULT;
     public String indexName;
     public String indexTag;
-    public long limit = -1;
-    public long offset = -1;
+    public Optional<Long> limit = Optional.empty();
+    public Optional<Long> offset = Optional.empty();
     
     public enum Traversal {
         // traversing without index is OK for this query, and does not fail or log a warning

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/SQL2Parser.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/SQL2Parser.java
@@ -182,6 +182,10 @@ public class SQL2Parser {
                     } else if (readIf("TAG")) {
                         options.indexTag = readLabel();
                     }
+                } else if (readIf("OFFSET")) {
+                    q.setOffset(readBase10WholeNumber());
+                } else if (readIf("LIMIT")) {
+                    q.setLimit(readBase10WholeNumber());
                 } else {
                     break;
                 }
@@ -289,6 +293,14 @@ public class SQL2Parser {
         }
 
         return factory.selector(nodeTypeInfo, selectorName);
+    }
+
+    private long readBase10WholeNumber() throws ParseException {
+        String label = readName();
+        if (!label.matches("\\d*") || label.isEmpty() || label.length() > 19 /* Length of MAX_LONG */) {
+            throw getSyntaxError("0-9");
+        }
+        return Long.parseLong(label);
     }
     
     private String readLabel() throws ParseException {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/SQL2Parser.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/SQL2Parser.java
@@ -183,9 +183,9 @@ public class SQL2Parser {
                         options.indexTag = readLabel();
                     }
                 } else if (readIf("OFFSET")) {
-                    q.setOffset(readBase10WholeNumber());
+                    q.setOffset(readNumber());
                 } else if (readIf("LIMIT")) {
-                    q.setLimit(readBase10WholeNumber());
+                    q.setLimit(readNumber());
                 } else {
                     break;
                 }
@@ -295,12 +295,13 @@ public class SQL2Parser {
         return factory.selector(nodeTypeInfo, selectorName);
     }
 
-    private long readBase10WholeNumber() throws ParseException {
+    private long readNumber() throws ParseException {
         String label = readName();
-        if (!label.matches("\\d*") || label.isEmpty() || label.length() > 19 /* Length of MAX_LONG */) {
+        try {
+            return Long.parseLong(label);
+        } catch (NumberFormatException nfe) {
             throw getSyntaxError("0-9");
         }
-        return Long.parseLong(label);
     }
     
     private String readLabel() throws ParseException {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
@@ -20,12 +20,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Maps;
-import com.google.common.collect.PeekingIterator;
 import org.apache.jackrabbit.oak.api.PropertyValue;
 import org.apache.jackrabbit.oak.api.Result;
 import org.apache.jackrabbit.oak.api.Result.SizePrecision;
@@ -42,6 +38,12 @@ import org.apache.jackrabbit.oak.spi.query.QueryConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import com.google.common.collect.PeekingIterator;
+
 /**
  * Represents a union query.
  */
@@ -55,8 +57,8 @@ public class UnionQueryImpl implements Query {
     private OrderingImpl[] orderings;
     private boolean explain;
     private boolean measure;
-    private long limit = Long.MAX_VALUE;
-    private long offset;
+    private Optional<Long> limit = Optional.empty();
+    private Optional<Long> offset = Optional.empty();
     private long size = -1;
     private final QueryEngineSettings settings;
     private boolean isInternal;
@@ -96,18 +98,18 @@ public class UnionQueryImpl implements Query {
 
     @Override
     public void setLimit(long limit) {
-        this.limit = limit;
+        this.limit = Optional.of(limit);
         applyLimitOffset();
     }
 
     @Override
     public void setOffset(long offset) {
-        this.offset = offset;
+        this.offset = Optional.of(offset);
         applyLimitOffset();
     }
 
     private void applyLimitOffset() {
-        long subqueryLimit = QueryImpl.saturatedAdd(limit, offset);
+        long subqueryLimit = QueryImpl.saturatedAdd(limit.orElse(Long.MAX_VALUE), offset.orElse(0L));
         left.setLimit(subqueryLimit);
         right.setLimit(subqueryLimit);
     }
@@ -178,19 +180,20 @@ public class UnionQueryImpl implements Query {
     public long getSize(SizePrecision precision, long max) {
         // Note: for "unionAll == false", overlapping entries are counted twice
         // (this can result in a larger reported size, but it is not a security problem)
+        long localLimit = limit.orElse(Long.MAX_VALUE);
         long a = left.getSize(precision, max);
         if (a < 0) {
             return -1;
         }
-        if (a >= limit) {
-            return limit;
+        if (a >= localLimit) {
+            return localLimit;
         }
         long b = right.getSize(precision, max);
         if (b < 0) {
             return -1;
         }
         long total = QueryImpl.saturatedAdd(a, b);
-        return Math.min(limit, total);
+        return Math.min(localLimit, total);
     }
     
     @Override
@@ -329,7 +332,7 @@ public class UnionQueryImpl implements Query {
             it = Iterators.mergeSorted(ImmutableList.of(leftIter, rightIter), orderBy);
         }
 
-        it = FilterIterators.newCombinedFilter(it, distinct, limit, offset, null, settings);
+        it = FilterIterators.newCombinedFilter(it, distinct, limit.orElse(Long.MAX_VALUE), offset.orElse(0L), null, settings);
 
         if (measure) {
             // return the measuring iterator for the union
@@ -517,12 +520,12 @@ public class UnionQueryImpl implements Query {
     }
 
     @Override
-    public long getLimit() {
-        return -1;
+    public Optional<Long> getLimit() {
+        return limit;
     }
 
     @Override
-    public long getOffset() {
-        return -1;
+    public Optional<Long> getOffset() {
+        return offset;
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
@@ -515,4 +515,14 @@ public class UnionQueryImpl implements Query {
             }
         }
     }
+
+    @Override
+    public long getLimit() {
+        return -1;
+    }
+
+    @Override
+    public long getOffset() {
+        return -1;
+    }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
@@ -376,6 +376,21 @@ public class Statement {
             buff.append("]");
             optionCount++;
         }
+        if (queryOptions.offset != -1) {
+            if (optionCount > 0) {
+                buff.append(", ");
+            }
+            buff.append("offset ");
+            buff.append(queryOptions.offset);
+            optionCount++;
+        }
+        if (queryOptions.limit != -1) {
+            if (optionCount > 0) {
+                buff.append(", ");
+            }
+            buff.append("limit ");
+            buff.append(queryOptions.limit);
+        }
         buff.append(")");
     }
     

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
@@ -17,6 +17,8 @@
 package org.apache.jackrabbit.oak.query.xpath;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.jackrabbit.oak.query.QueryOptions;
 import org.apache.jackrabbit.oak.query.QueryOptions.Traversal;
@@ -353,44 +355,23 @@ public class Statement {
             return;
         }
         buff.append(" option(");
-        int optionCount = 0;
+        List<String> optionValues = new ArrayList<>();
         if (queryOptions.traversal != Traversal.DEFAULT) {
-            buff.append("traversal " + queryOptions.traversal);
-            optionCount++;
+            optionValues.add("traversal " + queryOptions.traversal);
         }
         if (queryOptions.indexName != null) {
-            if (optionCount > 0) {
-                buff.append(", ");
-            }
-            buff.append("index name [");
-            buff.append(queryOptions.indexName);
-            buff.append("]");
-            optionCount++;
+            optionValues.add("index name [" + queryOptions.indexName + "]");
         }
         if (queryOptions.indexTag != null) {
-            if (optionCount > 0) {
-                buff.append(", ");
-            }
-            buff.append("index tag [");
-            buff.append(queryOptions.indexTag);
-            buff.append("]");
-            optionCount++;
+            optionValues.add("index tag [" + queryOptions.indexTag + "]");
         }
         if (queryOptions.offset != -1) {
-            if (optionCount > 0) {
-                buff.append(", ");
-            }
-            buff.append("offset ");
-            buff.append(queryOptions.offset);
-            optionCount++;
+            optionValues.add("offset " + queryOptions.offset);
         }
         if (queryOptions.limit != -1) {
-            if (optionCount > 0) {
-                buff.append(", ");
-            }
-            buff.append("limit ");
-            buff.append(queryOptions.limit);
+            optionValues.add("limit " + queryOptions.limit);
         }
+        buff.append(optionValues.stream().collect(Collectors.joining(", ")));
         buff.append(")");
     }
     

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
@@ -371,7 +371,7 @@ public class Statement {
         if (queryOptions.limit != -1) {
             optionValues.add("limit " + queryOptions.limit);
         }
-        buff.append(optionValues.stream().collect(Collectors.joining(", ")));
+        buff.append(String.join(", ", optionValues));
         buff.append(")");
     }
     

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/Statement.java
@@ -365,11 +365,11 @@ public class Statement {
         if (queryOptions.indexTag != null) {
             optionValues.add("index tag [" + queryOptions.indexTag + "]");
         }
-        if (queryOptions.offset != -1) {
-            optionValues.add("offset " + queryOptions.offset);
+        if (queryOptions.offset.isPresent()) {
+            optionValues.add("offset " + queryOptions.offset.get());
         }
-        if (queryOptions.limit != -1) {
-            optionValues.add("limit " + queryOptions.limit);
+        if (queryOptions.limit.isPresent()) {
+            optionValues.add("limit " + queryOptions.limit.get());
         }
         buff.append(String.join(", ", optionValues));
         buff.append(")");

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
@@ -402,7 +402,7 @@ public class XPathToSQL2Converter {
                     options.offset = Optional.of(readNumber());
                 } else if (readIf("limit")) {
                     options.limit = Optional.of(readNumber());
-                }else { 
+                } else { 
                     break;
                 }
                 readIf(",");

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
@@ -16,6 +16,12 @@
  */
 package org.apache.jackrabbit.oak.query.xpath;
 
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Optional;
+
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.query.QueryOptions;
 import org.apache.jackrabbit.oak.query.QueryOptions.Traversal;
@@ -23,11 +29,6 @@ import org.apache.jackrabbit.oak.query.xpath.Statement.UnionStatement;
 import org.apache.jackrabbit.util.ISO9075;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.math.BigDecimal;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Locale;
 
 /**
  * This class can can convert a XPATH query to a SQL2 query.
@@ -398,9 +399,9 @@ public class XPathToSQL2Converter {
                         options.indexTag = readIdentifier();
                     }
                 } else if (readIf("offset")) {
-                    options.offset = readNumber();
+                    options.offset = Optional.of(readNumber());
                 } else if (readIf("limit")) {
-                    options.limit = readNumber();
+                    options.limit = Optional.of(readNumber());
                 }else { 
                     break;
                 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
@@ -397,7 +397,11 @@ public class XPathToSQL2Converter {
                     } else if (readIf("tag")) {
                         options.indexTag = readIdentifier();
                     }
-                } else {
+                } else if (readIf("offset")) {
+                    options.offset = readNumber();
+                } else if (readIf("limit")) {
+                    options.limit = readNumber();
+                }else { 
                     break;
                 }
                 readIf(",");
@@ -832,6 +836,20 @@ public class XPathToSQL2Converter {
             throw getSyntaxError(expected);
         }
         read();
+    }
+
+    private long readNumber() throws ParseException {
+        if (currentTokenType == VALUE_NUMBER) {
+            try {
+                long l = Long.parseLong(currentToken);
+                read();
+                return l;
+            } catch (NumberFormatException nfe) {
+                throw getSyntaxError("[0-9]");
+            }
+        } else {
+            throw getSyntaxError("[0-9]");
+        }
     }
 
     private Expression.Property readProperty() throws ParseException {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryLimitTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryLimitTest.java
@@ -26,8 +26,6 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.Properties;
 
-import javax.jcr.query.Row;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryLimitTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryLimitTest.java
@@ -17,11 +17,23 @@
 
 package org.apache.jackrabbit.oak.query;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Properties;
+
+import javax.jcr.query.Row;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.api.QueryEngine;
+import org.apache.jackrabbit.oak.api.ResultRow;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.spi.security.OpenSecurityProvider;
@@ -31,11 +43,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.event.Level;
-
-import java.text.ParseException;
-import java.util.Properties;
-
-import static org.junit.Assert.assertThrows;
 
 public class QueryLimitTest extends AbstractQueryTest {
 
@@ -107,5 +114,19 @@ public class QueryLimitTest extends AbstractQueryTest {
         } finally {
             customLogs.finished();
         }
+    }
+
+    @Test
+    public void queryLimitFromOptions() throws Exception {
+        String query = "SELECT [jcr:path] FROM [nt:base] AS a OPTION(LIMIT 10)";
+
+        Iterator<? extends ResultRow> row = qe.executeQuery(query, QueryEngineImpl.SQL2, Optional.empty(),
+                Optional.empty(), Collections.emptyMap(), Collections.emptyMap()).getRows().iterator();
+        int count = 0;
+        while (row.hasNext()) {
+            count++;
+            row.next();
+        }
+        assertEquals(10, count);
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/SQL2ParserTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/SQL2ParserTest.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.query;
 
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.text.ParseException;
@@ -116,22 +117,22 @@ public class SQL2ParserTest {
     @Test
     public void testLimitOffSet() throws ParseException {
         QueryImpl parsed = (QueryImpl) p.parse("SELECT * FROM [nt:base] WHERE b=2 OPTION(OFFSET 10, LIMIT 100)");
-        assertEquals(10L, parsed.getOffset());
-        assertEquals(100L, parsed.getLimit());
+        assertEquals(10L, parsed.getOffset().get().longValue());
+        assertEquals(100L, parsed.getLimit().get().longValue());
 
         QueryImpl parsedXPath = (QueryImpl) p.parse(new XPathToSQL2Converter()
                 .convert("/jcr:root/test/*/nt:resource[@jcr:encoding] option(offset 2, limit 75)"));
-        assertEquals(2L, parsedXPath.getOffset());
-        assertEquals(75L, parsedXPath.getLimit());
+        assertEquals(2L, parsedXPath.getOffset().get().longValue());
+        assertEquals(75L, parsedXPath.getLimit().get().longValue());
 
         QueryImpl parsedLimitOnly = (QueryImpl) p.parse(new XPathToSQL2Converter()
                 .convert("/jcr:root/test/*/nt:resource[@jcr:encoding] option(limit 98)"));
-        assertEquals(0L, parsedLimitOnly.getOffset());
-        assertEquals(98L, parsedLimitOnly.getLimit());
+        assertFalse(parsedLimitOnly.getOffset().isPresent());
+        assertEquals(98L, parsedLimitOnly.getLimit().get().longValue());
 
         QueryImpl parsedOffsetOnly = (QueryImpl) p.parse("SELECT * FROM [nt:base] WHERE b=2 OPTION(OFFSET 23)");
-        assertEquals(23L, parsedOffsetOnly.getOffset());
-        assertEquals(Long.MAX_VALUE, parsedOffsetOnly.getLimit());
+        assertEquals(23L, parsedOffsetOnly.getOffset().get().longValue());
+        assertFalse(parsedOffsetOnly.getLimit().isPresent());
     }
 
     @Test(expected = ParseException.class)

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
@@ -17,17 +17,13 @@
 
 package org.apache.jackrabbit.oak.query;
 
-import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
-import static org.apache.jackrabbit.oak.api.Type.NAME;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import org.apache.jackrabbit.oak.InitialContent;
@@ -224,6 +220,31 @@ public class UnionQueryTest extends AbstractQueryTest {
         };
 
         Result result = qe.executeQuery(union, QueryEngineImpl.SQL2, limit, offset,
+                QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
+
+        List<ResultRow> rows = Lists.newArrayList(result.getRows());
+        assertEquals(expected.length, rows.size());
+
+        int i = 0;
+        for (ResultRow rr: result.getRows()) {
+            assertEquals(rr.getPath(), expected[i++]);
+        }
+    }
+
+    @Test
+    public void testOrderLimitOption() throws Exception {
+        String left = "SELECT [jcr:path] FROM [nt:base] AS a WHERE ISDESCENDANTNODE(a, '/UnionQueryTest')";
+        String right = "SELECT [jcr:path] FROM [nt:base] AS a WHERE ISDESCENDANTNODE(a, '/UnionQueryTest')";
+        String order = "ORDER BY [jcr:path]";
+        String union = String.format("%s UNION %s %s OPTION(LIMIT 3, OFFSET 2)", left, right, order);
+
+        String[] expected = {
+                "/UnionQueryTest/a/b/c",
+                "/UnionQueryTest/a/b/c/d",
+                "/UnionQueryTest/a/b/c/d/e"
+        };
+
+        Result result = qe.executeQuery(union, QueryEngineImpl.SQL2, Optional.empty(), Optional.empty(),
                 QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
 
         List<ResultRow> rows = Lists.newArrayList(result.getRows());

--- a/oak-doc-railroad-macro/src/main/java/org/apache/jackrabbit/oak/doc/doxia/jcr/BnfRailroad.java
+++ b/oak-doc-railroad-macro/src/main/java/org/apache/jackrabbit/oak/doc/doxia/jcr/BnfRailroad.java
@@ -70,6 +70,8 @@ public class BnfRailroad implements BnfVisitor {
         XPATH_KEYWORD_TO_ESCAPE.put("order by", "@ORDER_BY@");
         XPATH_KEYWORD_TO_ESCAPE.put("option", "@OPTION@");
         XPATH_KEYWORD_TO_ESCAPE.put("traversal", "@TRAVERSAL@");
+        XPATH_KEYWORD_TO_ESCAPE.put("offset", "@OFFSET@");
+        XPATH_KEYWORD_TO_ESCAPE.put("limit", "@LIMIT@");
         XPATH_KEYWORD_TO_ESCAPE.put("ok", "@OK@");
         XPATH_KEYWORD_TO_ESCAPE.put("warn", "@WARN@");
         XPATH_KEYWORD_TO_ESCAPE.put("fail", "@FAIL@");

--- a/oak-doc/src/site/markdown/query/grammar-sql2.md.vm
+++ b/oak-doc/src/site/markdown/query/grammar-sql2.md.vm
@@ -292,6 +292,10 @@ To only consider some of the indexes, add tags (a multi-valued String property) 
 and specify this tag in the query.
 See <a href="query-engine.html#Query_Option_Index_Tag">Query Option Index Tag</a>.
 
+"offset" / "limit": sets the offset / limit at the time of parsing the query
+See <a href="query-engine.html#Query_Option_Offset__Limit">Query Option Offset / Limit</a>.
+
+
 Examples:
 
     option(traversal fail)

--- a/oak-doc/src/site/markdown/query/grammar-xpath.md.vm
+++ b/oak-doc/src/site/markdown/query/grammar-xpath.md.vm
@@ -335,6 +335,9 @@ To only consider some of the indexes, add tags (a multi-valued String property) 
 and specify this tag in the query.
 See <a href="query-engine.html#Query_Option_Index_Tag">Query Option Index Tag</a>.
 
+"offset" / "limit": sets the offset / limit at the time of parsing the query
+See <a href="query-engine.html#Query_Option_Offset__Limit">Query Option Offset / Limit</a>.
+
 Examples:
 
     option(traversal fail)

--- a/oak-doc/src/site/markdown/query/query-engine.md
+++ b/oak-doc/src/site/markdown/query/query-engine.md
@@ -160,7 +160,7 @@ This is supported for both XPath and SQL-2, as follows:
 `@since Oak 1.44.0 (OAK-9740)`
 
 By setting the offset / limit of a query you can set the limits and offsets set on the query object.
-Note, this setting will be overriden by any settings made via the `Query#setOffset` or `Query#setLimit` methods.
+Note, this setting will be overridden by any settings made via the `Query#setOffset` or `Query#setLimit` methods.
 
 The syntax is `option(limit {num}, offset {num})` at the very end of the statement, after `order by` 
 and can be used in conjunction with any other option.

--- a/oak-doc/src/site/markdown/query/query-engine.md
+++ b/oak-doc/src/site/markdown/query/query-engine.md
@@ -28,6 +28,7 @@ grep "^#.*$" src/site/markdown/query/query-engine.md | sed 's/#/    /g' | sed 's
     * [Query Options](#Query_Options)
         * [Query Option Traversal](#Query_Option_Traversal)
         * [Query Option Index Tag](#Query_Option_Index_Tag)
+        * [Query Option Offset / Limit](#Query_Option_Offset__Limit)
         * [Index Selection Policy](#Index_Selection_Policy)
     * [Compatibility](#Compatibility)
         * [Result Size](#Result_Size)
@@ -123,8 +124,8 @@ If an index implementation can not query the data, it has to return `Infinity` (
 
 ### Query Options
 
-With query options, you can enforce the usage of indexes (failing the query if there is no index),
-and you can limit which indexes should be considered.
+With query options, you can enforce the usage of indexes (failing the query if there is no index), 
+limit which indexes should be considered and set the limit and offset for a query.
 
 #### Query Option Traversal
 
@@ -152,6 +153,26 @@ This is supported for both XPath and SQL-2, as follows:
     where ischildnode('/oak:index')
     order by name()
     option(traversal ok)
+
+
+#### Query Option Offset / Limit
+
+`@since Oak 1.44.0 (OAK-9740)`
+
+By setting the offset / limit of a query you can set the limits and offsets set on the query object.
+Note, this setting will be overriden by any settings made via the `Query#setOffset` or `Query#setLimit` methods.
+
+The syntax is `option(limit {num}, offset {num})` at the very end of the statement, after `order by` 
+and can be used in conjunction with any other option.
+
+This is supported for both XPath and SQL-2, as follows:
+
+    /jcr:root/oak:index/*[@type='lucene'] option(limit 100)
+
+    select * from [nt:base]
+    where ischildnode('/oak:index')
+    order by name()
+    option(offset 19, limit 20)
 
 #### Query Option Index Tag
 

--- a/oak-doc/src/site/resources/grammar/sql2.csv
+++ b/oak-doc/src/site/resources/grammar/sql2.csv
@@ -127,7 +127,9 @@ simpleName
 "Grammar","Options","
 OPTION( {
     TRAVERSAL { OK | WARN | FAIL | DEFAULT } |
-    INDEX TAG tagName
+    INDEX TAG tagName |
+    OFFSET number |
+    LIMIT number
     } [ , ... ] )
 ","
 "

--- a/oak-doc/src/site/resources/grammar/xpath.csv
+++ b/oak-doc/src/site/resources/grammar/xpath.csv
@@ -133,7 +133,9 @@ simpleType
 "Grammar","Options","
 'option'( {
     'traversal' { 'ok' | 'warn' | 'fail' | 'default' } |
-    'index' 'tag' tagName
+    'index' 'tag' tagName |
+    'offset' number |
+    'limit' number 
     } [ , ... ] )
 ","
 "

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/QueryImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/QueryImpl.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.jcr.query;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
@@ -50,8 +51,8 @@ public class QueryImpl implements Query {
     private final HashMap<String, Value> bindVariableMap = new HashMap<String, Value>();
     private final String language;
     private final String statement;
-    private long limit = Long.MAX_VALUE;
-    private long offset;
+    private Optional<Long> limit = Optional.empty();
+    private Optional<Long> offset = Optional.empty();
     private boolean parsed;
     private String storedQueryPath;
 
@@ -138,7 +139,7 @@ public class QueryImpl implements Query {
         if (limit < 0) {
             throw new IllegalArgumentException("Limit may not be negative, is: " + limit);
         }
-        this.limit = limit;
+        this.limit = Optional.of(limit);
     }
 
     @Override
@@ -146,7 +147,7 @@ public class QueryImpl implements Query {
         if (offset < 0) {
             throw new IllegalArgumentException("Offset may not be negative, is: " + offset);
         }
-        this.offset = offset;
+        this.offset = Optional.of(offset);
     }
 
     @Override

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/QueryManagerImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/QueryManagerImpl.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.jcr.Node;
@@ -129,7 +130,7 @@ public class QueryManagerImpl implements QueryManager {
     }
 
     public QueryResult executeQuery(String statement, String language,
-            long limit, long offset, HashMap<String, Value> bindVariableMap) throws RepositoryException {
+        Optional<Long> limit, Optional<Long> offset, HashMap<String, Value> bindVariableMap) throws RepositoryException {
         try {
             Map<String, PropertyValue> bindMap = convertMap(bindVariableMap);
             TimerStats.Context context = queryDuration.time();

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/qom/QueryObjectModelImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/qom/QueryObjectModelImpl.java
@@ -14,6 +14,8 @@
 package org.apache.jackrabbit.oak.jcr.query.qom;
 
 import java.util.HashMap;
+import java.util.Optional;
+
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -26,6 +28,7 @@ import javax.jcr.query.qom.Constraint;
 import javax.jcr.query.qom.Ordering;
 import javax.jcr.query.qom.QueryObjectModel;
 import javax.jcr.query.qom.Source;
+
 import org.apache.jackrabbit.oak.jcr.query.QueryManagerImpl;
 
 /**
@@ -40,8 +43,8 @@ public class QueryObjectModelImpl implements QueryObjectModel {
     private final ValueFactory valueFactory;
     private final Ordering[] orderings;
     private final Column[] columns;
-    private long limit = Long.MAX_VALUE;
-    private long offset;
+    private Optional<Long> limit = Optional.empty();
+    private Optional<Long> offset = Optional.empty();
     private boolean parsed;
     private String storedQueryPath;
 
@@ -92,12 +95,12 @@ public class QueryObjectModelImpl implements QueryObjectModel {
 
     @Override
     public void setLimit(long limit) {
-        this.limit = limit;
+        this.limit = Optional.of(limit);
     }
 
     @Override
     public void setOffset(long offset) {
-        this.offset = offset;
+        this.offset = Optional.of(offset);
     }
 
     public ValueFactory getValueFactory() {

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
@@ -115,6 +115,29 @@ public class QueryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void testSettingsOverride() throws Exception {
+        Session session = getAdminSession();
+        QueryManager qm = session.getWorkspace().getQueryManager();
+
+
+        Node testRoot = session.getNode("/").addNode("settings-override-test","nt:unstructured");
+        for(int count: IntStream.range(0, 100).toArray()){
+            testRoot.addNode("settings-override-test-child"+count,"nt:unstructured");
+        }
+        session.save();
+
+        Query q = qm.createQuery("SELECT * FROM [nt:unstructured] WHERE ISCHILDNODE([/settings-override-test]) OPTION(OFFSET 10)", Query.JCR_SQL2);
+        q.setLimit(90);
+        NodeIterator it = q.execute().getNodes();
+        int count = 0;
+        while(it.hasNext()){
+            count++;
+            it.next();
+        }
+        assertEquals(90, count);
+    }
+
+    @Test
     public void traversalOption() throws Exception {
         Session session = getAdminSession();
         QueryManager qm = session.getWorkspace().getQueryManager();

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -68,6 +69,49 @@ public class QueryTest extends AbstractRepositoryTest {
 
     public QueryTest(NodeStoreFixture fixture) {
         super(fixture);
+    }
+
+    @Test
+    public void limitOption() throws Exception {
+        Session session = getAdminSession();
+        QueryManager qm = session.getWorkspace().getQueryManager();
+
+        // grammar supports limit option
+        assertTrue(isValidQuery(qm, Query.JCR_SQL2,
+                "select * from [nt:base] where ischildnode('/') or [jcr:uuid] = 1 option(limit 10)"));
+       
+
+        Node testRoot = session.getNode("/").addNode("limit-test","nt:unstructured");
+        for(int count: IntStream.range(0, 100).toArray()){
+            testRoot.addNode("limit-test-child"+count,"nt:unstructured");
+        }
+        session.save();
+
+        String[] paths = getNodeList(session, "SELECT * FROM [nt:unstructured] WHERE ISCHILDNODE([/limit-test]) OPTION(LIMIT 10)", Query.JCR_SQL2).split(",");
+        assertEquals(10, paths.length);
+    }
+
+    @Test
+    public void offsetOption() throws Exception {
+        Session session = getAdminSession();
+        QueryManager qm = session.getWorkspace().getQueryManager();
+
+        // grammar supports offset option
+        assertTrue(isValidQuery(qm, Query.JCR_SQL2,
+                "select * from [nt:base] where ischildnode('/') or [jcr:uuid] = 1 option(offset 10)"));
+       
+
+        Node testRoot = session.getNode("/").addNode("offset-test","nt:unstructured");
+        for(int count: IntStream.range(0, 100).toArray()){
+            testRoot.addNode("offset-test-child"+count,"nt:unstructured");
+        }
+        session.save();
+
+        String[] paths = getNodeList(session, "SELECT * FROM [nt:unstructured] WHERE ISCHILDNODE([/offset-test]) OPTION(OFFSET 80)", Query.JCR_SQL2).split(",");
+        assertEquals(20, paths.length);
+
+        paths = getNodeList(session, "SELECT * FROM [nt:unstructured] WHERE ISCHILDNODE([/offset-test]) OPTION(OFFSET 80, LIMIT 10)", Query.JCR_SQL2).split(",");
+        assertEquals(10, paths.length);
     }
 
     @Test


### PR DESCRIPTION
Adds support for setting the offset / limit via options within the query body in the form:

    SELECT * FROM [nt:base] OPTION(LIMIT 10, OFFSET 10)
   
Note this also supports XPath:

    /jcr:root/test/*/nt:resource[@jcr:encoding] option(offset 2, limit 75)

Any settings on the query will override the values parsed out of the query options. 