### PR TITLE
OAK-9756 statistics for the IndexSanityChecker

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopier.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopier.java
@@ -109,6 +109,7 @@ public class IndexCopier implements CopyOnReadStatsMBean, Closeable {
     private volatile boolean closed;
     private final IndexRootDirectory indexRootDirectory;
     private final Set<String> validatedIndexPaths = Sets.newConcurrentHashSet();
+    private final IndexSanityChecker.IndexSanityStatistics indexSanityStatistics = new IndexSanityChecker.IndexSanityStatistics();
 
     public IndexCopier(Executor executor, File indexRootDir) throws IOException {
         this(executor, indexRootDir, false);
@@ -233,7 +234,7 @@ public class IndexCopier implements CopyOnReadStatsMBean, Closeable {
         //Also at this time its required that state in local dir should exactly same as
         //one in remote dir
         synchronized (validatedIndexPaths){
-            new IndexSanityChecker(indexPath, local, remote).check();
+            new IndexSanityChecker(indexPath, local, remote).check(indexSanityStatistics);
             validatedIndexPaths.add(indexPath);
         }
     }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexSanityChecker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexSanityChecker.java
@@ -169,7 +169,7 @@ public class IndexSanityChecker {
         public String toString() {
             return String.format("[duration: %d ms, "
                     + "checked index size: %d bytes (%s)]", totalDurationInMs,
-                    totalIndexSize,IOUtils.humanReadableByteCount(totalIndexSize));
+                    totalIndexSize, IOUtils.humanReadableByteCount(totalIndexSize));
         }
     }
 }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexSanityChecker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexSanityChecker.java
@@ -130,14 +130,14 @@ public class IndexSanityChecker {
      */
     public static class IndexSanityStatistics {
         
-        long totalDurationInMs = 0;
-        long totalIndexSize = 0;
+        long totalDurationInMs;
+        long totalIndexSize;
         
         /**
          * Record the time spend to check the sanity of indexes
          * @param milis the time in miliseconds
          */
-        public void addDuration (long milis) {
+        public void addDuration(long milis) {
             totalDurationInMs += milis;
         }
         

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexSanityCheckerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexSanityCheckerTest.java
@@ -36,13 +36,15 @@ public class IndexSanityCheckerTest {
 
     private Directory local = new RAMDirectory();
     private Directory remote = new RAMDirectory();
+    
+    private IndexSanityChecker.IndexSanityStatistics stats = new IndexSanityChecker.IndexSanityStatistics();
 
     @Test
     public void validDirs() throws Exception{
         byte[] t1 = writeFile(local, "t1", 100);
         writeFile(remote, "t1", t1);
 
-        assertTrue(new IndexSanityChecker("/foo", local, remote).check());
+        assertTrue(new IndexSanityChecker("/foo", local, remote).check(stats));
 
         assertTrue(local.fileExists("t1"));
         assertTrue(remote.fileExists("t1"));
@@ -59,7 +61,7 @@ public class IndexSanityCheckerTest {
         byte[] t3R = writeFile(remote, "t3", 140);
         writeFile(local, "t3", t3R);
 
-        assertFalse(new IndexSanityChecker("/foo", local, remote).check());
+        assertFalse(new IndexSanityChecker("/foo", local, remote).check(stats));
 
         assertTrue(remote.fileExists("t3"));
 
@@ -74,7 +76,7 @@ public class IndexSanityCheckerTest {
         byte[] t3R = writeFile(remote, "t3", 140);
         writeFile(local, "t3", t3R);
 
-        new IndexSanityChecker("/foo", local, remote).check();
+        new IndexSanityChecker("/foo", local, remote).check(stats);
 
         //t1 exist in local but not in remote
         //it must be removed


### PR DESCRIPTION
I made the experience that the IndexSanityChecker can take quite a bit of time, especially if the index binaries need to be downloaded first, and that these downloads can cause massive delays in the startup of the application. Right now it's not possible to determine exactly how much time is actually spent on these activities.

The IndexSanityChecker is invoked for each index indepedently, so there is no way to tell "this was the last index, now dump the timing information". So on every successful check the accumulated statistics are added to the already existing log message including timing information and the size of the indexes already checked.

With this additional logging in place it's now possible to determine if this index download is a bottleneck in terms of startup time.

