### PR TITLE
OAK-9747 Download resume needs to save progress and handle hidden node on exception

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -19,16 +19,6 @@
 
 package org.apache.jackrabbit.oak.index.indexer.document;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
-
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.Closer;
@@ -65,6 +55,16 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.FlatFileNodeStoreBuilder.OAK_INDEXER_SORTED_FILE_PATH;
@@ -115,7 +115,8 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
         }
 
         private MongoNodeStateEntryTraverserFactory(RevisionVector rootRevision, DocumentNodeStore documentNodeStore,
-                                                    MongoDocumentStore documentStore, Logger traversalLogger, CompositeIndexer indexer, Predicate<String> pathPredicate) {
+                                                    MongoDocumentStore documentStore, Logger traversalLogger, CompositeIndexer indexer,
+                                                    Predicate<String> pathPredicate) {
             this.rootRevision = rootRevision;
             this.documentNodeStore = documentNodeStore;
             this.documentStore = documentStore;
@@ -140,8 +141,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
                                     throw new RuntimeException(e);
                                 }
                                 traversalLogger.trace(id);
-                            })
-                            .withPathPredicate((pathPredicate != null) ? pathPredicate : indexer::shouldInclude);
+                            });
         }
     }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import com.google.common.collect.Iterables;
 import org.apache.commons.io.FileUtils;
@@ -101,6 +102,7 @@ public class FlatFileNodeStoreBuilder {
     private File flatFileStoreDir;
     private final MemoryManager memoryManager;
     private long dumpThreshold = DEFAULT_DUMP_THRESHOLD;
+    private Predicate<String> pathPredicate = path -> true;
 
     private final boolean useZip = Boolean.parseBoolean(System.getProperty(OAK_INDEXER_USE_ZIP, "true"));
     private final boolean useTraverseWithSort = Boolean.parseBoolean(System.getProperty(OAK_INDEXER_TRAVERSE_WITH_SORT, "true"));
@@ -165,6 +167,11 @@ public class FlatFileNodeStoreBuilder {
         return this;
     }
 
+    public FlatFileNodeStoreBuilder withPathPredicate(Predicate<String> pathPredicate) {
+        this.pathPredicate = pathPredicate;
+        return this;
+    }
+
     public FlatFileStore build() throws IOException, CompositeException {
         logFlags();
         comparator = new PathElementComparator(preferredPathElements);
@@ -210,7 +217,7 @@ public class FlatFileNodeStoreBuilder {
             case MULTITHREADED_TRAVERSE_WITH_SORT:
                 log.info("Using MultithreadedTraverseWithSortStrategy");
                 return new MultithreadedTraverseWithSortStrategy(nodeStateEntryTraverserFactory, lastModifiedBreakPoints, comparator,
-                        blobStore, dir, existingDataDumpDirs, useZip, memoryManager, dumpThreshold);
+                        blobStore, dir, existingDataDumpDirs, useZip, memoryManager, dumpThreshold, pathPredicate);
         }
         throw new IllegalStateException("Not a valid sort strategy value " + sortStrategyType);
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/MergeRunner.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/MergeRunner.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
+import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -339,12 +340,12 @@ public class MergeRunner implements Runnable {
                 String mergedFileName = mergedFile.getName();
                 if (mergeCancelled.get()) {
                     log.debug("merge cancelled, skipping merge task");
-                    throw new Exception("merge skipped for " + mergedFileName);
+                    throw new EOFException("merge skipped for " + mergedFileName);
                 } else if (merge(mergeTarget, mergedFile)) {
                     log.info("merge complete for {}", mergedFileName);
                 } else {
                     log.error("merge failed for {}", mergedFileName);
-                    throw new Exception("merge failed for " + mergedFileName);
+                    throw new RuntimeException("merge failed for " + mergedFileName);
                 }
             } finally {
                 mergeTaskPhaser.arriveAndDeregister();

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreTest.java
@@ -20,6 +20,7 @@
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
 import com.google.common.collect.Iterables;
+import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.index.indexer.document.CompositeException;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntryTraverser;
@@ -27,6 +28,7 @@ import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntryTraverserF
 import org.apache.jackrabbit.oak.plugins.document.mongo.DocumentStoreSplitter;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentTraverser;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
+import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,23 +38,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.FlatFileNodeStoreBuilder.OAK_INDEXER_SORT_STRATEGY_TYPE;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.FlatFileNodeStoreBuilder.OAK_INDEXER_USE_ZIP;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.FlatFileNodeStoreBuilder.PROP_MERGE_TASK_BATCH_SIZE;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.FlatFileNodeStoreBuilder.PROP_THREAD_POOL_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("StaticPseudoFunctionalStyleMethod")
 public class FlatFileStoreTest {
@@ -159,7 +167,7 @@ public class FlatFileStoreTest {
     }
 
     private FlatFileStore buildFlatFileStore(FlatFileNodeStoreBuilder spyBuilder, List<Long> lastModifiedBreakpoints,
-                                    TestNodeStateEntryTraverserFactory nsetf, boolean expectException) throws Exception {
+                                    TestNodeStateEntryTraverserFactory nsetf, boolean expectException, Long dumpThreshold) throws Exception {
         boolean exceptionCaught = false;
         FlatFileStore flatFileStore = null;
         try {
@@ -167,7 +175,7 @@ public class FlatFileStoreTest {
                     .withPreferredPathElements(preferred)
                     .withLastModifiedBreakPoints(lastModifiedBreakpoints)
                     .withNodeStateEntryTraverserFactory(nsetf)
-                    .withDumpThreshold(0)
+                    .withDumpThreshold(dumpThreshold)
                     .build();
         } catch (CompositeException e) {
             exceptionCaught = true;
@@ -182,6 +190,7 @@ public class FlatFileStoreTest {
 
     @Test
     public void resumePreviousUnfinishedDownload() throws Exception {
+        Long dumpThreshold = 0L;
         try {
             System.setProperty(OAK_INDEXER_SORT_STRATEGY_TYPE, FlatFileNodeStoreBuilder.SortStrategyType.MULTITHREADED_TRAVERSE_WITH_SORT.toString());
             List<TestMongoDoc> mongoDocs = getTestData();
@@ -191,17 +200,17 @@ public class FlatFileStoreTest {
             FlatFileNodeStoreBuilder spyBuilder = Mockito.spy(new FlatFileNodeStoreBuilder(folder.getRoot(), memoryManager));
             TestNodeStateEntryTraverserFactory nsetf = new TestNodeStateEntryTraverserFactory(mongoDocs);
             nsetf.setDeliveryBreakPoint((int)(mongoDocs.size() * 0.25));
-            FlatFileStore flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true);
+            FlatFileStore flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true, dumpThreshold);
             assertNull(flatStore);
             spyBuilder.addExistingDataDumpDir(spyBuilder.getFlatFileStoreDir());
             nsetf.setDeliveryBreakPoint((int)(mongoDocs.size() * 0.50));
-            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true);
+            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true, dumpThreshold);
             assertNull(flatStore);
             memoryManager.isMemoryLow = false;
             List<String> entryPaths;
             spyBuilder.addExistingDataDumpDir(spyBuilder.getFlatFileStoreDir());
             nsetf.setDeliveryBreakPoint(Integer.MAX_VALUE);
-            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, false);
+            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, false, dumpThreshold);
             entryPaths = StreamSupport.stream(flatStore.spliterator(), false)
                     .map(NodeStateEntry::getPath)
                     .collect(Collectors.toList());
@@ -211,6 +220,124 @@ public class FlatFileStoreTest {
             assertEquals(sortedPaths, entryPaths);
         } finally {
             System.clearProperty(OAK_INDEXER_SORT_STRATEGY_TYPE);
+        }
+    }
+
+    private boolean flatFileStoreMatchCondition(File dir, String filenamePattern, String entry) {
+        Pattern pattern = Pattern.compile(filenamePattern, Pattern.CASE_INSENSITIVE);
+        for (File innerDir : Objects.requireNonNull(dir.listFiles())) {
+            if (innerDir.isDirectory()) {
+                for (File innerFile : Objects.requireNonNull(innerDir.listFiles())) {
+                    if (!pattern.matcher(innerFile.getName()).find()) {
+                        continue;
+                    }
+                    List<String> lines = null;
+                    try {
+                        lines = FileUtils.readLines(innerFile, StandardCharsets.UTF_8);
+                    } catch (Exception e) {
+                        fail("failed to read FlatFileStore");
+                    }
+                    for (String line : lines) {
+                        if (line.contains(entry)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    // with larger size of dump threshold (which result in almost never dump),
+    // fail in the middle, check that hidden node progress are saved
+    @Test
+    public void resumePreviousUnfinishedDownloadWithHiddenNode() throws Exception {
+        Long dumpThreshold = FileUtils.ONE_MB;
+        try {
+            System.setProperty(OAK_INDEXER_SORT_STRATEGY_TYPE, FlatFileNodeStoreBuilder.SortStrategyType.MULTITHREADED_TRAVERSE_WITH_SORT.toString());
+            System.setProperty(PROP_THREAD_POOL_SIZE, "1");
+            System.setProperty(OAK_INDEXER_USE_ZIP, "false");
+            List<TestMongoDoc> mongoDocs = new ArrayList<TestMongoDoc>() {{
+                add(new TestMongoDoc("/10-0", 10));
+                add(new TestMongoDoc("/10-0/:hidden1", 10));
+                add(new TestMongoDoc("/10-0/:hidden2", 10));
+                add(new TestMongoDoc("/10-0/:hidden3", 10));
+                add(new TestMongoDoc("/10-0/:hidden4", 10));
+                add(new TestMongoDoc("/10-1/end", 10));
+            }};
+            List<Long> lmValues = mongoDocs.stream().map(md -> md.lastModified).distinct().sorted().collect(Collectors.toList());
+            List<Long> lastModifiedBreakpoints = DocumentStoreSplitter.simpleSplit(lmValues.get(0), lmValues.get(lmValues.size() - 1), 1);
+            TestMemoryManager memoryManager = new TestMemoryManager(true);
+            FlatFileNodeStoreBuilder spyBuilder = Mockito.spy(new FlatFileNodeStoreBuilder(folder.getRoot(), memoryManager));
+            TestNodeStateEntryTraverserFactory nsetf = new TestNodeStateEntryTraverserFactory(mongoDocs);
+            List<String> entryPaths;
+            nsetf.setDeliveryBreakPoint(4);
+            FlatFileStore flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true, dumpThreshold);
+            assertNull(flatStore);
+            File existingFlatFileStoreDir1 = spyBuilder.getFlatFileStoreDir();
+            assertTrue("flatFileStore should dump entry even if exception caught",
+                    flatFileStoreMatchCondition(existingFlatFileStoreDir1, "flatfile", "/10-0"));
+            assertTrue("flatFileStore should save hidden node progress on exception caught",
+                    flatFileStoreMatchCondition(existingFlatFileStoreDir1, "last-saved","/10-0/:hidden3"));
+            nsetf.setDeliveryBreakPoint(Integer.MAX_VALUE);
+            spyBuilder.addExistingDataDumpDir(existingFlatFileStoreDir1);
+            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, false, dumpThreshold);
+            entryPaths = StreamSupport.stream(flatStore.spliterator(), false)
+                    .map(NodeStateEntry::getPath)
+                    .collect(Collectors.toList());
+
+            List<String> sortedPaths = TestUtils.sortPaths(mongoDocs.stream()
+                    .map(md -> md.path)
+                    .filter(path -> !NodeStateUtils.isHiddenPath(path))
+                    .collect(Collectors.toList()));
+            assertEquals(mongoDocs.size(), nsetf.getTotalProvidedDocCount());
+            assertEquals(sortedPaths, entryPaths);
+        } finally {
+            System.clearProperty(OAK_INDEXER_SORT_STRATEGY_TYPE);
+            System.clearProperty(PROP_THREAD_POOL_SIZE);
+            System.clearProperty(OAK_INDEXER_USE_ZIP);
+        }
+    }
+
+    // with larger size of dump threshold (which result in almost never dump),
+    // fail in the middle, check that there are data being dumped
+    @Test
+    public void resumePreviousUnfinishedDownloadWithGracefulDump() throws Exception {
+        Long dumpThreshold = FileUtils.ONE_MB;
+        try {
+            System.setProperty(OAK_INDEXER_SORT_STRATEGY_TYPE, FlatFileNodeStoreBuilder.SortStrategyType.MULTITHREADED_TRAVERSE_WITH_SORT.toString());
+            System.setProperty(PROP_THREAD_POOL_SIZE, "1");
+            System.setProperty(OAK_INDEXER_USE_ZIP, "false");
+            List<TestMongoDoc> mongoDocs = new ArrayList<TestMongoDoc>() {{
+                add(new TestMongoDoc("/10-0", 10));
+                add(new TestMongoDoc("/10-1", 10));
+            }};
+            List<Long> lmValues = mongoDocs.stream().map(md -> md.lastModified).distinct().sorted().collect(Collectors.toList());
+            List<Long> lastModifiedBreakpoints = DocumentStoreSplitter.simpleSplit(lmValues.get(0), lmValues.get(lmValues.size() - 1), 1);
+            TestMemoryManager memoryManager = new TestMemoryManager(true);
+            FlatFileNodeStoreBuilder spyBuilder = Mockito.spy(new FlatFileNodeStoreBuilder(folder.getRoot(), memoryManager));
+            TestNodeStateEntryTraverserFactory nsetf = new TestNodeStateEntryTraverserFactory(mongoDocs);
+            List<String> entryPaths;
+            nsetf.setDeliveryBreakPoint(1);
+            FlatFileStore flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true, dumpThreshold);
+            assertNull(flatStore);
+            File existingFlatFileStoreDir1 = spyBuilder.getFlatFileStoreDir();
+            assertTrue("flatFileStore should dump entry even if exception caught",
+                    flatFileStoreMatchCondition(existingFlatFileStoreDir1, "flatfile", "/10-0"));
+            nsetf.setDeliveryBreakPoint(Integer.MAX_VALUE);
+            spyBuilder.addExistingDataDumpDir(existingFlatFileStoreDir1);
+            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, false, dumpThreshold);
+            entryPaths = StreamSupport.stream(flatStore.spliterator(), false)
+                    .map(NodeStateEntry::getPath)
+                    .collect(Collectors.toList());
+
+            List<String> sortedPaths = TestUtils.sortPaths(mongoDocs.stream().map(md -> md.path).collect(Collectors.toList()));
+            assertEquals(mongoDocs.size(), nsetf.getTotalProvidedDocCount());
+            assertEquals(sortedPaths, entryPaths);
+        } finally {
+            System.clearProperty(OAK_INDEXER_SORT_STRATEGY_TYPE);
+            System.clearProperty(PROP_THREAD_POOL_SIZE);
+            System.clearProperty(OAK_INDEXER_USE_ZIP);
         }
     }
 
@@ -230,6 +357,7 @@ public class FlatFileStoreTest {
 
     @Test
     public void resumePreviousUnfinishedDownloadAndMerge() throws Exception {
+        Long dumpThreshold = 0L;
         try {
             System.setProperty(OAK_INDEXER_SORT_STRATEGY_TYPE, FlatFileNodeStoreBuilder.SortStrategyType.MULTITHREADED_TRAVERSE_WITH_SORT.toString());
             System.setProperty(PROP_MERGE_TASK_BATCH_SIZE, "2");
@@ -240,13 +368,13 @@ public class FlatFileStoreTest {
             FlatFileNodeStoreBuilder spyBuilder = Mockito.spy(new FlatFileNodeStoreBuilder(folder.getRoot(), memoryManager));
             TestNodeStateEntryTraverserFactory nsetf = new TestNodeStateEntryTraverserFactory(mongoDocs);
             nsetf.setDeliveryBreakPoint((int)(mongoDocs.size() * 0.50));
-            FlatFileStore flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true);
+            FlatFileStore flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true, dumpThreshold);
             assertNull(flatStore);
             File existingFlatFileStoreDir1 = spyBuilder.getFlatFileStoreDir();
             assertContainsMergeFolder(existingFlatFileStoreDir1, false);
             spyBuilder.addExistingDataDumpDir(existingFlatFileStoreDir1);
             nsetf.setDeliveryBreakPoint((int)(mongoDocs.size() * 0.75));
-            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true);
+            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, true, dumpThreshold);
             assertNull(flatStore);
             memoryManager.isMemoryLow = false;
             List<String> entryPaths;
@@ -254,7 +382,7 @@ public class FlatFileStoreTest {
             assertContainsMergeFolder(existingFlatFileStoreDir2, false);
             spyBuilder.addExistingDataDumpDir(existingFlatFileStoreDir2);
             nsetf.setDeliveryBreakPoint(Integer.MAX_VALUE);
-            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, false);
+            flatStore = buildFlatFileStore(spyBuilder, lastModifiedBreakpoints, nsetf, false, dumpThreshold);
             entryPaths = StreamSupport.stream(flatStore.spliterator(), false)
                     .map(NodeStateEntry::getPath)
                     .collect(Collectors.toList());
@@ -320,16 +448,11 @@ public class FlatFileStoreTest {
          * factory has created till now.
          */
         final AtomicInteger providedDocuments;
-        /**
-         * Keeps count of documents which have already been returned in the past
-         */
-        final AtomicInteger duplicateCount;
 
         public TestNodeStateEntryTraverserFactory(List<TestMongoDoc> mongoDocs) {
             this.mongoDocs = mongoDocs;
             this.breakAfterDelivering = new AtomicInteger(Integer.MAX_VALUE);
             this.providedDocuments = new AtomicInteger(0);
-            this.duplicateCount = new AtomicInteger(0);
         }
 
         void setDeliveryBreakPoint(int value) {
@@ -363,7 +486,6 @@ public class FlatFileStoreTest {
                         public NodeStateEntry next() {
                             if (providedDocuments.get() == breakAfterDelivering.get()) {
                                 logger.debug("{} Breaking after getting docs with id {}", traverserId, lastReturnedDoc.getId());
-                                duplicateCount.incrementAndGet();
                                 throw new IllegalStateException(EXCEPTION_MESSAGE);
                             }
                             providedDocuments.incrementAndGet();
@@ -378,9 +500,8 @@ public class FlatFileStoreTest {
         }
 
         int getTotalProvidedDocCount() {
-            return providedDocuments.get() - duplicateCount.get();
+            return providedDocuments.get();
         }
-
     }
 
     private List<String> createTestPaths() {
@@ -467,5 +588,4 @@ public class FlatFileStoreTest {
 
         }};
     }
-
 }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/MultithreadedTraverseWithSortStrategyTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/MultithreadedTraverseWithSortStrategyTest.java
@@ -44,7 +44,7 @@ public class MultithreadedTraverseWithSortStrategyTest {
         List<TraversingRange> ranges = new ArrayList<>();
         MultithreadedTraverseWithSortStrategy mtws = new MultithreadedTraverseWithSortStrategy(null,
                 lastModifiedBreakpoints, null, null, null, null, true, null,
-                FlatFileNodeStoreBuilder.DEFAULT_DUMP_THRESHOLD) {
+                FlatFileNodeStoreBuilder.DEFAULT_DUMP_THRESHOLD, path -> true) {
 
             @Override
             void addTask(TraversingRange range, NodeStateEntryTraverserFactory nodeStateEntryTraverserFactory, BlobStore blobStore, ConcurrentLinkedQueue<String> completedTasks) throws IOException {
@@ -104,7 +104,7 @@ public class MultithreadedTraverseWithSortStrategyTest {
         List<TraversingRange> ranges = new ArrayList<>();
         MultithreadedTraverseWithSortStrategy mtws = new MultithreadedTraverseWithSortStrategy(null,
                 null, null, null, null, workDirs, true, null,
-                FlatFileNodeStoreBuilder.DEFAULT_DUMP_THRESHOLD) {
+                FlatFileNodeStoreBuilder.DEFAULT_DUMP_THRESHOLD, path -> true) {
             @Override
             void addTask(TraversingRange range, NodeStateEntryTraverserFactory nodeStateEntryTraverserFactory,
                          BlobStore blobStore, ConcurrentLinkedQueue<String> completedTasks) throws IOException {

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TraverseAndSortTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TraverseAndSortTaskTest.java
@@ -70,7 +70,7 @@ public class TraverseAndSortTaskTest {
         File store = new File("target/" + this.getClass().getSimpleName() + "-" + System.currentTimeMillis());
         TraverseAndSortTask tst = new TraverseAndSortTask(traversingRange, null, null, store, true,
                 new LinkedList<>(Collections.singletonList("1")), newTaskQueue, phaser, new NodeStateEntryTraverserFactoryImpl(), mockMemManager,
-                FlatFileNodeStoreBuilder.DEFAULT_DUMP_THRESHOLD, new LinkedBlockingQueue<File>());
+                FlatFileNodeStoreBuilder.DEFAULT_DUMP_THRESHOLD, new LinkedBlockingQueue<File>(), path -> true);
 
         NodeStateEntry mockEntry = Mockito.mock(NodeStateEntry.class);
         long lastModified = (lmRange.getLastModifiedFrom() + lmRange.getLastModifiedTo())/2;


### PR DESCRIPTION
## Problem
```
V1, V2, H1, H2, H3, H4, V3, V4, V5, V6, V7
```
Suppose TraverseAndSortTask has downloaded till H3 and last dump is `V1`. As per current code, TraverseAndSortTask has last-saved reference to `V2`, and last dump is till `V1` (due to memory low). 
Now mongo connection break up. With current implementation The progress will be saved as last-saved reference to `V2`, and last dumped `V1`.
This will result in duplication of download.

## Fix
Change will make the state to be as last-saved reference to `H3`__(handle hidden node)__, and last dumped `V2`__(dump all progress on exception)__.