### PR TITLE
OAK-10095 | Fix NPE in FieldFactory.dateToLong

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/FieldFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/FieldFactory.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.plugins.index.lucene;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 
 import com.google.common.primitives.Ints;
@@ -186,7 +187,17 @@ public final class FieldFactory {
             return null;
         }
         //TODO OAK-2204 - Should we change the precision to lower resolution
-        return ISO8601.parse(date).getTimeInMillis();
+        Calendar c = ISO8601.parse(date);
+        if (c != null) {
+            return c.getTimeInMillis();
+        } else {
+            // ISO8601.parse returns null in case of multiple exceptions like IllegalFormatException, IndexOutOfBoundsException, NumberFormatException etc
+            // However returning null for us would basically store a null value in the document (which seems wrong).
+            // So throwing an unchecked exception here with a proper description.
+            // Earlier such a situation was leading to an NPE which was confusing to understand.
+            // Refer https://jackrabbit.apache.org/api/2.12/index.html?org/apache/jackrabbit/util/ISO8601.html
+            throw new RuntimeException("Unable to parse the provided date field : " + date + " to convert to millis. Supported format is ±YYYY-MM-DDThh:mm:ss.SSSTZD");
+        }
     }
 
 }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/FieldFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/FieldFactory.java
@@ -195,7 +195,7 @@ public final class FieldFactory {
             // However returning null for us would basically store a null value in the document (which seems wrong).
             // So throwing an unchecked exception here with a proper description.
             // Earlier such a situation was leading to an NPE which was confusing to understand.
-            // Refer https://jackrabbit.apache.org/api/2.12/index.html?org/apache/jackrabbit/util/ISO8601.html
+            // Refer https://jackrabbit.apache.org/api/2.20/index.html?org/apache/jackrabbit/util/ISO8601.html
             throw new RuntimeException("Unable to parse the provided date field : " + date + " to convert to millis. Supported format is ±YYYY-MM-DDThh:mm:ss.SSSTZD");
         }
     }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditorTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditorTest.java
@@ -233,6 +233,16 @@ public class LuceneIndexEditorTest {
         //Date
         assertEquals("/test", getPath(NumericRangeQuery.newLongRange("creationTime",
                 dateToTime("05/05/2014"), dateToTime("05/07/2014"), true, true)));
+
+        // Call FieldFactory.dateToLong with an unsupported Date format - this should throw a RuntimeException
+        try {
+            getPath(NumericRangeQuery.newLongRange("creationTime",
+                    FieldFactory.dateToLong("05/05/2014"), FieldFactory.dateToLong("05/07/2014"), true, true));
+        } catch (Exception e) {
+            assertEquals("Unable to parse the provided date field : 05/05/2014 to convert to millis." +
+                    " Supported format is ±YYYY-MM-DDThh:mm:ss.SSSTZD", e.getMessage());
+        }
+
     }
 
     @Test

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditorTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditorTest.java
@@ -238,7 +238,7 @@ public class LuceneIndexEditorTest {
         try {
             getPath(NumericRangeQuery.newLongRange("creationTime",
                     FieldFactory.dateToLong("05/05/2014"), FieldFactory.dateToLong("05/07/2014"), true, true));
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             assertEquals("Unable to parse the provided date field : 05/05/2014 to convert to millis." +
                     " Supported format is ±YYYY-MM-DDThh:mm:ss.SSSTZD", e.getMessage());
         }


### PR DESCRIPTION
Throw a RuntimeException with a proper message in case ISO8601.parse in FieldFactory.dateToLong returns null. This prevents an NPE which was confusing.

We still throw an exception because that is what is expected from the caller - just throwing one with a proper detailed message now. 