### PR TITLE
OAK-10061 : WARN when for an external group a local group with the same name is already present

### DIFF
--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/package-info.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/basic/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.7.0")
+@Version("1.8.0")
 package org.apache.jackrabbit.oak.spi.security.authentication.external.basic;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContext.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContext.java
@@ -104,6 +104,7 @@ public class DynamicSyncContext extends DefaultSyncContext {
             ExternalIdentityRef ref = identity.getExternalId();
             if (!isSameIDP(ref)) {
                 // create result in accordance with sync(String) where status is FOREIGN
+                warnForeign(identity);
                 return new DefaultSyncResultImpl(new DefaultSyncedIdentity(identity.getId(), ref, true, -1), SyncResult.Status.FOREIGN);
             }
             return sync((ExternalGroup) identity, ref);
@@ -286,7 +287,7 @@ public class DynamicSyncContext extends DefaultSyncContext {
             // there exists a group with the same id or principal name but it doesn't belong to the same IDP
             // in consistency with DefaultSyncContext don't sync this very membership into the repository
             // and log a warning about the collision instead.
-            log.warn("Existing group with id '{}' and principal name '{}' is not defined by IDP '{}'.", authorizable.getID(), authorizable.getPrincipal().getName(), idp.getName());
+            warnForeignExisting(authorizable, true);
             return true;
         } else if (!principalName.equals(authorizable.getPrincipal().getName())) {
             // there exists a group with matching ID but principal-mismatch, don't sync this very membership into the 


### PR DESCRIPTION
hi @joerghoh , i would appreciate if you could review the suggested improvement wrt log output.