### PR TITLE
OAK-10081: (tests) create temp folders in .target to avoid leftovers …

### DIFF
--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -57,7 +57,7 @@ public class DataStoreCopyCommandTest {
     private static final ImmutableSet<String> BLOBS = ImmutableSet.of(BLOB1, BLOB2);
 
     @Rule
-    public TemporaryFolder outDir = new TemporaryFolder();
+    public TemporaryFolder outDir = new TemporaryFolder(new File("target"));
 
     private CloudBlobContainer container;
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DownloaderTest.java
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertTrue;
 public class DownloaderTest {
 
     @Rule
-    public TemporaryFolder sourceFolder = new TemporaryFolder();
+    public TemporaryFolder sourceFolder = new TemporaryFolder(new File("target"));
 
     @Rule
-    public TemporaryFolder destinationFolder = new TemporaryFolder();
+    public TemporaryFolder destinationFolder = new TemporaryFolder(new File("target"));
 
     @Before
     public void setUp() throws IOException {


### PR DESCRIPTION
…on some platforms