### PR TITLE
OAK-9898 expire PRs older than 2 years

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: 'Close stale PR and Issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+          days-before-pr-stale: 730
+          days-before-pr-close: 30


### PR DESCRIPTION
Let's start with all PRs older than 2 years; when we dealt with them (the list is long!) we can reduce it in a second step to all PRs older than 1 year.