### PR TITLE
Deeper representation of the trees with properties and in json format.

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -41,6 +41,7 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.json.JsopBuilder;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.reference.NodeReferenceConstants;
 import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
@@ -175,18 +176,18 @@ public abstract class AbstractTree implements Tree {
                 str.append("[ ");
                 for (int i = 0; i < ps.count(); i++) {
                     try {
-                        str.append(quote(escapeJsonString(ps.getValue(Type.STRING, i))) + ",");
+                        str.append(JsopBuilder.encode(ps.getValue(Type.STRING, i)) + ",");
                     } catch (Exception e) {
-                        str.append(quote("ERROR:" + escapeJsonString(e.getMessage())) + ",");
+                        str.append(quote("ERROR:" + JsopBuilder.encode(e.getMessage())) + ",");
                     }
                 }
                 str.deleteCharAt(str.length() - 1); //removing the space or the ,
                 str.append("],");
             } else {
                 try {
-                    str.append(quote(escapeJsonString(ps.getValue(Type.STRING))) + ",");
+                    str.append(JsopBuilder.encode(ps.getValue(Type.STRING)) + ",");
                 } catch (Exception e) {
-                    str.append(quote("ERROR:" + escapeJsonString(e.getMessage())) + ",");
+                    str.append(quote("ERROR:" + JsopBuilder.encode(e.getMessage())) + ",");
                 }
             }
         }
@@ -199,10 +200,6 @@ public abstract class AbstractTree implements Tree {
         str.deleteCharAt(str.length() - 1); //removing the ,
         str.append("}");
         return str.toString();
-    }
-
-    private String escapeJsonString(String value) {
-        return value.replaceAll("\"", "\\/");
     }
 
     private String quote(String toQuote) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -31,7 +31,6 @@ import static org.apache.jackrabbit.oak.api.Tree.Status.UNCHANGED;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
 import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -166,39 +165,40 @@ public abstract class AbstractTree implements Tree {
         if(depth == 0){
             return quote("...");
         }
-        String str = "{";
-        str += quote("_properties_")+":{ ";
+        StringBuilder str = new StringBuilder();
+        str.append("{");
+        str.append(quote("_properties_")+":{ ");
         for (PropertyState ps : this.getProperties()){
-            str+=quote(ps.getName())+":";
+            str.append(quote(ps.getName())+":");
 
             if(ps.getType().isArray()){
-                str += "[ ";
+                str.append("[ ");
                 for(int i=0; i<ps.count(); i++){
                     try {
-                        str += quote(jsonStringEscaper(ps.getValue(Type.STRING, i)))+",";
+                        str.append(quote(jsonStringEscaper(ps.getValue(Type.STRING, i)))+",");
                     }catch (Exception e){
-                        str += quote("ERROR:" + jsonStringEscaper(e.getMessage()))+",";
+                        str.append(quote("ERROR:" + jsonStringEscaper(e.getMessage()))+",");
                     }
                 }
-                str = str.substring(0,str.length()-1); //removing the space or the ,
-                str += "],";
+                str.deleteCharAt(str.length()-1); //removing the space or the ,
+                str.append("],");
             }else {
                 try{
-                    str += quote(jsonStringEscaper(ps.getValue(Type.STRING))) + ",";
+                    str.append(quote(jsonStringEscaper(ps.getValue(Type.STRING))) + ",");
                 }catch (Exception e){
-                    str += quote("ERROR:" + jsonStringEscaper(e.getMessage())) + ",";
+                    str.append(quote("ERROR:" + jsonStringEscaper(e.getMessage())) + ",");
                 }
             }
         }
-        str = str.substring(0,str.length()-1); //removing the space or the ,
-        str+="},";
+        str.deleteCharAt(str.length()-1);  //removing the space or the ,
+        str.append("},");
         for (Tree child : this.getChildren()){
-            str+=quote(child.getName())+":";
-            str+=((AbstractTree)child).toJsonString(depth-1)+",";
+            str.append(quote(child.getName())+":");
+            str.append(((AbstractTree)child).toJsonString(depth-1)+",");
         }
-        str = str.substring(0,str.length()-1); //removing the ,
-        str+="}";
-        return str;
+        str.deleteCharAt(str.length()-1); //removing the ,
+        str.append("}");
+        return str.toString();
     }
 
     private String jsonStringEscaper(String value){

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -177,7 +177,6 @@ public abstract class AbstractTree implements Tree {
                     try {
                         str += "\"" + jsonStringEscaper(ps.getValue(Type.STRING, i)) + "\",";
                     }catch (Exception e){
-                        e.printStackTrace();
                         str += "\"ERROR:" + jsonStringEscaper(e.getMessage()) + "\",";
                     }
                 }
@@ -187,7 +186,6 @@ public abstract class AbstractTree implements Tree {
                 try{
                     str += "\"" + jsonStringEscaper(ps.getValue(Type.STRING)) + "\",";
                 }catch (Exception e){
-                    e.printStackTrace();
                     str += "\"ERROR:" + jsonStringEscaper(e.getMessage()) + "\",";
                 }
             }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -161,51 +161,51 @@ public abstract class AbstractTree implements Tree {
      * @param depth tree depth to represent. Use -1 for an unlimited depth.
      * @return json object representation of the tree as a string
      */
-    public String toJsonString(int depth){
-        if(depth == 0){
+    public String toJsonString(int depth) {
+        if (depth == 0) {
             return quote("...");
         }
         StringBuilder str = new StringBuilder();
         str.append("{");
-        str.append(quote("_properties_")+":{ ");
-        for (PropertyState ps : this.getProperties()){
-            str.append(quote(ps.getName())+":");
+        str.append(quote("_properties_") + ":{ ");
+        for (PropertyState ps : this.getProperties()) {
+            str.append(quote(ps.getName()) + ":");
 
-            if(ps.getType().isArray()){
+            if (ps.getType().isArray()) {
                 str.append("[ ");
-                for(int i=0; i<ps.count(); i++){
+                for (int i = 0; i < ps.count(); i++) {
                     try {
-                        str.append(quote(jsonStringEscaper(ps.getValue(Type.STRING, i)))+",");
-                    }catch (Exception e){
-                        str.append(quote("ERROR:" + jsonStringEscaper(e.getMessage()))+",");
+                        str.append(quote(escapeJsonString(ps.getValue(Type.STRING, i))) + ",");
+                    } catch (Exception e) {
+                        str.append(quote("ERROR:" + escapeJsonString(e.getMessage())) + ",");
                     }
                 }
-                str.deleteCharAt(str.length()-1); //removing the space or the ,
+                str.deleteCharAt(str.length() - 1); //removing the space or the ,
                 str.append("],");
-            }else {
-                try{
-                    str.append(quote(jsonStringEscaper(ps.getValue(Type.STRING))) + ",");
-                }catch (Exception e){
-                    str.append(quote("ERROR:" + jsonStringEscaper(e.getMessage())) + ",");
+            } else {
+                try {
+                    str.append(quote(escapeJsonString(ps.getValue(Type.STRING))) + ",");
+                } catch (Exception e) {
+                    str.append(quote("ERROR:" + escapeJsonString(e.getMessage())) + ",");
                 }
             }
         }
-        str.deleteCharAt(str.length()-1);  //removing the space or the ,
+        str.deleteCharAt(str.length() - 1);  //removing the space or the ,
         str.append("},");
-        for (Tree child : this.getChildren()){
-            str.append(quote(child.getName())+":");
-            str.append(((AbstractTree)child).toJsonString(depth-1)+",");
+        for (Tree child : this.getChildren()) {
+            str.append(quote(child.getName()) + ":");
+            str.append(((AbstractTree) child).toJsonString(depth - 1) + ",");
         }
-        str.deleteCharAt(str.length()-1); //removing the ,
+        str.deleteCharAt(str.length() - 1); //removing the ,
         str.append("}");
         return str.toString();
     }
 
-    private String jsonStringEscaper(String value){
+    private String escapeJsonString(String value) {
         return value.replaceAll("\"","\\/");
     }
 
-    private String quote (String toQuote) {
+    private String quote(String toQuote) {
         return "\"" + toQuote + "\"";
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -202,7 +202,7 @@ public abstract class AbstractTree implements Tree {
     }
 
     private String escapeJsonString(String value) {
-        return value.replaceAll("\"","\\/");
+        return value.replaceAll("\"", "\\/");
     }
 
     private String quote(String toQuote) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -164,36 +164,36 @@ public abstract class AbstractTree implements Tree {
      */
     public String toJsonString(int depth){
         if(depth == 0){
-            return "\"...\"";
+            return quote("...");
         }
         String str = "{";
-        str += "\"_properties_\":{ ";
+        str += quote("_properties_")+":{ ";
         for (PropertyState ps : this.getProperties()){
-            str+="\""+ps.getName()+"\":";
+            str+=quote(ps.getName())+":";
 
             if(ps.getType().isArray()){
                 str += "[ ";
                 for(int i=0; i<ps.count(); i++){
                     try {
-                        str += "\"" + jsonStringEscaper(ps.getValue(Type.STRING, i)) + "\",";
+                        str += quote(jsonStringEscaper(ps.getValue(Type.STRING, i)))+",";
                     }catch (Exception e){
-                        str += "\"ERROR:" + jsonStringEscaper(e.getMessage()) + "\",";
+                        str += quote("ERROR:" + jsonStringEscaper(e.getMessage()))+",";
                     }
                 }
                 str = str.substring(0,str.length()-1); //removing the space or the ,
                 str += "],";
             }else {
                 try{
-                    str += "\"" + jsonStringEscaper(ps.getValue(Type.STRING)) + "\",";
+                    str += quote(jsonStringEscaper(ps.getValue(Type.STRING))) + ",";
                 }catch (Exception e){
-                    str += "\"ERROR:" + jsonStringEscaper(e.getMessage()) + "\",";
+                    str += quote("ERROR:" + jsonStringEscaper(e.getMessage())) + ",";
                 }
             }
         }
         str = str.substring(0,str.length()-1); //removing the space or the ,
         str+="},";
         for (Tree child : this.getChildren()){
-            str+="\""+child.getName()+"\":";
+            str+=quote(child.getName())+":";
             str+=((AbstractTree)child).toJsonString(depth-1)+",";
         }
         str = str.substring(0,str.length()-1); //removing the ,
@@ -203,6 +203,10 @@ public abstract class AbstractTree implements Tree {
 
     private String jsonStringEscaper(String value){
         return value.replaceAll("\"","\\/");
+    }
+
+    private String quote (String toQuote) {
+        return "\"" + toQuote + "\"";
     }
 
     //---------------------------------------------------------------< Tree >---

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -202,7 +202,7 @@ public abstract class AbstractTree implements Tree {
         return str.toString();
     }
 
-    private String quote(String toQuote) {
+    private static String quote(String toQuote) {
         return "\"" + toQuote + "\"";
     }
 


### PR DESCRIPTION
AbstractTree's previous toString() method was calling a toString(int depth) method that wasn't working really. It did only represent the first level of the tree. Also the properties were represented together with the child nodes.
This implementation goes as deep as necessary and represents the node in JSON format. Therefore, making it queryable with JSON tools like jq. 