### PR TITLE
OAK-9982: avoid direct use of Json.createObject

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndex.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndex.java
@@ -16,11 +16,11 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.query;
 
+import co.elastic.clients.json.JsonpUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNode;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.ElasticResultRowAsyncIterator;
-import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexNode;
 import org.apache.jackrabbit.oak.plugins.index.search.SizeEstimator;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex;
@@ -91,7 +91,7 @@ class ElasticIndex extends FulltextIndex {
 
     @Override
     protected String getFulltextRequestString(IndexPlan plan, IndexNode indexNode, NodeState rootState) {
-        return ElasticIndexUtils.toString(new ElasticRequestHandler(plan, getPlanResult(plan), rootState).baseQuery());
+        return JsonpUtils.toString(new ElasticRequestHandler(plan, getPlanResult(plan), rootState).baseQuery(), new StringBuilder()).toString();
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -56,6 +56,7 @@ import javax.jcr.PropertyType;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.search.Highlight;
 import co.elastic.clients.elasticsearch.core.search.HighlightField;
+import co.elastic.clients.json.JsonpUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -442,6 +443,7 @@ public class ElasticRequestHandler {
 
         nonFullTextConstraints(indexPlan, planResult).forEach(bqBuilder::must);
         Query query = Query.of(q -> q.bool(bqBuilder.build()));
+        StringBuilder queryString = JsonpUtils.toString(query, new StringBuilder());
         return PhraseSuggester.of(ps -> ps
                 .field(FieldNames.SPELLCHECK)
                 .size(10)
@@ -453,7 +455,7 @@ public class ElasticRequestHandler {
                 // https://github.com/elastic/elasticsearch-java/issues/404
                 .highlight(f -> f.preTag("").postTag(""))
                 .directGenerator(d -> d.field(FieldNames.SPELLCHECK).suggestMode(SuggestMode.Missing).size(10))
-                .collate(c -> c.query(q -> q.source(ElasticIndexUtils.toString(query))))
+                .collate(c -> c.query(q -> q.source(queryString.toString())))
         );
     }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -30,7 +30,6 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNode;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticRequestHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticResponseHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.facets.ElasticFacetProvider;
-import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex.FulltextResultRow;
 import org.apache.jackrabbit.oak.plugins.index.search.util.LMSEstimator;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex;
@@ -76,7 +75,7 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
     private final ElasticRequestHandler elasticRequestHandler;
     private final ElasticResponseHandler elasticResponseHandler;
     private final ElasticFacetProvider elasticFacetProvider;
-    private final AtomicReference<Throwable> errorRef = new AtomicReference();
+    private final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
     private FulltextResultRow nextRow;
 
@@ -253,9 +252,8 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                     }
             );
 
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Kicking initial search for query {}", ElasticIndexUtils.toString(searchReq));
-            }
+
+            LOG.trace("Kicking initial search for query {}", searchReq);
             semaphore.tryAcquire();
 
             searchStartTime = System.currentTimeMillis();
@@ -343,7 +341,7 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
             }
 
             LOG.error("Error retrieving data for jcr query [{}] :: Corresponding ES query {} : closing scanner, notifying listeners",
-                indexPlan.getFilter(), ElasticIndexUtils.toString(query), t);
+                indexPlan.getFilter(), query, t);
             // closing scanner immediately after a failure avoiding them to hang (potentially) forever
             close();
         }
@@ -363,9 +361,7 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                         .highlight(highlight)
                         .size(getFetchSize(requests++))
                 );
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("Kicking new search after query {}", ElasticIndexUtils.toString(searchReq));
-                }
+                LOG.trace("Kicking new search after query {}", searchReq);
 
                 searchStartTime = System.currentTimeMillis();
                 indexNode.getConnection().getAsyncClient()

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -252,7 +252,6 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                     }
             );
 
-
             LOG.trace("Kicking initial search for query {}", searchReq);
             semaphore.tryAcquire();
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
@@ -16,8 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -28,11 +26,6 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.JsonpSerializable;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import jakarta.json.stream.JsonGenerator;
 
 public class ElasticIndexUtils {
 
@@ -93,25 +86,5 @@ public class ElasticIndexUtils {
         }
         return bytes;
     }
-    
-    /**
-     * Provides a string with the serialisation of the object.
-     * Typically, used to obtain the DSL representation of Elasticsearch requests or partial requests.
-     *
-     * TODO: remove this when <a href="https://github.com/elastic/elasticsearch-java/issues/101">#101</a> gets implemented
-     *
-     * @return Json serialisation as a string.
-     */
-    public static String toString(JsonpSerializable query) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        JsonpMapper mapper = new JacksonJsonpMapper();
-        JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
-        query.serialize(generator, mapper);
-        generator.close();
-        try {
-            return baos.toString("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("Error creating request entity", e);
-        }
-    }
+
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticSimilarQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticSimilarQueryTest.java
@@ -276,7 +276,7 @@ public class ElasticSimilarQueryTest extends ElasticAbstractQueryTest {
         URI uri = getClass().getResource("/org/apache/jackrabbit/oak/query/fvs.csv").toURI();
         File file = new File(uri);
 
-        for (String line : IOUtils.readLines(new FileInputStream(file), Charset.defaultCharset())) {
+        for (String line : IOUtils.readLines(Files.newInputStream(file.toPath()), Charset.defaultCharset())) {
             String[] split = line.split(",");
             List<Double> values = Arrays.stream(split).skip(1).map(Double::parseDouble).collect(Collectors.toList());
             byte[] bytes = toByteArray(values);

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelperTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelperTest.java
@@ -26,7 +26,6 @@ import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.elasticsearch.indices.IndexSettingsAnalysis;
 import co.elastic.clients.json.JsonData;
-import jakarta.json.JsonValue;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
@@ -121,7 +120,7 @@ public class ElasticIndexHelperTest {
         assertThat(wdgfDef.splitOnNumerics(), is(expectedSplitOnNumerics));
 
         Map<String, JsonData> otherSettings = req.settings().otherSettings();
-        assertThat(otherSettings.get(ElasticIndexDefinition.ELASTIKNN).toJson(), is(JsonValue.TRUE));
+        assertThat(otherSettings.get(ElasticIndexDefinition.ELASTIKNN).to(Boolean.class), is(true));
     }
 
     @Test


### PR DESCRIPTION
This could lead to dependency issues at runtime. Safer to use Elasticseaech java client utilities.