### PR TITLE
OAK-9830 Fix typos in documentation

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -107,7 +107,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
      * Name of service property which determines the name of Async task
      */
     public static final String PROP_ASYNC_NAME = "oak.async";
-    private static final String CONCURRENT_EXCEPTIPN_MSG ="Another copy of the index update is already running; skipping this update. ";
+    private static final String CONCURRENT_EXCEPTION_MSG ="Another copy of the index update is already running; skipping this update. ";
     private static final Logger log = LoggerFactory
             .getLogger(AsyncIndexUpdate.class);
 
@@ -151,7 +151,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
 
     /**
      * Set of reindexed definitions updated between runs because a single diff
-     * can report less definitions than there really are. Used in coordination
+     * can report fewer definitions than there really are. Used in coordination
      * with the switchOnSync flag, so we know which def need to be updated after
      * a run with no changes.
      */
@@ -510,7 +510,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
             long currentTime = System.currentTimeMillis();
             if (leaseEndTime > currentTime) {
                 long leaseExpMsg = (leaseEndTime - currentTime) / 1000;
-                String err = String.format(CONCURRENT_EXCEPTIPN_MSG +
+                String err = String.format(CONCURRENT_EXCEPTION_MSG +
                         "Time left for lease to expire %d s. Indexing can resume by %tT", leaseExpMsg, leaseEndTime);
                 indexStats.failed(new Exception(err, newConcurrentUpdateException()));
                 return;
@@ -1078,7 +1078,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
 
         public void failed(Exception e) {
             boolean isConcurrentUpdateException = (e.getMessage() != null)
-                    && (e.getMessage().startsWith(CONCURRENT_EXCEPTIPN_MSG));
+                    && (e.getMessage().startsWith(CONCURRENT_EXCEPTION_MSG));
             if (e == INTERRUPTED){
                 status = STATUS_INTERRUPTED;
                 log.info("[{}] The index update interrupted", name);

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/explain_result.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/explain_result.txt
@@ -15,14 +15,13 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
-# * lines starting with "xpath2sql" are just converted
-  from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * lines starting with "xpath2sql" are just converted from xpath to sql2
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 commit / + "test": { "a": { "name": "Hello" }, "b": { "name" : "World" }}

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql1.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql1.txt
@@ -15,14 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
 # * lines starting with "xpath2sql" are just converted from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 # sql-1 query (nt:unstructured needs to be escaped in sql-2)
 

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2-fulltext.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2-fulltext.txt
@@ -15,15 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
-# * lines starting with "xpath2sql" are just converted
-  from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * lines starting with "xpath2sql" are just converted from xpath to sql2
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 # fulltext search
 

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2.txt
@@ -15,15 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
-# * lines starting with "xpath2sql" are just converted
-  from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * lines starting with "xpath2sql" are just converted from xpath to sql2
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 # union, distinct
 

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_explain.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_explain.txt
@@ -15,14 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
 # * lines starting with "xpath2sql" are just converted from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 # TODO current not used, as property and prefix indexes are no longer supported
 

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_index.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_index.txt
@@ -15,14 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
 # * lines starting with "xpath2sql" are just converted from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 explain select [jcr:path], [jcr:score], * from [nt:base] as a where lower([test]) <> 'lower'
 [nt:base] as [a] /* traverse "*"

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_measure.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_measure.txt
@@ -15,14 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
 # * lines starting with "xpath2sql" are just converted from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 # OAK-5949
 explain [SELECT] * from [nt:base]

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_native.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2_native.txt
@@ -15,14 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
 # * lines starting with "xpath2sql" are just converted from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 commit / + "test": { "a": { "name": "Hello" }, "b": { "name" : "World" }}
 

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/xpath.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/xpath.txt
@@ -15,14 +15,14 @@
 #
 # Syntax:
 # * lines that start with spaces belong to the previous line
-# * lines starting with "#" are remarks.
+# * lines starting with "#" are remarks
 # * lines starting with "select" are queries, followed by expected results and an empty line
 # * lines starting with "explain" are followed by expected query plan and an empty line
 # * lines starting with "sql1" are run using the sql1 language
 # * lines starting with "xpath2sql" are just converted from xpath to sql2
-# * all other lines are are committed into the microkernel (line by line)
-# * new tests are typically be added on top, after the syntax docs
-# * use ascii character only
+# * all other lines are committed into the microkernel (line by line)
+# * new tests are typically added on top, after the syntax docs
+# * use ascii characters only
 
 #
 

--- a/oak-doc/README.md
+++ b/oak-doc/README.md
@@ -19,7 +19,7 @@ Oak Documentation
 =================
 
 The Oak documentation lives as Markdown files in `src/site/markdown` such
-that it easy to view e.g. from GitHub. Alternatively the Maven site plugin
+that it's easy to view e.g. from GitHub. Alternatively the Maven site plugin
 can be used to build and deploy a web site as follows:
 
 From the reactor do

--- a/oak-doc/src/site/markdown/query/indexing.md
+++ b/oak-doc/src/site/markdown/query/indexing.md
@@ -56,7 +56,7 @@ The indexing mode defines how comparing is performed, and when the index content
 Indexing uses [Commit Editors](../architecture/nodestate.html#commit-editors). 
 Some of the editors are of type `IndexEditor`, which are responsible for updating index content 
 based on changes in main content. 
-Currently, Oak has following in built editors:
+Currently, Oak has the following built-in editors:
 
 1. PropertyIndexEditor
 2. ReferenceEditor
@@ -102,7 +102,7 @@ The index definitions nodes have the following properties:
     * `lucene`
     * `solr`
 2. `async` - This determines if the index is to be updated synchronously or asynchronously. 
-    It can have following values:
+    It can have the following values:
     * `sync` - The default value. It indicates that index is meant to be updated as part of each commit.
     * `nrt`  - Indicates that index is a [near real time](#nrt-indexing) index. 
     * `async` - Indicates that index is to be updated asynchronously. 
@@ -130,7 +130,7 @@ Currently only `lucene` indexes support creating index definitions at non-root p
 
 ### <a name="sync-indexing"></a> Synchronous Indexing
 
-Under synchronous indexing, the index content gets updates as part of the commit itself. 
+Under synchronous indexing, the index content gets updated as part of the commit itself. 
 Changes to both the main content, as well as the index content, are done atomically in a single commit. 
 
 This mode is currently supported by `property` and `reference` indexes.
@@ -201,9 +201,9 @@ while _assetIndex_ is bound to  the "fulltext-async" lane.
 Oak [setup](#async-index-setup) configures two `AsyncIndexUpdate` jobs: 
 one for "async", and one for "fulltext-async".
 When the job for "async" is run, 
-it only processes index definition where the `async` value is `async`, 
+it only processes index definitions where the `async` value is `async`, 
 while when the job for "fulltext-async" is run,
-it only pick up index definitions where the `async` value is `fulltext-async`.
+it only picks up index definitions where the `async` value is `fulltext-async`.
 
 These jobs can be scheduled to run at different intervals, and also on different cluster nodes. 
 Each job keeps its own bookkeeping of checkpoint state, 
@@ -258,12 +258,12 @@ and can keep the results more up to date.
 
 `@since Oak 1.6`
 
-Async indexers can be configure via the OSGi config for `org.apache.jackrabbit.oak.plugins.index.AsyncIndexerService`.
+Async indexers can be configured via the OSGi config for `org.apache.jackrabbit.oak.plugins.index.AsyncIndexerService`.
 
 ![Async Indexing Config](async-index-config.png)
 
 Different lanes can be configured by adding more rows of _Async Indexer Configs_. 
-Prior to 1.6, the indexers were created programatically while constructing Oak.
+Prior to 1.6, the indexers were created programmatically while constructing Oak.
 
 #### <a name="async-index-mbean"></a> Async Indexing MBean
 
@@ -273,7 +273,7 @@ which provides various stats around the current indexing state:
     org.apache.jackrabbit.oak: async (IndexStats)
     org.apache.jackrabbit.oak: fulltext-async (IndexStats)
 
-It provide the following details:
+It provides the following details:
 
 * FailingIndexStats - Stats around indexes which are [failing and marked as corrupt](#corrupt-index-handling).
 * LastIndexedTime - Time up to which the repository state has been indexed.
@@ -537,7 +537,7 @@ Once reindexing is complete, the `reindex` flag is set to `false` automatically.
 
 If the index being reindexed has full text extraction configured then reindexing can take long time as most of the 
 time is spent in text extraction. 
-For such cases its recommended to use text [pre-extraction support](pre-extract-text.html).
+For such cases it's recommended to use text [pre-extraction support](pre-extract-text.html).
 The text pre-extraction can be done before starting the actual reindexing. This would then ensure that during reindexing
 time is not spent in performing text extraction and hence the actual time taken for reindexing such an index gets reduced
 considerably.

--- a/oak-doc/src/site/markdown/query/lucene.md
+++ b/oak-doc/src/site/markdown/query/lucene.md
@@ -104,7 +104,7 @@ _Note that compared to [Property Index](query.html#property-index) Lucene
 Property Index is always configured in Async mode hence it might lag behind
 in reflecting the current repository state while performing the query_
 
-Taking another example. To support following query
+Taking another example. To support the following query
 
     /jcr:root/content//*[jcr:contains(., 'text')]
 
@@ -181,7 +181,7 @@ codec
 compatVersion
 : Required integer property and should be set to 2
 : By default Oak uses older Lucene index implementation which does not
-  supports property restrictions, index time aggregation etc.
+  support property restrictions, index time aggregation etc.
   To make use of this feature set it to 2.
   Please note for full text indexing with compatVersion 2,
   at query time, only the access right of the parent (aggregate) node is checked,
@@ -272,7 +272,7 @@ indexPath
 
 #### <a name="indexing-rules"></a> Indexing Rules
 
-Indexing rules defines which types of node and properties are indexed. An
+Indexing rules define which types of nodes and properties are indexed. An
 index configuration can define one or more `indexingRules` for different
 nodeTypes.
 
@@ -297,7 +297,7 @@ nodeTypes.
               - name = "jcr:content/metadata/imageType"
 
 Rules are defined per nodeType and each rule has one or more property
-definitions determine which properties are indexed. Below is the canonical index
+definitions that determine which properties are indexed. Below is the canonical index
 definition structure
 
     ruleName (nt:unstructured)

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryIndex.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryIndex.java
@@ -169,7 +169,7 @@ public interface QueryIndex {
     }
 
     /**
-     * An query index that may support using multiple access orders
+     * A query index that may support using multiple access orders
      * (returning the rows in a specific order), and that can provide detailed
      * information about the cost.
      */
@@ -279,7 +279,7 @@ public interface QueryIndex {
          * Whether the cursor is able to read all properties from a node.
          * If yes, then the query engine will not have to read the data itself.
          *
-         * @return wheter node data is returned
+         * @return whether node data is returned
          */
         boolean includesNodeData();
 


### PR DESCRIPTION
This PR fixes some typos in both the public documentation and in code comments.