### PR TITLE
OAK-9907 Allow comparing indexes in the same file

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/merge/IndexDiff.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/merge/IndexDiff.java
@@ -234,6 +234,13 @@ public class IndexDiff {
         }
     }
 
+    public static JsonObject compareIndexesInFile(Path indexPath, String index1, String index2) {
+        JsonObject indexDefinitions = IndexDiff.parseIndexDefinitions(indexPath.toString());
+        JsonObject target = new JsonObject(true);
+        compareIndexes(indexDefinitions, "", indexPath.toString(), index1, index2, target);
+        return target;
+    }
+
     private static void compareIndexesInDirectory(Path indexPath, String index1, String index2,
             JsonObject target) {
         if (Files.isDirectory(indexPath)) {


### PR DESCRIPTION
Details see https://issues.apache.org/jira/browse/OAK-9907

```
java -jar target/oak-run-1.45-SNAPSHOT.jar index-diff 
  --compare target/temp/indexes.json 
  --index1 "/oak:index/lucene-2" 
  --index2 "/oak:index/lucene-2-custom-1" 

Apache Jackrabbit Oak 1.45-SNAPSHOT
Comparing indexes /oak:index/lucene-2 and /oak:index/lucene-2-custom-1 in file "target/temp/indexes.json"
{
  "target/temp/indexes.json": {
    "indexRules/dam:Asset/properties/bmwPrismExpirationDate": "added",
    "reindexCount": {
      "old": 2,
      "new": 1
    },
    "seed": {
      "old": 2332276777086697624,
      "new": -8603665069484847725
    },
    "merges": {
      "new": ["/oak:index/damAsset"]
    }
  }
}
```