### PR TITLE
OAK-9870 | Escaped characters from client get unescaped in ES implementation

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LucenePropertyIndex.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LucenePropertyIndex.java
@@ -534,7 +534,7 @@ public class LucenePropertyIndex extends FulltextIndex {
                         }
                     }
                 } catch (Exception e) {
-                    LOG.warn("query via {} failed.", LucenePropertyIndex.this, e);
+                    LOG.warn("query [{}] via {} failed.", plan.getFilter() , LucenePropertyIndex.this.getClass().getCanonicalName(), e);
                 } finally {
                     indexNode.release();
                 }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneFullTextIndexCommonTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneFullTextIndexCommonTest.java
@@ -17,13 +17,17 @@
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
 import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.FullTextIndexCommonTest;
 import org.apache.jackrabbit.oak.plugins.index.LuceneIndexOptions;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.event.Level;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -48,5 +52,24 @@ public class LuceneFullTextIndexCommonTest extends FullTextIndexCommonTest {
     @After
     public void shutdownExecutor() {
         executorService.shutdown();
+    }
+
+    @Override
+    protected LogCustomizer setupLogCustomizer() {
+        return LogCustomizer.forLogger(LucenePropertyIndex.class.getName()).enable(Level.WARN).create();
+    }
+
+    @Override
+    protected List<String> getExpectedLogMessage() {
+        List<String> expectedLogList = new ArrayList<>();
+        String log1 = "query [Filter(query=select [jcr:path], [jcr:score], * from [nt:base] as a where contains([analyzed_field], 'foo}') /* xpath: " +
+                "//*[jcr:contains(@analyzed_field, 'foo}')] */ fullText=analyzed_field:\"foo}\", path=*)] via org.apache.jackrabbit.oak.plugins.index.lucene.LucenePropertyIndex failed.";
+        String log2 = "query [Filter(query=select [jcr:path], [jcr:score], * from [nt:base] as a where contains([analyzed_field], 'foo]') /* xpath: " +
+                "//*[jcr:contains(@analyzed_field, 'foo]')] */ fullText=analyzed_field:\"foo]\", path=*)] via org.apache.jackrabbit.oak.plugins.index.lucene.LucenePropertyIndex failed.";
+
+        expectedLogList.add(log1);
+        expectedLogList.add(log2);
+
+        return expectedLogList;
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -775,6 +775,7 @@ public class ElasticRequestHandler {
     private static QueryStringQuery.Builder fullTextQuery(String text, String fieldName, PlanResult pr) {
         LOG.debug("fullTextQuery for text: '{}', fieldName: '{}'", text, fieldName);
         QueryStringQuery.Builder qsqBuilder = new QueryStringQuery.Builder()
+                .escape(true)
                 .query(FulltextIndex.rewriteQueryText(text))
                 .defaultOperator(co.elastic.clients.elasticsearch._types.query_dsl.Operator.And)
                 .type(TextQueryType.CrossFields);

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextIndexCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextIndexCommonTest.java
@@ -17,8 +17,14 @@
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
 import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.FullTextIndexCommonTest;
+import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.ElasticResultRowAsyncIterator;
 import org.junit.ClassRule;
+import org.slf4j.event.Level;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ElasticFullTextIndexCommonTest extends FullTextIndexCommonTest {
 
@@ -39,5 +45,26 @@ public class ElasticFullTextIndexCommonTest extends FullTextIndexCommonTest {
     @Override
     protected void createTestIndexNode() {
         setTraversalEnabled(false);
+    }
+
+    @Override
+    protected LogCustomizer setupLogCustomizer() {
+        return LogCustomizer.forLogger(ElasticResultRowAsyncIterator.class.getName()).enable(Level.ERROR).create();
+    }
+
+    @Override
+    protected List<String> getExpectedLogMessage() {
+        List<String> expectedLogList = new ArrayList<>();
+        String log1 = "Error while fetching results from Elastic for [Filter(query=select [jcr:path], [jcr:score]," +
+                " * from [nt:base] as a where contains([analyzed_field], 'foo}') /* xpath: //*[jcr:contains(@analyzed_field, 'foo}')]" +
+                " */ fullText=analyzed_field:\"foo}\", path=*)]";
+
+        String log2 = "Error while fetching results from Elastic for [Filter(query=select [jcr:path], [jcr:score]," +
+                " * from [nt:base] as a where contains([analyzed_field], 'foo]') /* xpath: //*[jcr:contains(@analyzed_field, 'foo]')]" +
+                " */ fullText=analyzed_field:\"foo]\", path=*)]";
+
+        expectedLogList.add(log1);
+        expectedLogList.add(log2);
+        return expectedLogList;
     }
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -281,7 +281,7 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
     }
 
     /**
-     * Following chars are used as operators in Lucene Query and should be escaped
+     * Following chars are used as operators in Lucene and Elastic Queries and should be escaped
      */
     private static final char[] QUERY_OPERATORS = {':' , '/', '!', '&', '|', '=', '{', '}', '[', ']', '(', ')'};
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -289,7 +289,6 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
      * Following logic is taken from org.apache.jackrabbit.core.query.lucene.JackrabbitQueryParser#parse(java.lang.String)
      */
     public static String rewriteQueryText(String textsearch) {
-
         // replace escaped ' with just '
         StringBuilder rewritten = new StringBuilder();
         // most query parsers recognize 'AND' and 'NOT' as

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -281,9 +281,9 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
     }
 
     /**
-     * Following chars are used as operators in Lucene and Elastic Queries and should be escaped
+     * Following chars are used as operators in Lucene Query and should be escaped
      */
-    private static final char[] QUERY_OPERATORS = {':' , '/', '!', '&', '|', '=', '{', '}', '[', ']', '(', ')'};
+    private static final char[] QUERY_OPERATORS = {':' , '/', '!', '&', '|', '='};
 
     /**
      * Following logic is taken from org.apache.jackrabbit.core.query.lucene.JackrabbitQueryParser#parse(java.lang.String)

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -283,12 +283,13 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
     /**
      * Following chars are used as operators in Lucene Query and should be escaped
      */
-    private static final char[] QUERY_OPERATORS = {':' , '/', '!', '&', '|', '='};
+    private static final char[] QUERY_OPERATORS = {':' , '/', '!', '&', '|', '=', '{', '}', '[', ']', '(', ')'};
 
     /**
      * Following logic is taken from org.apache.jackrabbit.core.query.lucene.JackrabbitQueryParser#parse(java.lang.String)
      */
     public static String rewriteQueryText(String textsearch) {
+
         // replace escaped ' with just '
         StringBuilder rewritten = new StringBuilder();
         // most query parsers recognize 'AND' and 'NOT' as

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
@@ -22,6 +22,7 @@ import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilde
 import org.apache.jackrabbit.oak.query.AbstractQueryTest;
 import org.junit.Assert;
 import org.junit.Test;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -134,6 +135,7 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
     // TODO : If needed in future, we can possibly use test metadata to change the
     // TODO : returned values from these based on which test is being executed
     protected abstract LogCustomizer setupLogCustomizer();
-    protected  abstract List<String> getExpectedLogMessage();
+
+    protected abstract List<String> getExpectedLogMessage();
 
 }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
@@ -92,7 +92,7 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
     @Test
     public void testWithSpecialCharsInSearchTerm() throws Exception {
         IndexDefinitionBuilder builder = indexOptions.createIndex(
-                indexOptions.createIndexDefinitionBuilder(), false, "testProp");
+                indexOptions.createIndexDefinitionBuilder(), false, "analyzed_field");
         builder.noAsync();
         builder.indexRule("nt:base")
                 .property("analyzed_field")
@@ -112,6 +112,7 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
             assertQuery("//*[jcr:contains(@analyzed_field, '\\{foo}')] ", XPATH, Collections.singletonList("/test/a"));
             assertQuery("//*[jcr:contains(@analyzed_field, 'foo:')] ", XPATH, Collections.singletonList("/test/a"));
             assertQuery("//*[jcr:contains(@analyzed_field, '[foo]')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '|foo/')] ", XPATH, Collections.singletonList("/test/a"));
             assertQuery("//*[jcr:contains(@analyzed_field, '(&=!foo')] ", XPATH, Collections.singletonList("/test/a"));
         });
 

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
@@ -17,11 +17,13 @@
 package org.apache.jackrabbit.oak.plugins.index;
 
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
 import org.apache.jackrabbit.oak.query.AbstractQueryTest;
+import org.junit.Assert;
 import org.junit.Test;
-
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
@@ -36,18 +38,7 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
 
     @Test
     public void defaultAnalyzer() throws Exception {
-        IndexDefinitionBuilder builder = indexOptions.createIndex(
-                indexOptions.createIndexDefinitionBuilder(), false, "analyzed_field");
-        builder.noAsync();
-        builder.indexRule("nt:base")
-                .property("analyzed_field")
-                .analyzed().nodeScopeIndex();
-
-        indexOptions.setIndex(root, UUID.randomUUID().toString(), builder);
-        root.commit();
-
-        //add content
-        Tree test = root.getTree("/").addChild("test");
+        Tree test = setup();
 
         test.addChild("a").setProperty("analyzed_field", "sun.jpg");
         root.commit();
@@ -64,18 +55,7 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
 
     @Test
     public void defaultAnalyzerHonourSplitOptions() throws Exception {
-        IndexDefinitionBuilder builder = indexOptions.createIndex(
-                indexOptions.createIndexDefinitionBuilder(), false, "analyzed_field");
-        builder.noAsync();
-        builder.indexRule("nt:base")
-                .property("analyzed_field")
-                .analyzed().nodeScopeIndex();
-
-        indexOptions.setIndex(root, UUID.randomUUID().toString(), builder);
-        root.commit();
-
-        //add content
-        Tree test = root.getTree("/").addChild("test");
+        Tree test = setup();
 
         test.addChild("a").setProperty("analyzed_field", "1234abCd5678");
         root.commit();
@@ -91,6 +71,48 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
 
     @Test
     public void testWithSpecialCharsInSearchTerm() throws Exception {
+        Tree test = setup();
+        test.addChild("a").setProperty("analyzed_field", "foo");
+        root.commit();
+
+        assertEventually(() -> {
+            // Special characters {':' , '/', '!', '&', '|', '='} are escaped before creating lucene/elastic queries using
+            // {@see org.apache.jackrabbit.oak.plugins.index.search.spi.query.FullTextIndex#rewriteQueryText}
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo:')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '|foo/')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '&=!foo')] ", XPATH, Collections.singletonList("/test/a"));
+
+            // Braces are not escaped in the above rewriteQueryText method - we do not change that to maintain backward compatibility
+            // So these need explicit escaping or filtering on client side while creating the jcr query
+            assertQuery("//*[jcr:contains(@analyzed_field, '\\{foo\\}')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '\\[foo\\]')] ", XPATH, Collections.singletonList("/test/a"));
+        });
+
+    }
+
+    @Test()
+    public void testFullTextTermWithUnescapedBraces() throws Exception {
+        LogCustomizer customLogs = setupLogCustomizer();
+        Tree test = setup();
+
+        test.addChild("a").setProperty("analyzed_field", "foo");
+        root.commit();
+
+        // Below queries would fail silently (return 0 results with an entry in logs for the query that failed)
+        // due to unescaped special character (which is not handled in backend)
+        try {
+            customLogs.starting();
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo}')] ", XPATH, Collections.emptyList());
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo]')] ", XPATH, Collections.emptyList());
+
+            Assert.assertTrue(customLogs.getLogs().containsAll(getExpectedLogMessage()));
+        } finally {
+            customLogs.finished();
+        }
+    }
+
+
+    protected Tree setup() throws Exception {
         IndexDefinitionBuilder builder = indexOptions.createIndex(
                 indexOptions.createIndexDefinitionBuilder(), false, "analyzed_field");
         builder.noAsync();
@@ -103,19 +125,15 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
 
         //add content
         Tree test = root.getTree("/").addChild("test");
-
-        test.addChild("a").setProperty("analyzed_field", "foo");
         root.commit();
 
-        assertEventually(() -> {
-            assertQuery("//*[jcr:contains(@analyzed_field, '{foo}')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '\\{foo}')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, 'foo:')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '[foo]')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '|foo/')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '(&=!foo')] ", XPATH, Collections.singletonList("/test/a"));
-        });
-
+        return test;
     }
+
+    // TODO : Below two method are only used for testFullTextTermWithUnescapedBraces
+    // TODO : If needed in future, we can possibly use test metadata to change the
+    // TODO : returned values from these based on which test is being executed
+    protected abstract LogCustomizer setupLogCustomizer();
+    protected  abstract List<String> getExpectedLogMessage();
 
 }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
@@ -88,4 +88,33 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         });
     }
 
+
+    @Test
+    public void testWithSpecialCharsInSearchTerm() throws Exception {
+        IndexDefinitionBuilder builder = indexOptions.createIndex(
+                indexOptions.createIndexDefinitionBuilder(), false, "testProp");
+        builder.noAsync();
+        builder.indexRule("nt:base")
+                .property("analyzed_field")
+                .analyzed().nodeScopeIndex();
+
+        indexOptions.setIndex(root, UUID.randomUUID().toString(), builder);
+        root.commit();
+
+        //add content
+        Tree test = root.getTree("/").addChild("test");
+
+        test.addChild("a").setProperty("analyzed_field", "foo");
+        root.commit();
+
+        assertEventually(() -> {
+            assertQuery("//*[jcr:contains(@analyzed_field, '{foo}')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '\\{foo}')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo:')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '[foo]')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '(&=!foo')] ", XPATH, Collections.singletonList("/test/a"));
+        });
+
+    }
+
 }


### PR DESCRIPTION
As part of https://github.com/apache/jackrabbit-oak/commit/695d5ab33ec23ad5cae9fd47dc5f207d6dc0cd6c, we handled the case of double negation in case of ES implementation by not using raw text from FullTextContains and instead using text from FullTextTerm to build the final ES query.

This fixed the double negation, but broke another case where the client might be escaping special characters such as '{' . But  FullTextTerm#getText() does not have the escapes as opposed to FullTextContains#getRawText() that was used previously.

We are not handling these escapes in backend (initially fixed it like that but then reverted the change here https://github.com/apache/jackrabbit-oak/commit/e71d4f1fd5ef5eeb1cbc238646c9c465af74e631 post suggestions that this might cause change in lucene behaviour which is not something we want) so as to not change the current behaviour of lucene which basically expects the client to escape some special characters such as '{' and if these are not escaped by client - then the query fails silently (logging failure and returning 0 results) - The newly added tests in this PR try and demonstrate the same.