### PR TITLE
OAK-10010 : Fix Flaky Test in org.apache.jackrabbit.oak.plugins.document.RandomizedClusterTest.addRemoveSet

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RandomizedClusterTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/RandomizedClusterTest.java
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.junit.Rule;
 import org.junit.Test;
+import com.google.gson.JsonParser;
 
 /**
  * A simple randomized dual-instance test.
@@ -321,11 +322,12 @@ public class RandomizedClusterTest {
             assertTrue("path: " + p + " is supposed to exist",
                     mk.nodeExists(p, head));
         }
+        JsonParser parser = new JsonParser();
         String expected = "{\":childNodeCount\":0,\"x\":" + value + "}";
         String result = mk.getNodes(p, head, 0, 0, Integer.MAX_VALUE, null);
         expected = normalize(expected);
         result = normalize(result);
-        assertEquals(expected, result);
+        assertEquals(parser.parse(expected), parser.parse(result));
         return true;
     }
 


### PR DESCRIPTION
Test 
`org.apache.jackrabbit.oak.plugins.document.RandomizedClusterTest.addRemoveSet`
is flaky as mentioned in [OAK-10010](https://issues.apache.org/jira/browse/OAK-10010) and it's due to comparisons between Json Strings in the `boolean get(int maxOp, String node, String head)` method.

However, JsonObject does not guarantee entry orders, its object is an unordered set of name/value pairs.

A simple fix for this problem is to use the GSON library JsonParser to convert the string back to JSON Object and compare them.