### PR TITLE
OAK-9950|Update tika version in oak

### DIFF
--- a/oak-it-osgi/src/test/resources/versions.properties
+++ b/oak-it-osgi/src/test/resources/versions.properties
@@ -18,5 +18,5 @@ tika=${tika.version}
 poi=4.0.1
 commons-collections4=4.1
 commons-compress=1.20
-commons-lang3=3.10
+commons-lang3=3.12.0
 commons-math3=3.6.1

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -617,7 +617,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.10</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -61,7 +61,7 @@
     <slf4j.version>1.7.32</slf4j.version> <!-- sync with logback version -->
     <logback.version>1.2.10</logback.version>
     <h2.version>2.0.206</h2.version>
-    <tika.version>1.24.1</tika.version>
+    <tika.version>1.26</tika.version>
     <guava.version>15.0</guava.version>
     <guava.osgi.import>com.google.common.*;version="[15.0,21)"</guava.osgi.import>
     <derby.version>10.14.2.0</derby.version>


### PR DESCRIPTION
BDSA-2021-0824 (CVE-2021-28657)

A carefully crafted or corrupt file may trigger an infinite loop in Tika's MP3Parser up to and including Tika 1.25. Apache Tika users should upgrade to 1.26 or later.