### PR TITLE
OAK-9827: Flaky test: SplitPersistenceBlobTest

### DIFF
--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzuriteDockerRule.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzuriteDockerRule.java
@@ -33,6 +33,7 @@ import org.junit.runners.model.Statement;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
+import java.util.UUID;
 
 public class AzuriteDockerRule implements TestRule {
 
@@ -41,12 +42,14 @@ public class AzuriteDockerRule implements TestRule {
     public static final String ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
     public static final String ACCOUNT_NAME = "devstoreaccount1";
 
+    private static final String CONTAINER_SUFFIX = UUID.randomUUID().toString().substring(0, 8);
+
     private final DockerRule wrappedRule;
 
     public AzuriteDockerRule() {
         wrappedRule = new DockerRule(ImmutableDockerConfig.builder()
             .image(IMAGE)
-            .name("oak-test-azurite")
+            .name("oak-test-azurite-" + CONTAINER_SUFFIX)
             .ports("10000")
             .addStartedListener(container -> {
                 container.waitForPort("10000/tcp");


### PR DESCRIPTION
Use a random suffix for test container name to prevent clashes when two modules are built on the same Jenkins worker.