### PR TITLE
OAK-9891: Removal (purge) of version of a node does not remove associated labels

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/ReadWriteVersionManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/ReadWriteVersionManager.java
@@ -187,7 +187,7 @@ public class ReadWriteVersionManager extends ReadOnlyVersionManager {
         NodeBuilder versionNode = vh.getChildNode(versionName);
         String versionId = versionNode.getProperty(JCR_UUID).getValue(Type.STRING);
         // unregister from labels
-        for (String label : getVersionLabels(versionRelPath, versionId)) {
+        for (String label : getVersionLabels(historyRelPath, versionId)) {
             removeVersionLabel(historyRelPath, label);
         }
         // reconnected predecessors and successors of the version being removed

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryTest.java
@@ -163,20 +163,17 @@ public class VersionHistoryTest extends AbstractJCRTest {
         assertFalse("VersionHistory node should have disappeared", superuser.itemExists(vhrpath));
     }
 
-    public void testRemoveVersionLabelWithRemovalOfVersion() throws RepositoryException{
+    public void testRemoveVersionLabelWithRemovalOfVersion() throws RepositoryException {
         int createVersions = 3;
         Node n = testRootNode.addNode(nodeName1, testNodeType);
         n.addMixin(mixVersionable);
         superuser.save();
-
-        VersionManager vm = superuser.getWorkspace().getVersionManager();
         for (int i = 0; i < createVersions; i++) {
-            vm.checkout(n.getPath());
-            vm.checkin(n.getPath());
+            versionManager.checkout(n.getPath());
+            versionManager.checkin(n.getPath());
         }
-        superuser.save();
 
-        VersionHistory vhr = vm.getVersionHistory(n.getPath());
+        VersionHistory vhr = versionManager.getVersionHistory(n.getPath());
         // initialize versionName
         String versionName = "";
         VersionIterator allversions = vhr.getAllVersions();
@@ -188,20 +185,16 @@ public class VersionHistoryTest extends AbstractJCRTest {
             }
             count++;
         }
-        int versonLabelCount = 3;
+        int versionLabelCount = 3;
         List<String> versionLabels = new ArrayList<>();
-        for(int i = 0; i < versonLabelCount; i++) {
+        for(int i = 0; i < versionLabelCount; i++) {
             String labelName = "Label_" + versionName + "_" + i;
             vhr.addVersionLabel(versionName, labelName,false);
             versionLabels.add(labelName);
         }
-
-        superuser.save();
         vhr.removeVersion(versionName);
-        superuser.save();
-
         for(String label : versionLabels) {
-            assertEquals("version label should not exist", false, vhr.hasVersionLabel(label));
+            assertFalse("version label should not exist", vhr.hasVersionLabel(label));
         }
 
     }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryTest.java
@@ -159,4 +159,43 @@ public class VersionHistoryTest extends AbstractJCRTest {
 
         assertFalse("VersionHistory node should have disappeared", superuser.itemExists(vhrpath));
     }
+
+    public void testRemoveVersionLabelWithRemovalOfVersion() throws RepositoryException{
+        int createVersions = 3;
+        Node n = testRootNode.addNode(nodeName1, testNodeType);
+        n.addMixin(mixVersionable);
+        superuser.save();
+
+        VersionManager vm = superuser.getWorkspace().getVersionManager();
+        for (int i = 0; i < createVersions; i++) {
+            vm.checkout(n.getPath());
+            vm.checkin(n.getPath());
+        }
+        superuser.save();
+
+        VersionHistory vhr = vm.getVersionHistory(n.getPath());
+        // initialize versionName
+        String versionName= "";
+        VersionIterator allversions = vhr.getAllVersions();
+        int count=0;
+        while (allversions.hasNext()) {
+            Version version = allversions.nextVersion();
+            if(count == 1) {
+                versionName=version.getName();
+            }
+            count++;
+        }
+        vhr.addVersionLabel(versionName,"Label_" + versionName + "_0",false);
+        vhr.addVersionLabel(versionName,"Label_" + versionName + "_1",false);
+        vhr.addVersionLabel(versionName,"Label_" + versionName + "_2",false);
+        superuser.save();
+        vhr.removeVersion(versionName);
+        superuser.save();
+
+        assertEquals("version label should not exist", false, vhr.hasVersionLabel("Label_" + versionName + "_0"));
+        assertEquals("version label should not exist", false, vhr.hasVersionLabel("Label_" + versionName + "_1"));
+        assertEquals("version label should not exist", false, vhr.hasVersionLabel("Label_" + versionName + "_2"));
+
+    }
+
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryTest.java
@@ -27,6 +27,9 @@ import javax.jcr.version.VersionManager;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.test.AbstractJCRTest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Contains {@link VersionHistory} related tests.
  */
@@ -175,26 +178,31 @@ public class VersionHistoryTest extends AbstractJCRTest {
 
         VersionHistory vhr = vm.getVersionHistory(n.getPath());
         // initialize versionName
-        String versionName= "";
+        String versionName = "";
         VersionIterator allversions = vhr.getAllVersions();
-        int count=0;
+        int count = 0;
         while (allversions.hasNext()) {
             Version version = allversions.nextVersion();
             if(count == 1) {
-                versionName=version.getName();
+                versionName = version.getName();
             }
             count++;
         }
-        vhr.addVersionLabel(versionName,"Label_" + versionName + "_0",false);
-        vhr.addVersionLabel(versionName,"Label_" + versionName + "_1",false);
-        vhr.addVersionLabel(versionName,"Label_" + versionName + "_2",false);
+        int versonLabelCount = 3;
+        List<String> versionLabels = new ArrayList<>();
+        for(int i = 0; i < versonLabelCount; i++) {
+            String labelName = "Label_" + versionName + "_" + i;
+            vhr.addVersionLabel(versionName, labelName,false);
+            versionLabels.add(labelName);
+        }
+
         superuser.save();
         vhr.removeVersion(versionName);
         superuser.save();
 
-        assertEquals("version label should not exist", false, vhr.hasVersionLabel("Label_" + versionName + "_0"));
-        assertEquals("version label should not exist", false, vhr.hasVersionLabel("Label_" + versionName + "_1"));
-        assertEquals("version label should not exist", false, vhr.hasVersionLabel("Label_" + versionName + "_2"));
+        for(String label : versionLabels) {
+            assertEquals("version label should not exist", false, vhr.hasVersionLabel(label));
+        }
 
     }
 


### PR DESCRIPTION
pull request for issue : OAK-9891
mail thread link: https://lists.apache.org/thread/b1g2f3cxxfpfnqxzr3oz20lyp8676tnm