### PR TITLE
[Oak 9919] Add support for zstd, zlib to document store with mongodb

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -276,4 +276,9 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreServic
                     ". Note that this value can be overridden via framework " +
                     "property 'oak.documentstore.throttlingEnabled'")
     boolean throttlingEnabled() default DEFAULT_THROTTLING_ENABLED;
+
+    @AttributeDefinition(
+            name = "Document Node Store Compression",
+            description = "Select compressor type for collections. 'Snappy' is the default supported compression.")
+    String collectionCompressionType() default "snappy";
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -81,7 +81,6 @@ import org.apache.jackrabbit.oak.plugins.blob.datastore.BlobIdTracker;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils;
 import org.apache.jackrabbit.oak.plugins.document.persistentCache.PersistentCacheStats;
 import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
-import org.apache.jackrabbit.oak.plugins.document.util.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.spi.cluster.ClusterRepositoryInfo;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.BlobStoreWrapper;
@@ -314,6 +313,7 @@ public class DocumentNodeStoreService {
             builder.setSocketKeepAlive(soKeepAlive);
             builder.setLeaseSocketTimeout(config.mongoLeaseSocketTimeout());
             builder.setMongoDB(uri, db, config.blobCacheSize());
+            builder.setCollectionCompressionType(config.collectionCompressionType());
             mkBuilder = builder;
 
             log.info("Connected to database '{}'", db);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfig.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfig.java
@@ -25,10 +25,8 @@ import java.util.Map;
 
 public class MongoDBConfig {
     public static final String COLLECTION_COMPRESSION_TYPE = "collectionCompressionType";
-
-    private static final String STORAGE_ENGINE = "wiredTiger";
-
-    private static final String CONFIG = "configString";
+    public static final String STORAGE_ENGINE = "wiredTiger";
+    public static final String STORAGE_CONFIG = "configString";
 
     enum CollectionCompressor {
         SNAPPY("snappy"), ZLIB("zlib"), ZSTD("zstd");
@@ -70,7 +68,7 @@ public class MongoDBConfig {
         if (CollectionCompressor.isSupportedCompressor(compressionType)) {
             JsonObject root = new JsonObject();
             JsonObject configString = new JsonObject();
-            configString.getProperties().put(CONFIG,
+            configString.getProperties().put(STORAGE_CONFIG,
                     getCompressionConfig(mongoStorageOptions));
             root.getChildren().put(STORAGE_ENGINE, configString);
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfig.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfig.java
@@ -1,30 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jackrabbit.oak.plugins.document.mongo;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.jackrabbit.oak.commons.json.JsonObject;
 import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-/**
- * defines default mongodb config, provides support to add system properties
- */
+import java.util.Map;
+
 public class MongoDBConfig {
-    private static final Logger LOG = LoggerFactory.getLogger(MongoDBConfig.class);
+    public static final String COLLECTION_COMPRESSION_TYPE = "collectionCompressionType";
 
     private static final String STORAGE_ENGINE = "wiredTiger";
-    private static final String CONFIG = "configString";
-    private static final String ZSTD_COMPRESSION = "\"block_compressor=zstd\"";
 
-    public static Bson getCollectionStorageOptions(){
-        JsonObject root = new JsonObject();
-        JsonObject configString = new JsonObject();
-        configString.getProperties().put(CONFIG, ZSTD_COMPRESSION);
+    private static final String CONFIG = "configString";
+
+    enum CollectionCompressor {
+        SNAPPY("snappy"), ZLIB("zlib"), ZSTD("zstd");
+
+        private final String compressionType;
+
+        private static final Map<String, CollectionCompressor> supportedCompressionTypes = ImmutableMap.of(
+                "snappy", CollectionCompressor.SNAPPY, "zlib",
+                CollectionCompressor.ZLIB, "zstd", CollectionCompressor.ZSTD);
+
+        CollectionCompressor(String compressionType) {
+            this.compressionType = compressionType;
+        }
+
+        public String getCompressionType() {
+            return compressionType;
+        }
+
+        public static boolean isSupportedCompressor(String compressionType) {
+            return supportedCompressionTypes.containsKey(compressionType);
+        }
+
+    }
+
+    /**
+     * reads all storage options from map backed by config, and constructs
+     * storage options for collection to be created
+     *
+     * @param mongoStorageOptions
+     * @return
+     */
+    public static Bson getCollectionStorageOptions(
+            Map<String, String> mongoStorageOptions) {
+
+        String compressionType = mongoStorageOptions.getOrDefault(
+                COLLECTION_COMPRESSION_TYPE,
+                CollectionCompressor.SNAPPY.getCompressionType());
+
+        if (CollectionCompressor.isSupportedCompressor(compressionType)) {
+            JsonObject root = new JsonObject();
+            JsonObject configString = new JsonObject();
+            configString.getProperties().put(CONFIG,
+                    getCompressionConfig(mongoStorageOptions));
             root.getChildren().put(STORAGE_ENGINE, configString);
 
-        LOG.info("Collection Config:" + root.toString());
-        Bson storageOptions = BsonDocument.parse(root.toString());
-        return storageOptions;
+            Bson storageOptions = BsonDocument.parse(root.toString());
+            return storageOptions;
+        } else {
+            throw new IllegalArgumentException("Invalid collection compression type provided " + compressionType);
+        }
+    }
+
+    private static String getCompressionConfig(
+            Map<String, String> storageOptions) {
+        return "\"block_compressor=" + storageOptions.getOrDefault(
+                COLLECTION_COMPRESSION_TYPE, "snappy") + "\"";
     }
 
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfig.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfig.java
@@ -1,0 +1,30 @@
+package org.apache.jackrabbit.oak.plugins.document.mongo;
+
+import org.apache.jackrabbit.oak.commons.json.JsonObject;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * defines default mongodb config, provides support to add system properties
+ */
+public class MongoDBConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBConfig.class);
+
+    private static final String STORAGE_ENGINE = "wiredTiger";
+    private static final String CONFIG = "configString";
+    private static final String ZSTD_COMPRESSION = "\"block_compressor=zstd\"";
+
+    public static Bson getCollectionStorageOptions(){
+        JsonObject root = new JsonObject();
+        JsonObject configString = new JsonObject();
+        configString.getProperties().put(CONFIG, ZSTD_COMPRESSION);
+            root.getChildren().put(STORAGE_ENGINE, configString);
+
+        LOG.info("Collection Config:" + root.toString());
+        Bson storageOptions = BsonDocument.parse(root.toString());
+        return storageOptions;
+    }
+
+}

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -162,6 +162,11 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         return thisBuilder();
     }
 
+    public T setCollectionCompressionType(String compressionType) {
+        this.collectionCompressionType = compressionType;
+        return thisBuilder();
+    }
+
     @Override
     public VersionGCSupport createVersionGCSupport() {
         DocumentStore store = getDocumentStore();
@@ -192,14 +197,6 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         }
     }
 
-    public T setCollectionCompressionType(String type) {
-        //final DocumentStore store = getDocumentStore();
-       // if (store instanceof MongoDocumentStore) {
-            this.collectionCompressionType = type;
-       // }
-
-        return thisBuilder();
-    }
 
     public String getCollectionCompressionType(){
         return collectionCompressionType;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -46,6 +46,7 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     private int leaseSocketTimeout = 0;
     private String uri;
     private String name;
+    private String collectionCompressionType;
 
     /**
      * Uses the given information to connect to to MongoDB as backend
@@ -189,6 +190,19 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         } else {
             return super.createMissingLastRevSeeker();
         }
+    }
+
+    public T setCollectionCompressionType(String type) {
+        //final DocumentStore store = getDocumentStore();
+       // if (store instanceof MongoDocumentStore) {
+            this.collectionCompressionType = type;
+       // }
+
+        return thisBuilder();
+    }
+
+    public String getCollectionCompressionType(){
+        return collectionCompressionType;
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -244,7 +244,7 @@ public class MongoDocumentStore implements DocumentStore {
      * How many times should be the bulk update request retries in case of
      * a conflict.
      * <p>
-     * Default is 0 (no retries).≠≠
+     * Default is 0 (no retries).
      */
     private int bulkRetries =
             Integer.getInteger("oak.mongo.bulkRetries", 0);
@@ -393,7 +393,7 @@ public class MongoDocumentStore implements DocumentStore {
         return mc;
     }
 
-    private void ensureIndexes(MongoDatabase db, @NotNull MongoStatus mongoStatus) {
+    private void ensureIndexes(@NotNull MongoDatabase db, @NotNull MongoStatus mongoStatus) {
         // reading documents in the nodes collection and checking
         // existing indexes is performed against the MongoDB primary
         // this ensures the information is up-to-date and accurate

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -459,8 +459,7 @@ public class MongoDocumentStore implements DocumentStore {
 
         if (mongoStatus.isVersion(4, 2)) {
             options.storageEngineOptions(MongoDBConfig.getCollectionStorageOptions(mongoStorageOptions));
-            if (!db.listCollectionNames()
-                    .into(new ArrayList<>()).contains(collectionName)) {
+            if (!Iterables.tryFind(db.listCollectionNames(), s -> Objects.equals(collectionName, s)).isPresent()) {
                 db.createCollection(collectionName, options);
                 LOG.info("Creating Collection {}, with collection storage options", collectionName);
             }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -462,7 +462,7 @@ public class MongoDocumentStore implements DocumentStore {
             if (!db.listCollectionNames()
                     .into(new ArrayList<>()).contains(collectionName)) {
                 db.createCollection(collectionName, options);
-                LOG.info("Creating Collection {}, by applying collection storage options", collectionName);
+                LOG.info("Creating Collection {}, with collection storage options", collectionName);
             }
         }
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -195,8 +195,6 @@ public class MongoDocumentStore implements DocumentStore {
     private final MongoDBConnection connection;
     private final MongoDBConnection clusterNodesConnection;
 
-    private String MongoDBBlockCompressor;
-
     private final NodeDocumentCache nodesCache;
 
     private final NodeDocumentLocks nodeLocks;
@@ -1822,14 +1820,6 @@ public class MongoDocumentStore implements DocumentStore {
             doc = null;
         }
         return doc;
-    }
-
-    public String getMongoDBBlockCompressor() {
-        return MongoDBBlockCompressor;
-    }
-
-    public void setMongoDBBlockCompressor(String mongoDBBlockCompressor) {
-        MongoDBBlockCompressor = mongoDBBlockCompressor;
     }
 
     @NotNull

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfigTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.mongo;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBConfig.CollectionCompressor;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.junit.Test;
+
+import java.util.Collections;
+import static org.junit.Assert.assertTrue;
+
+
+public class MongoDBConfigTest {
+
+    private MongoDBConfig mongoDBConfig;
+
+    @Test
+    public void defaultCollectionStorageOptions() {
+        Bson bson = mongoDBConfig.getCollectionStorageOptions(Collections.emptyMap());
+        BsonDocument bsonDocument = bson.toBsonDocument(BasicDBObject.class, MongoClient.getDefaultCodecRegistry());
+        String  configuredCompressor = bsonDocument.getDocument(MongoDBConfig.STORAGE_ENGINE).getString(MongoDBConfig.STORAGE_CONFIG).getValue();
+        assertTrue(configuredCompressor.indexOf(CollectionCompressor.SNAPPY.getCompressionType()) > 0);
+
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void invalidCollectionStorageOptions() throws Exception {
+        mongoDBConfig.getCollectionStorageOptions(Collections.singletonMap(MongoDBConfig.COLLECTION_COMPRESSION_TYPE, "Invalid"));
+    }
+
+    @Test
+    public void overrideDefaultCollectionStorageOptions() {
+        Bson bson = mongoDBConfig.getCollectionStorageOptions(Collections.singletonMap(MongoDBConfig.COLLECTION_COMPRESSION_TYPE, "zstd"));
+        BsonDocument bsonDocument = bson.toBsonDocument(BasicDBObject.class, MongoClient.getDefaultCodecRegistry());
+        String  configuredCompressor = bsonDocument.getDocument(MongoDBConfig.STORAGE_ENGINE).getString(MongoDBConfig.STORAGE_CONFIG).getValue();
+
+        assertTrue(configuredCompressor.indexOf(CollectionCompressor.ZSTD.getCompressionType()) > 0);
+    }
+
+
+
+}

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfigTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfigTest.java
@@ -24,36 +24,44 @@ import org.bson.conversions.Bson;
 import org.junit.Test;
 
 import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBConfig.getCollectionStorageOptions;
+import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBConfig.COLLECTION_COMPRESSION_TYPE;
+import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBConfig.STORAGE_CONFIG;
+import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDBConfig.STORAGE_ENGINE;
 
 
 public class MongoDBConfigTest {
 
-    private MongoDBConfig mongoDBConfig;
-
     @Test
     public void defaultCollectionStorageOptions() {
-        Bson bson = mongoDBConfig.getCollectionStorageOptions(Collections.emptyMap());
+        Bson bson = getCollectionStorageOptions(Collections.emptyMap());
         BsonDocument bsonDocument = bson.toBsonDocument(BasicDBObject.class, MongoClient.getDefaultCodecRegistry());
-        String  configuredCompressor = bsonDocument.getDocument(MongoDBConfig.STORAGE_ENGINE).getString(MongoDBConfig.STORAGE_CONFIG).getValue();
-        assertTrue(configuredCompressor.indexOf(CollectionCompressor.SNAPPY.getCompressionType()) > 0);
+        String  configuredCompressor = bsonDocument.getDocument(STORAGE_ENGINE).getString(STORAGE_CONFIG).getValue();
+        assertTrue(configuredCompressor.indexOf(CollectionCompressor.SNAPPY.getName()) > 0);
 
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void invalidCollectionStorageOptions() throws Exception {
-        mongoDBConfig.getCollectionStorageOptions(Collections.singletonMap(MongoDBConfig.COLLECTION_COMPRESSION_TYPE, "Invalid"));
+    @Test
+    public void invalidCollectionStorageOptions() {
+        try {
+            getCollectionStorageOptions(Collections.singletonMap(COLLECTION_COMPRESSION_TYPE, "Invalid"));
+            fail("Fail with IllegalArgumentException");
+        } catch(Exception e) {
+            assertEquals("Invalid collection compressionType provided: Invalid", e.getMessage());
+        }
     }
 
     @Test
     public void overrideDefaultCollectionStorageOptions() {
-        Bson bson = mongoDBConfig.getCollectionStorageOptions(Collections.singletonMap(MongoDBConfig.COLLECTION_COMPRESSION_TYPE, "zstd"));
+        Bson bson = getCollectionStorageOptions(Collections.singletonMap(COLLECTION_COMPRESSION_TYPE, "zstd"));
         BsonDocument bsonDocument = bson.toBsonDocument(BasicDBObject.class, MongoClient.getDefaultCodecRegistry());
-        String  configuredCompressor = bsonDocument.getDocument(MongoDBConfig.STORAGE_ENGINE).getString(MongoDBConfig.STORAGE_CONFIG).getValue();
+        String  configuredCompressor = bsonDocument.getDocument(STORAGE_ENGINE).getString(STORAGE_CONFIG).getValue();
 
-        assertTrue(configuredCompressor.indexOf(CollectionCompressor.ZSTD.getCompressionType()) > 0);
+        assertTrue(configuredCompressor.indexOf(CollectionCompressor.ZSTD.getName()) > 0);
     }
-
-
 
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfigTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConfigTest.java
@@ -45,14 +45,10 @@ public class MongoDBConfigTest {
 
     }
 
-    @Test
+    @Test (expected = IllegalArgumentException.class)
     public void invalidCollectionStorageOptions() {
-        try {
-            getCollectionStorageOptions(Collections.singletonMap(COLLECTION_COMPRESSION_TYPE, "Invalid"));
-            fail("Fail with IllegalArgumentException");
-        } catch(Exception e) {
-            assertEquals("Invalid collection compressionType provided: Invalid", e.getMessage());
-        }
+        getCollectionStorageOptions(Collections.singletonMap(COLLECTION_COMPRESSION_TYPE, "Invalid"));
+        fail("Should fail with IllegalArgumentException due to Invalid Compressor");
     }
 
     @Test

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderTest.java
@@ -47,4 +47,10 @@ public class MongoDocumentNodeStoreBuilderTest {
         MongoDocumentNodeStoreBuilder builder = new MongoDocumentNodeStoreBuilder();
         assertNull(builder.getDocStoreThrottlingFeature());
     }
+
+    @Test
+    public void collectionCompressionDisabled() {
+        MongoDocumentNodeStoreBuilder builder = new MongoDocumentNodeStoreBuilder();
+        assertNull(builder.getCollectionCompressionType());
+    }
 }


### PR DESCRIPTION
- Provides support for other compression algorithms (zstd, zlib) besides default collection compressor (snappy)
- This compressors (zstd) are only valid for mongodb v4.2 and above.
- These compressors are applicable to collections only
- Currently the document compressors should be applied per collection, as there is no ability to apply the compressors for all collections at once.