### PR TITLE
OAK-10006 Prevent writes to Azure storage if lock is not held

### DIFF
--- a/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/AwsPersistence.java
+++ b/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/AwsPersistence.java
@@ -81,11 +81,11 @@ public class AwsPersistence implements SegmentNodeStorePersistence {
 
     @Override
     public RepositoryLock lockRepository() throws IOException {
-        return new AwsRepositoryLock(awsContext.dynamoDBClient, awsContext.getPath("repo.lock")).lock();
+        return lockRepository(s -> {});
     }
 
     @Override
     public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
-        return lockRepository();
+        return new AwsRepositoryLock(awsContext.dynamoDBClient, awsContext.getPath("repo.lock"), lockStatusChangedCallback).lock();
     }
 }

--- a/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/AwsPersistence.java
+++ b/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/AwsPersistence.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.segment.aws;
 
 import java.io.IOException;
 
+import java.util.function.Consumer;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitor;
@@ -81,5 +82,10 @@ public class AwsPersistence implements SegmentNodeStorePersistence {
     @Override
     public RepositoryLock lockRepository() throws IOException {
         return new AwsRepositoryLock(awsContext.dynamoDBClient, awsContext.getPath("repo.lock")).lock();
+    }
+
+    @Override
+    public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
+        return lockRepository();
     }
 }

--- a/oak-segment-aws/src/test/java/org/apache/jackrabbit/oak/segment/aws/AwsGCJournalFileTest.java
+++ b/oak-segment-aws/src/test/java/org/apache/jackrabbit/oak/segment/aws/AwsGCJournalFileTest.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
 
+import java.util.function.Consumer;
 import org.apache.jackrabbit.oak.segment.file.GcJournalTest;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
@@ -106,6 +107,11 @@ public class AwsGCJournalFileTest extends GcJournalTest {
 
         @Override
         public RepositoryLock lockRepository() throws IOException {
+            throw new IOException();
+        }
+
+        @Override
+        public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
             throw new IOException();
         }
 

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
@@ -21,13 +21,14 @@ import com.microsoft.azure.storage.StorageErrorCodeStrings;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobRequestOptions;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.apache.jackrabbit.oak.segment.spi.persistence.RepositoryLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -39,41 +40,58 @@ public class AzureRepositoryLock implements RepositoryLock {
 
     private static final int TIMEOUT_SEC = Integer.getInteger("oak.segment.azure.lock.timeout", 0);
 
-    private static final int INTERVAL = 60;
+    private static final int INTERVAL_SEC = 60;
 
     private final Consumer<LockStatus> lockStatusChangedCallback;
 
     private final CloudBlockBlob blob;
 
-    private final ExecutorService executor;
+    private final ScheduledExecutorService refreshLeaseExecutor;
 
     private final int timeoutSec;
 
-    private final int renewalInterval;
+    private final int renewalIntervalInSec;
+    
+    private final int leaseTimeInSecs;
     
     private String leaseId;
 
-    private volatile boolean doUpdate;
+    private volatile boolean unlocked;
+    private final BlobRequestOptions renewLeaseRequestOptions;
 
     public AzureRepositoryLock(CloudBlockBlob blob, Consumer<LockStatus> lockStatusChangedCallback) {
-        this(blob, lockStatusChangedCallback, TIMEOUT_SEC, INTERVAL / 2);
+        this(blob, lockStatusChangedCallback, TIMEOUT_SEC, INTERVAL_SEC / 2);
     }
 
-    public AzureRepositoryLock(CloudBlockBlob blob, Consumer<LockStatus> lockStatusChangedCallback, int timeoutSec, int renewalInterval) {
-        this.lockStatusChangedCallback = lockStatusChangedCallback;
-        this.blob = blob;
-        this.executor = Executors.newSingleThreadExecutor();
-        this.timeoutSec = timeoutSec;
-        this.renewalInterval = renewalInterval;
+    public AzureRepositoryLock(CloudBlockBlob blob, Consumer<LockStatus> lockStatusChangedCallback, int timeoutSec, int renewalIntervalInSec) {
+        this(blob, lockStatusChangedCallback, timeoutSec, renewalIntervalInSec, INTERVAL_SEC);
     }
     
+    public AzureRepositoryLock(CloudBlockBlob blob, Consumer<LockStatus> lockStatusChangedCallback, int timeoutSec, int renewalIntervalInSec, 
+        int leaseTimeInSecs) {
+        this.lockStatusChangedCallback = lockStatusChangedCallback;
+        this.blob = blob;
+        this.refreshLeaseExecutor = Executors.newSingleThreadScheduledExecutor();
+        this.timeoutSec = timeoutSec;
+        this.renewalIntervalInSec = Math.min(Math.max(renewalIntervalInSec, 0), INTERVAL_SEC / 2);
+        this.leaseTimeInSecs = leaseTimeInSecs;
+        this.unlocked = false;
+        
+        // Set default request options for `renewLease()` call, as we cannot rely on the default options.
+        // In case of network issues, the `renewLease()` call should time out at least 1 second before the current lease expires. 
+        renewLeaseRequestOptions = new BlobRequestOptions();
+        int maxAllowedTimeToRenewBeforeLeaseExpiration = leaseTimeInSecs - renewalIntervalInSec - 1;
+        renewLeaseRequestOptions.setMaximumExecutionTimeInMs(maxAllowedTimeToRenewBeforeLeaseExpiration * 1000);
+        renewLeaseRequestOptions.setTimeoutIntervalInMs(5000);
+    }
+
     public AzureRepositoryLock lock() throws IOException {
         long start = System.currentTimeMillis();
         Exception ex = null;
         do {
             try {
                 blob.openOutputStream().close();
-                leaseId = blob.acquireLease(INTERVAL, null);
+                leaseId = blob.acquireLease(leaseTimeInSecs, null);
                 log.info("Acquired lease {}", leaseId);
                 notifyLockStatusChange(LockStatus.ACQUIRED);
             } catch (StorageException | IOException e) {
@@ -94,41 +112,41 @@ public class AzureRepositoryLock implements RepositoryLock {
         } while (leaseId == null);
         if (leaseId == null) {
             log.error("Can't acquire the lease in {}s.", timeoutSec);
+            notifyLockStatusChange(LockStatus.ACQUIRE_FAILED);
             throw new IOException(ex);
         } else {
-            executor.submit(this::refreshLease);
+            scheduleRefreshLease(renewalIntervalInSec);
             return this;
         }
     }
 
     private void refreshLease() {
-        doUpdate = true;
-        long lastUpdate = System.currentTimeMillis();
-        while (doUpdate) {
-            try {
-                long timeSinceLastUpdate = (System.currentTimeMillis() - lastUpdate) / 1000;
-                if (timeSinceLastUpdate > renewalInterval) {
-                    notifyLockStatusChange(LockStatus.RENEWAL);
-                    doRenewLease();
-                    lastUpdate = System.currentTimeMillis();
-                    notifyLockStatusChange(LockStatus.RENEWAL_SUCCEEDED);
-                }
-            } catch (StorageException e) {
-                if (e.getErrorCode().equals(StorageErrorCodeStrings.OPERATION_TIMED_OUT)) {
-                    log.warn("Could not renew the lease due to the operation timeout. Retry in progress ...", e);
-                    notifyLockStatusChange(LockStatus.RENEWAL_FAILED);
-                } else {
-                    log.error("Can't renew the lease", e);
-                    doUpdate = false;
-                    notifyLockStatusChange(LockStatus.LOST);
-                    return;
-                }
+        if (unlocked) {
+            return;
+        }
+        try {
+            notifyLockStatusChange(LockStatus.RENEWAL);
+            doRenewLease();
+            scheduleRefreshLease(renewalIntervalInSec);
+            notifyLockStatusChange(LockStatus.RENEWAL_SUCCEEDED);
+        } catch (StorageException e) {
+            if (e.getErrorCode().equals(StorageErrorCodeStrings.OPERATION_TIMED_OUT)) {
+                log.warn("Could not renew the lease due to the operation timeout. Retry in progress ...", e);
+                // re-schedule immediately
+                scheduleRefreshLease(0);
+                notifyLockStatusChange(LockStatus.RENEWAL_FAILED);
+            } else {
+                log.error("Can't renew the lease", e);
+                notifyLockStatusChange(LockStatus.LOST);
             }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                log.error("Interrupted the lease renewal loop", e);
-            }
+        }
+    }
+
+    private void scheduleRefreshLease(int delayInSecs) {
+        try {
+            refreshLeaseExecutor.schedule(this::refreshLease, delayInSecs, TimeUnit.SECONDS);
+        } catch (RejectedExecutionException e) {
+            throw new RuntimeException("Cannot schedule lock refresh task as this lock was unlocked");
         }
     }
 
@@ -136,23 +154,21 @@ public class AzureRepositoryLock implements RepositoryLock {
         try {
             lockStatusChangedCallback.accept(renewal);
         } catch (RuntimeException e) {
+            // Log but don't propagate exceptions thrown by the callback
             log.warn("Exception in lock status change callback", e);
         }
     }
 
     void doRenewLease() throws StorageException {
-        BlobRequestOptions blobRequestOptions = new BlobRequestOptions();
-        blobRequestOptions.setMaximumExecutionTimeInMs(Math.max(INTERVAL - renewalInterval - 1, INTERVAL / 2 - 1));
-        blobRequestOptions.setTimeoutIntervalInMs(5); //TODO: extract field
-        blob.renewLease(AccessCondition.generateLeaseCondition(leaseId), blobRequestOptions, null);
+        blob.renewLease(AccessCondition.generateLeaseCondition(leaseId), renewLeaseRequestOptions, null);
     }
 
     @Override
     public void unlock() throws IOException {
-        doUpdate = false;
-        executor.shutdown();
+        unlocked = true;
+        refreshLeaseExecutor.shutdownNow();
         try {
-            executor.awaitTermination(1, TimeUnit.MINUTES);
+            refreshLeaseExecutor.awaitTermination(1, TimeUnit.MINUTES);
         } catch (InterruptedException e) {
             throw new IOException(e);
         } finally {

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
@@ -57,6 +57,7 @@ public class AzureRepositoryLock implements RepositoryLock {
     private String leaseId;
 
     private volatile boolean unlocked;
+    
     private final BlobRequestOptions renewLeaseRequestOptions;
 
     public AzureRepositoryLock(CloudBlockBlob blob, Consumer<LockStatus> lockStatusChangedCallback) {

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureArchiveManagerTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureArchiveManagerTest.java
@@ -16,10 +16,19 @@
  */
 package org.apache.jackrabbit.oak.segment.azure;
 
+import com.microsoft.azure.storage.StorageErrorCodeStrings;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudBlobDirectory;
+import com.microsoft.azure.storage.blob.CloudBlockBlob;
 import com.microsoft.azure.storage.blob.ListBlobItem;
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -33,10 +42,10 @@ import org.apache.jackrabbit.oak.segment.file.FileStoreBuilder;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
 import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
 import org.apache.jackrabbit.oak.segment.file.tar.TarPersistence;
-import org.apache.jackrabbit.oak.segment.spi.RepositoryNotReachableException;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.persistence.RepositoryLock;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveReader;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
@@ -48,7 +57,9 @@ import org.apache.jackrabbit.oak.segment.spi.persistence.split.SplitPersistence;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
-import org.junit.Assert;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -59,23 +70,19 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class AzureArchiveManagerTest {
 
@@ -85,29 +92,21 @@ public class AzureArchiveManagerTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File("target"));
 
-    private CloudBlobContainer container;
+    private Fixture fixture;
 
     @Before
-    public void setup() throws StorageException, InvalidKeyException, URISyntaxException {
-        container = azurite.getContainer("oak-test");
+    public void setup() throws Exception {
+        fixture = new Fixture(azurite);
     }
 
     @Test
     public void testRecovery() throws StorageException, URISyntaxException, IOException {
-        SegmentArchiveManager manager = new AzurePersistence(container.getDirectoryReference("oak")).createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
+        SegmentArchiveManager manager = fixture.newSegmentArchiveManager();
         SegmentArchiveWriter writer = manager.create("data00000a.tar");
 
-        List<UUID> uuids = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            UUID u = UUID.randomUUID();
-            writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
-            uuids.add(u);
-        }
+        List<UUID> uuids = writeSegments(writer, 10);
 
-        writer.flush();
-        writer.close();
-
-        container.getBlockBlobReference("oak/data00000a.tar/0005." + uuids.get(5).toString()).delete();
+        fixture.deleteBlob("oak/data00000a.tar/0005." + uuids.get(5).toString());
 
         LinkedHashMap<UUID, byte[]> recovered = new LinkedHashMap<>();
         manager.recoverEntries("data00000a.tar", recovered);
@@ -116,20 +115,12 @@ public class AzureArchiveManagerTest {
 
     @Test
     public void testBackupWithRecoveredEntries() throws StorageException, URISyntaxException, IOException {
-        SegmentArchiveManager manager = new AzurePersistence(container.getDirectoryReference("oak")).createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
+        SegmentArchiveManager manager = fixture.newSegmentArchiveManager();
         SegmentArchiveWriter writer = manager.create("data00000a.tar");
 
-        List<UUID> uuids = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            UUID u = UUID.randomUUID();
-            writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
-            uuids.add(u);
-        }
+        List<UUID> uuids = writeSegments(writer, 10);
 
-        writer.flush();
-        writer.close();
-
-        container.getBlockBlobReference("oak/data00000a.tar/0005." + uuids.get(5).toString()).delete();
+        fixture.deleteBlob("oak/data00000a.tar/0005." + uuids.get(5).toString());
 
         LinkedHashMap<UUID, byte[]> recovered = new LinkedHashMap<>();
         manager.recoverEntries("data00000a.tar", recovered);
@@ -137,270 +128,356 @@ public class AzureArchiveManagerTest {
         manager.backup("data00000a.tar", "data00000a.tar.bak", recovered.keySet());
 
         for (int i = 0; i <= 4; i++) {
-            assertTrue(container.getBlockBlobReference("oak/data00000a.tar/000"+ i + "." + uuids.get(i)).exists());
+            assertTrue(fixture.blobExists("oak/data00000a.tar/000" + i + "." + uuids.get(i)));
         }
 
         for (int i = 5; i <= 9; i++) {
-            assertFalse(String.format("Segment %s.??? should have been deleted.", "oak/data00000a.tar/000"+ i), container.getBlockBlobReference("oak/data00000a.tar/000"+ i + "." + uuids.get(i)).exists());
+            assertFalse(String.format("Segment %s.??? should have been deleted.", "oak/data00000a.tar/000" + i),
+                fixture.blobExists("oak/data00000a.tar/000" + i + "." + uuids.get(i)));
         }
     }
 
     @Test
-    public void testUncleanStop() throws URISyntaxException, IOException, InvalidFileStoreVersionException, CommitFailedException, StorageException {
-        AzurePersistence p = new AzurePersistence(container.getDirectoryReference("oak"));
-        FileStore fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        SegmentNodeStore segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        NodeBuilder builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo", "bar");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.close();
+    public void testUncleanStop() throws URISyntaxException, StorageException {
+        fixture.mergeChanges(builder -> builder.setProperty("foo", "bar"));
 
-        container.getBlockBlobReference("oak/data00000a.tar/closed").delete();
-        container.getBlockBlobReference("oak/data00000a.tar/data00000a.tar.brf").delete();
-        container.getBlockBlobReference("oak/data00000a.tar/data00000a.tar.gph").delete();
+        fixture.deleteBlob("oak/data00000a.tar/closed");
+        fixture.deleteBlob("oak/data00000a.tar/data00000a.tar.brf");
+        fixture.deleteBlob("oak/data00000a.tar/data00000a.tar.gph");
 
-        fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        assertEquals("bar", segmentNodeStore.getRoot().getString("foo"));
-        fs.close();
+        fixture.withSegmentStore(segmentNodeStore ->
+            assertEquals("bar", segmentNodeStore.getRoot().getString("foo"))
+        );
     }
-
+    
     @Test
     // see OAK-8566
-    public void testUncleanStopWithEmptyArchive() throws URISyntaxException, IOException, InvalidFileStoreVersionException, CommitFailedException, StorageException {
-        AzurePersistence p = new AzurePersistence(container.getDirectoryReference("oak"));
-        FileStore fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        SegmentNodeStore segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        NodeBuilder builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo", "bar");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.close();
+    public void testUncleanStopWithEmptyArchive() throws URISyntaxException, StorageException {
+        fixture.mergeChanges(builder -> builder.setProperty("foo", "bar"));
 
         // make sure there are 2 archives
-        fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo2", "bar2");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.close();
+        fixture.mergeChanges(builder -> builder.setProperty("foo2", "bar2"));
 
         // remove the segment 0000 from the second archive
-        ListBlobItem segment0000 = container.listBlobs("oak/data00001a.tar/0000.").iterator().next();
-        ((CloudBlob) segment0000).delete();
-        container.getBlockBlobReference("oak/data00001a.tar/closed").delete();
+        fixture.deleteFirstBlobWithPrefix("oak/data00001a.tar/0000.");
+        fixture.deleteBlob("oak/data00001a.tar/closed");
 
-        fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        assertEquals("bar", segmentNodeStore.getRoot().getString("foo"));
-        fs.close();
+        fixture.withSegmentStore(segmentNodeStore ->
+            assertEquals("bar", segmentNodeStore.getRoot().getString("foo"))
+        );
     }
 
     @Test
-    public void testUncleanStopSegmentMissing() throws URISyntaxException, IOException, InvalidFileStoreVersionException, CommitFailedException, StorageException {
-        AzurePersistence p = new AzurePersistence(container.getDirectoryReference("oak"));
-        FileStore fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        SegmentNodeStore segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        NodeBuilder builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo", "bar");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.close();
+    public void testUncleanStopSegmentMissing() throws URISyntaxException, StorageException {
+        fixture.mergeChanges(builder -> builder.setProperty("foo", "bar"));
 
         // make sure there are 2 archives
-        fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo0", "bar0");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.flush();
-        //create segment 0001
-        builder.setProperty("foo1", "bar1");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.flush();
-        //create segment 0002
-        builder.setProperty("foo2", "bar2");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.flush();
-        //create segment 0003
-        builder.setProperty("foo3", "bar3");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        fs.flush();
-        fs.close();
+        fixture.flushEachChange(
+            b -> b.setProperty("foo0", "bar0"),
+            //create segment 0001
+            b -> b.setProperty("foo1", "bar1"),
+            //create segment 0002
+            b -> b.setProperty("foo2", "bar2"),
+            //create segment 0003
+            b -> b.setProperty("foo3", "bar3")
+        );
 
         // remove the segment 0002 from the second archive
-        ListBlobItem segment0002 = container.listBlobs("oak/data00001a.tar/0002.").iterator().next();
-        ((CloudBlob) segment0002).delete();
-        container.getBlockBlobReference("oak/data00001a.tar/closed").delete();
+        fixture.deleteFirstBlobWithPrefix("oak/data00001a.tar/0002.");
+        fixture.deleteBlob("oak/data00001a.tar/closed");
 
-        fs = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(p).build();
-        segmentNodeStore = SegmentNodeStoreBuilders.builder(fs).build();
-        assertEquals("bar", segmentNodeStore.getRoot().getString("foo"));
+        fixture.withSegmentStore(segmentNodeStore -> {
+            NodeState root = segmentNodeStore.getRoot();
+            assertEquals("bar", root.getString("foo"));
+
+            //verify content from recovered segments preserved
+            assertEquals("bar1", root.getString("foo1"));
+            //content from deleted segments not preserved
+            assertNull(root.getString("foo2"));
+            assertNull(root.getString("foo3"));
+        });
 
         //recovered archive data00001a.tar should not contain segments 0002 and 0003
-        assertFalse(container.listBlobs("oak/data00001a.tar/0002.").iterator().hasNext());
-        assertFalse(container.listBlobs("oak/data00001a.tar/0003.").iterator().hasNext());
+        assertFalse(fixture.hasBlobsWithPrefix("oak/data00001a.tar/0002."));
+        assertFalse(fixture.hasBlobsWithPrefix("oak/data00001a.tar/0003."));
 
-        assertTrue("Backup directory should have been created", container.listBlobs("oak/data00001a.tar.bak").iterator().hasNext());
+        assertTrue("Backup directory should have been created", fixture.hasBlobsWithPrefix("oak/data00001a.tar.bak"));
         //backup has all segments but 0002 since it was deleted before recovery
-        assertTrue(container.listBlobs("oak/data00001a.tar.bak/0001.").iterator().hasNext());
-        assertFalse(container.listBlobs("oak/data00001a.tar.bak/0002.").iterator().hasNext());
-        assertTrue(container.listBlobs("oak/data00001a.tar.bak/0003.").iterator().hasNext());
-
-        //verify content from recovered segments preserved
-        assertEquals("bar1", segmentNodeStore.getRoot().getString("foo1"));
-        //content from deleted segments not preserved
-        assertNull(segmentNodeStore.getRoot().getString("foo2"));
-        assertNull(segmentNodeStore.getRoot().getString("foo3"));
-        fs.close();
+        assertTrue(fixture.hasBlobsWithPrefix("oak/data00001a.tar.bak/0001."));
+        assertFalse(fixture.hasBlobsWithPrefix("oak/data00001a.tar.bak/0002."));
+        assertTrue(fixture.hasBlobsWithPrefix("oak/data00001a.tar.bak/0003."));
     }
 
     @Test
-    public void testExists() throws IOException, URISyntaxException {
-        SegmentArchiveManager manager = new AzurePersistence(container.getDirectoryReference("oak")).createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
+    public void testExists() throws IOException {
+        SegmentArchiveManager manager = fixture.newSegmentArchiveManager();
         SegmentArchiveWriter writer = manager.create("data00000a.tar");
 
-        List<UUID> uuids = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            UUID u = UUID.randomUUID();
-            writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
-            uuids.add(u);
+        writeSegments(writer, 10);
+
+        assertTrue(manager.exists("data00000a.tar"));
+        assertFalse(manager.exists("data00001a.tar"));
+    }
+
+    @Test
+    public void testArchiveExistsAfterFlush() throws IOException {
+        SegmentArchiveManager manager = fixture.newSegmentArchiveManager();
+        SegmentArchiveWriter writer = manager.create("data00000a.tar");
+
+        assertFalse(manager.exists("data00000a.tar"));
+        writeSegment(writer, UUID.randomUUID());
+        writer.flush();
+        assertTrue(manager.exists("data00000a.tar"));
+    }
+
+    @Test
+    public void testSegmentDeletedAfterCreatingReader() throws IOException, StorageException {
+        SegmentArchiveManager manager = fixture.newSegmentArchiveManager();
+        SegmentArchiveWriter writer = manager.create("data00000a.tar");
+
+        assertFalse(manager.exists("data00000a.tar"));
+        List<UUID> uuids = writeSegments(writer, 1);
+
+        UUID u = uuids.get(0);
+        try (SegmentArchiveReader reader = manager.open("data00000a.tar")) {
+            Buffer segment = readSegment(reader, u);
+            assertNotNull(segment);
+
+            fixture.deleteFirstBlobWithPrefix("oak/data00000a.tar/0000.");
+
+            assertThrows(FileNotFoundException.class, () -> readSegment(reader, u));
+        }
+    }
+
+    @Test
+    public void testMissingSegmentDetectedInFileStore() {
+        fixture.withFileStore(fileStore -> {
+            SegmentArchiveManager manager = fixture.newSegmentArchiveManager();
+            SegmentArchiveWriter writer = manager.create("data00000a.tar");
+
+            List<UUID> uuids = writeSegments(writer, 1);
+
+            UUID u = uuids.get(0);
+            try (SegmentArchiveReader reader = manager.open("data00000a.tar")) {
+                assertNotNull(readSegment(reader, u));
+            }
+
+            fixture.deleteFirstBlobWithPrefix("oak/data00000a.tar/0000.");
+
+            assertThrows(SegmentNotFoundException.class, () ->
+                fileStore.readSegment(new SegmentId(fileStore, u.getMostSignificantBits(), u.getLeastSignificantBits())));
+        });
+    }
+
+    @Test
+    public void testReadOnlyRecovery() throws URISyntaxException, StorageException {
+        fixture.withSegmentStore((rwFileStore, segmentNodeStore) -> {
+            fixture.flushChanges(rwFileStore, b -> b.setProperty("foo", "bar"));
+
+            assertTrue(fixture.hasBlobsInArchive("oak/data00000a.tar"));
+            assertFalse(fixture.hasBlobsInArchive("oak/data00000a.tar.ro.bak"));
+
+            // create read-only FS, while read-write FS is still open
+            fixture.withReadOnlyFileStore(roFileStore -> {
+                PropertyState fooProperty = segmentNodeStore(roFileStore)
+                    .getRoot()
+                    .getProperty("foo");
+                assertNotNull(fooProperty);
+                assertEquals("bar", fooProperty.getValue(Type.STRING));
+            });
+        });
+
+        assertTrue(fixture.hasBlobsInArchive("oak/data00000a.tar"));
+        // after creating a read-only FS, the recovery procedure should not be started since there is another running Oak process
+        assertFalse(fixture.hasBlobsInArchive("oak/data00000a.tar.ro.bak"));
+    }
+
+    @Test
+    public void testCachingPersistenceTarRecovery() throws URISyntaxException, InvalidFileStoreVersionException, IOException, StorageException {
+        FileStoreBuilder fileStoreBuilder = FileStoreBuilder.fileStoreBuilder(folder.newFolder())
+            .withCustomPersistence(fixture.newAzurePersistence());
+        try (FileStore rwFileStore = fileStoreBuilder.build()) {
+            fixture.flushChanges(rwFileStore, b -> b.setProperty("foo", "bar"));
+
+            assertTrue(fixture.hasBlobsInArchive("oak/data00000a.tar"));
+            assertFalse(fixture.hasBlobsInArchive("oak/data00000a.tar.ro.bak"));
+
+            // create files store with split persistence
+            AzurePersistence azureSharedPersistence = fixture.newAzurePersistence();
+
+            CachingPersistence cachingPersistence = new CachingPersistence(createPersistenceCache(), azureSharedPersistence);
+            File localFolder = folder.newFolder();
+            SegmentNodeStorePersistence localPersistence = new TarPersistence(localFolder);
+            SegmentNodeStorePersistence splitPersistence = new SplitPersistence(cachingPersistence, localPersistence);
+
+            // exception should not be thrown here
+            try (FileStore ignore = FileStoreBuilder.fileStoreBuilder(localFolder).withCustomPersistence(splitPersistence).build()) {
+            }
         }
 
-        writer.flush();
-        writer.close();
-
-        Assert.assertTrue(manager.exists("data00000a.tar"));
-        Assert.assertFalse(manager.exists("data00001a.tar"));
+        assertTrue(fixture.hasBlobsInArchive("oak/data00000a.tar"));
+        // after creating a read-only FS, the recovery procedure should not be started since there is another running Oak process
+        assertFalse(fixture.hasBlobsInArchive("oak/data00000a.tar.ro.bak"));
     }
 
     @Test
-    public void testArchiveExistsAfterFlush() throws URISyntaxException, IOException {
-        SegmentArchiveManager manager = new AzurePersistence(container.getDirectoryReference("oak")).createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
-        SegmentArchiveWriter writer = manager.create("data00000a.tar");
+    public void testShouldNotWriteSegmentsAfterLeaseLost() {
+        fixture.persistence = new AzurePersistence(fixture.getOakDirectory()) {
+            @Override
+            public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
+                return loseLockAtSecondFailedRenewal(getLockBlob(), lockStatusChangedCallback).lock();
+            }
+        };
 
-        Assert.assertFalse(manager.exists("data00000a.tar"));
-        UUID u = UUID.randomUUID();
-        writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
-        writer.flush();
-        Assert.assertTrue(manager.exists("data00000a.tar"));
+        AtomicInteger lastPersisted = new AtomicInteger(-1);
+
+        int totalChanges = 500;
+        // When lease is lost, an exception must be thrown as it becomes illegal to continue writing
+        assertThrows(IllegalStateException.class, () ->
+            fixture.flushEachChange(totalChanges, (i, builder) -> builder.setProperty("foo" + i, "bar" + i), lastPersisted::set)
+        );
+
+        int lastPersistedIndex = lastPersisted.get();
+        assertTrue("Writes should have been interrupted, but all " + totalChanges + " changes have been persisted", lastPersistedIndex < totalChanges - 1);
+        fixture.withSegmentStore(segmentNodeStore -> {
+            assertEquals("bar" + lastPersistedIndex, segmentNodeStore.getRoot().getString("foo" + lastPersistedIndex)); // last successful write
+            assertNull("Should have not been able to write after lease is lost:", segmentNodeStore.getRoot()
+                .getString("foo" + (lastPersistedIndex + 1)));
+        });
     }
 
-    @Test(expected = FileNotFoundException.class)
-    public void testSegmentDeletedAfterCreatingReader() throws IOException, URISyntaxException, StorageException, InvalidFileStoreVersionException {
+    @Test
+    public void testShouldSuspendWritesWhenUnableToRenewLease() {
+        SuspendWritesState state = new SuspendWritesState();
+        fixture.persistence = new AzurePersistence(fixture.getOakDirectory()) {
+            @Override
+            public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
+                return failToRenewLeaseThenSucceed(getLockBlob(), lockStatusChangedCallback, state).lock();
+            }
+        };
 
-        AzurePersistence azurePersistence = new AzurePersistence(container.getDirectoryReference("oak"));
+        int totalChanges = 200;
+        fixture.flushEachChange(totalChanges, (i, builder) -> builder.setProperty("foo" + i, "bar" + i), state.lastPersisted::set);
 
-        SegmentArchiveManager manager = azurePersistence.createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
-        SegmentArchiveWriter writer = manager.create("data00000a.tar");
+        assertTrue("Writes should have been suspended", state.writesSuspended.get());
+        assertFalse("No writes should have been persisted while suspended", state.writesWhileSuspendedDetected.get());
+        assertTrue("Writes should have resumed", state.writesResumed.get());
+        int lastIndex = totalChanges - 1;
+        assertEquals("All writes have been persisted, after renewal succeeds", state.lastPersisted.get(), lastIndex);
+        fixture.withSegmentStore(segmentNodeStore ->
+            assertEquals("Last write persisted", "bar" + lastIndex, segmentNodeStore.getRoot().getString("foo" + lastIndex)));
+    }
 
-        Assert.assertFalse(manager.exists("data00000a.tar"));
-        UUID u = UUID.randomUUID();
-        writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
-        writer.flush();
-        writer.close();
+    @NotNull
+    private static AzureRepositoryLock loseLockAtSecondFailedRenewal(
+        final CloudBlockBlob lockBlob,
+        final Consumer<LockStatus> lockStatusChangedCallback) {
+        return new AzureRepositoryLock(lockBlob, lockStatusChangedCallback, 1, 1) {
+            private int calls = 0;
+            
+            @Override
+            void doRenewLease() throws StorageException {
+                calls++;
+                if (calls == 1) {
+                    throw new StorageException(
+                        StorageErrorCodeStrings.OPERATION_TIMED_OUT,
+                        "The client could not finish the operation within specified maximum execution timeout.", null);
+                }
+                try {
+                    releaseLease();
+                } catch (Exception e) {
+                    throw new RuntimeException("Could not release the lease", e);
+                }
+                throw new StorageException(
+                    StorageErrorCodeStrings.LEASE_ID_MISMATCH_WITH_LEASE_OPERATION,
+                    "The lease ID specified did not match the lease ID for the blob.", null);
 
-        SegmentArchiveReader reader = manager.open("data00000a.tar");
-        Buffer segment = reader.readSegment(u.getMostSignificantBits(), u.getLeastSignificantBits());
-        assertNotNull(segment);
+            }
+        };
+    }
 
-        ListBlobItem segment0000 = container.listBlobs("oak/data00000a.tar/0000.").iterator().next();
-        ((CloudBlob) segment0000).delete();
+    @NotNull
+    private static AzureRepositoryLock failToRenewLeaseThenSucceed(
+        final CloudBlockBlob lockBlob,
+        Consumer<LockStatus> lockStatusChangedCallback,
+        SuspendWritesState state) {
+        return new AzureRepositoryLock(lockBlob, state.checkSuspendedWrites(lockStatusChangedCallback), 1, 1) {
+            @Override
+            void doRenewLease() throws StorageException {
+                // Fail to renew 20 times, then succeed
+                if (state.renewalCounter.getAndIncrement() < 20) {
+                    throw new StorageException(
+                        StorageErrorCodeStrings.OPERATION_TIMED_OUT,
+                        "The client could not finish the operation within specified maximum execution timeout.", null);
+                }
+            }
+        };
+    }
 
+    static class SuspendWritesState {
+        final AtomicInteger renewalCounter = new AtomicInteger();
+        final AtomicInteger lastPersisted = new AtomicInteger(-1);
+        final AtomicInteger persistedBeforeSuspension = new AtomicInteger();
+        final AtomicBoolean writesWhileSuspendedDetected = new AtomicBoolean(false);
+        final AtomicBoolean writesResumed = new AtomicBoolean(false);
+        final AtomicBoolean writesSuspended = new AtomicBoolean(false);
+
+        @NotNull
+        Consumer<LockStatus> checkSuspendedWrites(Consumer<LockStatus> lockStatusChangedCallback) {
+            return lockStatus -> {
+                lockStatusChangedCallback.accept(lockStatus);
+                if (lockStatus.equals(LockStatus.RENEWAL_FAILED)) {
+                    writesSuspended.set(true);
+                    if (renewalCounter.get() <= 1) {
+                        persistedBeforeSuspension.set(lastPersisted.get());
+                    } else if (lastPersisted.get() - persistedBeforeSuspension.get() > 1) { // diff of 1 is ok, as it may be caused by concurrency
+                        writesWhileSuspendedDetected.set(true);
+                    }
+                } else if (lockStatus.equals(LockStatus.RENEWAL_SUCCEEDED)) {
+                    writesResumed.set(true);
+                }
+            };
+        }
+    }
+    
+    @NotNull
+    private static List<UUID> writeSegments(SegmentArchiveWriter writer, int maxSegments) throws IOException {
         try {
-            // FileNotFoundException should be thrown here
-            reader.readSegment(u.getMostSignificantBits(), u.getLeastSignificantBits());
-            fail();
-        } catch (RepositoryNotReachableException e) {
-            fail();
+            List<UUID> uuids = new ArrayList<>();
+            for (int i = 0; i < maxSegments; i++) {
+                UUID u = UUID.randomUUID();
+                writeSegment(writer, u);
+                uuids.add(u);
+            }
+
+            writer.flush();
+            return uuids;
+        } finally {
+            writer.close();
         }
     }
 
-    @Test(expected = SegmentNotFoundException.class)
-    public void testMissngSegmentDetectedInFileStore() throws IOException, StorageException, URISyntaxException, InvalidFileStoreVersionException {
-
-        AzurePersistence azurePersistence = new AzurePersistence(container.getDirectoryReference("oak"));
-        FileStore fileStore = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(azurePersistence).build();
-
-        SegmentArchiveManager manager = azurePersistence.createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
-        SegmentArchiveWriter writer = manager.create("data00000a.tar");
-
-        //Assert.assertFalse(manager.exists("data00000a.tar"));
-        UUID u = UUID.randomUUID();
+    private static void writeSegment(SegmentArchiveWriter writer, UUID u) throws IOException {
         writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
-        writer.flush();
-        writer.close();
-
-        SegmentArchiveReader reader = manager.open("data00000a.tar");
-        Buffer segment = reader.readSegment(u.getMostSignificantBits(), u.getLeastSignificantBits());
-        assertNotNull(segment);
-
-        ListBlobItem segment0000 = container.listBlobs("oak/data00000a.tar/0000.").iterator().next();
-        ((CloudBlob) segment0000).delete();
-
-        // SegmentNotFoundException should be thrown here
-        fileStore.readSegment(new SegmentId(fileStore, u.getMostSignificantBits(), u.getLeastSignificantBits()));
     }
 
-    @Test
-    public void testReadOnlyRecovery() throws URISyntaxException, InvalidFileStoreVersionException, IOException, CommitFailedException, StorageException {
-        AzurePersistence rwPersistence = new AzurePersistence(container.getDirectoryReference("oak"));
-        FileStore rwFileStore = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(rwPersistence).build();
-        SegmentNodeStore segmentNodeStore = SegmentNodeStoreBuilders.builder(rwFileStore).build();
-        NodeBuilder builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo", "bar");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        rwFileStore.flush();
-
-        assertTrue(container.getDirectoryReference("oak/data00000a.tar").listBlobs().iterator().hasNext());
-        assertFalse(container.getDirectoryReference("oak/data00000a.tar.ro.bak").listBlobs().iterator().hasNext());
-
-        // create read-only FS
-        AzurePersistence roPersistence = new AzurePersistence(container.getDirectoryReference("oak"));
-        ReadOnlyFileStore roFileStore = FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(roPersistence).buildReadOnly();
-
-        PropertyState fooProperty = SegmentNodeStoreBuilders.builder(roFileStore).build()
-                .getRoot()
-                .getProperty("foo");
-        assertThat(fooProperty, not(nullValue()));
-        assertThat(fooProperty.getValue(Type.STRING), equalTo("bar"));
-
-        roFileStore.close();
-        rwFileStore.close();
-
-        assertTrue(container.getDirectoryReference("oak/data00000a.tar").listBlobs().iterator().hasNext());
-        // after creating a read-only FS, the recovery procedure should not be started since there is another running Oak process
-        assertFalse(container.getDirectoryReference("oak/data00000a.tar.ro.bak").listBlobs().iterator().hasNext());
+    @Nullable
+    private static Buffer readSegment(@Nullable SegmentArchiveReader reader, UUID u) throws IOException {
+        assertNotNull(reader);
+        return reader.readSegment(u.getMostSignificantBits(), u.getLeastSignificantBits());
     }
 
-    @Test
-    public void testCachingPersistenceTarRecovery() throws URISyntaxException, InvalidFileStoreVersionException, IOException, CommitFailedException, StorageException {
-        AzurePersistence rwPersistence = new AzurePersistence(container.getDirectoryReference("oak"));
-        FileStore rwFileStore = FileStoreBuilder.fileStoreBuilder(folder.newFolder()).withCustomPersistence(rwPersistence).build();
-        SegmentNodeStore segmentNodeStore = SegmentNodeStoreBuilders.builder(rwFileStore).build();
-        NodeBuilder builder = segmentNodeStore.getRoot().builder();
-        builder.setProperty("foo", "bar");
-        segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        rwFileStore.flush();
-
-        assertTrue(container.getDirectoryReference("oak/data00000a.tar").listBlobs().iterator().hasNext());
-        assertFalse(container.getDirectoryReference("oak/data00000a.tar.ro.bak").listBlobs().iterator().hasNext());
-
-        // create files store with split persistence
-        AzurePersistence azureSharedPersistence = new AzurePersistence(container.getDirectoryReference("oak"));
-
-        CachingPersistence cachingPersistence = new CachingPersistence(createPersistenceCache(), azureSharedPersistence);
-        File localFolder = folder.newFolder();
-        SegmentNodeStorePersistence localPersistence = new TarPersistence(localFolder);
-        SegmentNodeStorePersistence splitPersistence = new SplitPersistence(cachingPersistence, localPersistence);
-
-        // exception should not be thrown here
-        FileStore splitPersistenceFileStore = FileStoreBuilder.fileStoreBuilder(localFolder).withCustomPersistence(splitPersistence).build();
-
-        assertTrue(container.getDirectoryReference("oak/data00000a.tar").listBlobs().iterator().hasNext());
-        // after creating a read-only FS, the recovery procedure should not be started since there is another running Oak process
-        assertFalse(container.getDirectoryReference("oak/data00000a.tar.ro.bak").listBlobs().iterator().hasNext());
+    @NotNull
+    private static SegmentNodeStore segmentNodeStore(FileStore fs) {
+        return SegmentNodeStoreBuilders.builder(fs).build();
     }
 
-    private PersistentCache createPersistenceCache() {
+    @NotNull
+    private static SegmentNodeStore segmentNodeStore(ReadOnlyFileStore fs) {
+        return SegmentNodeStoreBuilders.builder(fs).build();
+    }
+    
+    private static PersistentCache createPersistenceCache() {
         return new AbstractPersistentCache() {
             @Override
             protected Buffer readSegmentInternal(long msb, long lsb) {
@@ -424,4 +501,163 @@ public class AzureArchiveManagerTest {
         };
     }
 
+    static class Fixture {
+        private final CloudBlobContainer container;
+
+        private AzurePersistence persistence;
+
+        public Fixture(AzuriteDockerRule azurite) throws Exception {
+            this.container = azurite.getContainer("oak-test");
+            this.persistence = newAzurePersistence();
+        }
+
+        @NotNull
+        AzurePersistence newAzurePersistence() throws URISyntaxException {
+            return new AzurePersistence(container.getDirectoryReference("oak"));
+        }
+
+        void withSegmentStore(ThrowingConsumer<SegmentNodeStore> segmentNodeStoreConsumer) {
+            try (FileStore fs = newFileStore()) {
+                segmentNodeStoreConsumer.accept(segmentNodeStore(fs));
+            } catch (Exception e) {
+                throw rethrow(e);
+            }
+        }
+
+        void withSegmentStore(ThrowingBiConsumer<FileStore, SegmentNodeStore> segmentNodeStoreConsumer) {
+            catching(this::newFileStore, fs -> segmentNodeStoreConsumer.accept(fs, segmentNodeStore(fs)));
+        }
+
+        void withFileStore(ThrowingConsumer<FileStore> fileStoreConsumer) {
+            catching(this::newFileStore, fileStoreConsumer);
+        }
+
+        void withReadOnlyFileStore(ThrowingConsumer<ReadOnlyFileStore> readOnlyFileStoreConsumer) {
+            catching(() -> FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(persistence).buildReadOnly(), 
+                readOnlyFileStoreConsumer);
+        }
+
+        static <T extends Closeable> void catching(ThrowingSupplier<T> supplier, ThrowingConsumer<T> consumer) {
+            try (T t = supplier.get()) {
+                consumer.accept(t);
+            } catch (Exception e) {
+                throw rethrow(e);
+            }
+        }
+
+        private static RuntimeException rethrow(Exception e) {
+            if (e instanceof RuntimeException) {
+                return (RuntimeException) e;
+            }
+            return new RuntimeException(e);
+        }
+
+        void mergeChanges(Consumer<NodeBuilder> builderConsumer) {
+            withSegmentStore(segmentNodeStore -> {
+                NodeBuilder builder = segmentNodeStore.getRoot().builder();
+                builderConsumer.accept(builder);
+                segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+            });
+        }
+
+        void flushChanges(FileStore fileStore, Consumer<NodeBuilder> builderConsumer) {
+            try {
+                SegmentNodeStore segmentNodeStore = segmentNodeStore(fileStore);
+                NodeBuilder builder = segmentNodeStore.getRoot().builder();
+                builderConsumer.accept(builder);
+                segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+                fileStore.flush();
+            } catch (CommitFailedException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @SafeVarargs
+        final void flushEachChange(Consumer<NodeBuilder>... builderConsumers) {
+            withSegmentStore((fs, segmentNodeStore) -> {
+                NodeBuilder builder = segmentNodeStore.getRoot().builder();
+                for (Consumer<NodeBuilder> builderConsumer : builderConsumers) {
+                    builderConsumer.accept(builder);
+                    segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+                    fs.flush();
+                }
+            });
+        }
+
+        void flushEachChange(int count, BiConsumer<Integer, NodeBuilder> builderConsumer, Consumer<Integer> afterFlushCallback) {
+            withSegmentStore((fs, segmentNodeStore) -> {
+                NodeBuilder builder = segmentNodeStore.getRoot().builder();
+                for (int i = 0; i < count; i++) {
+                    builderConsumer.accept(i, builder);
+                    segmentNodeStore.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+                    fs.flush();
+                    afterFlushCallback.accept(i);
+                }
+            });
+        }
+
+        @NotNull
+        FileStore newFileStore() {
+            try {
+                return FileStoreBuilder.fileStoreBuilder(new File("target")).withCustomPersistence(persistence).build();
+            } catch (InvalidFileStoreVersionException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        SegmentArchiveManager newSegmentArchiveManager() {
+            return persistence.createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
+        }
+
+        boolean hasBlobsInArchive(String directoryName) throws StorageException, URISyntaxException {
+            return container.getDirectoryReference(directoryName).listBlobs().iterator().hasNext();
+        }
+
+        void deleteBlob(String blobName) throws StorageException, URISyntaxException {
+            this.container.getBlockBlobReference(blobName).delete();
+        }
+
+        boolean blobExists(String blobName) throws StorageException, URISyntaxException {
+            return this.container.getBlockBlobReference(blobName).exists();
+        }
+
+        ListBlobItem getFirstBlobWithPrefix(String prefix) {
+            return listBlobsWithPrefix(prefix).next();
+        }
+
+        boolean hasBlobsWithPrefix(String prefix) {
+            return listBlobsWithPrefix(prefix).hasNext();
+        }
+
+        @NotNull
+        Iterator<ListBlobItem> listBlobsWithPrefix(String prefix) {
+            return container.listBlobs(prefix).iterator();
+        }
+
+        void deleteFirstBlobWithPrefix(String prefix) throws StorageException {
+            ListBlobItem firstBlob = getFirstBlobWithPrefix(prefix);
+            ((CloudBlob) firstBlob).delete();
+        }
+
+        @NotNull
+        CloudBlobDirectory getOakDirectory() {
+            try {
+                return container.getDirectoryReference("oak");
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+    
+    interface ThrowingConsumer<T> {
+        void accept(T t) throws Exception;
+    }
+
+    interface ThrowingBiConsumer<T, U> {
+        void accept(T t, U u) throws Exception;
+    }
+    
+    interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
 }

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLockTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLockTest.java
@@ -18,11 +18,23 @@
  */
 package org.apache.jackrabbit.oak.segment.azure;
 
+import com.google.common.collect.ImmutableList;
 import com.microsoft.azure.storage.StorageErrorCodeStrings;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.jackrabbit.oak.segment.spi.persistence.RepositoryLock;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -30,13 +42,15 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeoutException;
-
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus.ACQUIRED;
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus.ACQUIRE_FAILED;
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus.LOST;
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus.RENEWAL;
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus.RENEWAL_FAILED;
+import static org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence.LockStatus.RENEWAL_SUCCEEDED;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 public class AzureRepositoryLockTest {
@@ -56,17 +70,22 @@ public class AzureRepositoryLockTest {
     @Test
     public void testFailingLock() throws URISyntaxException, IOException, StorageException {
         CloudBlockBlob blob = container.getBlockBlobReference("oak/repo.lock");
-        new AzureRepositoryLock(blob, s -> {}, 0, 0).lock();
-        assertThrows("The second lock should fail", IOException.class, () -> new AzureRepositoryLock(blob, s -> {}, 0, 0).lock());
+        AtomicReference<LockStatus> status = new AtomicReference<>();
+        new AzureRepositoryLock(blob, status::set, 0, 0).lock();
+        assertEquals(ACQUIRED, status.get());
+        assertThrows("The second lock should fail", IOException.class, () -> new AzureRepositoryLock(blob, status::set, 0, 0).lock());
+        assertEquals(ACQUIRE_FAILED, status.get());
     }
 
     @Test
     public void testWaitingLock() throws URISyntaxException, IOException, StorageException, InterruptedException {
         CloudBlockBlob blob = container.getBlockBlobReference("oak/repo.lock");
+        List<LockStatus> statusHistory1 = new ArrayList<>();
+        List<LockStatus> statusHistory2 = new ArrayList<>();
         Semaphore s = new Semaphore(0);
         new Thread(() -> {
             try {
-                RepositoryLock lock = new AzureRepositoryLock(blob, status -> {}, 0, 0).lock();
+                RepositoryLock lock = new AzureRepositoryLock(blob, statusHistory1::add, 10, 10).lock();
                 s.release();
                 Thread.sleep(1000);
                 lock.unlock();
@@ -76,7 +95,10 @@ public class AzureRepositoryLockTest {
         }).start();
 
         s.acquire();
-        new AzureRepositoryLock(blob, status -> {}, 10, 10).lock();
+        assertEquals(ImmutableList.of(ACQUIRED), statusHistory1);
+        new AzureRepositoryLock(blob, statusHistory2::add, 10, 10).lock();
+        assertEquals(ImmutableList.of(ACQUIRED, LockStatus.RELEASED), statusHistory1);
+        assertEquals(ImmutableList.of(ACQUIRED), statusHistory2);
     }
 
     @Test
@@ -91,16 +113,52 @@ public class AzureRepositoryLockTest {
         Mockito.doThrow(storageException)
                 .doThrow(storageException)
                 .doCallRealMethod()
-                .when(blobMocked).renewLease(any());
+                .when(blobMocked).renewLease(any(), any(), any());
 
-        new AzureRepositoryLock(blobMocked, s -> {}, 0, 0).lock();
+        Queue<LockStatus> statusHistory = new ConcurrentLinkedDeque<>();
+        new AzureRepositoryLock(blobMocked, statusHistory::add, 0, 10, 15).lock();
 
         // wait till lease expires
-        Thread.sleep(70000);
+        Thread.sleep(16000);
+
+        assertEquals("Should fail to renew twice", 2, statusHistory.stream().limit(5).filter(s -> s == RENEWAL_FAILED).count());
+        assertTrue("Should succeed to renew after 2 failures",  statusHistory.stream().skip(5).anyMatch(s -> s == RENEWAL_SUCCEEDED));
 
         // reset the mock to default behaviour
-        Mockito.doCallRealMethod().when(blobMocked).renewLease(any());
-        
-        assertThrows("The second lock should fail", IOException.class, () -> new AzureRepositoryLock(blobMocked, s -> {}, 0, 0).lock());
+        Mockito.doCallRealMethod().when(blobMocked).renewLease(any(), any(), any());
+
+        assertThrows("The second lock should fail because the first has been renewed", IOException.class, () -> 
+            new AzureRepositoryLock(blobMocked, s -> {}, 0, 0).lock());
     }
+
+    @Test
+    public void testLeaseLost() throws URISyntaxException, StorageException, IOException, InterruptedException {
+        CloudBlockBlob blob = container.getBlockBlobReference("oak/repo.lock");
+
+        CloudBlockBlob blobMocked = Mockito.spy(blob);
+
+        // instrument the mock to throw the exception when renewing the lease
+        StorageException storageException =
+            new StorageException(
+                StorageErrorCodeStrings.LEASE_ID_MISMATCH_WITH_LEASE_OPERATION,
+                "The lease ID specified did not match the lease ID for the blob.", null);
+        Mockito.doThrow(storageException)
+            .when(blobMocked).renewLease(any(), any(), any());
+
+        Queue<LockStatus> statusHistory = new ConcurrentLinkedDeque<>();
+        new AzureRepositoryLock(blobMocked, statusHistory::add, 0, 2, 15).lock();
+
+        // wait till lease expires
+        Thread.sleep(16000);
+
+        assertEquals("Lease should be lost", ImmutableList.of(ACQUIRED, RENEWAL, LOST), ImmutableList.copyOf(statusHistory));
+
+        // reset the mock to default behaviour
+        Mockito.doCallRealMethod().when(blobMocked).renewLease(any(), any(), any());
+
+        AtomicReference<LockStatus> status = new AtomicReference<>();
+        new AzureRepositoryLock(blobMocked, status::set, 0, 0).lock();
+        assertEquals("The second lock should succeed because the first has been lost", ACQUIRED, status.get());
+    }
+
 }

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/package-info.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/package-info.java
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Internal(since = "1.0.0")
-@Version("1.1.0")
-package org.apache.jackrabbit.oak.segment.remote.queue;
+@Version("2.0.0")
+package org.apache.jackrabbit.oak.segment.remote;
 
-import org.apache.jackrabbit.oak.commons.annotations.Internal;
 import org.osgi.annotation.versioning.Version;

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/queue/SegmentWriteQueue.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/queue/SegmentWriteQueue.java
@@ -216,7 +216,7 @@ public class SegmentWriteQueue implements Closeable {
         try {
             executor.shutdown();
             if (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
-                throw new IOException("The write wasn't able to shut down clearly");
+                throw new IOException("The write wasn't able to shut down cleanly");
             }
         } catch (InterruptedException e) {
             throw new IOException(e);

--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/queue/SegmentWriteQueueTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/queue/SegmentWriteQueueTest.java
@@ -42,6 +42,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -67,11 +68,10 @@ public class SegmentWriteQueueTest {
     }
 
     @Test
-    public void testThreadInterruptedWhileAddigToQueue() throws InterruptedException, NoSuchFieldException {
+    public void testThreadInterruptedWhileAddingToQueue() throws InterruptedException, NoSuchFieldException {
 
         Set<UUID> added = Collections.synchronizedSet(new HashSet<>());
         Semaphore semaphore = new Semaphore(0);
-
 
         BlockingDeque<SegmentWriteAction> queue = Mockito.mock(BlockingDeque.class);
 
@@ -200,11 +200,11 @@ public class SegmentWriteQueueTest {
             addedAfterFlush.containsAll(expectedAddedAfterFlush));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testClose() throws IOException {
         queue = new SegmentWriteQueue((tarEntry, data, offset, size) -> {});
         queue.close();
-        queue.addToQueue(tarEntry(10), EMPTY_DATA, 0, 0);
+        assertThrows(IllegalStateException.class, () -> queue.addToQueue(tarEntry(10), EMPTY_DATA, 0, 0));
     }
 
     @Test
@@ -317,6 +317,11 @@ public class SegmentWriteQueueTest {
 
         assertTrue("Segment queue should be empty", flushFinished.get());
         assertEquals(3, added.size());
+    }
+
+    @Test
+    public void testSuspendWrites() {
+        
     }
 
     private static RemoteSegmentArchiveEntry tarEntry(long i) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/SegmentTarWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/SegmentTarWriter.java
@@ -227,6 +227,11 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
+    public void unsafeClose() throws IOException {
+        access.close();
+    }
+
+    @Override
     public boolean isCreated() {
         return access != null;
     }
@@ -239,6 +244,21 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     @Override
     public String getName() {
         return file.getName();
+    }
+
+    @Override
+    public void suspendWrites() {
+        SegmentArchiveWriter.super.suspendWrites();
+    }
+
+    @Override
+    public void resumeWrites() {
+        SegmentArchiveWriter.super.resumeWrites();
+    }
+
+    @Override
+    public boolean isWritesSuspended() {
+        return SegmentArchiveWriter.super.isWritesSuspended();
     }
 
     private static byte[] newEntryHeader(String name, int size) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/SegmentArchiveWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/SegmentArchiveWriter.java
@@ -120,6 +120,14 @@ public interface SegmentArchiveWriter {
     void close() throws IOException;
 
     /**
+     * Close the archive unsafely, without flushing to persistent storage, potentially losing data. To be used only to cope with permanent 
+     * failure modes where attempting to flush would likely corrupt the archive. 
+     * <p>
+     * Implementations should close the archive without flushing pending writes to a persistent storage, leaving it in a valid state.
+     */
+    void unsafeClose() throws IOException;
+
+    /**
      * Check if the archive has been created (eg. something has been written).
      *
      * @return true if the archive has been created, false otherwise
@@ -140,4 +148,24 @@ public interface SegmentArchiveWriter {
      */
     @NotNull
     String getName();
+
+    /**
+     * Suspend all writes to the archive, keeping them in memory. To be used only to cope with temporary failure modes where attempting to 
+     * write to a temporary storage could corrupt the archive. 
+     */
+    default void suspendWrites() {
+    }
+
+    /**
+     * Resume all writes to the archive, in case they were previously suspended
+     */
+    default void resumeWrites() {
+    }
+
+    /**
+     * Whether writes are currently suspended.
+     */
+    default boolean isWritesSuspended() {
+        return false;
+    }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingPersistence.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingPersistence.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
+import java.util.function.Consumer;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitor;
@@ -70,4 +71,8 @@ public class CachingPersistence implements SegmentNodeStorePersistence {
         return delegate.lockRepository();
     }
 
+    @Override
+    public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
+        return delegate.lockRepository(lockStatusChangedCallback);
+    }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("3.0.0")
+@Version("3.1.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/split/SplitPersistence.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/split/SplitPersistence.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.segment.spi.persistence.split;
 
+import java.util.function.Consumer;
 import org.apache.jackrabbit.oak.segment.spi.monitor.*;
 import org.apache.jackrabbit.oak.segment.spi.persistence.GCJournalFile;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
@@ -121,4 +122,8 @@ public class SplitPersistence implements SegmentNodeStorePersistence {
         return rwPersistence.lockRepository();
     }
 
+    @Override
+    public RepositoryLock lockRepository(Consumer<LockStatus> lockStatusChangedCallback) throws IOException {
+        return rwPersistence.lockRepository(lockStatusChangedCallback);
+    }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/split/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/split/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("1.0.0")
+@Version("1.1.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.split;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;


### PR DESCRIPTION
If the lock is lost to another instance, all writes attempts should fail with an exception.
If the lock fails to be renewed, all writes are suspended (blocked) until the renewal succeed.