### PR TITLE
OAK-9879: CacheLIRS statistics may return incorrect load count

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
@@ -1025,7 +1025,9 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
             long start = System.nanoTime();
             try {
                 value = valueLoader.call();
-                loadSuccessCount++;
+                synchronized (this) {
+                    loadSuccessCount++;
+                }
             } catch (Exception e) {
                 loadExceptionCount++;
                 throw new ExecutionException(e);

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/ConcurrentTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/ConcurrentTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -247,7 +246,6 @@ public class ConcurrentTest {
         }
     }
 
-    @Ignore("OAK-9879")
     @Test
     public void loadCount() throws Exception {
         for (int i = 0; i < 50; i++) {

--- a/oak-core-spi/src/test/resources/logback-test.xml
+++ b/oak-core-spi/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+        <!--
+           Licensed to the Apache Software Foundation (ASF) under one or more
+           contributor license agreements.  See the NOTICE file distributed with
+           this work for additional information regarding copyright ownership.
+           The ASF licenses this file to You under the Apache License, Version 2.0
+           (the "License"); you may not use this file except in compliance with
+           the License.  You may obtain a copy of the License at
+
+               http://www.apache.org/licenses/LICENSE-2.0
+
+           Unless required by applicable law or agreed to in writing, software
+           distributed under the License is distributed on an "AS IS" BASIS,
+           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           See the License for the specific language governing permissions and
+           limitations under the License.
+          -->
+<configuration>
+
+<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+        <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+    </encoder>
+</appender>
+
+<appender name="file" class="ch.qos.logback.core.FileAppender">
+    <file>target/unit-tests.log</file>
+    <encoder>
+        <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+    </encoder>
+</appender>
+
+<root level="ERROR">
+    <!--
+    <appender-ref ref="console"/>
+    -->
+    <appender-ref ref="file"/>
+</root>
+
+</configuration>


### PR DESCRIPTION
Synchronize access to loadSuccessCount
Enable test