### PR TITLE
OAK-9769: PathPredicate not being used properly when building FlatFileStore

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -158,7 +158,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
                         .withBlobStore(indexHelper.getGCBlobStore())
                         .withPreferredPathElements((preferredPathElements != null) ? preferredPathElements : indexer.getRelativeIndexedNodeNames())
                         .addExistingDataDumpDir(indexerSupport.getExistingDataDumpDir())
-                        .withPathPredicate((pathPredicate != null) ? pathPredicate : indexer::shouldInclude)
+                        .withPathPredicate(pathPredicate)
                         .withNodeStateEntryTraverserFactory(new MongoNodeStateEntryTraverserFactory(rootDocumentState.getRootRevision(),
                                 nodeStore, getMongoDocumentStore(), traversalLog, indexer));
                 for (File dir : previousDownloadDirs) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -105,24 +105,14 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
         private final MongoDocumentStore documentStore;
         private final Logger traversalLogger;
         private final CompositeIndexer indexer;
-        private final Predicate<String> pathPredicate;
-
 
         private MongoNodeStateEntryTraverserFactory(RevisionVector rootRevision, DocumentNodeStore documentNodeStore,
-                                                   MongoDocumentStore documentStore, Logger traversalLogger,
-                                                   CompositeIndexer indexer) {
-            this(rootRevision, documentNodeStore, documentStore, traversalLogger, indexer, null);
-        }
-
-        private MongoNodeStateEntryTraverserFactory(RevisionVector rootRevision, DocumentNodeStore documentNodeStore,
-                                                    MongoDocumentStore documentStore, Logger traversalLogger, CompositeIndexer indexer,
-                                                    Predicate<String> pathPredicate) {
+                                                    MongoDocumentStore documentStore, Logger traversalLogger, CompositeIndexer indexer) {
             this.rootRevision = rootRevision;
             this.documentNodeStore = documentNodeStore;
             this.documentStore = documentStore;
             this.traversalLogger = traversalLogger;
             this.indexer = indexer;
-            this.pathPredicate = pathPredicate;
         }
 
         @Override
@@ -143,10 +133,6 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
                                 traversalLogger.trace(id);
                             });
         }
-    }
-
-    private FlatFileStore buildFlatFileStore(NodeState checkpointedState, CompositeIndexer indexer) throws IOException {
-        return buildFlatFileStore(checkpointedState, indexer, null, null);
     }
 
     private FlatFileStore buildFlatFileStore(NodeState checkpointedState, CompositeIndexer indexer, Predicate<String> pathPredicate, Set<String> preferredPathElements) throws IOException {
@@ -172,8 +158,9 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
                         .withBlobStore(indexHelper.getGCBlobStore())
                         .withPreferredPathElements((preferredPathElements != null) ? preferredPathElements : indexer.getRelativeIndexedNodeNames())
                         .addExistingDataDumpDir(indexerSupport.getExistingDataDumpDir())
+                        .withPathPredicate((pathPredicate != null) ? pathPredicate : indexer::shouldInclude)
                         .withNodeStateEntryTraverserFactory(new MongoNodeStateEntryTraverserFactory(rootDocumentState.getRootRevision(),
-                                nodeStore, getMongoDocumentStore(), traversalLog, indexer, pathPredicate));
+                                nodeStore, getMongoDocumentStore(), traversalLog, indexer));
                 for (File dir : previousDownloadDirs) {
                     builder.addExistingDataDumpDir(dir);
                 }
@@ -251,7 +238,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable{
 
         closer.register(indexer);
 
-        FlatFileStore flatFileStore = buildFlatFileStore(checkpointedState, indexer);
+        FlatFileStore flatFileStore = buildFlatFileStore(checkpointedState, indexer, indexer::shouldInclude, null);
 
         progressReporter.reset();
         if (flatFileStore.getEntryCount() > 0){

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -210,10 +210,10 @@ public class FlatFileNodeStoreBuilder {
         switch (sortStrategyType) {
             case STORE_AND_SORT:
                 log.info("Using StoreAndSortStrategy");
-                return new StoreAndSortStrategy(nodeStateEntryTraverserFactory, comparator, entryWriter, dir, useZip);
+                return new StoreAndSortStrategy(nodeStateEntryTraverserFactory, comparator, entryWriter, dir, useZip, pathPredicate);
             case TRAVERSE_WITH_SORT:
                 log.info("Using TraverseWithSortStrategy");
-                return new TraverseWithSortStrategy(nodeStateEntryTraverserFactory, comparator, entryWriter, dir, useZip);
+                return new TraverseWithSortStrategy(nodeStateEntryTraverserFactory, comparator, entryWriter, dir, useZip, pathPredicate);
             case MULTITHREADED_TRAVERSE_WITH_SORT:
                 log.info("Using MultithreadedTraverseWithSortStrategy");
                 return new MultithreadedTraverseWithSortStrategy(nodeStateEntryTraverserFactory, lastModifiedBreakPoints, comparator,

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestUtils.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestUtils.java
@@ -19,21 +19,17 @@
 
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry.NodeStateEntryBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.copyOf;
 import static java.util.Collections.emptySet;
@@ -49,6 +45,10 @@ public class TestUtils {
 
     static List<String> sortPaths(List<String> paths, Set<String> preferredElements) {
         return sortPaths(paths, new PathElementComparator(preferredElements));
+    }
+
+    static List<String> extractPredicatePaths(List<String> paths, Predicate<String> pathPredicate) {
+        return paths.stream().filter(pathPredicate).collect(toList());
     }
 
     static List<String> sortPaths(List<String> paths, Comparator<Iterable<String>> comparator) {


### PR DESCRIPTION
PathPredicate not being used properly when building FlatFileStore

This is a bug introduced in [OAK-9747](https://issues.apache.org/jira/browse/OAK-9747) where PathPredicate and hidden node check are separated out from NodeTraverser.

The bug will affect the previous mode performance such as StoreAndSortStrategy and TraverseWithSortStrategy, where we might be indexing more than what we want.

The intention in [OAK-9747](https://issues.apache.org/jira/browse/OAK-9747) was to move the pathPredicate and hidden node check out from the Traverser so that we can save the progress more often for download retry, but this bug with missing configuration and old mode does not honor new way of pathPredicate was created as a side affect.