### PR TITLE
OAK-9980: Index Purging Logic fails when trying to delete :oak:mount-…

### DIFF
--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
@@ -18,11 +18,17 @@
  */
 package org.apache.jackrabbit.oak.composite.blueGreen;
 
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
-import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexFormatVersion;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.junit.Assert;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -33,12 +39,14 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
-import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstants;
-import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
-import org.apache.jackrabbit.oak.plugins.index.search.IndexFormatVersion;
-import org.junit.Assert;
+import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NODE_TYPE;
+import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 
 /**
  * Utilities for indexing and query tests.
@@ -145,6 +153,40 @@ public class IndexUtils {
         } catch (RepositoryException e) {
             // expected
         }
+    }
+
+    public static boolean isIndexDisabledAndHiddenNodesDeleted(NodeStore store, String path) throws CommitFailedException {
+        NodeState nodeState = NodeStateUtils.getNode(store.getRoot(), path);
+        if (!nodeState.getProperty("type").getValue(Type.STRING).equals("disabled")) {
+            return false;
+        }
+        Iterable<String> childNodeNames = nodeState.getChildNodeNames();
+        for (String childNodeName : childNodeNames) {
+            if (NodeStateUtils.isHidden(childNodeName)) {
+                if (!childNodeName.startsWith(IndexDefinition.HIDDEN_OAK_MOUNT_PREFIX)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public static boolean isIndexEnabledAndHiddenNodesPreset(NodeStore store, String path) {
+        NodeState nodeState = NodeStateUtils.getNode(store.getRoot(), path);
+        if (!nodeState.getProperty("type").getValue(Type.STRING).equals("lucene")
+                && !nodeState.getProperty("type").getValue(Type.STRING).equals("elastic")) {
+            return false;
+        }
+        Iterable<String> childNodeNames = nodeState.getChildNodeNames();
+        Set<String> indexHiddenNodes = new HashSet<>();
+        for (String childNodeName : childNodeNames) {
+            if (NodeStateUtils.isHidden(childNodeName)) {
+                indexHiddenNodes.add(childNodeName);
+            }
+        }
+        List<String> defaultHiddenNodes = Arrays.asList(":data", ":status",
+                ":index-definition", ":oak:mount-libs-index-data");
+        return indexHiddenNodes.containsAll(defaultHiddenNodes);
     }
 
 }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
@@ -155,7 +155,7 @@ public class IndexUtils {
         }
     }
 
-    public static boolean isIndexDisabledAndHiddenNodesDeleted(NodeStore store, String path) throws CommitFailedException {
+    public static boolean isIndexDisabledAndHiddenNodesDeleted(NodeStore store, String path) {
         NodeState nodeState = NodeStateUtils.getNode(store.getRoot(), path);
         if (!nodeState.getProperty("type").getValue(Type.STRING).equals("disabled")) {
             return false;

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
@@ -171,7 +171,7 @@ public class IndexUtils {
         return true;
     }
 
-    public static boolean isIndexEnabledAndHiddenNodesPreset(NodeStore store, String path) {
+    public static boolean isIndexEnabledAndHiddenNodesPresent(NodeStore store, String path) {
         NodeState nodeState = NodeStateUtils.getNode(store.getRoot(), path);
         if (!nodeState.getProperty("type").getValue(Type.STRING).equals("lucene")
                 && !nodeState.getProperty("type").getValue(Type.STRING).equals("elastic")) {

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
@@ -155,6 +155,7 @@ public class IndexUtils {
         }
     }
 
+    // Could throw NPE, but we don't care as it's a test
     public static boolean isIndexDisabledAndHiddenNodesDeleted(NodeStore store, String path) {
         NodeState nodeState = NodeStateUtils.getNode(store.getRoot(), path);
         if (!nodeState.getProperty("type").getValue(Type.STRING).equals("disabled")) {

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/Persistence.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/Persistence.java
@@ -152,7 +152,9 @@ public class Persistence {
 
     @Nullable
     public NodeStore getCompositeNodestore() {
-        // returns null if Persistence object is not created in composite mode
+        if (compositeNodestore == null) {
+            throw new IllegalStateException("persistence object was not opened in composite mode");
+        }
         return compositeNodestore;
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/Persistence.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/Persistence.java
@@ -118,6 +118,8 @@ public class Persistence {
 
     private final ArrayList<FileStore> fileStores = new ArrayList<>();
     private JackrabbitRepository repository;
+    private NodeStore compositeNodestore;
+
     public Session session;
 
     public static Persistence open(File directory, Config config) throws Exception {
@@ -138,13 +140,20 @@ public class Persistence {
         FileStore globalFileStore = openFileStore(globalDir, config.blobStore);
         result.fileStores.add(globalFileStore);
         SegmentNodeStore globalStore = openSegmentStore(globalFileStore);
-        NodeStore cn = new CompositeNodeStore.Builder(
+        result.compositeNodestore = new CompositeNodeStore.Builder(
                 MOUNT_INFO_PROVIDER,
                 globalStore).addMount("libs", libsStore).
                 setPartialReadOnly(true).build();
-        result.repository = openRepsitory(cn, config.indexDir);
+        result.repository = openRepsitory(result.compositeNodestore, config.indexDir);
         result.session = result.repository.login(createCredentials());
         return result;
+    }
+
+    public NodeStore getCompositeNodestore() throws Exception {
+        if (compositeNodestore == null){
+            throw new Exception("persistence object was not opened in composite mode");
+        }
+        return compositeNodestore;
     }
 
     public void close() {

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/Persistence.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/Persistence.java
@@ -108,6 +108,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class to open a repository.
@@ -149,10 +150,9 @@ public class Persistence {
         return result;
     }
 
-    public NodeStore getCompositeNodestore() throws Exception {
-        if (compositeNodestore == null){
-            throw new Exception("persistence object was not opened in composite mode");
-        }
+    @Nullable
+    public NodeStore getCompositeNodestore() {
+        // returns null if Persistence object is not created in composite mode
         return compositeNodestore;
     }
 

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -538,6 +538,13 @@
           <type>test-jar</type>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.jackrabbit</groupId>
+          <artifactId>oak-lucene</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/indexversion/PurgeOldVersionUtils.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/indexversion/PurgeOldVersionUtils.java
@@ -21,6 +21,7 @@ package org.apache.jackrabbit.oak.indexversion;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.lucene.property.RecursiveDelete;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.IndexName;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
@@ -64,6 +65,9 @@ public class PurgeOldVersionUtils {
         Iterable<String> childNodeNames = nodeState.getChildNodeNames();
         for (String childNodeName : childNodeNames) {
             if (NodeStateUtils.isHidden(childNodeName)) {
+                if (childNodeName.startsWith(IndexDefinition.HIDDEN_OAK_MOUNT_PREFIX)) {
+                    continue;
+                }
                 RecursiveDelete recursiveDelete = new RecursiveDelete(store, EmptyHook.INSTANCE, () -> CommitInfo.EMPTY);
                 recursiveDelete.run(path + "/" + childNodeName);
             }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
@@ -77,7 +77,7 @@ public class PurgeOldIndexVersionIT {
         Assert.assertEquals(1, purgeOldIndexVersionLogger.getLogs().size());
         Assert.assertEquals(purgeLog, purgeOldIndexVersionLogger.getLogs().get(0).toString());
         Assert.assertTrue(IndexUtils.isIndexDisabledAndHiddenNodesDeleted(n, "/oak:index/test-1"));
-        Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPreset(n, "/oak:index/test-2"));
+        Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPresent(n, "/oak:index/test-2"));
     }
 
     private void initGlobal() throws Exception {

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
@@ -49,7 +49,8 @@ public class PurgeOldIndexVersionIT {
 
     @Before
     public void setup() {
-        purgeOldIndexVersionLogger = LogCustomizer.forLogger(PurgeOldIndexVersion.class.getName()).enable(Level.INFO).contains("Found some index need to be purged over base").create();
+        purgeOldIndexVersionLogger = LogCustomizer.forLogger(PurgeOldIndexVersion.class.getName())
+                .enable(Level.INFO).contains("Found some index need to be purged over base").create();
     }
 
     @After
@@ -111,7 +112,6 @@ public class PurgeOldIndexVersionIT {
         IndexUtils.createIndex(p, "test-1", "foo", 10);
         IndexUtils.createIndex(p, "test-2", "foo", 20);
 
-        // the new index must be used in the new version (with libs2)
         IndexUtils.assertQueryUsesIndexAndReturns(p,
                 "/jcr:root//*[@foo] order by @jcr:path",
                 "test-2",
@@ -121,7 +121,7 @@ public class PurgeOldIndexVersionIT {
 
     private void createFolders() throws IOException {
         globalDir = tempDir.newFolder("global");
-        libsDir = tempDir.newFolder("libs2");
+        libsDir = tempDir.newFolder("libs");
         datastoreDir = tempDir.newFolder("datastore");
         indexDir = tempDir.newFolder("index");
     }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
@@ -76,7 +76,7 @@ public class PurgeOldIndexVersionIT {
         String purgeLog = "Found some index need to be purged over base'/oak:index/test':" +
                 " '[/oak:index/test-1 base=/oak:index/test versioned product=1 custom=0 operation:DELETE_HIDDEN_AND_DISABLE]'";
         Assert.assertEquals(1, purgeOldIndexVersionLogger.getLogs().size());
-        Assert.assertEquals(purgeLog, purgeOldIndexVersionLogger.getLogs().get(0).toString());
+        Assert.assertEquals(purgeLog, purgeOldIndexVersionLogger.getLogs().get(0));
         Assert.assertTrue(IndexUtils.isIndexDisabledAndHiddenNodesDeleted(n, "/oak:index/test-1"));
         Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPresent(n, "/oak:index/test-2"));
     }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.indexversion;
+
+import ch.qos.logback.classic.Level;
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
+import org.apache.jackrabbit.oak.composite.blueGreen.IndexUtils;
+import org.apache.jackrabbit.oak.composite.blueGreen.Persistence;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class PurgeOldIndexVersionIT {
+
+    private final Persistence.Config config = new Persistence.Config();
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder(new File("target"));
+
+    private File globalDir;
+    private File libsDir;
+    private File datastoreDir;
+    private File indexDir;
+    private LogCustomizer purgeOldIndexVersionLogger;
+
+    @Before
+    public void setup() {
+        purgeOldIndexVersionLogger = LogCustomizer.forLogger(PurgeOldIndexVersion.class.getName()).enable(Level.INFO).contains("Found some index need to be purged over base").create();
+    }
+
+    @After
+    public void teardown() {
+        purgeOldIndexVersionLogger.finished();
+    }
+
+    @Test
+    public void test() throws Exception {
+        createFolders();
+        config.blobStore = Persistence.getFileBlobStore(datastoreDir);
+        config.indexDir = indexDir;
+        initGlobal();
+        initLibs();
+        compositeLibs();
+
+        purgeOldIndexVersionLogger.starting();
+        PurgeOldIndexVersion purgeOldIndexVersion = new PurgeOldIndexVersion();
+        Persistence p = Persistence.openComposite(globalDir, libsDir, config);
+        NodeStore n = p.getCompositeNodestore();
+        purgeOldIndexVersion.execute(n, true, 1, Arrays.asList("/oak:index"));
+
+        String purgeLog = "Found some index need to be purged over base'/oak:index/test':" +
+                " '[/oak:index/test-1 base=/oak:index/test versioned product=1 custom=0 operation:DELETE_HIDDEN_AND_DISABLE]'";
+        Assert.assertEquals(1, purgeOldIndexVersionLogger.getLogs().size());
+        Assert.assertEquals(purgeLog, purgeOldIndexVersionLogger.getLogs().get(0).toString());
+        Assert.assertTrue(IndexUtils.isIndexDisabledAndHiddenNodesDeleted(n, "/oak:index/test-1"));
+        Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPreset(n, "/oak:index/test-2"));
+    }
+
+    private void initGlobal() throws Exception {
+        Persistence p = Persistence.open(globalDir, config);
+        p.session.getRootNode().addNode("content").addNode("test").setProperty("foo", "a");
+        p.session.save();
+        p.close();
+    }
+
+    private void initLibs() throws Exception {
+        Persistence p = Persistence.open(libsDir, config);
+        p.session.getRootNode().addNode("libs").addNode("test2").setProperty("foo", "a");
+        p.session.save();
+        IndexUtils.createIndex(p, "test-1", "foo", 10);
+        IndexUtils.assertQueryUsesIndexAndReturns(p,
+                "/jcr:root//*[@foo]",
+                "test-1",
+                "[/libs/test2]");
+        IndexUtils.createIndex(p, "test-2", "foo", 20);
+        IndexUtils.assertQueryUsesIndexAndReturns(p,
+                "/jcr:root//*[@foo]",
+                "test-2",
+                "[/libs/test2]");
+        p.close();
+    }
+
+    private void compositeLibs() throws Exception {
+        Persistence p = Persistence.openComposite(globalDir, libsDir, config);
+        IndexUtils.checkLibsIsReadOnly(p);
+
+        IndexUtils.createIndex(p, "test-1", "foo", 10);
+        IndexUtils.createIndex(p, "test-2", "foo", 20);
+
+        // the new index must be used in the new version (with libs2)
+        IndexUtils.assertQueryUsesIndexAndReturns(p,
+                "/jcr:root//*[@foo] order by @jcr:path",
+                "test-2",
+                "[/content/test, /libs/test2]");
+        p.close();
+    }
+
+    private void createFolders() throws IOException {
+        globalDir = tempDir.newFolder("global");
+        libsDir = tempDir.newFolder("libs2");
+        datastoreDir = tempDir.newFolder("datastore");
+        indexDir = tempDir.newFolder("index");
+    }
+
+}


### PR DESCRIPTION
…libs* (read-only) node under index definition for composite nodestore