### PR TITLE
OAK-9840: wait for all required MountInfoConfigs

### DIFF
--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
@@ -19,9 +19,10 @@
 
 package org.apache.jackrabbit.oak.composite;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
@@ -33,14 +34,14 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 @Component
 @Designate(ocd = MountInfoProviderService.Props.class)
@@ -54,7 +55,7 @@ public class MountInfoProviderService {
 
         @AttributeDefinition(
             name = "Expected mounts",
-            description = "List of all expected read-only mount names"
+            description = "List of all required mount names"
         )
         String[] expectedMounts() default {};
 
@@ -90,7 +91,7 @@ public class MountInfoProviderService {
 
     private final List<MountInfoConfig> mountInfoConfigs = new CopyOnWriteArrayList<>();
 
-    private List<String> expectedMounts;
+    private Set<String> expectedMounts;
     private ServiceRegistration reg;
     private BundleContext context;
 
@@ -101,9 +102,9 @@ public class MountInfoProviderService {
             this.expectedMounts = Stream.of(expectedMounts)
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .collect(toList());
+                .collect(toSet());
         } else {
-            this.expectedMounts = new ArrayList<>();
+            this.expectedMounts = new HashSet<>();
         }
         context = bundleContext;
         addMountInfoConfigFromProperties(props);
@@ -125,7 +126,7 @@ public class MountInfoProviderService {
         }
     }
 
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE)
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
     protected void bindMountInfoConfig(MountInfoConfig config) {
         if (!config.getPaths().isEmpty()) { // Ignore empty configs
             mountInfoConfigs.add(config);
@@ -137,9 +138,10 @@ public class MountInfoProviderService {
         if (context == null || reg != null) {
             return;
         }
-        if (!mountInfoConfigs.stream().allMatch(mountInfo -> expectedMounts.contains(mountInfo.getMountName()))) {
+        Set<String> providedMounts = mountInfoConfigs.stream().map(MountInfoConfig::getMountName).collect(toSet());
+        if (!providedMounts.containsAll(expectedMounts)) {
             LOG.info("Not all expected mounts are present yet (expected: {}, current: {}). Postponing configuration...",
-                expectedMounts, mountInfoConfigs.stream().map(MountInfoConfig::getMountName).collect(joining(",", "[", "]")));
+                expectedMounts, providedMounts);
             return;
         }
 

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/MountInfoProviderService.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
@@ -126,7 +127,7 @@ public class MountInfoProviderService {
         }
     }
 
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policyOption = ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void bindMountInfoConfig(MountInfoConfig config) {
         if (!config.getPaths().isEmpty()) { // Ignore empty configs
             mountInfoConfigs.add(config);

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/MountInfoProviderServiceTest.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/MountInfoProviderServiceTest.java
@@ -122,6 +122,19 @@ public class MountInfoProviderServiceTest {
     }
 
     @Test
+    public void mountWithConfig_Multiple_NotAllExpected() {
+        registerActivateMountInfoConfig(propsBuilder().withMountName("foo").withMountPaths("/a").buildMountInfoProps());
+        registerActivateMountInfoConfig(propsBuilder().withMountName("bar").withMountPaths("/b").buildMountInfoProps());
+
+        MockOsgi.injectServices(service, context.bundleContext());
+        service.activate(context.bundleContext(), withExpectedMounts("foo", "bar", "baz"));
+        MockOsgi.activate(service, context.bundleContext(), ImmutableMap.of("expectedMounts", new String[]{"foo", "bar", "baz"}));
+
+        MountInfoProvider provider = context.getService(MountInfoProvider.class);
+        assertNull("Not all expected mounts have been provided", provider);
+    }
+
+    @Test
     public void mountWithConfig_Name() {
         registerActivateMountInfoConfig(propsBuilder().withMountName("foo").withMountPaths("/a", "/b").buildMountInfoProps());
 


### PR DESCRIPTION
also consider later configs by making the reference greedy