### PR TITLE
OAK-9966 :  Internal code calls Node.isCheckedOut and VersionManager.isCheckedOut

### DIFF
--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContext.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContext.java
@@ -280,18 +280,18 @@ public class DynamicSyncContext extends DefaultSyncContext {
         if (authorizable == null) {
             return false;
         } else if (!authorizable.isGroup()) {
-            log.warn("Existing user '{}' collides with external group.", authorizable.getID());
+            log.warn("Existing user '{}' collides with external group defined by IDP '{}'.", authorizable.getID(), idp.getName());
             return true;
         } else if (!isSameIDP(authorizable)) {
             // there exists a group with the same id or principal name but it doesn't belong to the same IDP
             // in consistency with DefaultSyncContext don't sync this very membership into the repository
             // and log a warning about the collision instead.
-            log.warn("Existing authorizable with id '{}' and principal name '{}' is not a group from this IDP '{}'.", authorizable.getID(), principalName, idp.getName());
+            log.warn("Existing group with id '{}' and principal name '{}' is not defined by IDP '{}'.", authorizable.getID(), authorizable.getPrincipal().getName(), idp.getName());
             return true;
         } else if (!principalName.equals(authorizable.getPrincipal().getName())) {
             // there exists a group with matching ID but principal-mismatch, don't sync this very membership into the 
             // repository and log a warning about the collision instead.
-            log.warn("Existing authorizable with id '{}' doesn't have matching principal name. found '{}', expected '{}'.", authorizable.getID(), authorizable.getPrincipal().getName(), principalName);
+            log.warn("Existing group with id '{}' doesn't have matching principal name. found '{}', expected '{}', IDP '{}'.", authorizable.getID(), authorizable.getPrincipal().getName(), principalName, idp.getName());
             return true;            
         } else {
             // group has been synced before (same IDP, same principal-name)

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContext.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContext.java
@@ -51,6 +51,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Extension of the {@code DefaultSyncContext} that doesn't synchronize group
  * membership of new external users into the user management of the repository.
@@ -162,7 +164,7 @@ public class DynamicSyncContext extends DefaultSyncContext {
                 // if dynamic-group option is enabled -> sync groups without member-information
                 // in case group-membership has been synched before -> clear it
                 if (hasDynamicGroups() && depth > 0) {
-                    createDynamicGroups(map);
+                    createDynamicGroups(map.values());
                 }
                 
                 // clean up any other membership
@@ -220,7 +222,7 @@ public class DynamicSyncContext extends DefaultSyncContext {
      * @throws ExternalIdentityException If an error occurs while resolving the the external group references.
      */
     private void collectSyncEntries(@NotNull Iterable<ExternalIdentityRef> declaredGroupRefs, long depth, @NotNull Map<ExternalIdentityRef, SyncEntry> map) throws ExternalIdentityException, RepositoryException {
-        boolean shortcut = (depth <= 1 && idp instanceof PrincipalNameResolver);
+        boolean shortcut = shortcut(depth);
         for (ExternalIdentityRef ref : Iterables.filter(declaredGroupRefs, this::isSameIDP)) {
             String principalName = null;
             Authorizable a = null;
@@ -232,8 +234,9 @@ public class DynamicSyncContext extends DefaultSyncContext {
                 // get group from the IDP
                 externalGroup = getExternalGroupFromRef(ref);
                 if (externalGroup != null) {
+                    // only set principal-name if the ref can be resolved to a valid external group
                     principalName = externalGroup.getPrincipalName();
-                    a = userManager.getAuthorizable(new PrincipalImpl(principalName));
+                    a = userManager.getAuthorizable(externalGroup.getId());
 
                     // recursively apply further membership until the configured depth is reached
                     if (depth > 1) {
@@ -246,6 +249,18 @@ public class DynamicSyncContext extends DefaultSyncContext {
                 map.put(ref, new SyncEntry(principalName, externalGroup, (Group) a));
             }
         }
+    }
+
+    /**
+     * Evaluate if looking up the external group from the IDP can be omitted (i.e. no nesting and IDP implements PrincipalNameResolver.
+     * Finally, the shortcut does not make sense if 'dynamic group' option is enabled, as the external group is needed
+     * for the subsequent group sync.
+     * 
+     * @param depth The configured membership nesting depth.
+     * @return {@code true} if looking up the external group on IDP can be avoided; {@code false} otherwise.
+     */
+    private boolean shortcut(long depth) {
+        return depth <= 1 && idp instanceof PrincipalNameResolver && !hasDynamicGroups();
     }
     
     /**
@@ -268,35 +283,36 @@ public class DynamicSyncContext extends DefaultSyncContext {
             log.warn("Existing user '{}' collides with external group.", authorizable.getID());
             return true;
         } else if (!isSameIDP(authorizable)) {
-            // there exists a user or group with that principal name but it doesn't belong to the same IDP
+            // there exists a group with the same id or principal name but it doesn't belong to the same IDP
             // in consistency with DefaultSyncContext don't sync this very membership into the repository
             // and log a warning about the collision instead.
-            log.warn("Existing authorizable with principal name '{}' is not a group from this IDP '{}'.", principalName, idp.getName());
+            log.warn("Existing authorizable with id '{}' and principal name '{}' is not a group from this IDP '{}'.", authorizable.getID(), principalName, idp.getName());
             return true;
+        } else if (!principalName.equals(authorizable.getPrincipal().getName())) {
+            // there exists a group with matching ID but principal-mismatch, don't sync this very membership into the 
+            // repository and log a warning about the collision instead.
+            log.warn("Existing authorizable with id '{}' doesn't have matching principal name. found '{}', expected '{}'.", authorizable.getID(), authorizable.getPrincipal().getName(), principalName);
+            return true;            
         } else {
             // group has been synced before (same IDP, same principal-name)
             return false;
         }
     }
-    
-    private void createDynamicGroups(@NotNull Map<ExternalIdentityRef, SyncEntry> map) throws RepositoryException {
-        for (Map.Entry<ExternalIdentityRef, SyncEntry> entry : map.entrySet()) {
-            ExternalIdentityRef groupRef = entry.getKey();
-            SyncEntry syncEntry = entry.getValue();
+
+    private void createDynamicGroups(@NotNull Iterable<SyncEntry> syncEntries) throws RepositoryException {
+        for (SyncEntry syncEntry : syncEntries) {
+            // since 'shortcut' is omitted if dynamic groups are enabled, there is no need to test if 'external-group' is 
+            // null, nor trying to retrieve external group again. if it could not be resolved during 'collectSyncEntries'
+            // before it didn't got added to the map
+            checkNotNull(syncEntry.externalGroup, "Cannot create dynamic group from null ExternalIdentity.");
             
-            // get external identity from IDP if it has not been resolved before (see 'shortcut' in 'collectSyncEntries').
-            ExternalGroup externalGroup = (syncEntry.externalGroup != null) ? syncEntry.externalGroup : getExternalGroupFromRef(groupRef);
-            if (externalGroup != null) {
-                // lookup of existing group by principal-name has been performed already 
-                // NOTE: if none exists no attempt is made to lookup again by ID as this may lead to inconsistencies 
-                // between rep:externalPrincipalNames and the dynamic group in case there existed a group with the same 
-                // ID but has a different principal name. in this case the sync will fail (conflict with ID).
-                Group gr = syncEntry.group;
-                if (gr == null) {
-                    gr = createGroup(externalGroup);
-                }
-                syncGroup(externalGroup, gr);
+            // lookup of existing group by ID has been performed already including check for conflicting authorizable 
+            // type or principal name
+            Group gr = syncEntry.group;
+            if (gr == null) {
+                gr = createGroup(syncEntry.externalGroup);
             }
+            syncGroup(syncEntry.externalGroup, gr);
         }
     }
     

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicGroupsTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicGroupsTest.java
@@ -62,6 +62,7 @@ public class DynamicGroupsTest extends DynamicSyncContextTest {
         return Lists.newArrayList(
                 new Object[] { DefaultSyncConfigImpl.PARAM_USER_MEMBERSHIP_NESTING_DEPTH_DEFAULT, false, "Membership-Nesting-Depth=0" },
                 new Object[] { DefaultSyncConfigImpl.PARAM_USER_MEMBERSHIP_NESTING_DEPTH_DEFAULT+1, false, "Membership-Nesting-Depth=1" },
+                // NOTE: shortcut for PrincipalNameResolver is ignored if dynamic-groups are enabled
                 new Object[] { DefaultSyncConfigImpl.PARAM_USER_MEMBERSHIP_NESTING_DEPTH_DEFAULT+1, true, "Membership-Nesting-Depth=1, IDP implements PrincipalNameResolver" },
                 new Object[] { DefaultSyncConfigImpl.PARAM_USER_MEMBERSHIP_NESTING_DEPTH_DEFAULT+2, false, "Membership-Nesting-Depth=2" });
     }
@@ -83,7 +84,6 @@ public class DynamicGroupsTest extends DynamicSyncContextTest {
             return super.createIDP();
         }
     }
-
 
     @Override
     protected @NotNull DefaultSyncConfig createSyncConfig() {

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContextTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContextTest.java
@@ -46,6 +46,7 @@ import org.apache.jackrabbit.oak.spi.security.authentication.external.basic.Defa
 import org.apache.jackrabbit.oak.spi.security.authentication.external.basic.DefaultSyncContext;
 import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -338,32 +339,71 @@ public class DynamicSyncContextTest extends AbstractExternalAuthTest {
         // create a local group that collides with the external group membership
         // i.e. doesn't have an rep:externalId set
         ExternalIdentity externalGroup = idp.getIdentity(externalUser.getDeclaredGroups().iterator().next());
-        userManager.createGroup(externalGroup.getId(), new PrincipalImpl(externalGroup.getPrincipalName()), null);
-        r.commit();
-        
-        // sync the user with dynamic membership enabled
-        sync(externalUser, SyncResult.Status.ADD);
+        assertNotNull(externalGroup);
 
-        // retrieve rep:externalPrincipalNames
-        Tree tree = r.getTree(userManager.getAuthorizable(USER_ID).getPath());
-        PropertyState extPrincipalNames = tree.getProperty(REP_EXTERNAL_PRINCIPAL_NAMES);
-        assertNotNull(extPrincipalNames);
-
-        // the resulting rep:externalPrincipalNames must NOT contain the name of the colliding principal
-        Set<String> pNames = Sets.newHashSet(extPrincipalNames.getValue(Type.STRINGS));
-        assertFalse(pNames + " must not contain " + externalGroup.getPrincipalName(), pNames.contains(externalGroup.getPrincipalName()));
+        assertIgnored(externalUser, externalGroup, externalGroup.getId(), externalGroup.getPrincipalName(), null);    
     }
 
     @Test
-    public void testSyncExternalUserGroupConflict2() throws Exception {
+    public void testSyncExternalUserGroupConflictDifferentIDP() throws Exception {
         ExternalUser externalUser = idp.getUser(USER_ID);
 
         // create a local group that collides with the external group membership
         // i.e. belongs to a different IDP
         ExternalIdentityRef ref = externalUser.getDeclaredGroups().iterator().next();
         ExternalIdentity externalGroup = idp.getIdentity(ref);
-        Group g = userManager.createGroup(externalGroup.getId(), new PrincipalImpl(externalGroup.getPrincipalName()), null);
-        g.setProperty(REP_EXTERNAL_ID, getValueFactory().createValue(new ExternalIdentityRef(ref.getId(), ref.getProviderName()+"_mod").getString()));
+        assertNotNull(externalGroup);
+
+        assertIgnored(externalUser, externalGroup, externalGroup.getId(), externalGroup.getPrincipalName(), 
+                new ExternalIdentityRef(ref.getId(), ref.getProviderName()+"_mod"));
+    }
+
+    @Test
+    public void testSyncExternalUserGroupConflictPrincipalNameMismatch() throws Exception {
+        ExternalUser externalUser = idp.getUser(USER_ID);
+
+        ExternalIdentityRef ref = externalUser.getDeclaredGroups().iterator().next();
+        ExternalIdentity externalGroup = idp.getIdentity(ref);
+        assertNotNull(externalGroup);
+
+        // create a local group that has the same ID but a mismatching principal name
+        // and verify that the group is ignored;
+        assertIgnored(externalUser, externalGroup, externalGroup.getId(), externalGroup.getPrincipalName()+"mismatch", ref);
+    }
+
+    @Test
+    public void testSyncExternalUserGroupConflictPrincipalNameCaseMismatch() throws Exception {
+        ExternalUser externalUser = idp.getUser(USER_ID);
+
+        ExternalIdentityRef ref = externalUser.getDeclaredGroups().iterator().next();
+        ExternalIdentity externalGroup = idp.getIdentity(ref);
+        assertNotNull(externalGroup);
+
+        // create a local group that has the same ID but a mismatching principal name (only case)
+        // and verify that the group is ignored;
+        assertIgnored(externalUser, externalGroup, externalGroup.getId(), externalGroup.getPrincipalName().toUpperCase(), ref);
+    }
+
+    @Test
+    public void testSyncExternalUserGroupConflictIdCaseMismatch() throws Exception {
+        ExternalUser externalUser = idp.getUser(USER_ID);
+        
+        ExternalIdentityRef ref = externalUser.getDeclaredGroups().iterator().next();
+        ExternalIdentity externalGroup = idp.getIdentity(ref);
+        assertNotNull(externalGroup);
+
+        // create a local group that has the case-mismatch in ID/principal name
+        // and verify that the external group is ignored;
+        assertIgnored(externalUser, externalGroup, externalGroup.getId().toUpperCase(), externalGroup.getPrincipalName(), null);
+    }
+    
+    private void assertIgnored(@NotNull ExternalUser externalUser, @NotNull ExternalIdentity externalGroup, 
+                               @NotNull String existingId, @NotNull String existingPrincipalName, @Nullable ExternalIdentityRef existingGroupRef) throws Exception {
+        
+        Group g = userManager.createGroup(existingId, new PrincipalImpl(existingPrincipalName), null);
+        if (existingGroupRef != null) {
+            g.setProperty(REP_EXTERNAL_ID, getValueFactory().createValue(existingGroupRef.getString()));
+        }
         r.commit();
 
         // sync the user with dynamic membership enabled
@@ -691,6 +731,9 @@ public class DynamicSyncContextTest extends AbstractExternalAuthTest {
         TestIdentityProvider.TestUser testuser = (TestIdentityProvider.TestUser) idp.getUser(ID_TEST_USER);
         Set<ExternalIdentityRef> groupRefs = getExpectedSyncedGroupRefs(syncConfig.user().getMembershipNestingDepth(), idp, testuser);
 
+        // verify that the conflicting user has not been synced before
+        assertNull(userManager.getAuthorizable(ID_SECOND_USER));
+        
         ExternalUser second = idp.getUser(ID_SECOND_USER);
         testuser.withGroups(second.getExternalId());
         assertFalse(Iterables.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
@@ -701,14 +744,31 @@ public class DynamicSyncContextTest extends AbstractExternalAuthTest {
         assertTrue(a.hasProperty(REP_EXTERNAL_PRINCIPAL_NAMES));
         Value[] extPrincipalNames = a.getProperty(REP_EXTERNAL_PRINCIPAL_NAMES);
 
-        if (idp instanceof PrincipalNameResolver) {
-            // with IDP implementing PrincipalNameResolver the extra verification for all member-refs being groups is omitted.
-            assertDynamicMembership(testuser, 1);
-        } else {
-            assertEquals(Iterables.size(groupRefs), extPrincipalNames.length);
-            for (Value v : extPrincipalNames) {
-                assertNotEquals(second.getPrincipalName(), v.getString());
-            }
+        assertEquals(Iterables.size(groupRefs), extPrincipalNames.length);
+        for (Value v : extPrincipalNames) {
+            assertNotEquals(second.getPrincipalName(), v.getString());
+        }
+    }
+
+    @Test
+    public void testSyncMembershipWithUserConflict() throws Exception {
+        TestIdentityProvider.TestUser testuser = (TestIdentityProvider.TestUser) idp.getUser(ID_TEST_USER);
+        Set<ExternalIdentityRef> groupRefs = getExpectedSyncedGroupRefs(syncConfig.user().getMembershipNestingDepth(), idp, testuser);
+
+        // in contrast to 'testSyncMembershipWithUserRef' the conflicting group-ref refers to a user in the repository
+        // and the conflict is spotted as the existing synched identity is not a group.
+        testuser.withGroups(previouslySyncedUser.getExternalId());
+        assertFalse(Iterables.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
+
+        sync(testuser, SyncResult.Status.ADD);
+
+        Authorizable a = userManager.getAuthorizable(ID_TEST_USER);
+        assertTrue(a.hasProperty(REP_EXTERNAL_PRINCIPAL_NAMES));
+        Value[] extPrincipalNames = a.getProperty(REP_EXTERNAL_PRINCIPAL_NAMES);
+
+        assertEquals(Iterables.size(groupRefs), extPrincipalNames.length);
+        for (Value v : extPrincipalNames) {
+            assertNotEquals(previouslySyncedUser.getPrincipalName(), v.getString());
         }
     }
 

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/PrincipalResolutionTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/PrincipalResolutionTest.java
@@ -16,8 +16,13 @@
  */
 package org.apache.jackrabbit.oak.spi.security.authentication.external.impl;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.Group;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentity;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentityException;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentityProvider;
@@ -26,14 +31,21 @@ import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalUs
 import org.apache.jackrabbit.oak.spi.security.authentication.external.PrincipalNameResolver;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.SyncResult;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.TestIdentityProvider;
+import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import java.util.Set;
 
 import static org.apache.jackrabbit.oak.spi.security.authentication.external.TestIdentityProvider.ID_SECOND_USER;
 import static org.apache.jackrabbit.oak.spi.security.authentication.external.TestIdentityProvider.ID_TEST_USER;
+import static org.apache.jackrabbit.oak.spi.security.authentication.external.impl.ExternalIdentityConstants.REP_EXTERNAL_ID;
+import static org.apache.jackrabbit.oak.spi.security.authentication.external.impl.ExternalIdentityConstants.REP_EXTERNAL_PRINCIPAL_NAMES;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class PrincipalResolutionTest extends DynamicSyncContextTest {
 
@@ -55,5 +67,79 @@ public class PrincipalResolutionTest extends DynamicSyncContextTest {
                 return identity.getPrincipalName();
             }
         }
+    }
+
+    @Test
+    public void testSyncExternalUserGroupConflictPrincipalNameMismatch() throws Exception {
+        ExternalUser externalUser = idp.getUser(USER_ID);
+
+        ExternalIdentityRef ref = externalUser.getDeclaredGroups().iterator().next();
+        ExternalIdentity externalGroup = idp.getIdentity(ref);
+        assertNotNull(externalGroup);
+
+        // create a local group that has the same ID but a mismatching principal name
+        // since the shortcut is in place and dynamic groups are not synched the mismatch in principal-name
+        // cannot be spotted (but also doesn't have too much implication apart from being confusing as principal names
+        // are not case-insensitive and conflicting dynamic groups are not being created)
+        assertSynched(externalUser, externalGroup, externalGroup.getId(), externalGroup.getPrincipalName()+"mismatch", ref);
+    }
+
+    @Test
+    public void testSyncExternalUserGroupConflictPrincipalNameCaseMismatch() throws Exception {
+        ExternalUser externalUser = idp.getUser(USER_ID);
+
+        ExternalIdentityRef ref = externalUser.getDeclaredGroups().iterator().next();
+        ExternalIdentity externalGroup = idp.getIdentity(ref);
+        assertNotNull(externalGroup);
+
+        // create a local group that has the same ID but a mismatching principal name
+        // since the shortcut is in place and dynamic groups are not synched the mismatch in principal-name
+        // cannot be spotted (but also doesn't have too much implication apart from being confusing as principal names
+        // are not case-insensitive and conflicting dynamic groups are not being created)
+        assertSynched(externalUser, externalGroup, externalGroup.getId(), externalGroup.getPrincipalName().toUpperCase(), ref);
+    }
+
+    private void assertSynched(@NotNull ExternalUser externalUser, @NotNull ExternalIdentity externalGroup,
+                               @NotNull String existingId, @NotNull String existingPrincipalName, @Nullable ExternalIdentityRef existingGroupRef) throws Exception {
+
+        Group g = userManager.createGroup(existingId, new PrincipalImpl(existingPrincipalName), null);
+        if (existingGroupRef != null) {
+            g.setProperty(REP_EXTERNAL_ID, getValueFactory().createValue(existingGroupRef.getString()));
+        }
+        r.commit();
+
+        // sync the user with dynamic membership enabled
+        sync(externalUser, SyncResult.Status.ADD);
+
+        // retrieve rep:externalPrincipalNames
+        Tree tree = r.getTree(userManager.getAuthorizable(USER_ID).getPath());
+        PropertyState extPrincipalNames = tree.getProperty(REP_EXTERNAL_PRINCIPAL_NAMES);
+        assertNotNull(extPrincipalNames);
+
+        // the resulting rep:externalPrincipalNames must contain the name of the principal
+        Set<String> pNames = Sets.newHashSet(extPrincipalNames.getValue(Type.STRINGS));
+        assertTrue(pNames + " must contain " + externalGroup.getPrincipalName(), pNames.contains(externalGroup.getPrincipalName()));
+    }
+
+    @Test
+    public void testSyncMembershipWithUserRef() throws Exception {
+        TestIdentityProvider.TestUser testuser = (TestIdentityProvider.TestUser) idp.getUser(ID_TEST_USER);
+        Set<ExternalIdentityRef> groupRefs = getExpectedSyncedGroupRefs(syncConfig.user().getMembershipNestingDepth(), idp, testuser);
+
+        // verify that the conflicting user has not been synced before
+        assertNull(userManager.getAuthorizable(ID_SECOND_USER));
+        
+        ExternalUser second = idp.getUser(ID_SECOND_USER);
+        testuser.withGroups(second.getExternalId());
+        assertFalse(Iterables.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
+
+        sync(testuser, SyncResult.Status.ADD);
+
+        Authorizable a = userManager.getAuthorizable(ID_TEST_USER);
+        assertTrue(a.hasProperty(REP_EXTERNAL_PRINCIPAL_NAMES));
+
+        // with IDP implementing PrincipalNameResolver the extra verification for all member-refs being groups 
+        // is omitted _unless_ dynamic groups are enabled as well, in which case the short-cut is ignored.
+        assertDynamicMembership(testuser, 1);
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/ReadOnlyVersionManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/ReadOnlyVersionManager.java
@@ -112,18 +112,16 @@ public abstract class ReadOnlyVersionManager {
      * @return whether the tree is checked out or not.
      */
     public boolean isCheckedOut(@NotNull Tree tree) {
-        if (checkNotNull(tree).exists()) {
-            PropertyState p = tree.getProperty(VersionConstants.JCR_ISCHECKEDOUT);
-            if (p != null) {
-                return p.getValue(Type.BOOLEAN);
-            }
-        } else {
-            // FIXME: this actually means access to the tree is restricted
-            // and may result in wrong isCheckedOut value. This should never
-            // be the case in a commit hook because it operates on non-access-
-            // controlled NodeStates. This means consistency is not at risk
-            // but it may mean oak-jcr sees a node as checked out even though
-            // it is in fact read-only because of a checked-in ancestor.
+        // NOTE: if the given tree does not exist it mean that it is a non-accessible ancestor
+        // in this case it may result in wrong isCheckedOut value. This should never
+        // be the case in a commit hook because it operates on non-access-
+        // controlled NodeStates. This means consistency is not at risk
+        // but it may mean oak-jcr sees a node as checked out even though
+        // it is in fact read-only because of a checked-in (but non-accessible) ancestor.
+        // if this turns out to be an issue see NodeImpl#getReadOnlyTree for an potential fix
+        PropertyState p = tree.getProperty(VersionConstants.JCR_ISCHECKEDOUT);
+        if (p != null) {
+            return p.getValue(Type.BOOLEAN);
         }
         if (tree.isRoot()) {
             return true;

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/QueryImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/query/QueryImpl.java
@@ -159,8 +159,8 @@ public class QueryImpl implements Query {
         if (parentDelegate == null) {
             throw new PathNotFoundException("The specified path does not exist: " + parent);
         }
-        Node parentNode = NodeImpl.createNode(parentDelegate, sessionContext);
-        if (!parentNode.isCheckedOut()) {
+        NodeImpl parentNode = NodeImpl.createNode(parentDelegate, sessionContext);
+        if (!parentNode.internalIsCheckedOut()) {
             throw new VersionException("Cannot store query. Node at " +
                     absPath + " is checked in.");
         }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/ItemImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/ItemImpl.java
@@ -40,7 +40,6 @@ import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
 import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.version.VersionManager;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -50,6 +49,7 @@ import org.apache.jackrabbit.oak.jcr.delegate.NodeDelegate;
 import org.apache.jackrabbit.oak.jcr.delegate.SessionDelegate;
 import org.apache.jackrabbit.oak.jcr.session.operation.ItemOperation;
 import org.apache.jackrabbit.oak.jcr.session.operation.SessionOperation;
+import org.apache.jackrabbit.oak.jcr.version.VersionManagerImpl;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyBuilder;
 import org.apache.jackrabbit.oak.plugins.nodetype.write.ReadWriteNodeTypeManager;
 import org.jetbrains.annotations.NotNull;
@@ -349,8 +349,8 @@ abstract class ItemImpl<T extends ItemDelegate> implements Item {
     }
 
     @NotNull
-    VersionManager getVersionManager() throws RepositoryException {
-        return sessionContext.getWorkspace().getVersionManager();
+    VersionManagerImpl getVersionManager() {
+        return sessionContext.getWorkspace().internalGetVersionManager();
     }
 
     @NotNull

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/PropertyImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/PropertyImpl.java
@@ -76,12 +76,7 @@ public class PropertyImpl extends ItemImpl<PropertyDelegate> implements Property
             @NotNull
             @Override
             public Node perform() throws RepositoryException {
-                NodeDelegate parent = property.getParent();
-                if (parent == null) {
-                    throw new AccessDeniedException();
-                } else {
-                    return NodeImpl.createNode(parent, sessionContext);
-                }
+                return internalGetParent(property, sessionContext);
             }
         });
     }
@@ -114,7 +109,7 @@ public class PropertyImpl extends ItemImpl<PropertyDelegate> implements Property
             @Override
             public void checkPreconditions() throws RepositoryException {
                 super.checkPreconditions();
-                if (!getParent().isCheckedOut() && getDefinition().getOnParentVersion() != OnParentVersionAction.IGNORE) {
+                if (!parentIsCheckedOut() && getDefinition().getOnParentVersion() != OnParentVersionAction.IGNORE) {
                     throw new VersionException(
                             "Cannot set property. Node is checked in.");
                 }
@@ -464,7 +459,7 @@ public class PropertyImpl extends ItemImpl<PropertyDelegate> implements Property
             @Override
             public void checkPreconditions() throws RepositoryException {
                 super.checkPreconditions();
-                if (!getParent().isCheckedOut() && getDefinition().getOnParentVersion() != OnParentVersionAction.IGNORE) {
+                if (!parentIsCheckedOut() && getDefinition().getOnParentVersion() != OnParentVersionAction.IGNORE) {
                     throw new VersionException(
                             "Cannot set property. Node is checked in.");
                 }
@@ -500,7 +495,7 @@ public class PropertyImpl extends ItemImpl<PropertyDelegate> implements Property
             @Override
             public void checkPreconditions() throws RepositoryException {
                 super.checkPreconditions();
-                if (!getParent().isCheckedOut() && getDefinition().getOnParentVersion() != OnParentVersionAction.IGNORE) {
+                if (!parentIsCheckedOut() && getDefinition().getOnParentVersion() != OnParentVersionAction.IGNORE) {
                     throw new VersionException(
                             "Cannot set property. Node is checked in.");
                 }
@@ -530,6 +525,20 @@ public class PropertyImpl extends ItemImpl<PropertyDelegate> implements Property
                 return String.format("Setting property [%s/%s]", dlg.getPath(), dlg.getName());
             }
         });
+    }
+
+    private boolean parentIsCheckedOut() throws RepositoryException {
+        return internalGetParent(dlg, sessionContext).internalIsCheckedOut();
+    }
+    
+    @NotNull 
+    private static NodeImpl<? extends NodeDelegate> internalGetParent(@NotNull PropertyDelegate propertyDlg, @NotNull SessionContext sessionContext) throws RepositoryException {
+        NodeDelegate parent = propertyDlg.getParent();
+        if (parent == null) {
+            throw new AccessDeniedException();
+        } else {
+            return NodeImpl.createNode(parent, sessionContext);
+        }
     }
 
 }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
@@ -686,8 +686,8 @@ public class SessionImpl implements JackrabbitSession {
             }
 
             boolean isNode = ((ItemImpl<?>) target).isNode();
-            Node parent = (isNode) ? (Node) target : ((ItemImpl<?>) target).getParent();
-            if (!parent.isCheckedOut()) {
+            NodeImpl parent = (NodeImpl) ((isNode) ? target : ((ItemImpl<?>) target).getParent());
+            if (!parent.internalIsCheckedOut()) {
                 return false;
             }
             boolean hasLocking = sessionContext.getRepository().getDescriptorValue(Repository.OPTION_LOCKING_SUPPORTED)

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/WorkspaceImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/WorkspaceImpl.java
@@ -327,6 +327,10 @@ public class WorkspaceImpl implements JackrabbitWorkspace {
         return sessionContext.getPrivilegeManager();
     }
 
+    //------------------------------------------------------------< internal >---
+    public @NotNull VersionManagerImpl internalGetVersionManager() {
+        return versionManager;
+    }
     //------------------------------------------------------------< private >---
 
     private void ensureIsAlive() throws RepositoryException {

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/version/VersionManagerImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/version/VersionManagerImpl.java
@@ -252,7 +252,7 @@ public class VersionManagerImpl implements VersionManager {
     @Override
     public boolean isCheckedOut(final String absPath) throws RepositoryException {
         final SessionDelegate sessionDelegate = sessionContext.getSessionDelegate();
-        return sessionDelegate.perform(new SessionOperation<Boolean>("isCheckoutOut") {
+        return sessionDelegate.perform(new SessionOperation<Boolean>("isCheckedOut") {
             @NotNull
             @Override
             public Boolean perform() throws RepositoryException {
@@ -261,20 +261,7 @@ public class VersionManagerImpl implements VersionManager {
                 if (nodeDelegate == null) {
                     throw new PathNotFoundException(absPath);
                 }
-                boolean isCheckedOut = versionManagerDelegate.isCheckedOut(nodeDelegate);
-                if (!isCheckedOut) {
-                    // check OPV
-                    ReadWriteNodeTypeManager ntMgr = sessionContext.getWorkspace().getNodeTypeManager();
-                    NodeDelegate parent = nodeDelegate.getParent();
-                    NodeDefinition definition;
-                    if (parent == null) {
-                        definition = ntMgr.getRootDefinition();
-                    } else {
-                        definition = ntMgr.getDefinition(parent.getTree(), nodeDelegate.getTree());
-                    }
-                    isCheckedOut = definition.getOnParentVersion() == OnParentVersionAction.IGNORE;
-                }
-                return isCheckedOut;
+                return isCheckedOut(nodeDelegate);
             }
         });
     }
@@ -380,6 +367,23 @@ public class VersionManagerImpl implements VersionManager {
     }
 
     //----------------------------< internal >----------------------------------
+    
+    public boolean isCheckedOut(final @NotNull NodeDelegate nodeDelegate) throws RepositoryException {
+        boolean isCheckedOut = versionManagerDelegate.isCheckedOut(nodeDelegate);
+        if (!isCheckedOut) {
+            // check OPV
+            ReadWriteNodeTypeManager ntMgr = sessionContext.getWorkspace().getNodeTypeManager();
+            NodeDelegate parent = nodeDelegate.getParent();
+            NodeDefinition definition;
+            if (parent == null) {
+                definition = ntMgr.getRootDefinition();
+            } else {
+                definition = ntMgr.getDefinition(parent.getTree(), nodeDelegate.getTree());
+            }
+            isCheckedOut = definition.getOnParentVersion() == OnParentVersionAction.IGNORE;
+        }
+        return isCheckedOut;
+    }
 
     private void checkPendingChangesForRestore(SessionDelegate sessionDelegate)
             throws InvalidItemStateException {

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
@@ -35,7 +35,6 @@ import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.NodeDefinition;
 import javax.jcr.nodetype.PropertyDefinition;
 import javax.jcr.version.VersionException;
-import javax.jcr.version.VersionManager;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
@@ -48,10 +47,12 @@ import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.jcr.delegate.NodeDelegate;
 import org.apache.jackrabbit.oak.jcr.delegate.SessionDelegate;
 import org.apache.jackrabbit.oak.jcr.security.AccessManager;
 import org.apache.jackrabbit.oak.jcr.session.SessionContext;
 import org.apache.jackrabbit.oak.jcr.session.WorkspaceImpl;
+import org.apache.jackrabbit.oak.jcr.version.VersionManagerImpl;
 import org.apache.jackrabbit.oak.plugins.identifier.IdentifierManager;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
@@ -143,8 +144,8 @@ public class ImporterImpl implements Importer {
         }
 
         WorkspaceImpl wsp = sessionContext.getWorkspace();
-        VersionManager vMgr = wsp.getVersionManager();
-        if (!vMgr.isCheckedOut(absPath)) {
+        VersionManagerImpl vMgr = wsp.internalGetVersionManager();
+        if (!vMgr.isCheckedOut(new NodeDelegate(sd, importTargetTree))) {
             throw new VersionException("Target node is checked in.");
         }
         boolean hasLocking = sessionContext.getRepository().getDescriptorValue(Repository.OPTION_LOCKING_SUPPORTED).getBoolean();

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionableTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionableTest.java
@@ -16,11 +16,13 @@
  */
 package org.apache.jackrabbit.oak.jcr.version;
 
+import javax.jcr.GuestCredentials;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
@@ -28,6 +30,10 @@ import javax.jcr.version.VersionManager;
 
 import com.google.common.base.Function;
 import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
+import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.test.AbstractJCRTest;
 import org.jetbrains.annotations.Nullable;
 
@@ -314,6 +320,46 @@ public class VersionableTest extends AbstractJCRTest {
 
         history.removeVersion("1.2");
         assertSuccessors(history, of("1.1.0", "1.3"), "1.1");
+    }
+
+    /**
+     * See {@link org.apache.jackrabbit.oak.plugins.version.ReadOnlyVersionManager#isCheckedOut(Tree)} for details.
+     */
+    public void testIsCheckedOutOnNonAccessibleParent() throws Exception {
+        Node node = testRootNode.addNode(nodeName1, testNodeType);
+        node.addMixin(mixVersionable);
+        Node child = node.addNode(nodeName2, testNodeType);
+        
+        String nodePath = node.getPath();
+        String childPath = child.getPath();
+        
+        // grant the guest-session read-access to child but not the parent.
+        AccessControlUtils.deny(node, EveryonePrincipal.NAME, PrivilegeConstants.JCR_READ);
+        AccessControlUtils.allow(child, EveryonePrincipal.NAME, PrivilegeConstants.JCR_READ);
+        superuser.save();
+        
+        node.checkin();
+        assertFalse(node.isCheckedOut());
+        assertFalse(child.isCheckedOut());
+        
+        Session guest = getHelper().getRepository().login(new GuestCredentials());
+        assertFalse(guest.nodeExists(nodePath));
+        assertTrue(guest.nodeExists((childPath)));
+        
+        assertTrue(guest.getWorkspace().getVersionManager().isCheckedOut(childPath));
+        assertTrue(guest.getNode(childPath).isCheckedOut());
+
+        // grant the guest-session read-access on the parent as well -> checkin-status is visible
+        AccessControlUtils.allow(node, EveryonePrincipal.NAME, PrivilegeConstants.JCR_READ);
+        superuser.save();
+
+        guest.refresh(false);
+        assertTrue(guest.nodeExists(nodePath));
+        assertFalse(guest.getWorkspace().getVersionManager().isCheckedOut(childPath));
+        assertFalse(guest.getWorkspace().getVersionManager().isCheckedOut(nodePath));
+
+        assertFalse(guest.getNode(childPath).isCheckedOut());
+        assertFalse(guest.getNode(nodePath).isCheckedOut());
     }
 
     private static void assertSuccessors(VersionHistory history, Set<String> expectedSuccessors, String versionName) throws RepositoryException {


### PR DESCRIPTION
hi @joerghoh , @mreutegg , @reschke , @Joscorbe , i would highly appreciate if you could take a careful look at this PR for the version-mgt implementation.

- as outlined in the ticket the implementation calling JCR API (and by doing so resolving the node again) is suboptiomal..... so the goal was to get rid of all JCR calls that create another operation-object inside a JCR call and avoid resolving the node again. 
- the check for the tree.existing in ReadOnlyVersionManager is IMHO redundant (and not relevant. i added an additional line in the comment illustrating how it could be fixed if really needed and added a test illustrating the mismatch that we had/have. i verified that the test both passed before and after my change)

please pay attention to the following subtle changes and let me know if you see any issue with that:
- ItemImpl.getVersionManager no longer calls JCR API on Workspace but the internal variant that returns the impl and does not perform a check if the session is still alive. that is handled in preconditions of the individual JCR calls)
- all internal checks for the node being checkedout should now call the internal method taking a nodedelegate without creating a separate operation object
