### PR TITLE
OAK-9746 : DefaultSyncHandler.syncProperties should sync Supplier type propertiesv

### DIFF
--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/DefaultSyncContext.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/DefaultSyncContext.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.jcr.Binary;
 import javax.jcr.RepositoryException;
@@ -624,6 +625,9 @@ public class DefaultSyncContext implements SyncContext {
             String relPath = entry.getKey();
             String name = entry.getValue();
             Object obj = properties.get(name);
+            if (obj instanceof Supplier) {
+                obj = ((Supplier) obj).get();
+            }
             if (obj == null) {
                 int nameLen = name.length();
                 if (nameLen > 1 && name.charAt(0) == '"' && name.charAt(nameLen-1) == '"') {

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/TestIdentityProvider.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/TestIdentityProvider.java
@@ -16,12 +16,14 @@
  */
 package org.apache.jackrabbit.oak.spi.security.authentication.external;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.jcr.Credentials;
 import javax.jcr.SimpleCredentials;
@@ -281,6 +283,22 @@ public class TestIdentityProvider implements ExternalIdentityProvider {
         @Override
         public Iterable<ExternalIdentityRef> getDeclaredMembers() {
             return ImmutableList.of();
+        }
+    }
+    public static class UserWithSupplierProperties extends TestUser {
+
+        public final String stringValue = "customValue";
+        public final BigDecimal bigDecimal = new BigDecimal("99.99");
+        public final Boolean boolValue = Boolean.TRUE;
+
+        public UserWithSupplierProperties(String userId, @NotNull String idpName) {
+            super(userId, idpName);
+            withProperty("profile/id", "zw2")
+                .withProperty("profile/name", "Supplied properties user")
+                .withProperty("stringSuppliedValue", (Supplier) () -> stringValue)
+                .withProperty("bigDecimalSuppliedValue", (Supplier) () -> bigDecimal)
+                .withProperty("nullSupplier", (Supplier) () -> null)
+                .withProperty("booleanSuppliedValue", (Supplier) () -> boolValue);
         }
     }
 }

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/TestIdentityProvider.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/TestIdentityProvider.java
@@ -285,7 +285,8 @@ public class TestIdentityProvider implements ExternalIdentityProvider {
             return ImmutableList.of();
         }
     }
-    public static class UserWithSupplierProperties extends TestUser {
+
+    public static final class UserWithSupplierProperties extends TestUser {
 
         public final String stringValue = "customValue";
         public final BigDecimal bigDecimal = new BigDecimal("99.99");

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/DefaultSyncContextTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/DefaultSyncContextTest.java
@@ -1202,6 +1202,36 @@ public class DefaultSyncContextTest extends AbstractExternalAuthTest {
     }
 
     @Test
+    public void testSyncPropertiesSupplier() throws Exception {
+        //given
+        TestIdentityProvider.UserWithSupplierProperties externalUser = new TestIdentityProvider.UserWithSupplierProperties("supplierPropsUser", "idp");
+        Authorizable a = syncCtx.createUser(externalUser);
+
+        // create exact mapping
+        Map<String, String> mapping = new HashMap<>();
+        Map<String, ?> extProps = externalUser.getProperties();
+        for (String propName : extProps.keySet()) {
+            mapping.put("a/"+propName, propName);
+        }
+        //when
+        syncCtx.syncProperties(externalUser, a, mapping);
+
+        //then
+        assertFalse(a.hasProperty("a/nullSupplier"));
+        assertTrue(a.hasProperty("a/profile/id"));
+        assertTrue(a.hasProperty("a/profile/name"));
+        assertTrue(a.hasProperty("a/stringSuppliedValue"));
+        assertTrue(a.hasProperty("a/bigDecimalSuppliedValue"));
+        assertTrue(a.hasProperty("a/booleanSuppliedValue"));
+
+        assertEquals(externalUser.getProperties().get("profile/id"), a.getProperty("a/profile/id")[0].getString());
+        assertEquals(externalUser.getProperties().get("profile/name"), a.getProperty("a/profile/name")[0].getString());
+        assertEquals(externalUser.stringValue,  a.getProperty("a/stringSuppliedValue")[0].getString());
+        assertEquals(externalUser.bigDecimal, a.getProperty("a/bigDecimalSuppliedValue")[0].getDecimal());
+        assertEquals(externalUser.boolValue, a.getProperty("a/booleanSuppliedValue")[0].getBoolean());
+    }
+
+    @Test
     public void testIsExpiredLocalGroup() throws Exception {
         Group gr = createTestGroup();
         assertTrue(syncCtx.isExpired(gr, syncConfig.group().getExpirationTime(), "any"));

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/DefaultSyncContextTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/DefaultSyncContextTest.java
@@ -1201,6 +1201,9 @@ public class DefaultSyncContextTest extends AbstractExternalAuthTest {
         }
     }
 
+    /**
+     * See https://issues.apache.org/jira/browse/OAK-9746
+     */
     @Test
     public void testSyncPropertiesSupplier() throws Exception {
         //given


### PR DESCRIPTION
Add support for synchronising user profile properties that implement Supplier interface. 
