### PR TITLE
Fix indeterminate map ordering that may causes Sweep2Test to fail

### DIFF
--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/ModifiedNodeState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/ModifiedNodeState.java
@@ -24,6 +24,7 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Maps.filterValues;
 import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newLinkedHashMap;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.apache.jackrabbit.oak.plugins.memory.MemoryChildNodeEntry.iterable;
@@ -276,7 +277,7 @@ public class ModifiedNodeState extends AbstractNodeState {
         if (checkNotNull(nodes).isEmpty()) {
             this.nodes = emptyMap();
         } else {
-            this.nodes = newHashMap();
+            this.nodes = newLinkedHashMap();
             for (Entry<String, MutableNodeState> entry : nodes.entrySet()) {
                 this.nodes.put(entry.getKey(), entry.getValue().snapshot());
             }

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MutableNodeState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MutableNodeState.java
@@ -21,6 +21,7 @@ package org.apache.jackrabbit.oak.plugins.memory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newLinkedHashMap;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.MISSING_NODE;
 
 import java.util.Map;
@@ -60,7 +61,7 @@ class MutableNodeState extends AbstractNodeState {
      * Set of added, modified or removed (non-existent value)
      * child nodes.
      */
-    private final Map<String, MutableNodeState> nodes = newHashMap();
+    private final Map<String, MutableNodeState> nodes = newLinkedHashMap();
 
     /**
      * Flag to indicate that this child has been replace in its parent.


### PR DESCRIPTION
The test `org.apache.jackrabbit.oak.plugins.document.Sweep2Test#testSweep2Uncommitted` can fail based on the order of iteration in `HashMap`. I found the issue using [NonDex](https://github.com/TestingResearchIllinois/NonDex):
```
mvn install -DskipTests -pl oak-store-document -am
mvn -pl oak-store-document edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.jackrabbit.oak.plugins.document.Sweep2Test#testSweep2Uncommitted
```
The proposed fix changes several `HashMap` to `LinkedHashMap`, which has determinate iteration order.