### PR TITLE
OAK-9813: [oak-run-commons] LoggingInitializer shutdownLogging should…

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/commons/LoggingInitializer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/commons/LoggingInitializer.java
@@ -77,7 +77,12 @@ public class LoggingInitializer {
         log.info("Logs would be written to {}", new File(workDir, logIdentifier + ".log"));
     }
 
-    public static void shutdownLogging(){
+    public static void shutdownLogging() {
+        //Only shutdown if init
+        if (System.getProperty(ContextInitializer.CONFIG_FILE_PROPERTY) != null) {
+            return;
+        }
+        
         LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
         context.stop();
     }


### PR DESCRIPTION
… not shut down if not initialized

Ignore if system prop logback.configurationFile set