### PR TITLE
OAK-9951 - Improve support for running unit tests with Elasticsearch 8

### DIFF
--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
@@ -45,7 +45,9 @@ public class ElasticTestServer implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticTestServer.class);
     private static final Map<String, String> PLUGIN_OFFICIAL_RELEASES_DIGEST_MAP = ImmutableMap.of(
             "7.17.3.0", "5e3b40bb72b2813f927be9bf6ecdf88668d89d2ef20c7ebafaa51ab8407fd179",
-            "7.17.6.0", "326893bb98ef1a0c569d9f4c4a9a073e53361924f990b17e87077985ce8a7478"
+            "7.17.6.0", "326893bb98ef1a0c569d9f4c4a9a073e53361924f990b17e87077985ce8a7478",
+            "8.3.3.0", "14d3223456f4b9f00f86628ec8400cb46513935e618ae0f5d0d1088739ccc233",
+            "8.4.1.0", "56797a1bac6ceeaa36d2358f818b14633124d79c5e04630fa3544603d82eaa01"
     );
 
     private static final ElasticTestServer SERVER = new ElasticTestServer();

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
@@ -47,7 +47,8 @@ public class ElasticTestServer implements AutoCloseable {
             "7.17.3.0", "5e3b40bb72b2813f927be9bf6ecdf88668d89d2ef20c7ebafaa51ab8407fd179",
             "7.17.6.0", "326893bb98ef1a0c569d9f4c4a9a073e53361924f990b17e87077985ce8a7478",
             "8.3.3.0", "14d3223456f4b9f00f86628ec8400cb46513935e618ae0f5d0d1088739ccc233",
-            "8.4.1.0", "56797a1bac6ceeaa36d2358f818b14633124d79c5e04630fa3544603d82eaa01"
+            "8.4.1.0", "56797a1bac6ceeaa36d2358f818b14633124d79c5e04630fa3544603d82eaa01",
+            "8.4.2.0", "5ce81ad043816900a496ad5b3cce7de1d99547ebf92aa1f9856343e48580c71c"
     );
 
     private static final ElasticTestServer SERVER = new ElasticTestServer();


### PR DESCRIPTION
Add OOTB support for testing with Elasticsearch 8.3.3, 8.4.1 and 8.4.2.  Now it is enough to pass the property -DelasticDockerImageVersion=[8.3.3|8.4.1|8.4.2] to the Maven build.

In more detail: the tests need to install the Elastiknn plugin in the test Elasticsearch container, with a matching version. The plugin is downloaded from GitHub at the start of the tests. To validate that the right plugin was downloaded, the test infrastructure compares the digest of the file with the plugin with an expected digest. This PR adds the digests for versions 8.3.3, 8.4.1 and 8.4.2 of the Elastiknn plugin.