### PR TITLE
OAK-10032 ensure that m-antrun-p execution comes after m-assembly-p

### DIFF
--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -117,7 +117,8 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <!-- ensure this comes after execution "create-oak" from maven-assembly-plugin -->
+            <phase>pre-integration-test</phase>
             <configuration>
               <target>
                 <!--


### PR DESCRIPTION
Given them separate phases is the safest approach as according to https://issues.apache.org/jira/browse/MNG-5987: "it was documented and chosen that order of execution is not something you cannot count on: phases are ordered, mojos in a phase simply are not"