### PR TITLE
OAK-9807: On DataStore initialization create the reference.key if absent

### DIFF
--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -220,6 +220,14 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
                 }
                 uploadDomainOverride = properties.getProperty(AzureConstants.PRESIGNED_HTTP_UPLOAD_URI_DOMAIN_OVERRIDE, null);
                 downloadDomainOverride = properties.getProperty(AzureConstants.PRESIGNED_HTTP_DOWNLOAD_URI_DOMAIN_OVERRIDE, null);
+
+                // Initialize reference key secret
+                boolean createRefSecretOnInit = PropertiesUtil.toBoolean(
+                    Strings.emptyToNull(properties.getProperty(AzureConstants.AZURE_REF_ON_INIT)), true);
+
+                if (createRefSecretOnInit) {
+                    getOrCreateReferenceKey();
+                }
             }
             catch (StorageException e) {
                 throw new DataStoreException(e);

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureConstants.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureConstants.java
@@ -119,5 +119,10 @@ public final class AzureConstants {
      */
     public static final String PRESIGNED_HTTP_UPLOAD_URI_DOMAIN_OVERRIDE = "presignedHttpUploadURIDomainOverride";
 
+    /**
+     * Property to enable/disable creation of reference secret on init.
+     */
+    public static final String AZURE_REF_ON_INIT = "refOnInit";
+    
     private AzureConstants() { }
 }

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataStoreTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataStoreTest.java
@@ -589,7 +589,9 @@ public class AzureDataStoreTest {
 
     @Test
     public void testBackendGetAllMetadataRecordsPrefixMatchesAll() throws DataStoreException {
-        assertEquals(0, backend.getAllMetadataRecords("").size());
+        // reference.key initialized in backend#init() - OAK-9807, so expected 1 record
+        assertEquals(1, backend.getAllMetadataRecords("").size());
+        backend.deleteAllMetadataRecords("");
 
         String prefixAll = "prefix1";
         String prefixSome = "prefix1.prefix2";
@@ -694,7 +696,8 @@ public class AzureDataStoreTest {
 
     @Test
     public void testBackendDeleteAllMetadataRecordsNoRecordsNoChange() {
-        assertEquals(0, backend.getAllMetadataRecords("").size());
+        // reference.key initialized in backend#init() - OAK-9807, so expected 1 record
+        assertEquals(1, backend.getAllMetadataRecords("").size());
 
         backend.deleteAllMetadataRecords("");
 
@@ -714,6 +717,10 @@ public class AzureDataStoreTest {
 
     @Test
     public void testSecret() throws Exception {
+        // assert secret already created on init
+        DataRecord refRec = ds.getMetadataRecord("reference.key");
+        assertNotNull("Reference data record null", refRec);
+        
         byte[] data = new byte[4096];
         randomGen.nextBytes(data);
         DataRecord rec = ds.addRecord(new ByteArrayInputStream(data));
@@ -731,9 +738,6 @@ public class AzureDataStoreTest {
         String calcRef = id + ':' + encodeHexString(hash);
 
         assertEquals("getReference() not equal", calcRef, ref);
-
-        DataRecord refRec = ds.getMetadataRecord("reference.key");
-        assertNotNull("Reference data record null", refRec);
 
         byte[] refDirectFromBackend = IOUtils.toByteArray(refRec.getStream());
         LOG.warn("Ref direct from backend {}", refDirectFromBackend);

--- a/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
+++ b/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
@@ -237,7 +237,10 @@ public class S3Backend extends AbstractSharedBackend {
 
             presignedDownloadURIVerifyExists =
                     PropertiesUtil.toBoolean(properties.get(S3Constants.PRESIGNED_HTTP_DOWNLOAD_URI_VERIFY_EXISTS), true);
-
+            
+            // Initialize reference key secret
+            getOrCreateReferenceKey();
+            
             LOG.debug("S3 Backend initialized in [{}] ms",
                 +(System.currentTimeMillis() - startTime.getTime()));
         } catch (Exception e) {


### PR DESCRIPTION
Create reference.key on init if not present