### PR TITLE
OAK-10162: Fix Version copier with preserveOnTarget to ignore diverge…

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/NodeStateCopier.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/NodeStateCopier.java
@@ -16,8 +16,10 @@
  */
 package org.apache.jackrabbit.oak.plugins.migration;
 
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
 import org.apache.jackrabbit.oak.spi.commit.CommitHook;
@@ -32,8 +34,11 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.copyOf;
@@ -145,28 +150,72 @@ public class NodeStateCopier {
      *
      * @param source The NodeState to copy from.
      * @param target The NodeBuilder to copy to.
+     * @param preserveOnTarget boolean to indicate no changes on target except additions
+     * @param path current path
      * @return Whether changes were made or not.
      */
-    public static boolean copyProperties(NodeState source, NodeBuilder target) {
+    public static boolean copyProperties(NodeState source, NodeBuilder target, boolean preserveOnTarget, String path) {
         boolean hasChanges = false;
 
         // remove removed properties
-        for (final PropertyState property : target.getProperties()) {
-            final String name = property.getName();
-            if (!source.hasProperty(name)) {
-                target.removeProperty(name);
-                hasChanges = true;
+        if (!preserveOnTarget) {
+            for (final PropertyState property : target.getProperties()) {
+                final String name = property.getName();
+                if (!source.hasProperty(name)) {
+                    target.removeProperty(name);
+                    hasChanges = true;
+                }
             }
         }
 
         // add new properties and change changed properties
         for (PropertyState property : source.getProperties()) {
             if (!property.equals(target.getProperty(property.getName()))) {
-                target.setProperty(property);
-                hasChanges = true;
+                if (!isVersionPropertyEmpty(source, property, preserveOnTarget, path)) {
+                    target.setProperty(property);
+                    hasChanges = true;
+                }
             }
         }
         return hasChanges;
+    }
+    
+    private static Set<String> getValues(NodeState nodeState, String prop) {
+        if (nodeState.hasProperty(prop)) {
+            Iterable<String> values = nodeState.getProperty(prop).getValue(Type.STRINGS);
+            return StreamSupport.stream(values.spliterator(), false).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
+        }
+        return new HashSet<>();
+    }
+    
+    private static boolean isVersionPropertyEmpty(NodeState source, PropertyState property, boolean preserveOnTarget,
+        String path) {
+        if (preserveOnTarget) {
+            if (property.getName().equals(JcrConstants.JCR_UUID) || 
+                property.getName().equals(JcrConstants.JCR_SUCCESSORS) || 
+                property.getName().equals(JcrConstants.JCR_PREDECESSORS)) {
+                boolean versionPropertyEmpty = getValues(source, property.getName()).isEmpty();
+                if (versionPropertyEmpty) {
+                    LOG.info("Version Property {} will be skipped for path {}", property.getName(), path);
+                } else {
+                    LOG.info("Version Property {} will be changed for path {}", property.getName(), path);
+                }
+                return versionPropertyEmpty;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Copies all changed properties from the source NodeState to the target
+     * NodeBuilder instance.
+     *
+     * @param source The NodeState to copy from.
+     * @param target The NodeBuilder to copy to.
+     * @return Whether changes were made or not.
+     */
+    public static boolean copyProperties(NodeState source, NodeBuilder target) {
+        return copyProperties(source, target, false, "");
     }
 
     private boolean copyNodeState(@NotNull final NodeState sourceRoot, @NotNull final NodeBuilder targetRoot) {
@@ -234,8 +283,8 @@ public class NodeStateCopier {
             }
         }
 
-        hasChanges = copyProperties(source, target) || hasChanges;
-
+        hasChanges = copyProperties(source, target, preserveOnTarget, currentPath) || hasChanges;
+        
         if (hasChanges) {
             LOG.trace("Node {} has changes", target);
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/NodeStateCopier.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/NodeStateCopier.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -181,11 +181,12 @@ public class NodeStateCopier {
     }
     
     private static Set<String> getValues(NodeState nodeState, String prop) {
-        if (nodeState.hasProperty(prop)) {
-            Iterable<String> values = nodeState.getProperty(prop).getValue(Type.STRINGS);
+        PropertyState ps = nodeState.getProperty(prop);
+        if (ps != null) {
+            Iterable<String> values = ps.getValue(Type.STRINGS);
             return StreamSupport.stream(values.spliterator(), false).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
         }
-        return new HashSet<>();
+        return Collections.emptySet();
     }
     
     private static boolean isVersionPropertyEmpty(NodeState source, PropertyState property, boolean preserveOnTarget,

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopier.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopier.java
@@ -21,6 +21,7 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -133,7 +134,8 @@ public class VersionCopier {
                 VersionComparator versionComparator = new VersionComparator();
 
                 // version history id not equal
-                boolean conflictingVersionHistory = !targetVersionHistory.getString(JCR_UUID).equals(sourceVersionHistory.getString(JCR_UUID));
+                boolean conflictingVersionHistory =
+                     !Objects.equals(targetVersionHistory.getString(JCR_UUID), sourceVersionHistory.getString(JCR_UUID));
                 if (conflictingVersionHistory) {
                     logger.info("Skipping version history for {}: Conflicting version history found",
                         versionHistoryPath);
@@ -164,7 +166,8 @@ public class VersionCopier {
 
                 // highest source version UUID does not match the corresponding version on target (diverged)
                 boolean conflictingHighestVersion =
-                    !sourceVersionHistory.getChildNode(sourceVersions.get(0)).getString(JCR_UUID).equals(targetVersionHistory.getChildNode(sourceVersions.get(0)).getString(JCR_UUID));
+                    !Objects.equals(sourceVersionHistory.getChildNode(sourceVersions.get(0)).getString(JCR_UUID), 
+                        targetVersionHistory.getChildNode(sourceVersions.get(0)).getString(JCR_UUID));
                 if (conflictingHighestVersion) {
                     logger.info("Skipping version history for {}: Old base version id changed", versionHistoryPath);
                     return false;
@@ -174,6 +177,9 @@ public class VersionCopier {
         return true;
     }
 
+    /**
+     * Descending numeric versions comparator
+     */
     static class VersionComparator implements Comparator<String> {
         @Override
         public int compare(String v1, String v2) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopier.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopier.java
@@ -16,10 +16,15 @@
  */
 package org.apache.jackrabbit.oak.plugins.migration.version;
 
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.jackrabbit.oak.plugins.migration.DescendantsIterator;
 import org.apache.jackrabbit.oak.plugins.migration.NodeStateCopier;
@@ -27,7 +32,12 @@ import org.apache.jackrabbit.oak.plugins.version.Utils;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static org.apache.jackrabbit.JcrConstants.JCR_ROOTVERSION;
+import static org.apache.jackrabbit.JcrConstants.JCR_UUID;
+import static org.apache.jackrabbit.JcrConstants.JCR_VERSIONLABELS;
 import static org.apache.jackrabbit.oak.plugins.migration.version.VersionHistoryUtil.getVersionHistoryBuilder;
 import static org.apache.jackrabbit.oak.spi.version.VersionConstants.VERSION_STORE_PATH;
 
@@ -40,6 +50,8 @@ import static org.apache.jackrabbit.oak.plugins.migration.version.VersionHistory
  * given date.
  */
 public class VersionCopier {
+
+    private static final Logger logger = LoggerFactory.getLogger(VersionCopier.class);
 
     private final NodeState sourceVersionStorage;
 
@@ -84,6 +96,7 @@ public class VersionCopier {
     /**
      * Copy history filtering versions using passed date and returns {@code
      * true} if the history has been copied.
+     * If preserveOnTarget is true then only copies non-conflicting versions.
      * 
      * @param versionableUuid
      *            Name of the version history node
@@ -98,7 +111,8 @@ public class VersionCopier {
         final NodeState sourceVersionHistory = getVersionHistoryNodeState(sourceVersionStorage, versionableUuid);
         final Calendar lastModified = getVersionHistoryLastModified(sourceVersionHistory);
 
-        if (sourceVersionHistory.exists() && (lastModified.after(minDate) || minDate.getTimeInMillis() == 0)) {
+        if (sourceVersionHistory.exists() && (lastModified.after(minDate) || minDate.getTimeInMillis() == 0) &&
+            hasNoConflicts(versionHistoryPath, versionableUuid, preserveOnTarget, sourceVersionHistory)) {
             NodeStateCopier.builder()
                     .include(versionHistoryPath)
                     .merge(VERSION_STORE_PATH)
@@ -109,6 +123,72 @@ public class VersionCopier {
             return true;
         }
         return false;
+    }
+
+    private boolean hasNoConflicts(String versionHistoryPath, String versionableUuid, boolean preserveOnTarget, NodeState sourceVersionHistory) {
+        // if preserveOnTarget is true then check no conflicts which means version history has moved forward only
+        if (preserveOnTarget) {
+            NodeBuilder targetVersionHistory = getVersionHistoryBuilder(targetVersionStorage, versionableUuid);
+            if (targetVersionHistory.exists()) {
+                VersionComparator versionComparator = new VersionComparator();
+
+                // version history id not equal
+                boolean conflictingVersionHistory = !targetVersionHistory.getString(JCR_UUID).equals(sourceVersionHistory.getString(JCR_UUID));
+                if (conflictingVersionHistory) {
+                    logger.info("Skipping version history for {}: Conflicting version history found",
+                        versionHistoryPath);
+                    return false;
+                }
+
+                // Get the version names except jcr:rootVersion
+                List<String> targetVersions =
+                    StreamSupport.stream(targetVersionHistory.getChildNodeNames().spliterator(), false).filter(s -> !s.equals(JCR_ROOTVERSION) && !s.equals(JCR_VERSIONLABELS))
+                        .sorted(versionComparator).collect(Collectors.toList());
+                List<String> sourceVersions =
+                    StreamSupport.stream(sourceVersionHistory.getChildNodeNames().spliterator(), false).filter(s -> !s.equals(JCR_ROOTVERSION) && !s.equals(JCR_VERSIONLABELS))
+                        .sorted(versionComparator).collect(Collectors.toList());
+                // source version only has a rootVersion which means nothing to update
+                boolean noUpdate = sourceVersions.isEmpty() || targetVersions.containsAll(sourceVersions);
+                if (noUpdate) {
+                    logger.info("Skipping version history for {}: No update required", versionHistoryPath);
+                    return false;
+                }
+
+                // highest source version does not exist on target or
+                // all source versions already exist on target (diverged or no diff)
+                boolean diverged = !targetVersions.contains(sourceVersions.get(0));
+                if (diverged) {
+                    logger.info("Skipping version history for {}: Versions diverged", versionHistoryPath);
+                    return false;
+                }
+
+                // highest source version UUID does not match the corresponding version on target (diverged)
+                boolean conflictingHighestVersion =
+                    !sourceVersionHistory.getChildNode(sourceVersions.get(0)).getString(JCR_UUID).equals(targetVersionHistory.getChildNode(sourceVersions.get(0)).getString(JCR_UUID));
+                if (conflictingHighestVersion) {
+                    logger.info("Skipping version history for {}: Old base version id changed", versionHistoryPath);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static class VersionComparator implements Comparator<String> {
+        @Override
+        public int compare(String v1, String v2) {
+            String[] v1Seg = v1.split("\\.");
+            String[] v2Seg = v2.split("\\.");
+            Iterator<String> i1 = Arrays.asList(v1Seg).iterator();
+            Iterator<String> i2 = Arrays.asList(v2Seg).iterator();
+            while (i1.hasNext() && i2.hasNext()) {
+                int cmp = Integer.compare(Integer.parseInt(i2.next()), Integer.parseInt(i1.next()));
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return Integer.compare(v2Seg.length, v1Seg.length);
+        }
     }
 
     private static final class IsFrozenNodeReferenceable implements Supplier<Boolean> {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopierTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopierTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.jackrabbit.oak.plugins.migration.version;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -25,6 +29,7 @@ import java.util.stream.StreamSupport;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
@@ -33,6 +38,7 @@ import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.core.ImmutableRoot;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
+import org.apache.jackrabbit.oak.plugins.memory.MultiStringPropertyState;
 import org.apache.jackrabbit.oak.plugins.migration.DescendantsIterator;
 import org.apache.jackrabbit.oak.plugins.migration.NodeStateCopier;
 import org.apache.jackrabbit.oak.plugins.version.ReadOnlyVersionManager;
@@ -44,18 +50,15 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Collections.singletonList;
-import static org.apache.jackrabbit.JcrConstants.JCR_FROZENNODE;
-import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
-import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
-import static org.apache.jackrabbit.JcrConstants.JCR_UUID;
-import static org.apache.jackrabbit.JcrConstants.MIX_VERSIONABLE;
-import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
+import static org.apache.jackrabbit.JcrConstants.*;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT_FROZEN_NODE_REFERENCEABLE;
 import static org.apache.jackrabbit.oak.plugins.migration.NodeStateTestUtils.commit;
 import static org.apache.jackrabbit.oak.plugins.migration.version.VersionHistoryUtil.getVersionHistoryBuilder;
 import static org.apache.jackrabbit.oak.plugins.migration.version.VersionHistoryUtil.getVersionHistoryNodeState;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -146,6 +149,81 @@ public class VersionCopierTest {
         // Verify the test properties no longer exist in the target version history.
         assertVersionHistoryPreserveTarget(source, target);
     }
+    
+    @Test
+    public void copyVersionSourceForIncrementalTargetVersionHistory() throws Exception {
+        String path = "/foo";
+        // create 2 paths & 2 versions
+        NodeStore sourceStore = createStore(false);
+        for (int i = 0; i < 2; i++) {
+            createVersionFor(path + i, sourceStore);
+            createNewVersion(path + i, sourceStore, "a");
+        }
+        NodeStore targetStore = createStore(false);
+
+        // Copy source to target as starting point to duplicate
+        for (int i = 0; i < 2; i++) {
+            copyContent(sourceStore, targetStore, path + i);
+        }
+        copyVersionStorage(sourceStore, targetStore);
+        
+        // Remove 1 version for path /foo0 and create a new one
+        removeSpecificVersion(targetStore, "/foo0", "1.0", "1.1");
+        createNewVersion("/foo0", targetStore, "a");
+
+        // copy versions again preserving any new target versions created
+        VersionCopyConfiguration config = new VersionCopyConfiguration();
+        config.setPreserveOnTarget(true);
+        copyVersionStorageInternal(sourceStore, targetStore, config);
+
+        assertVersionsAndUUID(targetStore, sourceStore, "/foo0", true, "1.2");
+        assertSuccessorBaseVersion(targetStore, "/foo0", "1.2");
+        assertVersionsAndUUID(targetStore, sourceStore, "/foo1", true, "1.1");
+        assertSuccessorBaseVersion(targetStore, "/foo1", "1.1");
+    }
+        
+    @Test
+    public void copyVersionSourceForMutatedTargetVersionHistory() throws Exception {
+        String path = "/foo";
+        // create 4 paths & version
+        NodeStore sourceStore = createStore(false);
+        for (int i = 0; i < 5; i++) {
+            createVersionFor(path + i, sourceStore);
+            // create another version for foo0
+            if (i == 0) {
+                createNewVersion(path + i, sourceStore, "");
+            }
+        }
+        NodeStore targetStore = createStore(false);
+
+        // Copy source to target as starting point to duplicate
+        for (int i = 0; i < 5; i++) {
+            copyContent(sourceStore, targetStore, path + i);
+        }
+        copyVersionStorage(sourceStore, targetStore);
+
+        // Remove version history for path foo3
+        removeVersionHistoryAndRecreate(targetStore, "/foo3");
+        // Remove version and recreate 1 version for foo0 // earlier had 2
+        removeVersionsAndRecreate(targetStore, "/foo0", false, true, 1);
+        // Remove version and recreate 2 versions for foo1 // earlier had 1
+        removeVersionsAndRecreate(targetStore, "/foo1", false, true, 2);
+        // Remove version and recreate 0 version for foo2 // earlier had 1
+        removeVersions(targetStore, "/foo2", false, true);
+        // Remove version and recreate 1 different branch versions for foo4 // earlier had 1
+        removeVersionsAndRecreate(targetStore, "/foo4", false, false, 1);
+
+        // copy versions again preserving any new target versions created
+        VersionCopyConfiguration config = new VersionCopyConfiguration();
+        config.setPreserveOnTarget(true);
+        copyVersionStorageInternal(sourceStore, targetStore, config);
+        
+        assertVersionsAndUUID(targetStore, sourceStore,"/foo3", false, "1.0");
+        assertVersionsAndUUID(targetStore, sourceStore, "/foo0", true, "1.0");
+        assertVersionsAndUUID(targetStore, sourceStore, "/foo1", true, "1.1");
+        assertVersionsAndUUID(targetStore, sourceStore, "/foo2", true, "jcr:rootVersion");
+        assertVersionsAndUUID(targetStore, sourceStore, "/foo4", true, "2.0");
+    }
 
     private void addVersionHistoryTestProperty(NodeStore source, NodeStore target) throws CommitFailedException {
         final NodeState sourceVersionStorage = VersionHistoryUtil.getVersionStorage(source.getRoot());
@@ -190,6 +268,15 @@ public class VersionCopierTest {
             assertTrue(targetList.containsAll(sourceList));
             // Check target has more versions
             assertTrue(targetList.size() > sourceList.size());
+            
+            // check successors not empty for 1.0 version
+            String successorId = historyNodeState.getChildNode("1.1").getString(JCR_UUID);
+            Iterable<String> values =
+                historyNodeState.getChildNode("1.0").getProperty(JCR_SUCCESSORS).getValue(Type.STRINGS);
+            Set<String> successorSet =
+                StreamSupport.stream(values.spliterator(), false).filter(s -> !s.isEmpty()).collect(Collectors.toSet());
+            assertFalse(successorSet.isEmpty());
+            assertTrue(successorSet.contains(successorId));
         }
     }
 
@@ -269,7 +356,7 @@ public class VersionCopierTest {
             builder = builder.child(name);
         }
         builder.setProperty(JCR_PRIMARYTYPE, NT_UNSTRUCTURED, Type.NAME);
-        builder.setProperty(JCR_MIXINTYPES, singletonList(MIX_VERSIONABLE), Type.NAMES);
+        builder.setProperty(JCR_MIXINTYPES, Arrays.asList(MIX_VERSIONABLE, MIX_REFERENCEABLE), Type.NAMES);
         builder.setProperty(JCR_UUID, UUID.randomUUID().toString());
         if (StringUtils.isNotEmpty(property)) {
             builder.setProperty(property, property);
@@ -292,6 +379,8 @@ public class VersionCopierTest {
         if (StringUtils.isNotEmpty(property)) {
             builder.setProperty(property, property);
         }
+        // Add the mixing mix:versionable
+        builder.setProperty(JCR_MIXINTYPES, Arrays.asList(MIX_VERSIONABLE, MIX_REFERENCEABLE), Type.NAMES);
         ReadWriteVersionManager vMgr = new ReadWriteVersionManager(
             VersionHistoryUtil.getVersionStorage(rootBuilder),
             rootBuilder
@@ -300,5 +389,179 @@ public class VersionCopierTest {
         vMgr.checkin(builder);
         commit(ns, rootBuilder);
         return ns;
+    }
+
+    protected String removeVersionableMixin(NodeStore ns, String path) throws CommitFailedException {
+        NodeBuilder rootBuilder = ns.getRoot().builder();
+        NodeBuilder builder = rootBuilder;
+        for (String name : PathUtils.elements(path)) {
+            builder = builder.child(name);
+        }
+
+        // remove mix:versionable mixin
+        builder.setProperty(JCR_MIXINTYPES, singletonList(MIX_REFERENCEABLE), Type.NAMES);
+        String versionableUuid = builder.getString(JCR_UUID);
+        commit(ns, rootBuilder);
+        return versionableUuid;
+    }
+    
+    protected void removeVersionHistory(NodeStore ns, String path) throws CommitFailedException {
+        String versionableUuid = removeVersionableMixin(ns, path);
+
+        NodeBuilder rootBuilder = ns.getRoot().builder();
+        NodeBuilder versionHistoryRoot = VersionHistoryUtil.getVersionStorage(rootBuilder);
+        NodeBuilder versionHistoryBuilder =
+            VersionHistoryUtil.getVersionHistoryBuilder(versionHistoryRoot, versionableUuid);
+        versionHistoryBuilder.remove();
+        commit(ns, rootBuilder);
+    }
+
+    protected void removeVersions(NodeStore ns, String path, boolean removeRootVersion, boolean removeRootSuccessor) throws CommitFailedException {
+        String versionableUuid = removeVersionableMixin(ns, path);
+        NodeBuilder rootBuilder = ns.getRoot().builder();
+        
+        // Remove versions 
+        NodeBuilder versionHistoryRoot = VersionHistoryUtil.getVersionStorage(rootBuilder);
+        NodeBuilder versionHistoryBuilder =
+            VersionHistoryUtil.getVersionHistoryBuilder(versionHistoryRoot, versionableUuid);
+        Iterable<String> versionNames = versionHistoryBuilder.getChildNodeNames();
+        for (String version: versionNames) {
+            if (!version.equals(JCR_ROOTVERSION) || removeRootVersion) {
+                versionHistoryBuilder.getChildNode(version).remove();
+            } else {
+                NodeBuilder rootVersionBuilder = versionHistoryBuilder.getChildNode(version);
+                String rootVersionUUID = rootVersionBuilder.getString(JCR_UUID);
+                if (removeRootSuccessor) {
+                    rootVersionBuilder.setProperty(MultiStringPropertyState.stringProperty(JCR_SUCCESSORS, new ArrayList<>()));
+                }
+                // Change base version of path to rootVersion
+                NodeBuilder builder = rootBuilder;
+                for (String name : PathUtils.elements(path)) {
+                    builder = builder.child(name);
+                }
+
+                // remove mix:versionable mixin
+                builder.setProperty(JCR_BASEVERSION, rootVersionUUID, Type.REFERENCE);
+            }
+        }
+        commit(ns, rootBuilder);
+    }
+    
+    protected void removeSpecificVersion(NodeStore ns, String path, String version, String successor) throws CommitFailedException {
+        NodeBuilder rootBuilder = ns.getRoot().builder();
+        NodeBuilder builder = rootBuilder;
+        for (String name : PathUtils.elements(path)) {
+            builder = builder.child(name);
+        }
+        String versionableUuid = builder.getString(JCR_UUID);
+
+        // Remove version
+        NodeBuilder versionHistoryRoot = VersionHistoryUtil.getVersionStorage(rootBuilder);
+        NodeBuilder versionHistoryBuilder =
+            VersionHistoryUtil.getVersionHistoryBuilder(versionHistoryRoot, versionableUuid);
+        NodeBuilder versionNode = versionHistoryBuilder.getChildNode(version);
+        NodeBuilder rootVersionNode = versionHistoryBuilder.getChildNode(JCR_ROOTVERSION);
+        NodeBuilder successorVersionNode = versionHistoryBuilder.getChildNode(successor);
+        versionNode.remove();
+        String rootVersionId = rootVersionNode.getString(JCR_UUID);
+        String successorVersionId = successorVersionNode.getString(JCR_UUID);
+        Set<String> successors = new HashSet<>();
+        successors.add(successorVersionId);
+        rootVersionNode.setProperty(JcrConstants.JCR_SUCCESSORS, successors, Type.REFERENCES);
+
+        Set<String> predecessors = new HashSet<>();
+        predecessors.add(rootVersionId);
+        successorVersionNode.setProperty(JCR_PREDECESSORS, predecessors, Type.REFERENCES);
+        commit(ns, rootBuilder);
+    }
+
+    protected void assertSuccessorBaseVersion(NodeStore ns, String path, String baseVersion) throws CommitFailedException {
+        NodeBuilder rootBuilder = ns.getRoot().builder();
+        NodeBuilder builder = rootBuilder;
+        for (String name : PathUtils.elements(path)) {
+            builder = builder.child(name);
+        }
+        String versionableUuid = builder.getString(JCR_UUID);
+
+        // Remove version
+        NodeBuilder versionHistoryRoot = VersionHistoryUtil.getVersionStorage(rootBuilder);
+        NodeBuilder versionHistoryBuilder =
+            VersionHistoryUtil.getVersionHistoryBuilder(versionHistoryRoot, versionableUuid);
+        NodeBuilder versionNode = versionHistoryBuilder.getChildNode(baseVersion);
+        
+        String predVersion = getPredecessorVersion(baseVersion);
+        NodeBuilder predecessorVersionNode = versionHistoryBuilder.getChildNode(predVersion);
+        String baseVersionId = versionNode.getString(JCR_UUID);
+        String baseVersionPredecessor =
+            StreamSupport.stream(versionNode.getProperty(JCR_PREDECESSORS).getValue(Type.STRINGS).spliterator(), false).collect(
+                Collectors.toList()).get(0);
+        String predecessorVersionId = predecessorVersionNode.getString(JCR_UUID);
+        assertEquals("predecessor version not correct", baseVersionPredecessor, predecessorVersionId);
+
+        String predSuccessorVersionId =
+            StreamSupport.stream(predecessorVersionNode.getProperty(JCR_SUCCESSORS).getValue(Type.STRINGS).spliterator(), false).collect(
+                Collectors.toList()).get(0);
+        assertEquals("successor version not correct", baseVersionId, predSuccessorVersionId);
+
+        NodeBuilder prevVersionNode = versionHistoryBuilder.getChildNode(getPredecessorVersion(predVersion));
+        String prevVersionSuccessor =
+            StreamSupport.stream(prevVersionNode.getProperty(JCR_SUCCESSORS).getValue(Type.STRINGS).spliterator(), false).collect(
+                Collectors.toList()).get(0);
+        assertEquals("root successor version not correct", predecessorVersionId, prevVersionSuccessor);
+    }
+
+    private static String getPredecessorVersion(String version) {
+        if (version.equals("1.0")) {
+            return JCR_ROOTVERSION;
+        }
+        String[] versionSegs = version.split("\\.");
+        return versionSegs[0] + "." + (Integer.parseInt(versionSegs[1]) - 1);
+    }
+    
+    private void removeVersionHistoryAndRecreate(NodeStore store, String path) throws Exception {
+        removeVersionHistory(store, path);
+        createNewVersion(path, store, "");
+    }
+
+    private void removeVersionsAndRecreate(NodeStore store, String path, boolean removeRootVersion,
+        boolean removeRootSuccessor, int num)
+        throws Exception {
+        removeVersions(store, path, removeRootVersion, removeRootSuccessor);
+        for (int i = 0; i < num; i++) {
+            createNewVersion(path, store, "");
+        }
+    }
+
+    private void assertVersionsAndUUID(NodeStore targetStore, NodeStore sourceStore, String path, boolean isVhSame,
+        String targetBaseVersion) {
+        NodeState targetRoot = targetStore.getRoot();
+        NodeState targetNodeState = targetRoot;
+        for (String name : PathUtils.elements(path)) {
+            targetNodeState = targetNodeState.getChildNode(name);
+        }
+
+        String uuid = targetNodeState.getString(JCR_UUID);
+        String baseVersionUuid = targetNodeState.getProperty(JCR_BASEVERSION).getValue(Type.STRING);
+        String vhId = targetNodeState.getProperty(JCR_VERSIONHISTORY).getValue(Type.STRING);
+
+        NodeState versionStorage = VersionHistoryUtil.getVersionStorage(targetRoot);
+        NodeState versionHistory = getVersionHistoryNodeState(versionStorage, uuid);
+        assertEquals(vhId, versionHistory.getString(JCR_UUID));
+
+        NodeState sourceRoot = sourceStore.getRoot();
+        NodeState sourceVersionHistory =
+            getVersionHistoryNodeState(VersionHistoryUtil.getVersionStorage(sourceRoot), uuid);
+        if (isVhSame) {
+            assertEquals(vhId, sourceVersionHistory.getString(JCR_UUID));
+        } else {
+            assertNotEquals(vhId, sourceVersionHistory.getString(JCR_UUID));
+        }
+        
+        List<String> baseVersionFoundList = StreamSupport.stream(versionHistory.getChildNodeNames().spliterator(), false)
+            .filter(s -> !s.equals(JCR_VERSIONLABELS))
+            .filter(s -> versionHistory.getChildNode(s).getString(JCR_UUID).equals(baseVersionUuid))
+            .collect(Collectors.toList());
+        assertFalse(baseVersionFoundList.isEmpty());
+        assertEquals(targetBaseVersion, baseVersionFoundList.get(0));
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopierTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopierTest.java
@@ -29,7 +29,6 @@ import java.util.stream.StreamSupport;
 import javax.jcr.RepositoryException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
@@ -50,7 +49,19 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.util.Collections.singletonList;
-import static org.apache.jackrabbit.JcrConstants.*;
+import static org.apache.jackrabbit.JcrConstants.JCR_BASEVERSION;
+import static org.apache.jackrabbit.JcrConstants.JCR_FROZENNODE;
+import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
+import static org.apache.jackrabbit.JcrConstants.JCR_PREDECESSORS;
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
+import static org.apache.jackrabbit.JcrConstants.JCR_ROOTVERSION;
+import static org.apache.jackrabbit.JcrConstants.JCR_SUCCESSORS;
+import static org.apache.jackrabbit.JcrConstants.JCR_UUID;
+import static org.apache.jackrabbit.JcrConstants.JCR_VERSIONHISTORY;
+import static org.apache.jackrabbit.JcrConstants.JCR_VERSIONLABELS;
+import static org.apache.jackrabbit.JcrConstants.MIX_REFERENCEABLE;
+import static org.apache.jackrabbit.JcrConstants.MIX_VERSIONABLE;
+import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT_FROZEN_NODE_REFERENCEABLE;
 import static org.apache.jackrabbit.oak.plugins.migration.NodeStateTestUtils.commit;
@@ -467,7 +478,7 @@ public class VersionCopierTest {
         String successorVersionId = successorVersionNode.getString(JCR_UUID);
         Set<String> successors = new HashSet<>();
         successors.add(successorVersionId);
-        rootVersionNode.setProperty(JcrConstants.JCR_SUCCESSORS, successors, Type.REFERENCES);
+        rootVersionNode.setProperty(JCR_SUCCESSORS, successors, Type.REFERENCES);
 
         Set<String> predecessors = new HashSet<>();
         predecessors.add(rootVersionId);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopierTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/version/VersionCopierTest.java
@@ -18,7 +18,6 @@ package org.apache.jackrabbit.oak.plugins.migration.version;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -42,6 +41,7 @@ import org.apache.jackrabbit.oak.plugins.migration.DescendantsIterator;
 import org.apache.jackrabbit.oak.plugins.migration.NodeStateCopier;
 import org.apache.jackrabbit.oak.plugins.version.ReadOnlyVersionManager;
 import org.apache.jackrabbit.oak.plugins.version.ReadWriteVersionManager;
+import org.apache.jackrabbit.oak.plugins.version.ReadWriteVersionManagerUtil;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
@@ -56,9 +56,11 @@ import static org.apache.jackrabbit.JcrConstants.JCR_PREDECESSORS;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 import static org.apache.jackrabbit.JcrConstants.JCR_ROOTVERSION;
 import static org.apache.jackrabbit.JcrConstants.JCR_SUCCESSORS;
+import static org.apache.jackrabbit.JcrConstants.JCR_SYSTEM;
 import static org.apache.jackrabbit.JcrConstants.JCR_UUID;
 import static org.apache.jackrabbit.JcrConstants.JCR_VERSIONHISTORY;
 import static org.apache.jackrabbit.JcrConstants.JCR_VERSIONLABELS;
+import static org.apache.jackrabbit.JcrConstants.JCR_VERSIONSTORAGE;
 import static org.apache.jackrabbit.JcrConstants.MIX_REFERENCEABLE;
 import static org.apache.jackrabbit.JcrConstants.MIX_VERSIONABLE;
 import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
@@ -179,7 +181,7 @@ public class VersionCopierTest {
         copyVersionStorage(sourceStore, targetStore);
         
         // Remove 1 version for path /foo0 and create a new one
-        removeSpecificVersion(targetStore, "/foo0", "1.0", "1.1");
+        removeSpecificVersion(targetStore, "/foo0", "1.0");
         createNewVersion("/foo0", targetStore, "a");
 
         // copy versions again preserving any new target versions created
@@ -458,31 +460,16 @@ public class VersionCopierTest {
         commit(ns, rootBuilder);
     }
     
-    protected void removeSpecificVersion(NodeStore ns, String path, String version, String successor) throws CommitFailedException {
+    protected void removeSpecificVersion(NodeStore ns, String path, String version) throws CommitFailedException {
         NodeBuilder rootBuilder = ns.getRoot().builder();
         NodeBuilder builder = rootBuilder;
         for (String name : PathUtils.elements(path)) {
             builder = builder.child(name);
         }
         String versionableUuid = builder.getString(JCR_UUID);
-
-        // Remove version
-        NodeBuilder versionHistoryRoot = VersionHistoryUtil.getVersionStorage(rootBuilder);
-        NodeBuilder versionHistoryBuilder =
-            VersionHistoryUtil.getVersionHistoryBuilder(versionHistoryRoot, versionableUuid);
-        NodeBuilder versionNode = versionHistoryBuilder.getChildNode(version);
-        NodeBuilder rootVersionNode = versionHistoryBuilder.getChildNode(JCR_ROOTVERSION);
-        NodeBuilder successorVersionNode = versionHistoryBuilder.getChildNode(successor);
-        versionNode.remove();
-        String rootVersionId = rootVersionNode.getString(JCR_UUID);
-        String successorVersionId = successorVersionNode.getString(JCR_UUID);
-        Set<String> successors = new HashSet<>();
-        successors.add(successorVersionId);
-        rootVersionNode.setProperty(JCR_SUCCESSORS, successors, Type.REFERENCES);
-
-        Set<String> predecessors = new HashSet<>();
-        predecessors.add(rootVersionId);
-        successorVersionNode.setProperty(JCR_PREDECESSORS, predecessors, Type.REFERENCES);
+        String relPath = VersionHistoryUtil.getRelativeVersionHistoryPath(versionableUuid);
+        String versionPath = PathUtils.concat("/", JCR_SYSTEM, JCR_VERSIONSTORAGE + relPath, version);
+        ReadWriteVersionManagerUtil.removeVersion(rootBuilder, versionPath);
         commit(ns, rootBuilder);
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/version/ReadWriteVersionManagerUtil.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/version/ReadWriteVersionManagerUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.version;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.plugins.migration.version.VersionHistoryUtil;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+
+import static org.apache.jackrabbit.oak.commons.PathUtils.relativize;
+import static org.apache.jackrabbit.oak.spi.version.VersionConstants.VERSION_STORE_PATH;
+
+public class ReadWriteVersionManagerUtil {
+
+    /**
+     * Remove a version at the given path.
+     *
+     * @param builder the root builder.
+     * @param path the path of a version to remove.
+     * @throws CommitFailedException if a constraint is violated.
+     */
+    public static void removeVersion(NodeBuilder builder, String path)
+            throws CommitFailedException {
+        ReadWriteVersionManager vMgr = new ReadWriteVersionManager(
+                VersionHistoryUtil.getVersionStorage(builder),
+                builder
+        );
+        String relPath = relativize(VERSION_STORE_PATH, path);
+        vMgr.removeVersion(relPath);
+    }
+}


### PR DESCRIPTION
…d history

When preserveOnTarget is true
- Ignoring diverged version history or if no change detected
- Not changing version properties if these properties are null in the source which prevents linkage to new successor versions being broken