### PR TITLE
OAK-9920 - ExternalPrivateStoreIT.testSyncBigBlob failures

### DIFF
--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/standby/DataStoreTestBase.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/standby/DataStoreTestBase.java
@@ -288,7 +288,7 @@ public abstract class DataStoreTestBase extends TestBase {
                 .withPort(serverPort.getPort())
                 .withFileStore(secondary)
                 .withSecureConnection(false)
-                .withReadTimeoutMs(2 * 60 * 1000)
+                .withReadTimeoutMs(4 * 60 * 1000)
                 .withAutoClean(false)
                 .withSpoolFolder(folder.newFolder())
                 .build()


### PR DESCRIPTION
Increased client read timeout to 4 mins