### PR TITLE
increase maven Xmx from 1 to 1.5 GB

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ def buildModule(moduleSpec) {
             sh '''
             echo "Setting MAVEN_OPTS"
             echo "MAVEN_OPTS was ${MAVEN_OPTS}"
-            export MAVEN_OPTS="-Xmx1024M"
+            export MAVEN_OPTS="-Xmx1536M"
             echo "MAVEN_OPTS now ${MAVEN_OPTS}"
             echo "Setting MAVEN_OPTS done"
             '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ def buildModule(moduleSpec) {
             '''
             timeout(70) {
                 checkout scm
-                withEnv(["Path+JDK=$JAVA_JDK_8/bin","Path+MAVEN=$MAVEN_3_LATEST/bin","JAVA_HOME=$JAVA_JDK_8","MAVEN_OPTS=-Xmx1024M"]) {
+                withEnv(["Path+JDK=$JAVA_JDK_8/bin","Path+MAVEN=$MAVEN_3_LATEST/bin","JAVA_HOME=$JAVA_JDK_8","MAVEN_OPTS=-Xmx1536M"]) {
                     sh '''
                     echo "MAVEN_OPTS is ${MAVEN_OPTS}"
                     '''


### PR DESCRIPTION
oak-search-elastic is failing lately due to OutOfMemory error. Increasing maven -Xmx to see if that helps (needs to be merged in order to be picked up by jenkins).