### PR TITLE
OAK-9833: UpgradeIT fails on Java 17

### DIFF
--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/upgrade/UpgradeIT.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/upgrade/UpgradeIT.java
@@ -30,10 +30,13 @@ import static org.apache.jackrabbit.oak.segment.file.ManifestChecker.newManifest
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.jackrabbit.oak.segment.SegmentVersion;
 import org.apache.jackrabbit.oak.segment.data.SegmentData;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
@@ -59,6 +62,7 @@ public class UpgradeIT {
      */
     @Before
     public void setup() throws IOException, InterruptedException {
+        assumeFalse(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_12));
         Process oakConsole = new ProcessBuilder(
                 "java", "-jar", "oak-run.jar",
                 "console", fileStoreHome.getRoot().getAbsolutePath(), "--read-write",


### PR DESCRIPTION
Disable test when running on Java version higher than 11. The Groovy version included in oak-run 1.6 does not work well on Java 17.