### PR TITLE
OAK-9924: elastic mbean reports both primary and store size

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexInfoProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexInfoProvider.java
@@ -66,7 +66,7 @@ class ElasticIndexInfoProvider implements IndexInfoProvider {
                     asyncInfo != null ? asyncInfo.getLastIndexedTo() : -1L,
                     getStatusTimestamp(node.getDefinition().getDefinitionNodeState(), IndexDefinition.STATUS_LAST_UPDATED),
                     node.getIndexStatistics().numDocs(),
-                    node.getIndexStatistics().size(),
+                    node.getIndexStatistics().primaryStoreSize(),
                     node.getIndexStatistics().creationDate(),
                     getStatusTimestamp(node.getDefinition().getDefinitionNodeState(), IndexDefinition.REINDEX_COMPLETION_TIMESTAMP)
             );

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexMBean.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexMBean.java
@@ -57,11 +57,14 @@ class ElasticIndexMBean implements IndexMBean {
                 try {
                     indexNode = indexTracker.acquireIndexNode(path);
                     if (indexNode != null) {
-                        long size = indexNode.getIndexStatistics().size();
+                        long primaryStoreSize = indexNode.getIndexStatistics().primaryStoreSize();
+                        long storeSize = indexNode.getIndexStatistics().storeSize();
                         Object[] values = new Object[]{
                                 path,
-                                IOUtils.humanReadableByteCount(size),
-                                size,
+                                IOUtils.humanReadableByteCount(primaryStoreSize),
+                                primaryStoreSize,
+                                IOUtils.humanReadableByteCount(storeSize),
+                                storeSize,
                                 indexNode.getIndexStatistics().numDocs(),
                                 indexNode.getIndexStatistics().luceneNumDocs(),
                                 indexNode.getIndexStatistics().luceneNumDeletedDocs()
@@ -85,7 +88,7 @@ class ElasticIndexMBean implements IndexMBean {
         ElasticIndexNode indexNode = indexTracker.acquireIndexNode(indexPath);
         if (indexNode != null) {
             try {
-                return String.valueOf(indexNode.getIndexStatistics().size());
+                return String.valueOf(indexNode.getIndexStatistics().primaryStoreSize());
             } finally {
                 indexNode.release();
             }
@@ -112,6 +115,8 @@ class ElasticIndexMBean implements IndexMBean {
                 "path",
                 "indexSizeStr",
                 "indexSize",
+                "indexSizeWithReplicasStr",
+                "indexSizeWithReplicas",
                 "numDocs",
                 "luceneNumDoc",
                 "luceneNumDeletedDocs"
@@ -121,6 +126,8 @@ class ElasticIndexMBean implements IndexMBean {
                 "Path",
                 "Index size in human readable format",
                 "Index size in bytes",
+                "Index size, including replicas, in human readable format",
+                "Index size, including replicas, in bytes",
                 "Number of documents in this index",
                 "Number of low-level lucene documents in this index, including nested ones",
                 "Number of deleted low-level lucene documents in this index, including nested ones"
@@ -129,6 +136,8 @@ class ElasticIndexMBean implements IndexMBean {
         @SuppressWarnings("rawtypes")
         static final OpenType[] FIELD_TYPES = new OpenType[]{
                 SimpleType.STRING,
+                SimpleType.STRING,
+                SimpleType.LONG,
                 SimpleType.STRING,
                 SimpleType.LONG,
                 SimpleType.INTEGER,

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -217,7 +217,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
             // Assuming a single index matches crd.index
             IndicesRecord record = records.get(0);
             String storeSize = record.storeSize();
-            String primaryStoreSize = record.storeSize();
+            String primaryStoreSize = record.priStoreSize();
             String creationDate = record.creationDateString();
             String luceneDocsCount = record.docsCount();
             String luceneDocsDeleted = record.docsDeleted();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticMetricHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticMetricHandler.java
@@ -46,14 +46,14 @@ public class ElasticMetricHandler {
 
     private static final String INDEX_DOCUMENTS = "ELASTIC_INDEX_DOCUMENTS";
     private static final String INDEX_SIZE = "ELASTIC_INDEX_SIZE";
+    private static final String INDEX_WITH_REPLICAS_SIZE = "ELASTIC_INDEX_WITH_REPLICAS_SIZE";
 
     private final BiFunction<String, Map<String, String>, MeterStats> meter;
     private final BiFunction<String, Map<String, String>, HistogramStats> histogram;
     private final BiFunction<String, Map<String, String>, TimerStats> timer;
-    private final StatsProviderUtil statsProviderUtil;
 
     public ElasticMetricHandler(StatisticsProvider sp) {
-        statsProviderUtil = new StatsProviderUtil(sp);
+        StatsProviderUtil statsProviderUtil = new StatsProviderUtil(sp);
         meter = statsProviderUtil.getMeterStats();
         histogram = statsProviderUtil.getHistoStats();
         timer = statsProviderUtil.getTimerStats();
@@ -123,11 +123,13 @@ public class ElasticMetricHandler {
     /**
      * Tracks the size of an index
      *
-     * @param index the index passed as metric label
-     * @param size the total size in bytes. The value includes potential replicas
+     * @param index         the index passed as metric label
+     * @param primarySize   the primary shards size
+     * @param storeSize     the total size in bytes. The value includes potential replicas
      */
-    public void markSize(String index, long size) {
+    public void markSize(String index, long primarySize, long storeSize) {
         Map<String, String> labels = Collections.singletonMap("index", index);
-        histogram.apply(INDEX_SIZE, labels).update(size);
+        histogram.apply(INDEX_SIZE, labels).update(primarySize);
+        histogram.apply(INDEX_WITH_REPLICAS_SIZE, labels).update(storeSize);
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNameHelper;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNode;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
@@ -144,9 +145,10 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     private void saveMetrics() {
         ElasticIndexNode indexNode = indexTracker.acquireIndexNode(indexDefinition.getIndexPath());
         if (indexNode != null) {
+            ElasticIndexStatistics stats = indexNode.getIndexStatistics();
             try {
                 indexTracker.getElasticMetricHandler().markDocuments(indexName, indexNode.getIndexStatistics().numDocs());
-                indexTracker.getElasticMetricHandler().markSize(indexName, indexNode.getIndexStatistics().size());
+                indexTracker.getElasticMetricHandler().markSize(indexName, stats.primaryStoreSize(), stats.storeSize());
             } catch (Exception e) {
                 LOG.warn("Unable to store metrics for {}", indexNode.getDefinition().getIndexPath(), e);
             } finally {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
@@ -70,7 +70,7 @@ public class ElasticContentTest extends ElasticAbstractQueryTest {
         assertTrue(exists(index));
         assertThat(0L, equalTo(countDocuments(index)));
         // there are no updates, so metrics won't be refreshed
-        verify(spyMetricHandler, never()).markSize(anyString(), anyLong());
+        verify(spyMetricHandler, never()).markSize(anyString(), anyLong(), anyLong());
         verify(spyMetricHandler, never()).markDocuments(anyString(), anyLong());
 
         reset(spyMetricHandler);
@@ -79,7 +79,7 @@ public class ElasticContentTest extends ElasticAbstractQueryTest {
         content.addChild("not-indexed").setProperty("b", "foo");
         root.commit();
 
-        verify(spyMetricHandler).markSize(eq(indexNameWithPrefix), geq(0L));
+        verify(spyMetricHandler).markSize(eq(indexNameWithPrefix), geq(0L), geq(0L));
         verify(spyMetricHandler).markDocuments(eq(indexNameWithPrefix), geq(0L));
         assertEventually(() -> assertThat(countDocuments(index), equalTo(1L)));
 


### PR DESCRIPTION
The Elastic MBean `indexSize` returned the total store size (which includes replicas). This was a bit confusing since, depending on the replica factor, this value could be way bigger than the sole primary shards' size.

`indexSize` now returns the primary shards' size, and a new column `indexSizeWithReplicas` returns the total size including replicas. Also aligned metrics to rerun both values.