### PR TITLE
OAK-9960: (oak-run) introduced datastore-copy command

### DIFF
--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -742,6 +742,9 @@ The following options are available:
     --sas-token             - The SAS token to access Azure Storage.
     --out-dir               - Path where to store the blobs (Optional). Otherwise, blobs will be stored in the current directory.
     --concurrency           - Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores).
+    --connect-timeout       - Sets a specific timeout value, in milliseconds, to be used when opening a connection for a
+                                single blob (default 60_000ms[1m])
+    --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 3_600_000ms[1h])
 
 Reset Cluster Id
 ---------------

--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -748,7 +748,7 @@ The following options are available:
     --connect-timeout       - Sets a specific timeout value, in milliseconds, to be used when opening a connection for a
                                 single blob (default 60_000ms[1m])
     --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 3_600_000ms[1h])
-    --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 30_000ms[30s])
+    --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 10_000ms[10s])
 
 Reset Cluster Id
 ---------------

--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -731,7 +731,10 @@ Command to concurrently download blobs from an Azure datastore using sas token a
             [--file-include-path <file_with_paths_to_include>] \
             [--sas-token <authentication_token>] \
             [--out-dir <output_path>] \
-            [--concurrency <max_requests>]
+            [--concurrency <max_requests>] \
+            [--connect-timeout <milliseconds>] \
+            [--read-timeout <milliseconds>] \
+            [--slow-log-threshold <milliseconds>]
 
 The following options are available:
 
@@ -745,6 +748,7 @@ The following options are available:
     --connect-timeout       - Sets a specific timeout value, in milliseconds, to be used when opening a connection for a
                                 single blob (default 60_000ms[1m])
     --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 3_600_000ms[1h])
+    --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 30_000ms[30s])
 
 Reset Cluster Id
 ---------------

--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -748,12 +748,12 @@ The following options are available:
     --out-dir               - Path where to store the blobs (Optional). Otherwise, blobs will be stored in the current directory.
     --concurrency           - Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores).
     --connect-timeout       - Sets a specific timeout value, in milliseconds, to be used when opening a connection for a
-                                single blob (default 0, no timeout)
-    --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 0, no timeout)
-    --max-retries           - Max number of retries when a blob download fails (default 3)
+                                single blob (default 0, no timeout).
+    --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 0, no timeout).
+    --max-retries           - Max number of retries when a blob download fails (default 3).
     --fail-on-error         - If true fails the execution immediately after the first error, otherwise it continues processing 
-                                all the blobs (default false)
-    --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 10_000ms[10s])
+                                all the blobs. When false, the command will fail only if no blobs were downloaded (default false).
+    --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 10_000ms[10s]).
 
 Reset Cluster Id
 ---------------

--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -734,6 +734,8 @@ Command to concurrently download blobs from an Azure datastore using sas token a
             [--concurrency <max_requests>] \
             [--connect-timeout <milliseconds>] \
             [--read-timeout <milliseconds>] \
+            [--max-retries <retries>] \
+            [--fail-on-error <boolean>] \
             [--slow-log-threshold <milliseconds>]
 
 The following options are available:
@@ -746,8 +748,11 @@ The following options are available:
     --out-dir               - Path where to store the blobs (Optional). Otherwise, blobs will be stored in the current directory.
     --concurrency           - Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores).
     --connect-timeout       - Sets a specific timeout value, in milliseconds, to be used when opening a connection for a
-                                single blob (default 60_000ms[1m])
-    --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 3_600_000ms[1h])
+                                single blob (default 0, no timeout)
+    --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 0, no timeout)
+    --max-retries           - Max number of retries when a blob download fails (default 3)
+    --fail-on-error         - If true fails the execution immediately after the first error, otherwise it continues processing 
+                                all the blobs (default false)
     --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 10_000ms[10s])
 
 Reset Cluster Id

--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -735,6 +735,7 @@ Command to concurrently download blobs from an Azure datastore using sas token a
             [--connect-timeout <milliseconds>] \
             [--read-timeout <milliseconds>] \
             [--max-retries <retries>] \
+            [--retry-interval <milliseconds>] \
             [--fail-on-error <boolean>] \
             [--slow-log-threshold <milliseconds>]
 
@@ -751,6 +752,7 @@ The following options are available:
                                 single blob (default 0, no timeout).
     --read-timeout          - Sets the read timeout, in milliseconds when reading a single blob (default 0, no timeout).
     --max-retries           - Max number of retries when a blob download fails (default 3).
+    --retry-interval        - The initial retry interval in milliseconds (default 100).
     --fail-on-error         - If true fails the execution immediately after the first error, otherwise it continues processing 
                                 all the blobs. When false, the command will fail only if no blobs were downloaded (default false).
     --slow-log-threshold    - Threshold to log a WARN message for blobs taking considerable time (default 10_000ms[10s]).

--- a/oak-run/README.md
+++ b/oak-run/README.md
@@ -719,8 +719,29 @@ The config files should be formatted according to the OSGi configuration admin s
     cat > org.apache.jackrabbit.oak.plugins.FileDataStore.config << EOF 
     path="/data/datastore"
     EOF        
-    
 
+Oak DataStoreCopy
+-------------------
+
+Command to concurrently download blobs from an Azure datastore using sas token authentication.
+
+    $ java -jar oak-run-*.jar datastore-copy \
+            [--source-repo <source_repository_url>] \
+            [--include-path <paths_to_include>] \
+            [--file-include-path <file_with_paths_to_include>] \
+            [--sas-token <authentication_token>] \
+            [--out-dir <output_path>] \
+            [--concurrency <max_requests>]
+
+The following options are available:
+
+    --source-repo           - The source Azure repository url.
+    --include-path          - Include only these paths when copying (separated by semicolon).
+    --file-include-path     - Include only the paths specified in the file (separated by newline). Useful when the number of blobs
+                                is big to avoid command prompt limitations.
+    --sas-token             - The SAS token to access Azure Storage.
+    --out-dir               - Path where to store the blobs (Optional). Otherwise, blobs will be stored in the current directory.
+    --concurrency           - Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores).
 
 Reset Cluster Id
 ---------------

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/AvailableModes.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/AvailableModes.java
@@ -38,7 +38,7 @@ public final class AvailableModes {
             .put("composite-prepare", new CompositePrepareCommand())
             .put("console", new ConsoleCommand())
             .put(DataStoreCommand.NAME, new DataStoreCommand())
-            .put("datastore-copy", new DataStoreCopyCommand())
+            .put(DataStoreCopyCommand.NAME, new DataStoreCopyCommand())
             .put("datastorecacheupgrade", new DataStoreCacheUpgradeCommand())
             .put("datastorecheck", new DataStoreCheckCommand())
             .put("debug", new DebugCommand())

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/AvailableModes.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/AvailableModes.java
@@ -38,6 +38,7 @@ public final class AvailableModes {
             .put("composite-prepare", new CompositePrepareCommand())
             .put("console", new ConsoleCommand())
             .put(DataStoreCommand.NAME, new DataStoreCommand())
+            .put("datastore-copy", new DataStoreCopyCommand())
             .put("datastorecacheupgrade", new DataStoreCacheUpgradeCommand())
             .put("datastorecheck", new DataStoreCheckCommand())
             .put("debug", new DebugCommand())

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.run;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.apache.jackrabbit.oak.commons.IOUtils;
+import org.apache.jackrabbit.oak.run.commons.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.StandardSystemProperty.FILE_SEPARATOR;
+
+/**
+ * Command to concurrently download blobs from an azure datastore using sas token authentication.
+ *
+ * Blobs are stored in a specific folder following the datastore structure format.
+ */
+public class DataStoreCopyCommand implements Command {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataStoreCopyCommand.class);
+
+    private String sourceRepo;
+    private String includePath;
+    private File fileIncludePath;
+    private String sasToken;
+    private String outDir;
+    private int concurrency;
+
+    @Override
+    public void execute(String... args) throws Exception {
+        parseCommandLineParams(args);
+
+        List<String> ids;
+        if (fileIncludePath != null) {
+            if (fileIncludePath.isDirectory() || !fileIncludePath.exists()) {
+                throw new IllegalArgumentException("file-include-path must be a valid file");
+            }
+            ids = org.apache.commons.io.IOUtils.readLines(Files.newInputStream(fileIncludePath.toPath()), StandardCharsets.UTF_8);
+        } else {
+            ids = Arrays.stream(includePath.split(";")).collect(Collectors.toList());
+        }
+        if (ids.isEmpty()) {
+            throw new IllegalArgumentException("Blob ids must be specified");
+        }
+
+        try (Downloader downloader = new Downloader(concurrency)) {
+            long start = System.currentTimeMillis();
+            List<Downloader.ItemResponse> responses = downloader.download(ids.stream().map(id -> {
+                Downloader.Item item = new Downloader.Item();
+                item.source = sourceRepo + "/" + id;
+                if (sasToken != null) {
+                    item.source += "?" + sasToken;
+                }
+                // Rename the blob names to match expected datastore cache format (remove the "-" in the name)
+                String blobName = id.replaceAll("-", "");
+                if (id.length() < 6) {
+                    LOG.warn("Blob with name {} is less than 6 chars. Cannot create data folder structure. Storing in the root folder", blobName);
+                    item.destination = outDir + FILE_SEPARATOR.value() + blobName;
+                } else {
+                    item.destination = outDir + FILE_SEPARATOR.value()
+                            + blobName.substring(0, 2) + FILE_SEPARATOR.value() + blobName.substring(2, 4) + FILE_SEPARATOR.value()
+                            + blobName.substring(4, 6) + FILE_SEPARATOR.value() + blobName;
+                }
+                return item;
+            }).collect(Collectors.toList()));
+            long totalTime = System.currentTimeMillis() - start;
+
+            Map<Boolean, List<Downloader.ItemResponse>> partitioned =
+                    responses.stream().collect(Collectors.partitioningBy(ir -> ir.failed));
+
+            List<Downloader.ItemResponse> success = partitioned.get(false);
+            if (!success.isEmpty()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("The following blobs were successfully downloaded:");
+                    success.forEach(s -> LOG.debug("{} [{}] downloaded in {} ms", s.item.source,
+                            IOUtils.humanReadableByteCount(s.size), s.time));
+                }
+
+                long totalBytes = success.stream().mapToLong(s -> s.size).sum();
+                if (totalTime > 60000) {
+                    LOG.info("Elapsed Time (Minutes): {}", TimeUnit.MILLISECONDS.toMinutes(totalTime));
+                } else {
+                    LOG.info("Elapsed Time (Seconds): {}", TimeUnit.MILLISECONDS.toSeconds(totalTime));
+                }
+                LOG.info("Number of File Transfers: {}", success.size());
+                LOG.info("TotalBytesTransferred: {}", totalBytes);
+                if (totalBytes > 10_000_000) {
+                    LOG.info("Speed (MB/sec): {}", (totalBytes / (1024 * 1024) / ((double) totalTime / 1000)));
+                } else {
+                    LOG.info("Speed (KB/sec): {}", (totalBytes / (1024) / ((double) totalTime / 1000)));
+                }
+            }
+
+            List<Downloader.ItemResponse> failures = partitioned.get(true);
+            if (!failures.isEmpty()) {
+                LOG.error("The following blobs threw an error:");
+                failures.forEach(f -> LOG.error(f.item.source, f.throwable));
+                throw new IllegalStateException("Errors while downloading blobs");
+            }
+        }
+
+    }
+
+    private void parseCommandLineParams(String... args) {
+        OptionParser parser = new OptionParser();
+
+        // options available for get-blobs only
+        OptionSpec<String> sourceRepoOpt = parser.accepts("source-repo", "The source repository url")
+                .withRequiredArg().ofType(String.class);
+        OptionSpec<String> includePathOpt = parser.accepts("include-path",
+                        "Include only these paths when copying (separated by semicolon)")
+                .withRequiredArg().ofType(String.class);
+        OptionSpec<File> fileIncludePathOpt = parser.accepts("file-include-path",
+                "Include only the paths specified in the file (separated by newline)").availableUnless(includePathOpt)
+                .withRequiredArg().ofType(File.class);
+        OptionSpec<String> sasTokenOpt = parser.accepts("sas-token", "The SAS token to access Azure Storage")
+                .withRequiredArg().ofType(String.class);
+        OptionSpec<String> outDirOpt = parser.accepts("out-dir",
+                "Path where to store the blobs (Optional). Otherwise, blobs will be stored in the current directory.")
+                .withRequiredArg().ofType(String.class).defaultsTo(System.getProperty("user.dir") + FILE_SEPARATOR.value() + "blobs");
+        OptionSpec<Integer> concurrencyOpt = parser.accepts("concurrency",
+                        "Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores)")
+                .withRequiredArg().ofType(Integer.class).defaultsTo(16 * Runtime.getRuntime().availableProcessors());
+
+        OptionSet optionSet = parser.parse(args);
+
+        this.sourceRepo = optionSet.valueOf(sourceRepoOpt);
+        this.includePath = optionSet.valueOf(includePathOpt);
+        this.fileIncludePath = optionSet.valueOf(fileIncludePathOpt);
+        this.sasToken = optionSet.valueOf(sasTokenOpt);
+        this.outDir = optionSet.valueOf(outDirOpt);
+        this.concurrency = optionSet.valueOf(concurrencyOpt);
+    }
+}

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -56,6 +56,7 @@ public class DataStoreCopyCommand implements Command {
     private int connectTimeout;
     private int readTimeout;
     private int maxRetries;
+    private long retryInitialInterval;
     private boolean failOnError;
     private int slowLogThreshold;
 
@@ -65,7 +66,8 @@ public class DataStoreCopyCommand implements Command {
         setupLogging();
 
         Stream<String> ids = null;
-        try (Downloader downloader = new Downloader(concurrency, connectTimeout, readTimeout, maxRetries, failOnError, slowLogThreshold)) {
+        try (Downloader downloader = new Downloader(concurrency, connectTimeout, readTimeout, maxRetries,
+                retryInitialInterval, failOnError, slowLogThreshold)) {
             if (fileIncludePath != null) {
                 ids = Files.lines(fileIncludePath);
             } else {
@@ -157,6 +159,8 @@ public class DataStoreCopyCommand implements Command {
                 .withRequiredArg().ofType(Integer.class).defaultsTo(10_000);
         OptionSpec<Integer> maxRetriesOpt = parser.accepts("max-retries", "Max number of retries when a blob download fails (default 3)")
                 .withRequiredArg().ofType(Integer.class).defaultsTo(3);
+        OptionSpec<Long> retryInitialIntervalOpt = parser.accepts("retry-interval", "The initial retry interval in milliseconds (default 100)")
+                .withRequiredArg().ofType(Long.class).defaultsTo(100L);
         OptionSpec<Boolean> failOnErrorOpt = parser.accepts("fail-on-error",
                         "If true fails the execution immediately after the first error, otherwise it continues processing all the blobs (default false)")
                 .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
@@ -173,6 +177,7 @@ public class DataStoreCopyCommand implements Command {
         this.readTimeout = optionSet.valueOf(readTimeoutOpt);
         this.slowLogThreshold = optionSet.valueOf(slowLogThresholdOpt);
         this.maxRetries = optionSet.valueOf(maxRetriesOpt);
+        this.retryInitialInterval = optionSet.valueOf(retryInitialIntervalOpt);
         this.fileIncludePath = optionSet.valueOf(fileIncludePathOpt);
         this.failOnError = optionSet.valueOf(failOnErrorOpt);
     }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -160,7 +160,7 @@ public class DataStoreCopyCommand implements Command {
                 .withRequiredArg().ofType(Integer.class).defaultsTo(60_000);
         OptionSpec<Integer> readTimeoutOpt = parser.accepts("read-timeout",
                         "Sets the read timeout, in milliseconds when reading a single blob (default 3_600_000ms[1h])")
-                .withRequiredArg().ofType(Integer.class).defaultsTo(3_600_00);
+                .withRequiredArg().ofType(Integer.class).defaultsTo(3_600_000);
 
         OptionSet optionSet = parser.parse(args);
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -20,19 +20,20 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
+import joptsimple.util.PathConverter;
+import joptsimple.util.PathProperties;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.run.commons.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.StandardSystemProperty.FILE_SEPARATOR;
 
@@ -47,7 +48,7 @@ public class DataStoreCopyCommand implements Command {
 
     private String sourceRepo;
     private String includePath;
-    private File fileIncludePath;
+    private Path fileIncludePath;
     private String sasToken;
     private String outDir;
     private int concurrency;
@@ -56,22 +57,16 @@ public class DataStoreCopyCommand implements Command {
     public void execute(String... args) throws Exception {
         parseCommandLineParams(args);
 
-        List<String> ids;
-        if (fileIncludePath != null) {
-            if (fileIncludePath.isDirectory() || !fileIncludePath.exists()) {
-                throw new IllegalArgumentException("file-include-path must be a valid file");
-            }
-            ids = org.apache.commons.io.IOUtils.readLines(Files.newInputStream(fileIncludePath.toPath()), StandardCharsets.UTF_8);
-        } else {
-            ids = Arrays.stream(includePath.split(";")).collect(Collectors.toList());
-        }
-        if (ids.isEmpty()) {
-            throw new IllegalArgumentException("Blob ids must be specified");
-        }
-
+        Stream<String> ids = null;
         try (Downloader downloader = new Downloader(concurrency)) {
-            long start = System.currentTimeMillis();
-            List<Downloader.ItemResponse> responses = downloader.download(ids.stream().map(id -> {
+            if (fileIncludePath != null) {
+                ids = Files.lines(fileIncludePath);
+            } else {
+                ids = Arrays.stream(includePath.split(";"));
+            }
+
+            long startNano = System.nanoTime();
+            List<Downloader.ItemResponse> responses = downloader.download(ids.map(id -> {
                 Downloader.Item item = new Downloader.Item();
                 item.source = sourceRepo + "/" + id;
                 if (sasToken != null) {
@@ -80,7 +75,7 @@ public class DataStoreCopyCommand implements Command {
                item.destination = getDestinationFromId(id);
                 return item;
             }).collect(Collectors.toList()));
-            long totalTime = System.currentTimeMillis() - start;
+            double totalTimeSeconds = (double) (System.nanoTime() - startNano) / 1_000_000_000;
 
             Map<Boolean, List<Downloader.ItemResponse>> partitioned =
                     responses.stream().collect(Collectors.partitioningBy(ir -> ir.failed));
@@ -94,13 +89,13 @@ public class DataStoreCopyCommand implements Command {
                 }
 
                 long totalBytes = success.stream().mapToLong(s -> s.size).sum();
-                LOG.info("Elapsed Time (Seconds): {}", TimeUnit.MILLISECONDS.toSeconds(totalTime));
+                LOG.info("Elapsed Time (Seconds): {}", totalTimeSeconds);
                 LOG.info("Number of File Transfers: {}", success.size());
                 LOG.info("Total Bytes Transferred: {}[{}]", totalBytes, IOUtils.humanReadableByteCount(totalBytes));
                 if (totalBytes > 10_000_000) {
-                    LOG.info("Speed (MB/sec): {}", (totalBytes / (1024 * 1024) / ((double) totalTime / 1000)));
+                    LOG.info("Speed (MB/sec): {}", ((double) totalBytes / (1024 * 1024)) / totalTimeSeconds);
                 } else {
-                    LOG.info("Speed (KB/sec): {}", (totalBytes / (1024) / ((double) totalTime / 1000)));
+                    LOG.info("Speed (KB/sec): {}", ((double) totalBytes / (1024)) / totalTimeSeconds);
                 }
             }
 
@@ -109,6 +104,10 @@ public class DataStoreCopyCommand implements Command {
                 LOG.error("The following blobs threw an error:");
                 failures.forEach(f -> LOG.error(f.item.source, f.throwable));
                 throw new IllegalStateException("Errors while downloading blobs");
+            }
+        } finally {
+            if (ids != null) {
+                ids.close();
             }
         }
     }
@@ -139,7 +138,8 @@ public class DataStoreCopyCommand implements Command {
                 "Include only the paths specified in the file (separated by newline)");
         parser.mutuallyExclusive(includePathBuilder, fileIncludePathBuilder);
         OptionSpec<String> includePathOpt = includePathBuilder.withRequiredArg().ofType(String.class);
-        OptionSpec<File> fileIncludePathOpt = fileIncludePathBuilder.withRequiredArg().ofType(File.class);
+        OptionSpec<Path> fileIncludePathOpt = fileIncludePathBuilder.withRequiredArg()
+                .withValuesConvertedBy(new PathConverter(PathProperties.FILE_EXISTING, PathProperties.READABLE));
 
         OptionSpec<String> sasTokenOpt = parser.accepts("sas-token", "The SAS token to access Azure Storage")
                 .withRequiredArg().ofType(String.class);

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -155,8 +155,8 @@ public class DataStoreCopyCommand implements Command {
                         "Sets the read timeout, in milliseconds when reading a single blob (default 3_600_000ms[1h])")
                 .withRequiredArg().ofType(Integer.class).defaultsTo(3_600_000);
         OptionSpec<Integer> slowLogThresholdOpt = parser.accepts("slow-log-threshold",
-                        "Threshold to log a WARN message for blobs taking considerable time (default 30_000ms[30s])")
-                .withRequiredArg().ofType(Integer.class).defaultsTo(3_600_000);
+                        "Threshold to log a WARN message for blobs taking considerable time (default 10_000ms[10s])")
+                .withRequiredArg().ofType(Integer.class).defaultsTo(10_000);
 
         OptionSet optionSet = parser.parse(args);
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -68,15 +68,18 @@ public class DataStoreCopyCommand implements Command {
             }
 
             long startNano = System.nanoTime();
-            List<Downloader.ItemResponse> responses = downloader.download(ids.map(id -> {
+
+            ids.forEach(id -> {
                 Downloader.Item item = new Downloader.Item();
                 item.source = sourceRepo + "/" + id;
                 if (sasToken != null) {
                     item.source += "?" + sasToken;
                 }
-               item.destination = getDestinationFromId(id);
-                return item;
-            }).collect(Collectors.toList()));
+                item.destination = getDestinationFromId(id);
+                downloader.offer(item);
+            });
+
+            List<Downloader.ItemResponse> responses = downloader.waitUntilComplete();
             double totalTimeSeconds = (double) (System.nanoTime() - startNano) / 1_000_000_000;
 
             Map<Boolean, List<Downloader.ItemResponse>> partitioned =

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -108,7 +108,7 @@ public class DataStoreCopyCommand implements Command {
                     LOG.info("Elapsed Time (Seconds): {}", TimeUnit.MILLISECONDS.toSeconds(totalTime));
                 }
                 LOG.info("Number of File Transfers: {}", success.size());
-                LOG.info("TotalBytesTransferred: {}", totalBytes);
+                LOG.info("TotalBytesTransferred: {}[{}]", totalBytes, IOUtils.humanReadableByteCount(totalBytes));
                 if (totalBytes > 10_000_000) {
                     LOG.info("Speed (MB/sec): {}", (totalBytes / (1024 * 1024) / ((double) totalTime / 1000)));
                 } else {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.run;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.run.commons.Command;
 import org.slf4j.Logger;
@@ -132,12 +133,15 @@ public class DataStoreCopyCommand implements Command {
         // options available for get-blobs only
         OptionSpec<String> sourceRepoOpt = parser.accepts("source-repo", "The source repository url")
                 .withRequiredArg().ofType(String.class).required();
-        OptionSpec<String> includePathOpt = parser.accepts("include-path",
-                        "Include only these paths when copying (separated by semicolon)")
-                .withRequiredArg().ofType(String.class);
-        OptionSpec<File> fileIncludePathOpt = parser.accepts("file-include-path",
-                "Include only the paths specified in the file (separated by newline)").availableUnless(includePathOpt)
-                .withRequiredArg().ofType(File.class);
+
+        OptionSpecBuilder includePathBuilder = parser.accepts("include-path",
+                "Include only these paths when copying (separated by semicolon)");
+        OptionSpecBuilder fileIncludePathBuilder = parser.accepts("file-include-path",
+                "Include only the paths specified in the file (separated by newline)");
+        parser.mutuallyExclusive(includePathBuilder, fileIncludePathBuilder);
+        OptionSpec<String> includePathOpt = includePathBuilder.withRequiredArg().ofType(String.class);
+        OptionSpec<File> fileIncludePathOpt = fileIncludePathBuilder.withRequiredArg().ofType(File.class);
+
         OptionSpec<String> sasTokenOpt = parser.accepts("sas-token", "The SAS token to access Azure Storage")
                 .withRequiredArg().ofType(String.class);
         OptionSpec<String> outDirOpt = parser.accepts("out-dir",

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -131,7 +131,7 @@ public class DataStoreCopyCommand implements Command {
 
         // options available for get-blobs only
         OptionSpec<String> sourceRepoOpt = parser.accepts("source-repo", "The source repository url")
-                .withRequiredArg().ofType(String.class);
+                .withRequiredArg().ofType(String.class).required();
         OptionSpec<String> includePathOpt = parser.accepts("include-path",
                         "Include only these paths when copying (separated by semicolon)")
                 .withRequiredArg().ofType(String.class);
@@ -141,7 +141,7 @@ public class DataStoreCopyCommand implements Command {
         OptionSpec<String> sasTokenOpt = parser.accepts("sas-token", "The SAS token to access Azure Storage")
                 .withRequiredArg().ofType(String.class);
         OptionSpec<String> outDirOpt = parser.accepts("out-dir",
-                "Path where to store the blobs (Optional). Otherwise, blobs will be stored in the current directory.")
+                "Path where to store the blobs. Otherwise, blobs will be stored in the current directory.")
                 .withRequiredArg().ofType(String.class).defaultsTo(System.getProperty("user.dir") + FILE_SEPARATOR.value() + "blobs");
         OptionSpec<Integer> concurrencyOpt = parser.accepts("concurrency",
                         "Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores)")

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -38,7 +38,7 @@ import static com.google.common.base.StandardSystemProperty.FILE_SEPARATOR;
 
 /**
  * Command to concurrently download blobs from an azure datastore using sas token authentication.
- *
+ * <p>
  * Blobs are stored in a specific folder following the datastore structure format.
  */
 public class DataStoreCopyCommand implements Command {
@@ -124,7 +124,6 @@ public class DataStoreCopyCommand implements Command {
                 throw new IllegalStateException("Errors while downloading blobs");
             }
         }
-
     }
 
     private void parseCommandLineParams(String... args) {
@@ -145,7 +144,7 @@ public class DataStoreCopyCommand implements Command {
         OptionSpec<String> sasTokenOpt = parser.accepts("sas-token", "The SAS token to access Azure Storage")
                 .withRequiredArg().ofType(String.class);
         OptionSpec<String> outDirOpt = parser.accepts("out-dir",
-                "Path where to store the blobs. Otherwise, blobs will be stored in the current directory.")
+                        "Path where to store the blobs. Otherwise, blobs will be stored in the current directory.")
                 .withRequiredArg().ofType(String.class).defaultsTo(System.getProperty("user.dir") + FILE_SEPARATOR.value() + "blobs");
         OptionSpec<Integer> concurrencyOpt = parser.accepts("concurrency",
                         "Max number of concurrent requests that can occur (the default value is equal to 16 multiplied by the number of cores)")

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -95,9 +95,10 @@ public class DataStoreCopyCommand implements Command {
             LOG.info("Speed (MB/sec): {}",
                     ((double) report.totalBytesTransferred / (1024 * 1024)) / totalTimeSeconds);
 
-            if (report.failures > 0) {
-                LOG.error("{} failures detected. Failing command", report.failures);
-                throw new IllegalStateException("Errors while downloading blobs");
+            // if failOnError=true the command already failed in case of errors. Here we are handling the failOnError=false case
+            if (report.successes <= 0 && report.failures > 0) {
+                LOG.error("No downloads succeeded. {} failures detected. Failing command", report.failures);
+                throw new RuntimeException("Errors while downloading blobs");
             }
         } finally {
             if (ids != null) {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -24,9 +24,11 @@ import joptsimple.util.PathConverter;
 import joptsimple.util.PathProperties;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.run.commons.Command;
+import org.apache.jackrabbit.oak.run.commons.LoggingInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -46,6 +48,8 @@ public class DataStoreCopyCommand implements Command {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataStoreCopyCommand.class);
 
+    public static final String NAME = "datastore-copy";
+
     private String sourceRepo;
     private String includePath;
     private Path fileIncludePath;
@@ -58,6 +62,7 @@ public class DataStoreCopyCommand implements Command {
     @Override
     public void execute(String... args) throws Exception {
         parseCommandLineParams(args);
+        setupLogging();
 
         Stream<String> ids = null;
         try (Downloader downloader = new Downloader(concurrency, connectTimeout, readTimeout)) {
@@ -114,6 +119,7 @@ public class DataStoreCopyCommand implements Command {
             if (ids != null) {
                 ids.close();
             }
+            shutdownLogging();
         }
     }
 
@@ -172,5 +178,12 @@ public class DataStoreCopyCommand implements Command {
         this.concurrency = optionSet.valueOf(concurrencyOpt);
         this.connectTimeout = optionSet.valueOf(connectTimeoutOpt);
         this.readTimeout = optionSet.valueOf(readTimeoutOpt);
+    }
+
+    protected static void setupLogging() throws IOException {
+        new LoggingInitializer(Files.createTempDirectory("oak-run_datastore-copy").toFile(), NAME, false).init();
+    }
+    private static void shutdownLogging() {
+        LoggingInitializer.shutdownLogging();
     }
 }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.run;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Generic concurrent file downloader which uses Java NIO channels to potentially leverage OS internal optimizations.
+ */
+public class Downloader implements Closeable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Downloader.class);
+
+    private final ExecutorService executorService;
+
+    public Downloader(int concurrency) {
+        LOG.info("Initializing Downloader with max number of concurrent requests={}", concurrency);
+        this.executorService = new ThreadPoolExecutor(
+                (int) Math.ceil(concurrency * .1), concurrency, 60L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(),
+                new ThreadFactoryBuilder()
+                        .setNameFormat("downloader-%d")
+                        .setDaemon(true)
+                        .build()
+        );
+    }
+
+    public List<ItemResponse> download(List<Item> items) {
+        LOG.debug("Preparing to download {} items.\n{}", items.size(), items);
+        try {
+            return executorService
+                    .invokeAll(items.stream().map(DownloadWorker::new).collect(Collectors.toList()))
+                    .stream()
+                    .map(itemResponseFuture -> {
+                        try {
+                            return itemResponseFuture.get();
+                        } catch (InterruptedException | ExecutionException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .collect(Collectors.toList());
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        executorService.shutdown();
+    }
+
+    public static class Item {
+        public String source;
+        public String destination;
+
+        @Override
+        public String toString() {
+            return "Item{" +
+                    "source='" + source + '\'' +
+                    ", destination='" + destination + '\'' +
+                    '}';
+        }
+    }
+
+    public static class ItemResponse {
+        public final Item item;
+        public boolean failed;
+        public long size;
+        public long time;
+        public Throwable throwable;
+
+        public ItemResponse(Item item) {
+            this.item = item;
+        }
+    }
+
+    private static class DownloadWorker implements Callable<ItemResponse> {
+
+        private final Item item;
+
+        DownloadWorker(Item item) {
+            this.item = item;
+        }
+
+        @Override
+        public ItemResponse call() {
+            ItemResponse response  = new ItemResponse(item);
+            long t0 = System.currentTimeMillis();
+            try {
+                URL sourceUrl = new URL(item.source);
+                File destinationFile = new File(item.destination);
+                destinationFile.getParentFile().mkdirs();
+                try (ReadableByteChannel byteChannel = Channels.newChannel(sourceUrl.openStream());
+                     FileOutputStream outputStream = new FileOutputStream(destinationFile)) {
+                    response.size = outputStream.getChannel()
+                            .transferFrom(byteChannel, 0, Long.MAX_VALUE);
+                }
+            } catch (Exception e) {
+                response.failed = true;
+                response.throwable = e;
+            } finally {
+                response.time = System.currentTimeMillis() - t0;
+            }
+            return response;
+        }
+    }
+
+}

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -90,7 +90,7 @@ public class Downloader implements Closeable {
                 try (ReadableByteChannel byteChannel = Channels.newChannel(sourceUrl.getInputStream());
                      FileOutputStream outputStream = new FileOutputStream(destinationPath.toFile())) {
                     response.size = outputStream.getChannel()
-                            .transferFrom(byteChannel, 0, sourceUrl.getContentLengthLong());
+                            .transferFrom(byteChannel, 0, Long.MAX_VALUE);
                 }
             } catch (Exception e) {
                 LOG.error("Error downloading " + item.source + ": " + e.getMessage());

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -119,11 +119,13 @@ public class Downloader implements Closeable {
         @Override
         public ItemResponse call() {
             ItemResponse response  = new ItemResponse(item);
-            long t0 = System.currentTimeMillis();
+            long t0 = System.nanoTime();
             try {
                 URL sourceUrl = new URL(item.source);
                 File destinationFile = new File(item.destination);
-                destinationFile.getParentFile().mkdirs();
+                if (!destinationFile.getParentFile().mkdirs()) {
+                    throw new IllegalStateException("Unable to create destination folder structure: " + destinationFile);
+                }
                 try (ReadableByteChannel byteChannel = Channels.newChannel(sourceUrl.openStream());
                      FileOutputStream outputStream = new FileOutputStream(destinationFile)) {
                     response.size = outputStream.getChannel()
@@ -133,7 +135,7 @@ public class Downloader implements Closeable {
                 response.failed = true;
                 response.throwable = e;
             } finally {
-                response.time = System.currentTimeMillis() - t0;
+                response.time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0);
             }
             return response;
         }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -184,7 +184,7 @@ public class Downloader implements Closeable {
             while (true) {
                 try {
                     return callable.call();
-                } catch (Exception e) {
+                } catch (IOException e) {
                     retried++;
                     exceptions.add(e);
 
@@ -200,6 +200,8 @@ public class Downloader implements Closeable {
                     } else {
                         LOG.warn("Callable " + callable + ". Retrying statement; number of times failed: " + retried + "; exception\n:" + e);
                     }
+                } catch (Exception e) {
+                    throw new RuntimeException("Callable " + callable + " threw an unrecoverable exception", e);
                 }
             }
         }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -53,6 +53,12 @@ public class Downloader implements Closeable {
     private final int readTimeoutMs;
 
     public Downloader(int concurrency, int connectTimeoutMs, int readTimeoutMs) {
+        if (concurrency <= 0 || concurrency > 1000) {
+            throw new IllegalArgumentException("concurrency range must be between 1 and 1000");
+        }
+        if (connectTimeoutMs < 0 || readTimeoutMs < 0) {
+            throw new IllegalArgumentException("connect and/or read timeouts can not be negative");
+        }
         LOG.info("Initializing Downloader with max number of concurrent requests={}", concurrency);
         this.connectTimeoutMs = connectTimeoutMs;
         this.readTimeoutMs = readTimeoutMs;

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -93,6 +93,7 @@ public class Downloader implements Closeable {
                             .transferFrom(byteChannel, 0, sourceUrl.getContentLengthLong());
                 }
             } catch (Exception e) {
+                LOG.error("Error downloading " + item.source + ": " + e.getMessage());
                 response.failed = true;
                 response.throwable = e;
             } finally {

--- a/oak-run/src/main/resources/logback-datastore-copy.xml
+++ b/oak-run/src/main/resources/logback-datastore-copy.xml
@@ -20,7 +20,7 @@
 <configuration scan="true" scanPeriod="1 second">
 
   <appender name="datastore-copy" class="ch.qos.logback.core.FileAppender">
-    <file>${oak.workDir}/datastore.log</file>
+    <file>${oak.workDir}/datastore-copy.log</file>
     <encoder>
       <pattern>%d{dd.MM.yyyy HH:mm:ss.SSS} %-5(*%level*) [%thread] %logger{30} %marker- %msg %n</pattern>
     </encoder>

--- a/oak-run/src/main/resources/logback-datastore-copy.xml
+++ b/oak-run/src/main/resources/logback-datastore-copy.xml
@@ -19,7 +19,7 @@
   -->
 <configuration scan="true" scanPeriod="1 second">
 
-  <appender name="datastore" class="ch.qos.logback.core.FileAppender">
+  <appender name="datastore-copy" class="ch.qos.logback.core.FileAppender">
     <file>${oak.workDir}/datastore.log</file>
     <encoder>
       <pattern>%d{dd.MM.yyyy HH:mm:ss.SSS} %-5(*%level*) [%thread] %logger{30} %marker- %msg %n</pattern>

--- a/oak-run/src/main/resources/logback-datastore-copy.xml
+++ b/oak-run/src/main/resources/logback-datastore-copy.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<configuration scan="true" scanPeriod="1 second">
+
+  <appender name="datastore" class="ch.qos.logback.core.FileAppender">
+    <file>${oak.workDir}/datastore.log</file>
+    <encoder>
+      <pattern>%d{dd.MM.yyyy HH:mm:ss.SSS} %-5(*%level*) [%thread] %logger{30} %marker- %msg %n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.out</target>
+    <encoder>
+      <pattern>%d{dd.MM.yyyy HH:mm:ss.SSS} %-5(*%level*) [%thread] %logger{30} %marker- %msg %n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="datastore-copy" />
+  </root>
+
+</configuration>

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/AzuriteDockerRule.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/AzuriteDockerRule.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.run;
+
+import com.arakelian.docker.junit.DockerRule;
+import com.arakelian.docker.junit.model.ImmutableDockerConfig;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.auth.FixedRegistryAuthSupplier;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class AzuriteDockerRule implements TestRule {
+
+    private static final String IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.19.0";
+
+    public static final String ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    public static final String ACCOUNT_NAME = "devstoreaccount1";
+
+    private final DockerRule wrappedRule;
+
+    public AzuriteDockerRule() {
+        wrappedRule = new DockerRule(ImmutableDockerConfig.builder()
+                .image(IMAGE)
+                .name("oak-test-azurite")
+                .ports("10000")
+                .addStartedListener(container -> {
+                    container.waitForPort("10000/tcp");
+                    container.waitForLog("Azurite Blob service is successfully listening at http://0.0.0.0:10000");
+                })
+                .addContainerConfigurer(builder -> builder.env("executable=blob"))
+                .alwaysRemoveContainer(true)
+                .build());
+    }
+
+    public CloudBlobContainer getContainer(String name) throws URISyntaxException, StorageException, InvalidKeyException {
+        CloudStorageAccount cloud = getCloudStorageAccount();
+        CloudBlobClient cloudBlobClient = cloud.createCloudBlobClient();
+        CloudBlobContainer container = cloudBlobClient.getContainerReference(name);
+        container.deleteIfExists();
+        container.create();
+        return container;
+    }
+
+    public CloudStorageAccount getCloudStorageAccount() throws URISyntaxException, InvalidKeyException {
+        String blobEndpoint = "BlobEndpoint=" + getBlobEndpoint();
+        String accountName = "AccountName=" + ACCOUNT_NAME;
+        String accountKey = "AccountKey=" + ACCOUNT_KEY;
+        return CloudStorageAccount.parse("DefaultEndpointsProtocol=http;" + ";" + accountName + ";" + accountKey + ";" + blobEndpoint);
+    }
+
+    @NotNull
+    public String getBlobEndpoint() {
+        int mappedPort = getMappedPort();
+        return "http://127.0.0.1:" + mappedPort + "/devstoreaccount1";
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        try {
+            DefaultDockerClient client = DefaultDockerClient.fromEnv()
+                    .connectTimeoutMillis(5000L)
+                    .readTimeoutMillis(20000L)
+                    .registryAuthSupplier(new FixedRegistryAuthSupplier())
+                    .build();
+            client.ping();
+            client.pull(IMAGE);
+            client.close();
+        } catch (Throwable t) {
+            Assume.assumeNoException(t);
+        }
+
+        return wrappedRule.apply(statement, description);
+    }
+
+    public int getMappedPort() {
+        return wrappedRule.getContainer().getPortBinding("10000/tcp").getPort();
+    }
+}

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/AzuriteDockerRule.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/AzuriteDockerRule.java
@@ -24,8 +24,10 @@ import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.auth.FixedRegistryAuthSupplier;
+
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
+
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.rules.TestRule;

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.run;
+
+import com.google.common.collect.ImmutableSet;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.SharedAccessBlobPermissions;
+import com.microsoft.azure.storage.blob.SharedAccessBlobPolicy;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.EnumSet;
+
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.LIST;
+import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.READ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class DataStoreCopyCommandTest {
+
+    @ClassRule
+    public static AzuriteDockerRule AZURITE = new AzuriteDockerRule();
+
+    private static final String BLOB1 = "8897-b9025dc534d4a9fa5920569b373cd714c8cfe5d030ca3f5edb25004894a5";
+    private static final String BLOB2 = "c1f0-8893512e1e00910a9caff05487805632031f15a0bd8ee869c9205da59cb8";
+    private static final ImmutableSet<String> BLOBS = ImmutableSet.of(BLOB1, BLOB2);
+
+    @Rule
+    public TemporaryFolder outDir = new TemporaryFolder();
+
+    private CloudBlobContainer container;
+
+    @Before
+    public void setUp() throws Exception {
+        container = createBlobContainer();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (container != null) {
+            container.deleteIfExists();
+        }
+        FileUtils.cleanDirectory(outDir.getRoot());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void missingRequiredOptions() throws Exception {
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString()
+        );
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void unauthenticated() throws Exception {
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--include-path",
+                BLOB1
+        );
+    }
+
+    @Test
+    public void singleBlobWithIncludePath() throws Exception {
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--include-path",
+                BLOB1,
+                "--sas-token",
+                container.generateSharedAccessSignature(policy(EnumSet.of(READ, LIST)), null),
+                "--out-dir",
+                outDir.getRoot().getAbsolutePath()
+        );
+
+        File outDirRoot = outDir.getRoot();
+        String blobName = BLOB1.replaceAll("-", "");
+        File firstNode = new File(outDirRoot, blobName.substring(0, 2));
+        assertTrue(firstNode.exists() && firstNode.isDirectory());
+        File secondNode = new File(firstNode, blobName.substring(2, 4));
+        assertTrue(secondNode.exists() && secondNode.isDirectory());
+        File thirdNode = new File(secondNode, blobName.substring(4, 6));
+        assertTrue(thirdNode.exists() && thirdNode.isDirectory());
+        File blob = new File(thirdNode, blobName);
+        assertTrue(blob.exists() && blob.isFile());
+        assertEquals(BLOB1, IOUtils.toString(blob.toURI(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void allBlobsWithFileIncludePath() throws Exception {
+        Path blobs = Files.createTempFile("blobs", "txt");
+        IOUtils.write(BLOB1 + "\n" + BLOB2, Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--file-include-path",
+                blobs.toString(),
+                "--sas-token",
+                container.generateSharedAccessSignature(policy(EnumSet.of(READ, LIST)), null),
+                "--out-dir",
+                outDir.getRoot().getAbsolutePath()
+        );
+
+        long files = Files.walk(outDir.getRoot().toPath())
+                        .filter(p -> p.toFile().isFile())
+                        .count();
+        assertEquals(2, files);
+    }
+
+    @Test
+    public void allBlobsPlusMissingOne() throws Exception {
+        Path blobs = Files.createTempFile("blobs", "txt");
+        IOUtils.write(BLOB1 + "\n" + BLOB2 + "\n" + "foo", Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        assertThrows(IllegalStateException.class, () -> cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--file-include-path",
+                blobs.toString(),
+                "--sas-token",
+                container.generateSharedAccessSignature(policy(EnumSet.of(READ, LIST)), null),
+                "--out-dir",
+                outDir.getRoot().getAbsolutePath()
+        ));
+        // command failed but existing blobs were successfully downloaded
+        long files = Files.walk(outDir.getRoot().toPath())
+                .filter(p -> p.toFile().isFile())
+                .count();
+        assertEquals(2, files);
+    }
+
+    private CloudBlobContainer createBlobContainer() throws Exception {
+        container = AZURITE.getContainer("blobstore");
+        for (String blob : BLOBS) {
+            container.getBlockBlobReference(blob).uploadText(blob);
+        }
+        return container;
+    }
+
+    @NotNull
+    private static SharedAccessBlobPolicy policy(EnumSet<SharedAccessBlobPermissions> permissions, Instant expirationTime) {
+        SharedAccessBlobPolicy sharedAccessBlobPolicy = new SharedAccessBlobPolicy();
+        sharedAccessBlobPolicy.setPermissions(permissions);
+        sharedAccessBlobPolicy.setSharedAccessExpiryTime(Date.from(expirationTime));
+        return sharedAccessBlobPolicy;
+    }
+
+    @NotNull
+    private static SharedAccessBlobPolicy policy(EnumSet<SharedAccessBlobPermissions> permissions) {
+        return policy(permissions, Instant.now().plus(Duration.ofDays(7)));
+    }
+}

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -163,6 +163,23 @@ public class DataStoreCopyCommandTest {
         assertEquals(2, files);
     }
 
+    @Test
+    public void destinationFromBlobId() throws Exception {
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        cmd.parseCommandLineParams(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--include-path",
+                BLOB1,
+                "--out-dir",
+                outDir.getRoot().getAbsolutePath()
+        );
+        assertEquals(
+                outDir.getRoot().getAbsolutePath() + "/88/97/b9/8897b9025dc534d4a9fa5920569b373cd714c8cfe5d030ca3f5edb25004894a5",
+                cmd.getDestinationFromId(BLOB1)
+        );
+    }
+
     private CloudBlobContainer createBlobContainer() throws Exception {
         container = AZURITE.getContainer("blobstore");
         for (String blob : BLOBS) {

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -136,8 +136,8 @@ public class DataStoreCopyCommandTest {
         );
 
         long files = Files.walk(outDir.getRoot().toPath())
-                        .filter(p -> p.toFile().isFile())
-                        .count();
+                .filter(p -> p.toFile().isFile())
+                .count();
         assertEquals(2, files);
     }
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.run;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class DownloaderTest {
+
+    @Rule
+    public TemporaryFolder sourceFolder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder destinationFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws IOException {
+        FileUtils.cleanDirectory(sourceFolder.getRoot());
+        FileUtils.cleanDirectory(destinationFolder.getRoot());
+        // create sparse files
+        try (RandomAccessFile file1 = new RandomAccessFile(sourceFolder.newFile("file1.txt"), "rw");
+                RandomAccessFile file2 = new RandomAccessFile(sourceFolder.newFile("file2.txt"), "rw")) {
+            file1.setLength(1024);
+            file2.setLength(1024 * 1024);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void downloadInvalidConcurrency() throws IOException {
+        try (Downloader downloader = new Downloader(0)) {
+            downloader.download(Collections.emptyList());
+        }
+    }
+
+    @Test
+    public void downloadSingle() throws IOException {
+        try (Downloader downloader = new Downloader(4)) {
+            List<Downloader.ItemResponse> responses = downloader
+                    .download(Collections.singletonList(createItem("file1.txt", "dest-file1.txt")));
+            assertEquals(1, responses.size());
+            assertFalse(responses.get(0).failed);
+            assertEquals(1024, responses.get(0).size);
+
+            File f = new File(destinationFolder.getRoot(), "dest-file1.txt");
+            assertTrue(f.exists());
+            assertTrue(f.isFile());
+            assertEquals(1024, Files.size(f.toPath()));
+        }
+    }
+
+    @Test
+    public void downloadMulti() throws IOException {
+        List<Downloader.Item> items = new ArrayList<>(2);
+        items.add(createItem("file1.txt", "file1.txt"));
+        items.add(createItem("file2.txt", "file2.txt"));
+        try (Downloader downloader = new Downloader(4)) {
+            List<Downloader.ItemResponse> responses = downloader.download(items);
+            assertEquals(2, responses.size());
+        }
+    }
+
+    @Test
+    public void downloadMultiWithMissingOne() throws IOException {
+        List<Downloader.Item> items = new ArrayList<>(2);
+        items.add(createItem("file1.txt", "file1.txt"));
+        items.add(createItem("file2.txt", "file2.txt"));
+        items.add(createItem("file3.txt", "file3.txt"));
+        try (Downloader downloader = new Downloader(4)) {
+            List<Downloader.ItemResponse> responses = downloader.download(items);
+            assertEquals(3, responses.size());
+
+            Map<Boolean, List<Downloader.ItemResponse>> partitioned =
+                    responses.stream().collect(Collectors.partitioningBy(ir -> ir.failed));
+
+            List<Downloader.ItemResponse> success = partitioned.get(false);
+            assertEquals(2, success.size());
+
+            List<Downloader.ItemResponse> failures = partitioned.get(true);
+            assertNotNull(failures.get(0).throwable);
+        }
+    }
+
+    private Downloader.Item createItem(String source, String destination) throws MalformedURLException {
+        Downloader.Item item = new Downloader.Item();
+        item.source = new File(sourceFolder.getRoot(), source).toURI().toURL().toString();
+        item.destination = new File(destinationFolder.getRoot(), destination).getAbsolutePath();
+        return item;
+    }
+
+}

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
@@ -59,15 +59,15 @@ public class DownloaderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void downloadInvalidConcurrency() throws IOException {
-        try (Downloader downloader = new Downloader(0)) {
+    public void invalidConfigurations() throws IOException {
+        try (Downloader downloader = new Downloader(0, 1000, 10000)) {
             downloader.download(Collections.emptyList());
         }
     }
 
     @Test
     public void downloadSingle() throws IOException {
-        try (Downloader downloader = new Downloader(4)) {
+        try (Downloader downloader = new Downloader(4, 1000, 10000)) {
             List<Downloader.ItemResponse> responses = downloader
                     .download(Collections.singletonList(createItem("file1.txt", "dest-file1.txt")));
             assertEquals(1, responses.size());
@@ -86,7 +86,7 @@ public class DownloaderTest {
         List<Downloader.Item> items = new ArrayList<>(2);
         items.add(createItem("file1.txt", "file1.txt"));
         items.add(createItem("file2.txt", "file2.txt"));
-        try (Downloader downloader = new Downloader(4)) {
+        try (Downloader downloader = new Downloader(4, 1000, 10000)) {
             List<Downloader.ItemResponse> responses = downloader.download(items);
             assertEquals(2, responses.size());
         }
@@ -98,7 +98,7 @@ public class DownloaderTest {
         items.add(createItem("file1.txt", "file1.txt"));
         items.add(createItem("file2.txt", "file2.txt"));
         items.add(createItem("file3.txt", "file3.txt"));
-        try (Downloader downloader = new Downloader(4)) {
+        try (Downloader downloader = new Downloader(4, 1000, 10000)) {
             List<Downloader.ItemResponse> responses = downloader.download(items);
             assertEquals(3, responses.size());
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class DownloaderTest {
@@ -58,11 +59,23 @@ public class DownloaderTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void invalidConfigurations() throws IOException {
-        try (Downloader downloader = new Downloader(0, 1000, 10000)) {
-            downloader.download(Collections.emptyList());
-        }
+    @Test
+    public void invalidConfigurations() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            try (Downloader downloader = new Downloader(0, 1000, 10000)) {
+                downloader.download(Collections.emptyList());
+            }
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            try (Downloader downloader = new Downloader(100, -1000, 10000)) {
+                downloader.download(Collections.emptyList());
+            }
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            try (Downloader downloader = new Downloader(100, 1000, -10000)) {
+                downloader.download(Collections.emptyList());
+            }
+        });
     }
 
     @Test

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
@@ -52,7 +52,7 @@ public class DownloaderTest {
         FileUtils.cleanDirectory(destinationFolder.getRoot());
         // create sparse files
         try (RandomAccessFile file1 = new RandomAccessFile(sourceFolder.newFile("file1.txt"), "rw");
-                RandomAccessFile file2 = new RandomAccessFile(sourceFolder.newFile("file2.txt"), "rw")) {
+             RandomAccessFile file2 = new RandomAccessFile(sourceFolder.newFile("file2.txt"), "rw")) {
             file1.setLength(1024);
             file2.setLength(1024 * 1024);
         }


### PR DESCRIPTION
Introduced `datastore-copy` command in oak-run to download blobs/files from an Azure repository using multiple threads.