### PR TITLE
OAK-9850: ConcurrentPrefetchAndUpdateIT.cacheConsistency fails occasi…

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -1411,7 +1411,7 @@ public class MongoDocumentStore implements DocumentStore {
         List<String> resultKeys = new ArrayList<>(keys.size());
         CacheChangesTracker tracker = null;
         if (collection == Collection.NODES) {
-            tracker = nodesCache.registerTracker(keys);
+            tracker = nodesCache.registerTracker(new HashSet<>(keys));
         }
         Throwable t;
         try {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -1411,6 +1411,8 @@ public class MongoDocumentStore implements DocumentStore {
         List<String> resultKeys = new ArrayList<>(keys.size());
         CacheChangesTracker tracker = null;
         if (collection == Collection.NODES) {
+            // keys set is modified later. create a copy of the keys set
+            // owned by the cache changes tracker.
             tracker = nodesCache.registerTracker(new HashSet<>(keys));
         }
         Throwable t;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ConcurrentPrefetchAndUpdateIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ConcurrentPrefetchAndUpdateIT.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
@@ -71,7 +70,6 @@ public class ConcurrentPrefetchAndUpdateIT extends AbstractMongoConnectionTest {
         System.clearProperty(DocumentNodeStore.SYS_PROP_PREFETCH);
     }
 
-    @Ignore("OAK-9850")
     @Test
     public void cacheConsistency() throws Exception {
         Revision r = newRevision();

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/cache/NodeDocumentCacheTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/cache/NodeDocumentCacheTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.cache;
+
+import org.apache.jackrabbit.oak.plugins.document.Document;
+import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.plugins.document.locks.NodeDocumentLocks;
+import org.apache.jackrabbit.oak.plugins.document.locks.StripedNodeDocumentLocks;
+import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Collections.singleton;
+import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreBuilder.newDocumentNodeStoreBuilder;
+import static org.junit.Assert.assertEquals;
+
+public class NodeDocumentCacheTest {
+
+    private static final String ID = "some-id";
+
+    private final DocumentStore store = new MemoryDocumentStore();
+
+    private final NodeDocumentLocks locks = new StripedNodeDocumentLocks();
+
+    private NodeDocumentCache cache;
+
+    @Before
+    public void setup() {
+        cache = newDocumentNodeStoreBuilder()
+                .buildNodeDocumentCache(store, locks);
+    }
+
+    @Test
+    public void cacheConsistency() throws Exception {
+        NodeDocument current = createDocument(0L);
+        NodeDocument updated = createDocument(1L);
+
+        // an update operation starts and registers a tracker
+        CacheChangesTracker updateTracker = cache.registerTracker(singleton(ID));
+        // the document is invalidated. this informs the update tracker
+        cache.invalidate(ID);
+        // a query operation starts and registers a tracker
+        CacheChangesTracker queryTracker = cache.registerTracker(singleton(ID));
+        // the query operation is able to read the document before it is updated
+        // but then gets delayed.
+        // the update operation wants to put the document into the cache, but
+        // can't because its tracker was informed by the cache invalidation
+        cache.putNonConflictingDocs(updateTracker, singleton(updated));
+        // the query operation wants to put the outdated document into the
+        // cache. the cache must not accept this outdated document.
+        cache.putNonConflictingDocs(queryTracker, singleton(current));
+
+        assertEquals(updated.getModCount(), cache.get(ID, () -> updated).getModCount());
+    }
+
+    private NodeDocument createDocument(long modCount) {
+        NodeDocument doc = new NodeDocument(store, modCount);
+        doc.put(Document.ID, ID);
+        doc.put(Document.MOD_COUNT, modCount);
+        return doc;
+    }
+}


### PR DESCRIPTION
…onally

Keys collection passed to registerTracker must not be modified later.
NodeDocumentCache.putNonConflictingDocs() must always notify other trackers.
Enable test again.