### PR TITLE
OAK-9878 | OAK-9858 | Fixing failing(Ignored) tests for ES

### DIFF
--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/AbstractQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/AbstractQueryTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -227,7 +228,16 @@ public abstract class AbstractQueryTest {
                     w.println(line);
                     line = line.substring("commit".length()).trim();
                     apply(root, line);
-                    root.commit();
+                    // This part of code is used by both lucene and elastic tests.
+                    // The index definitions in these tests don't have async property set
+                    // So lucene, in this case behaves in a sync manner. But the tests fail on Elastic,
+                    // since ES indexing is always async.
+                    // The below commit info map (sync-xmode = rt) would make Elastic use RealTimeBulkProcessHandler.
+                    // This would make ES indexes also sync.
+                    // This will NOT have any impact on the lucene tests.
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("sync-mode", "rt");
+                    root.commit(map);
                 }
                 w.flush();
             }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/AbstractQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/AbstractQueryTest.java
@@ -232,12 +232,10 @@ public abstract class AbstractQueryTest {
                     // The index definitions in these tests don't have async property set
                     // So lucene, in this case behaves in a sync manner. But the tests fail on Elastic,
                     // since ES indexing is always async.
-                    // The below commit info map (sync-xmode = rt) would make Elastic use RealTimeBulkProcessHandler.
+                    // The below commit info map (sync-mode = rt) would make Elastic use RealTimeBulkProcessHandler.
                     // This would make ES indexes also sync.
                     // This will NOT have any impact on the lucene tests.
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("sync-mode", "rt");
-                    root.commit(map);
+                    root.commit(Collections.singletonMap("sync-mode", "rt"));
                 }
                 w.flush();
             }

--- a/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2.txt
+++ b/oak-core/src/test/resources/org/apache/jackrabbit/oak/query/sql2.txt
@@ -407,21 +407,22 @@ commit /testRoot + "test2": { "name": "World!" }
 commit /testRoot + "test3": { "name": "Hallo" }
 commit /testRoot + "test4": { "name": "10%" }
 commit /testRoot + "test5": { "name": "10 percent" }
+commit /testRoot + "test6": { "name": "brave" }
 
 select a.name
   from [nt:base] as a
   where a.name is not null and isdescendantnode(a , '/testRoot') order by upper(a.name)
 10 percent
 10%
+brave
 Hallo
 hello
 World!
 
 select [jcr:path]
   from [nt:base]
-  where length(name) = 5
-/testRoot/test
-/testRoot/test3
+  where length(name) = 10
+/testRoot/test5
 
 select [jcr:path]
   from [nt:base]
@@ -440,8 +441,9 @@ select [jcr:path]
 
 select [jcr:path]
   from [nt:base]
-  where name like '%o_%'
-/testRoot/test2
+  where name like '%e_%'
+/testRoot/test
+/testRoot/test5
 
 select [jcr:path]
   from [nt:base]

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexQueryCommonTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexQueryCommonTest.java
@@ -23,17 +23,10 @@ import org.apache.jackrabbit.oak.plugins.index.LuceneIndexOptions;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.junit.After;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import javax.jcr.query.Query;
 
 /**
  * Tests the query engine using the default index implementation: the
@@ -59,14 +52,6 @@ public class LuceneIndexQueryCommonTest extends IndexQueryCommonTest {
         executorService.shutdown();
     }
 
-    @Test
-    public void descendantTestWithIndexTagExplain() throws Exception {
-        List<String> result = executeQuery(
-                    "explain select [jcr:path] from [nt:base] where isdescendantnode('/test') option (index tag x)", Query.JCR_SQL2);
-        assertEquals("[[nt:base] as [nt:base] /* lucene:test-index(/oak:index/test-index) :ancestors:/test\n"
-                + "  where isdescendantnode([nt:base], [/test]) */]", result.toString());
-    }
-
     @Override
     public String getContainsValueForEqualityQuery_native() {
         return "+:ancestors:/test +propa:bar";
@@ -90,5 +75,11 @@ public class LuceneIndexQueryCommonTest extends IndexQueryCommonTest {
     @Override
     public String getContainsValueForNotNullQuery_native() {
         return "+:ancestors:/test +propa:[* TO *]";
+    }
+
+    @Override
+    public String getExplainValueForDescendantTestWithIndexTagExplain() {
+        return "[nt:base] as [nt:base] /* lucene:test-index(/oak:index/test-index) :ancestors:/test" +
+                " where isdescendantnode([nt:base], [/test]) */";
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -736,7 +736,7 @@ public class ElasticRequestHandler {
         String first = pr.first != null ? pr.first.getValue(Type.STRING) : null;
         if (pr.first != null && pr.first.equals(pr.last) && pr.firstIncluding && pr.lastIncluding) {
             // [property]=[value]
-            return Query.of(q -> q.term(t -> t.field(FieldNames.NODE_NAME).value(FieldValue.of(first))));
+            return Query.of(q -> q.term(t -> t.field(elasticIndexDefinition.getElasticKeyword(FieldNames.NODE_NAME)).value(FieldValue.of(first))));
         }
 
         if (pr.isLike) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -228,7 +228,7 @@ public class ElasticRequestHandler {
             } else if (JCR_SCORE.equals(sortPropertyName)) {
                 fieldName = "_score";
             } else if (indexProperties.containsKey(sortPropertyName) || elasticIndexDefinition.getDefinedRules()
-                    .stream().map(rule -> Optional.ofNullable(rule.getConfig(sortPropertyName))).anyMatch(Optional::isPresent)) {
+                    .stream().anyMatch(rule -> rule.getConfig(sortPropertyName) != null)) {
                 // There are 2 conditions in this if statement -
                 // First one returns true if sortPropertyName is one of the defined indexed properties on the index
                 // Second condition returns true if sortPropertyName might not be explicitly defined but covered by a regex property

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
@@ -227,11 +228,13 @@ public class ElasticRequestHandler {
             } else if (JCR_SCORE.equals(sortPropertyName)) {
                 fieldName = "_score";
             } else if (indexProperties.containsKey(sortPropertyName) || elasticIndexDefinition.getDefinedRules()
-                    .stream().map(rule -> rule.getConfig(sortPropertyName))
+                    .stream().map(rule -> Optional.ofNullable(rule.getConfig(sortPropertyName)))
+                    .filter(Optional::isPresent)
                     .collect(Collectors.toList()).size() > 0) {
                 // There are 2 conditions in this if statement -
                 // First one returns true if sortPropertyName is one of the defined indexed properties on the index
-                // Second condition returns true if sortPropertyName might not be explicitly defined but covered by a regex property.
+                // Second condition returns true if sortPropertyName might not be explicitly defined but covered by a regex property
+                // in any of the defined index rules.
                 fieldName = elasticIndexDefinition.getElasticKeyword(sortPropertyName);
             } else {
                 LOG.warn("Unable to sort by {} for index {}", sortPropertyName, elasticIndexDefinition.getIndexName());

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -228,9 +228,7 @@ public class ElasticRequestHandler {
             } else if (JCR_SCORE.equals(sortPropertyName)) {
                 fieldName = "_score";
             } else if (indexProperties.containsKey(sortPropertyName) || elasticIndexDefinition.getDefinedRules()
-                    .stream().map(rule -> Optional.ofNullable(rule.getConfig(sortPropertyName)))
-                    .filter(Optional::isPresent)
-                    .collect(Collectors.toList()).size() > 0) {
+                    .stream().map(rule -> Optional.ofNullable(rule.getConfig(sortPropertyName))).anyMatch(Optional::isPresent)) {
                 // There are 2 conditions in this if statement -
                 // First one returns true if sortPropertyName is one of the defined indexed properties on the index
                 // Second condition returns true if sortPropertyName might not be explicitly defined but covered by a regex property

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -765,13 +765,13 @@ public class ElasticRequestHandler {
         if (indexOfWS == len || indexOfWC == len) {
             // remove trailing "*" for prefix query
             first = first.substring(0, first.length() - 1);
-            if (JCR_PATH.equals(field)) {
+            if (JCR_PATH.equals(name)) {
                 return newPrefixPathQuery(first);
             } else {
                 return newPrefixQuery(field, first);
             }
         } else {
-            if (JCR_PATH.equals(field)) {
+            if (JCR_PATH.equals(name)) {
                 return newWildcardPathQuery(first);
             } else {
                 return newWildcardQuery(field, first);

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
@@ -93,7 +93,6 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
     }
 
     @Override
-    @Ignore("OAK-9858")
     @Test
     public void sql2FullText() throws Exception {
         super.sql2FullText();

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
@@ -21,14 +21,6 @@ import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.plugins.index.IndexQueryCommonTest;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-
-import javax.jcr.query.Query;
 
 public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
 
@@ -46,15 +38,6 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
         elasticTestRepositoryBuilder.setNodeStore(new MemoryNodeStore(InitialContentHelper.INITIAL_CONTENT));
         repositoryOptionsUtil = elasticTestRepositoryBuilder.build();
         return repositoryOptionsUtil.getOak().createContentRepository();
-    }
-
-    @Test
-    public void descendantTestWithIndexTagExplain() {
-        List<String> result = executeQuery(
-                    "explain select [jcr:path] from [nt:base] where isdescendantnode('/test') option (index tag x)", Query.JCR_SQL2);
-        assertEquals("[[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) "
-                + "{\"bool\":{\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}}]}}\n"
-                + "  where isdescendantnode([nt:base], [/test]) */]", result.toString());
     }
 
     @Override
@@ -86,16 +69,10 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
     }
 
     @Override
-    @Ignore("Failing on ES")
-    @Test
-    public void isChildNodeTest() throws Exception {
-        super.isChildNodeTest();
-    }
-
-    @Override
-    @Test
-    public void sql2FullText() throws Exception {
-        super.sql2FullText();
+    public String getExplainValueForDescendantTestWithIndexTagExplain() {
+        return "[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) "
+                + "{\"bool\":{\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}}]}}"
+                + " where isdescendantnode([nt:base], [/test]) */";
     }
 
 }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexQueryCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexQueryCommonTest.java
@@ -56,7 +56,6 @@ public abstract class IndexQueryCommonTest extends AbstractQueryTest {
 
     @Override
     protected void createTestIndexNode() throws Exception {
-        setTraversalEnabled(false);
         Tree index = root.getTree("/");
         indexDefn = createTestIndexNode(index, indexOptions.getIndexType());
         TestUtil.useV2(indexDefn);
@@ -78,16 +77,27 @@ public abstract class IndexQueryCommonTest extends AbstractQueryTest {
         Tree dateProp = TestUtil.enableForOrdered(props, "propDate");
         dateProp.setProperty(FulltextIndexConstants.PROP_TYPE, "Date");
 
+        // Note  - certain tests in this class like #sql2 test regex based like queries.
+        // And since all the tests here use this common full text index - please be careful while adding any new properties.
+        // For example - #sql2() tests with a query on length of name property.
+        // Since this is a fulltext index with a regex property that indexes everything, those property names are also indexed.
+        // So if we add any property with propName that has length equal to what that test expects - that will effectively break the #sql2() test (giving more results).
+        // Ideally one would see the test failing while adding new properties - but there have been cases where this test was ignored due to a different reason
+        // and adding a new property added more failure reasons.
+
+        // So just be careful while changing the test collateral/setup here.
+
         root.commit();
     }
 
+    // TODO : The below 3 tests - #sql1, #sq2 and #sql2FullText need refactoring.
+    //  These are huge tests with multiple queries running and verification happening in the end by comparing against results in an expected test file.
+    //  These could possibly be broken down into several smaller tests instead which would make debugging much easier.
     @Test
     public void sql1() throws Exception {
         test("sql1.txt");
     }
 
-    // TODO: Test failing on Lucene and ES
-    @Ignore("OAK-9858")
     @Test
     public void sql2() throws Exception {
         test("sql2.txt");
@@ -184,8 +194,6 @@ public abstract class IndexQueryCommonTest extends AbstractQueryTest {
         });
     }
 
-    // TODO: Test failing on Lucene and ES
-    @Ignore("OAK-9859")
     @Test
     public void isChildNodeTest() throws Exception {
         Tree tree = root.getTree("/");


### PR DESCRIPTION
This PR fixes multiple issues - both in tests as well as implementation code.

* https://github.com/apache/jackrabbit-oak/pull/653/commits/5ee6730f50171c657c40bbed986270a511c48229 - Make ES indexing sync using commit info map for IndexQueryCommonTests (this fixed a lot of test failures - behaviour is now similar to lucene)
* https://github.com/apache/jackrabbit-oak/pull/653/commits/4808d85e2bf33dacdf33cb2791a92dedf3b5c781 - Re-enable travesal for queries because there are some join queries in the tests where one part of the join requires traversal , this commit also fixes some expectations in tests that have been ignored for a while during which new tests added more collateral which changed the test expectations.
* https://github.com/apache/jackrabbit-oak/pull/653/commits/6c04951ecbd00b9f280872cc127ed49128dfdedf - Fixing sort for ES in case of sort property is not explicitly defined in the index definition but covered via a regex property.
* https://github.com/apache/jackrabbit-oak/pull/653/commits/5f161a2501342188f412241bf00489021e10d5eb - Fixing like queries in ES in case of fulltext/analyzed properties (needed to use fieldName.keyword instead of fieldName)
* https://github.com/apache/jackrabbit-oak/pull/653/commits/ce86979395ff1d1d632e2d18b11aceb0da41be1c - Fixing queries on nodeName constraint (:nodeName)
* https://github.com/apache/jackrabbit-oak/pull/653/commits/fa3dc375a0b83900eb5ae726553806ec5011b14b - Added missing test for path() function