### PR TITLE
OAK-9797: Direct access blob cache override breaks metrics and monito…

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -176,6 +176,9 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
             return new FileCache(maxSize, root, loader, executor);
         }
         return new FileCache() {
+
+            private final Cache<?,?> cache = new CacheLIRS<>(0);
+
             @Override public void put(String key, File file) {
             }
 
@@ -195,7 +198,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
             }
 
             @Override public DataStoreCacheStatsMBean getStats() {
-                return new FileCacheStats(this, weigher, memWeigher, 0);
+                return new FileCacheStats(cache, weigher, memWeigher, 0);
             }
 
             @Override public void close() {

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
@@ -108,6 +108,7 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
         assertNull(cache.getIfPresent(ID_PREFIX + 0));
         assertNull(cache.get(ID_PREFIX + 0));
         assertEquals(0, cache.getStats().getMaxTotalWeight());
+        assertEquals(0, cache.getStats().getElementCount());
         cache.invalidate(ID_PREFIX + 0);
         assertFalse(cache.containsKey(ID_PREFIX + 0));
         cache.close();

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
@@ -115,7 +115,7 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
         assertEquals(0.0, cache.getStats().getMissRate(), 0.0);
         assertEquals(0, cache.getStats().getMissCount());
         assertEquals(0, cache.getStats().getHitCount());
-        assertEquals(0.0, cache.getStats().getHitRate(), 0.0);
+        assertEquals(1.0, cache.getStats().getHitRate(), 0.0);
         assertEquals(0.0, cache.getStats().getAverageLoadPenalty(), 0.0);
         assertEquals(0, cache.getStats().getLoadCount());
         assertEquals(0, cache.getStats().getLoadExceptionCount());

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
@@ -109,6 +109,18 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
         assertNull(cache.get(ID_PREFIX + 0));
         assertEquals(0, cache.getStats().getMaxTotalWeight());
         assertEquals(0, cache.getStats().getElementCount());
+        assertEquals(0, cache.getStats().getEvictionCount());
+        assertEquals(0, cache.getStats().getTotalLoadTime());
+        assertEquals(0, cache.getStats().getLoadSuccessCount());
+        assertEquals(0.0, cache.getStats().getMissRate(), 0.0);
+        assertEquals(0, cache.getStats().getMissCount());
+        assertEquals(0, cache.getStats().getHitCount());
+        assertEquals(0.0, cache.getStats().getHitRate(), 0.0);
+        assertEquals(0.0, cache.getStats().getAverageLoadPenalty(), 0.0);
+        assertEquals(0, cache.getStats().getLoadCount());
+        assertEquals(0, cache.getStats().getLoadExceptionCount());
+        assertEquals(0.0, cache.getStats().getLoadExceptionRate(), 0.0);
+        assertEquals(0, cache.getStats().getRequestCount());
         cache.invalidate(ID_PREFIX + 0);
         assertFalse(cache.containsKey(ID_PREFIX + 0));
         cache.close();


### PR DESCRIPTION
…ring