### PR TITLE
OAK-9975: [DSGC] Report cummulative size of referenced blobs during Mark phase

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationStatsCollector.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationStatsCollector.java
@@ -46,7 +46,7 @@ public interface OperationStatsCollector {
         }
 
         @Override
-        public void updateSizeBlobReferences(long size) {
+        public void updateBlobReferencesSize(long size) {
         }
 
         @Override public void updateDuration(long time, TimeUnit timeUnit) {
@@ -97,7 +97,7 @@ public interface OperationStatsCollector {
      * Update the size of blob references
      * @param size
      */
-    public void updateSizeBlobReferences(long size);
+    public void updateBlobReferencesSize(long size);
     
     /**
      * Increment the duration timer

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationStatsCollector.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationStatsCollector.java
@@ -41,6 +41,14 @@ public interface OperationStatsCollector {
         @Override public void updateTotalSizeDeleted(long size) {
         }
 
+        @Override
+        public void updateNumBlobReferences(long num) {
+        }
+
+        @Override
+        public void updateSizeBlobReferences(long size) {
+        }
+
         @Override public void updateDuration(long time, TimeUnit timeUnit) {
         }
 
@@ -79,6 +87,18 @@ public interface OperationStatsCollector {
      */
     void updateTotalSizeDeleted(long size);
 
+    /**
+     * Update the number of blob references
+     * @param num
+     */
+    public void updateNumBlobReferences(long num);
+
+    /**
+     * Update the size of blob references
+     * @param size
+     */
+    public void updateSizeBlobReferences(long size);
+    
     /**
      * Increment the duration timer
      *

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationsStatsMBean.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationsStatsMBean.java
@@ -65,4 +65,16 @@ public interface OperationsStatsMBean {
      * @return
      */
     long sizeDeleted();
+
+    /**
+     * Returns the number of blob references
+     * @return
+     */
+    long numBlobReferences();
+
+    /**
+     * Returns the cummulative size of the blob references
+     * @return
+     */
+    long sizeBlobReferences();
 }

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationsStatsMBean.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/OperationsStatsMBean.java
@@ -70,11 +70,11 @@ public interface OperationsStatsMBean {
      * Returns the number of blob references
      * @return
      */
-    long numBlobReferences();
+    long getNumBlobReferences();
 
     /**
-     * Returns the cummulative size of the blob references
+     * Returns the cumulative size of the blob references
      * @return
      */
-    long sizeBlobReferences();
+    long getBlobReferencesSize();
 }


### PR DESCRIPTION
- Introduce new metrics NUM_BLOB_REFERENCES, BLOB_REFERENCES_SIZE
- calculate and push metrics in check consistency when aggregating all the references from all repositories
- calculate and push metrics on the mark phase and checkConsistencyAfterGc as well
- update tests to assert values for new metrics