### PR TITLE
OAK-9752 Update Tika version to 2.x

### DIFF
--- a/oak-examples/standalone/pom.xml
+++ b/oak-examples/standalone/pom.xml
@@ -123,7 +123,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
       <exclusions>
         <exclusion>

--- a/oak-examples/webapp/pom.xml
+++ b/oak-examples/webapp/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
       <exclusions>
         <exclusion>

--- a/oak-lucene/pom.xml
+++ b/oak-lucene/pom.xml
@@ -383,7 +383,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/property/PropertyIndexCleanerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/property/PropertyIndexCleanerTest.java
@@ -48,7 +48,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.stats.Clock;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.jetbrains.annotations.Nullable;
-import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -290,7 +289,7 @@ public class PropertyIndexCleanerTest {
         assertEquals(expected, stats.cleanupPerformed);
     }
 
-    private void assertJsonInfo(String indexPath, String expectedJson) throws ParseException {
+    private void assertJsonInfo(String indexPath, String expectedJson) {
         NodeState idx = NodeStateUtils.getNode(nodeStore.getRoot(), indexPath);
         String json = new HybridPropertyIndexInfo(idx).getInfoAsJson();
         JsonObject j1 = (JsonObject) new JsonParser().parse(json);

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -59,7 +59,7 @@
     <slf4j.version>1.7.32</slf4j.version> <!-- sync with logback version -->
     <logback.version>1.2.10</logback.version>
     <h2.version>2.0.206</h2.version>
-    <tika.version>1.24.1</tika.version>
+    <tika.version>2.4.1</tika.version>
     <guava.version>15.0</guava.version>
     <guava.osgi.import>com.google.common.*;version="[15.0,21)"</guava.osgi.import>
     <derby.version>10.14.2.0</derby.version>

--- a/oak-pojosr/pom.xml
+++ b/oak-pojosr/pom.xml
@@ -215,7 +215,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/oak-run-elastic/src/main/assembly/oak-run-elastic.xml
+++ b/oak-run-elastic/src/main/assembly/oak-run-elastic.xml
@@ -47,7 +47,7 @@
         </excludes>
       </unpackOptions>
     </dependencySet>
-    <!-- Exclude the transitive dependency as tika-parsers depend
+    <!-- Exclude the transitive dependency as tika-parsers-standard-package depend
       on many other jars. Instead users can include tika-app.jar in classpath-->
     <dependencySet>
       <outputDirectory>/</outputDirectory>

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -338,7 +338,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
     </dependency>
     <dependency>

--- a/oak-run/src/main/assembly/oak-run.xml
+++ b/oak-run/src/main/assembly/oak-run.xml
@@ -32,7 +32,7 @@
       <excludes>
         <exclude>org.apache.lucene</exclude>
         <exclude>org.apache.tika:tika-core:*</exclude>
-        <exclude>org.apache.tika:tika-parsers:*</exclude>
+        <exclude>org.apache.tika:tika-parsers-standard-package:*</exclude>
         <exclude>org.apache.jackrabbit:jackrabbit-aws-ext:*</exclude>
         <exclude>io.prometheus:simpleclient*:*</exclude>
       </excludes>
@@ -54,13 +54,13 @@
         </excludes>
       </unpackOptions>
     </dependencySet>
-    <!-- Exclude the transitive dependency as tika-parsers depend
+    <!-- Exclude the transitive dependency as tika-parsers-standard-package depend
       on many other jars. Instead users can include tika-app.jar in classpath-->
     <dependencySet>
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>org.apache.tika:tika-core</include>
-        <include>org.apache.tika:tika-parsers</include>
+        <include>org.apache.tika:tika-parsers-standard-package</include>
       </includes>
       <useStrictFiltering>true</useStrictFiltering>
       <useTransitiveDependencies>false</useTransitiveDependencies>

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/TextExtractor.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/TextExtractor.java
@@ -24,6 +24,7 @@ import com.google.common.io.CountingInputStream;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.commons.io.LazyInputStream;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.TextWriter;
+import org.apache.tika.exception.WriteLimitReachedException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.sax.WriteOutContentHandler;
@@ -279,7 +280,7 @@ class TextExtractor implements Closeable {
         } catch (Throwable t) {
             // Capture and report any other full text extraction problems.
             // The special STOP exception is used for normal termination.
-            if (!handler.isWriteLimitReached(t)) {
+            if (!WriteLimitReachedException.isWriteLimitReached(t)) {
                 parserErrorCount.incrementAndGet();
                 String format = "Failed to extract text from a binary property: {}. "
                         + "This is quite common, and usually nothing to worry about.";

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/TextPopulatorTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/TextPopulatorTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.jackrabbit.oak.plugins.tika;
 
-import com.beust.jcommander.internal.Maps;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteSource;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.TextWriter;
@@ -43,7 +43,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -201,7 +201,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
+      <artifactId>tika-core</artifactId>
+      <version>${tika.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-parsers-standard-package</artifactId>
       <version>${tika.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
@@ -36,6 +36,7 @@ import org.apache.jackrabbit.oak.stats.StatsOptions;
 import org.apache.jackrabbit.oak.stats.TimerStats;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.exception.WriteLimitReachedException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaType;
 import org.apache.tika.parser.AutoDetectParser;
@@ -192,7 +193,7 @@ public class FulltextBinaryTextExtractor {
     } catch (Throwable t) {
       // Capture and report any other full text extraction problems.
       // The special STOP exception is used for normal termination.
-      if (!handler.isWriteLimitReached(t)) {
+      if (!WriteLimitReachedException.isWriteLimitReached(t)) {
         String format = "[{}] Failed to extract text from a binary property: {}. "
                   + "This is quite common, and usually nothing to worry about.";
         String indexName = getIndexName();

--- a/oak-solr-core/pom.xml
+++ b/oak-solr-core/pom.xml
@@ -195,7 +195,7 @@
         </dependency>
         <dependency>
           <groupId>org.apache.tika</groupId>
-          <artifactId>tika-parsers</artifactId>
+          <artifactId>tika-parsers-standard-package</artifactId>
           <version>${tika.version}</version>
           <scope>test</scope>
           <exclusions>

--- a/oak-solr-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/solr/index/SolrIndexEditor.java
+++ b/oak-solr-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/solr/index/SolrIndexEditor.java
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.tika.exception.WriteLimitReachedException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
@@ -311,7 +312,7 @@ class SolrIndexEditor implements IndexEditor {
         } catch (Throwable t) {
             // Capture and report any other full text extraction problems.
             // The special STOP exception is used for normal termination.
-            if (!handler.isWriteLimitReached(t)) {
+            if (!WriteLimitReachedException.isWriteLimitReached(t)) {
                 log.debug("Failed to extract text from a binary property: "
                         + " This is a fairly common case, and nothing to"
                         + " worry about. The stack trace is included to"


### PR DESCRIPTION
Update the dependencies to tika version 2.4.1 with the guidance from [Migrating to Tika 2.0.0](https://cwiki.apache.org/confluence/display/TIKA/Migrating+to+Tika+2.0.0)

Also cleanup code that no longer compiles and ensure the tests still function as before.