### PR TITLE
OAK-9875-ut: full-text queries on date fields

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticAsyncQueryException.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticAsyncQueryException.java
@@ -22,7 +22,7 @@ public class ElasticAsyncQueryException extends RuntimeException {
 
     private final String esQuery;
 
-    public ElasticAsyncQueryException(Throwable cause, String jcrQuery, String esQuery) {
+    public ElasticAsyncQueryException(Throwable cause, String esQuery) {
         super(cause);
 
         this.esQuery = esQuery;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticAsyncQueryException.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticAsyncQueryException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.query.async;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+
+public class ElasticAsyncQueryException extends RuntimeException {
+
+    private final String esQuery;
+
+    public ElasticAsyncQueryException(Throwable cause, String jcrQuery, String esQuery) {
+        super(cause);
+
+        this.esQuery = esQuery;
+    }
+
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("Error retrieving data for ES query:\n\t%s", esQuery));
+        if (getCause() instanceof ElasticsearchException) {
+            ElasticsearchException esException = (ElasticsearchException) getCause();
+            sb.append("\n:: Elasticsearch response status: ").append(esException.status()).append(", message: ").append(esException.getMessage());
+            esException.error().rootCause().forEach(ec -> sb.append("\n\t* caused by ").append(ec.type()).append(": ").append(ec.reason()));
+        }
+        return sb.toString();
+    }
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -76,7 +76,7 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
     private final ElasticRequestHandler elasticRequestHandler;
     private final ElasticResponseHandler elasticResponseHandler;
     private final ElasticFacetProvider elasticFacetProvider;
-    private final AtomicReference<Throwable> errorRef = new AtomicReference();
+    private final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
     private FulltextResultRow nextRow;
 
@@ -336,13 +336,10 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                     System.currentTimeMillis() - searchStartTime);
             // Check in case errorRef is already set - this seems unlikely since we close the scanner once we hit failure.
             // But still, in case this do happen, we will log a warn.
-            Throwable error = errorRef.getAndSet(t);
+            Throwable error = errorRef.getAndSet(new ElasticAsyncQueryException(t, indexPlan.getFilter().toString(), ElasticIndexUtils.toString(query)));
             if (error != null) {
                 LOG.warn("Error reference for async iterator was previously set to {}. It has now been reset to new error {}", error.getMessage(), t.getMessage());
             }
-
-            LOG.error("Error retrieving data for jcr query [{}] :: Corresponding ES query {} : closing scanner, notifying listeners",
-                indexPlan.getFilter(), ElasticIndexUtils.toString(query), t);
             // closing scanner immediately after a failure avoiding them to hang (potentially) forever
             close();
         }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -336,7 +336,7 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                     System.currentTimeMillis() - searchStartTime);
             // Check in case errorRef is already set - this seems unlikely since we close the scanner once we hit failure.
             // But still, in case this do happen, we will log a warn.
-            Throwable error = errorRef.getAndSet(new ElasticAsyncQueryException(t, indexPlan.getFilter().toString(), ElasticIndexUtils.toString(query)));
+            Throwable error = errorRef.getAndSet(new ElasticAsyncQueryException(t, ElasticIndexUtils.toString(query)));
             if (error != null) {
                 LOG.warn("Error reference for async iterator was previously set to {}. It has now been reset to new error {}", error.getMessage(), t.getMessage());
             }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextIndexCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextIndexCommonTest.java
@@ -21,6 +21,8 @@ import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.FullTextIndexCommonTest;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.ElasticResultRowAsyncIterator;
 import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.slf4j.event.Level;
 
 import java.util.ArrayList;
@@ -67,4 +69,9 @@ public class ElasticFullTextIndexCommonTest extends FullTextIndexCommonTest {
         expectedLogList.add(log2);
         return expectedLogList;
     }
+
+    @Override
+    @Test
+    @Ignore("OAK-9875")
+    public void searchInDateField() {}
 }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.query.AbstractQueryTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -79,10 +80,16 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         Tree a = test.addChild("a");
         a.setProperty("analyzed_field", "1234abCd5678");
         a.setProperty("date_prop", "2014-04-01T09:58:03.231Z", Type.DATE);
+
+        Tree b = test.addChild("b");
+        b.setProperty("analyzed_field", "231Z");
+        b.setProperty("date_prop", "2014-04-01T10:58:03.000Z", Type.DATE);
         root.commit();
 
-        assertEventually(() ->
-                assertQuery("//*[jcr:contains(., '01T09')] ", XPATH, singletonList("/test/a")));
+        assertEventually(() -> {
+            assertQuery("//*[jcr:contains(., '01T09')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(., '231Z')] ", XPATH, Arrays.asList("/test/a", "/test/b"));
+        });
     }
 
 

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextIndexCommonTest.java
@@ -24,9 +24,11 @@ import org.apache.jackrabbit.oak.query.AbstractQueryTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
 
@@ -46,12 +48,12 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         root.commit();
 
         assertEventually(() -> {
-            assertQuery("//*[jcr:contains(@analyzed_field, 'SUN.JPG')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, 'Sun')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, 'jpg')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(., 'SUN.jpg')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(., 'sun')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(., 'jpg')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, 'SUN.JPG')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, 'Sun')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, 'jpg')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(., 'SUN.jpg')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(., 'sun')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(., 'jpg')] ", XPATH, singletonList("/test/a"));
         });
     }
 
@@ -63,10 +65,10 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         root.commit();
 
         assertEventually(() -> {
-            assertQuery("//*[jcr:contains(@analyzed_field, '1234')] ", XPATH, Collections.emptyList());
-            assertQuery("//*[jcr:contains(@analyzed_field, 'abcd')] ", XPATH, Collections.emptyList());
-            assertQuery("//*[jcr:contains(@analyzed_field, '5678')] ", XPATH, Collections.emptyList());
-            assertQuery("//*[jcr:contains(@analyzed_field, '1234abCd5678')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '1234')] ", XPATH, emptyList());
+            assertQuery("//*[jcr:contains(@analyzed_field, 'abcd')] ", XPATH, emptyList());
+            assertQuery("//*[jcr:contains(@analyzed_field, '5678')] ", XPATH, emptyList());
+            assertQuery("//*[jcr:contains(@analyzed_field, '1234abCd5678')] ", XPATH, singletonList("/test/a"));
         });
     }
 
@@ -80,7 +82,7 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         root.commit();
 
         assertEventually(() ->
-                assertQuery("//*[jcr:contains(., '01T09')] ", XPATH, Collections.singletonList("/test/a")));
+                assertQuery("//*[jcr:contains(., '01T09')] ", XPATH, singletonList("/test/a")));
     }
 
 
@@ -93,14 +95,14 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         assertEventually(() -> {
             // Special characters {':' , '/', '!', '&', '|', '='} are escaped before creating lucene/elastic queries using
             // {@see org.apache.jackrabbit.oak.plugins.index.search.spi.query.FullTextIndex#rewriteQueryText}
-            assertQuery("//*[jcr:contains(@analyzed_field, 'foo:')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '|foo/')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '&=!foo')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo:')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '|foo/')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '&=!foo')] ", XPATH, singletonList("/test/a"));
 
             // Braces are not escaped in the above rewriteQueryText method - we do not change that to maintain backward compatibility
             // So these need explicit escaping or filtering on client side while creating the jcr query
-            assertQuery("//*[jcr:contains(@analyzed_field, '\\{foo\\}')] ", XPATH, Collections.singletonList("/test/a"));
-            assertQuery("//*[jcr:contains(@analyzed_field, '\\[foo\\]')] ", XPATH, Collections.singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '\\{foo\\}')] ", XPATH, singletonList("/test/a"));
+            assertQuery("//*[jcr:contains(@analyzed_field, '\\[foo\\]')] ", XPATH, singletonList("/test/a"));
         });
 
     }
@@ -117,8 +119,8 @@ public abstract class FullTextIndexCommonTest extends AbstractQueryTest {
         // due to unescaped special character (which is not handled in backend)
         try {
             customLogs.starting();
-            assertQuery("//*[jcr:contains(@analyzed_field, 'foo}')] ", XPATH, Collections.emptyList());
-            assertQuery("//*[jcr:contains(@analyzed_field, 'foo]')] ", XPATH, Collections.emptyList());
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo}')] ", XPATH, emptyList());
+            assertQuery("//*[jcr:contains(@analyzed_field, 'foo]')] ", XPATH, emptyList());
 
             Assert.assertTrue(customLogs.getLogs().containsAll(getExpectedLogMessage()));
         } finally {


### PR DESCRIPTION
New unit test with full-text query on date field. Ignored in Elastic, it will be addressed with https://issues.apache.org/jira/browse/OAK-9875