### PR TITLE
OAK-9758 error out if tika dependencies are missing and improve loggi…

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/IndexOptions.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/IndexOptions.java
@@ -19,14 +19,6 @@
 
 package org.apache.jackrabbit.oak.index;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -36,6 +28,14 @@ import joptsimple.OptionSpec;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.run.cli.OptionsBean;
 import org.apache.jackrabbit.oak.run.cli.OptionsBeanFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class IndexOptions implements OptionsBean {
 
@@ -50,6 +50,7 @@ public class IndexOptions implements OptionsBean {
     private final OptionSpec<Void> definitions;
     private final OptionSpec<Void> dumpIndex;
     private final OptionSpec<Void> reindex;
+    private final OptionSpec<Void> ignoreMissingTikaDep;
     private final OptionSpec<Void> asyncIndex;
     private final OptionSpec<Void> importIndex;
     private final OptionSpec<Void> docTraversal;
@@ -99,6 +100,7 @@ public class IndexOptions implements OptionsBean {
 
         dumpIndex = parser.accepts("index-dump", "Dumps index content");
         reindex = parser.accepts("reindex", "Reindex the indexes specified by --index-paths or --index-definitions-file");
+        ignoreMissingTikaDep = parser.accepts("ignore-missing-tika-dep", "Ignore when there are missing tika dependencies and continue to run");
         asyncIndex = parser.accepts("async-index", "Runs async index cycle");
 
         asyncIndexLanes = parser.accepts("async-index-lanes", "Comma separated list of async index lanes for which the " +
@@ -205,6 +207,10 @@ public class IndexOptions implements OptionsBean {
 
     public boolean isReindex() {
         return options.has(reindex);
+    }
+
+    public boolean isIgnoreMissingTikaDep() {
+        return options.has(ignoreMissingTikaDep);
     }
 
     public boolean isAsyncIndex() {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/CommonOptions.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/CommonOptions.java
@@ -19,13 +19,13 @@
 
 package org.apache.jackrabbit.oak.run.cli;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/Options.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/Options.java
@@ -19,10 +19,6 @@
 
 package org.apache.jackrabbit.oak.run.cli;
 
-import java.io.IOException;
-import java.util.EnumSet;
-import java.util.Set;
-
 import com.google.common.collect.ClassToInstanceMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MutableClassToInstanceMap;
@@ -31,6 +27,10 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
 import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/TextExtractor.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/TextExtractor.java
@@ -288,7 +288,7 @@ class TextExtractor implements Closeable {
                         + " This is a fairly common case, and nothing to"
                         + " worry about. The stack trace is included to"
                         + " help improve the text extraction feature.";
-                parserError.warn(format, throwableErrorFound ? path : new Object[]{path, t});
+                parserError.info(format, throwableErrorFound ? path : new Object[]{path, t});
                 throwableErrorFound = true;
                 return ERROR_TEXT;
             } else {

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/IndexOptionsTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/IndexOptionsTest.java
@@ -19,15 +19,18 @@
 
 package org.apache.jackrabbit.oak.index;
 
-import java.util.List;
-
 import joptsimple.OptionParser;
 import org.apache.jackrabbit.oak.run.cli.Options;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class IndexOptionsTest {
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/ReindexIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/ReindexIT.java
@@ -19,22 +19,10 @@
 
 package org.apache.jackrabbit.oak.index;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.query.Query;
-import javax.jcr.query.QueryManager;
-import javax.jcr.query.QueryResult;
-import javax.jcr.query.Row;
-
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
@@ -48,10 +36,27 @@ import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.security.Permission;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import static com.google.common.base.Charsets.UTF_8;
+import static java.lang.System.getSecurityManager;
+import static java.lang.System.setSecurityManager;
 import static org.apache.jackrabbit.oak.spi.state.NodeStateUtils.getNode;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -62,13 +67,23 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ReindexIT extends AbstractIndexCommandTest {
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalErr = System.err;
 
     @Before
     public void setUp() {
         IndexCommand.setDisableExitOnError(true);
+        System.setErr(new PrintStream(errContent));
     }
+
+    @After
+    public void tearDown() {
+        System.setErr(originalErr);
+    }
+
 
     @Test
     public void reindexOutOfBand() throws Exception{
@@ -108,6 +123,23 @@ public class ReindexIT extends AbstractIndexCommandTest {
         List<LocalIndexDir> idxDirs = idxRoot.getAllLocalIndexes();
 
         assertEquals(1, idxDirs.size());
+    }
+
+    @Test
+    public void reindexIgnoreMissingTikaDepThrow() throws Exception{
+        IndexCommand command = new IndexCommand() {
+            @Override
+            public void checkTikaDependency() throws ClassNotFoundException {
+                throw new ClassNotFoundException();
+            }
+        };
+        String[] args = {
+                "--reindex",
+                "--", // -- indicates that options have ended and rest needs to be treated as non option
+                "test"
+        };
+        assertExits(1, () -> command.execute(args));
+        assertEquals("Missing tika parser dependencies, use --ignore-missing-tika-dep to force continue\n", errContent.toString());
     }
 
     @Test
@@ -342,6 +374,49 @@ public class ReindexIT extends AbstractIndexCommandTest {
         String explanation = explainRow.getValue("plan").getString();
         session.logout();
         return explanation;
+    }
+
+    public static <E extends Throwable> void assertExits(final int expectedStatus, final ThrowingExecutable<E> executable) throws E {
+        final SecurityManager originalSecurityManager = getSecurityManager();
+        setSecurityManager(new SecurityManager() {
+            @Override
+            public void checkPermission(final Permission perm) {
+                if (originalSecurityManager != null)
+                    originalSecurityManager.checkPermission(perm);
+            }
+
+            @Override
+            public void checkPermission(final Permission perm, final Object context) {
+                if (originalSecurityManager != null)
+                    originalSecurityManager.checkPermission(perm, context);
+            }
+
+            @Override
+            public void checkExit(final int status) {
+                super.checkExit(status);
+                throw new ExitException(status);
+            }
+        });
+        try {
+            executable.run();
+            fail("Expected System.exit(" + expectedStatus + ") to be called, but it wasn't called.");
+        } catch (final ExitException e) {
+            assertEquals(expectedStatus, e.status);
+        } finally {
+            setSecurityManager(originalSecurityManager);
+        }
+    }
+
+    public interface ThrowingExecutable<E extends Throwable> {
+        void run() throws E;
+    }
+
+    private static class ExitException extends SecurityException {
+        final int status;
+
+        private ExitException(final int status) {
+            this.status = status;
+        }
     }
 
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
@@ -201,7 +201,7 @@ public class FulltextBinaryTextExtractor {
                 + " worry about. The stack trace is included to"
                 + " help improve the text extraction feature.";
         String indexName = getIndexName();
-        log.warn(format, throwableErrorFound ? new Object[]{indexName, path} : new Object[]{indexName, path, t});
+        log.info(format, throwableErrorFound ? new Object[]{indexName, path} : new Object[]{indexName, path, t});
         extractedTextCache.put(v, ExtractedText.ERROR);
         throwableErrorFound = true;
         return TEXT_EXTRACTION_ERROR;


### PR DESCRIPTION
error out if `tika` dependencies are missing and improve logging to log warning instead of debug silently.

> !! Feel free to come up with a better flag name and log message if you think the current one does not explain the problem well


For manually testing it,
Build the `oak-run.jar` then run, 
```bash
$ JAR=<path to oak-run.jar>
$ STORE=<path to actual store>

# Test missing tika dependencies
$ java -jar $JAR index --reindex $STORE
Apache Jackrabbit Oak 1.xx-SNAPSHOT
Missing tika parser dependencies, use --ignore-missing-tika-dep to force continue

# Test missing tika dependencies with flag to force continue
# (For this command to properly finish, one will need to other configuration, here is just to show that it bypass the dependency check)
$ java -jar $JAR index --reindex $STORE
Apache Jackrabbit Oak 1.xx-SNAPSHOT
16:33:19 - Command line arguments used for indexing [--reindex .../assets-skyline-cli/instances/assets-skyline/crx-quickstart/repository/segmentstore --ignore-missing-tika-dep]
...
```