### PR TITLE
OAK-10167: Elastic bulk processor should fail when intermediate bulks fail

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -68,6 +68,14 @@ public class ElasticIndexDefinition extends IndexDefinition {
     public static final String TRACK_TOTAL_HITS = "trackTotalHits";
     public static final Integer TRACK_TOTAL_HITS_DEFAULT = 10000;
 
+    public static final String DYNAMIC_MAPPING = "dynamicMapping";
+    // possible values are: true, false, runtime, strict. See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html
+    public static final String DYNAMIC_MAPPING_DEFAULT = "true";
+
+    // when true, fails indexing in case of bulk failures
+    public static final String FAIL_ON_ERROR = "failOnError";
+    public static final boolean FAIL_ON_ERROR_DEFAULT = true;
+
     /**
      * Hidden property for storing a seed value to be used as suffix in remote index name.
      */
@@ -117,6 +125,8 @@ public class ElasticIndexDefinition extends IndexDefinition {
     public final int numberOfReplicas;
     public final int[] queryFetchSizes;
     public final Integer trackTotalHits;
+    public final String dynamicMapping;
+    public final boolean failOnError;
 
     private final Map<String, List<PropertyDefinition>> propertiesByName;
     private final List<PropertyDefinition> dynamicBoostProperties;
@@ -138,6 +148,10 @@ public class ElasticIndexDefinition extends IndexDefinition {
         this.queryFetchSizes = Arrays.stream(getOptionalValues(defn, QUERY_FETCH_SIZES, Type.LONGS, Long.class, QUERY_FETCH_SIZES_DEFAULT))
                 .mapToInt(Long::intValue).toArray();
         this.trackTotalHits = getOptionalValue(defn, TRACK_TOTAL_HITS, TRACK_TOTAL_HITS_DEFAULT);
+        this.dynamicMapping = getOptionalValue(defn, DYNAMIC_MAPPING, DYNAMIC_MAPPING_DEFAULT);
+        this.failOnError = getOptionalValue(defn, FAIL_ON_ERROR,
+                Boolean.parseBoolean(System.getProperty(TYPE_ELASTICSEARCH + "." + FAIL_ON_ERROR, ""+ FAIL_ON_ERROR_DEFAULT))
+        );
 
         this.propertiesByName = getDefinedRules()
                 .stream()

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -150,7 +150,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
         this.trackTotalHits = getOptionalValue(defn, TRACK_TOTAL_HITS, TRACK_TOTAL_HITS_DEFAULT);
         this.dynamicMapping = getOptionalValue(defn, DYNAMIC_MAPPING, DYNAMIC_MAPPING_DEFAULT);
         this.failOnError = getOptionalValue(defn, FAIL_ON_ERROR,
-                Boolean.parseBoolean(System.getProperty(TYPE_ELASTICSEARCH + "." + FAIL_ON_ERROR, ""+ FAIL_ON_ERROR_DEFAULT))
+                Boolean.parseBoolean(System.getProperty(TYPE_ELASTICSEARCH + "." + FAIL_ON_ERROR, Boolean.toString(FAIL_ON_ERROR_DEFAULT)))
         );
 
         this.propertiesByName = getDefinedRules()

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
 import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
@@ -35,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -71,6 +73,11 @@ class ElasticIndexHelper {
 
     private static ObjectBuilder<TypeMapping> loadMappings(@NotNull TypeMapping.Builder builder,
                                                            @NotNull ElasticIndexDefinition indexDefinition) {
+        builder.dynamic(Arrays
+                .stream(DynamicMapping.values())
+                .filter(dm -> dm.jsonValue().equals(indexDefinition.dynamicMapping))
+                .findFirst().orElse(DynamicMapping.True)
+        );
         mapInternalProperties(builder);
         mapIndexRules(builder, indexDefinition);
         return builder;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -131,7 +131,7 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     }
 
     @Override
-    public void updateDocument(String path, ElasticDocument doc) {
+    public void updateDocument(String path, ElasticDocument doc) throws IOException {
         IndexRequest request = new IndexRequest(indexName)
                 .id(ElasticIndexUtils.idFromPath(path))
                 .source(doc.build(), XContentType.JSON);
@@ -139,7 +139,7 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     }
 
     @Override
-    public void deleteDocuments(String path) {
+    public void deleteDocuments(String path) throws IOException {
         DeleteRequest request = new DeleteRequest(indexName).id(ElasticIndexUtils.idFromPath(path));
         bulkProcessorHandler.add(request);
     }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
@@ -24,10 +23,8 @@ import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilde
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROPDEF_PROP_NODE_NAME;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,8 +47,7 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
         String propaQuery = "select [jcr:path] from [nt:base] where [propa] = 'foo248'";
         assertEventually(() -> {
             assertThat(explain(propaQuery), containsString("elasticsearch:test1"));
-
-            assertQuery(propaQuery, singletonList("/test/a248"));
+            assertQuery(propaQuery, List.of("/test/a248"));
         });
 
         // Now we test for 250 < nodes < 500
@@ -63,8 +59,7 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
         String propaQuery2 = "select [jcr:path] from [nt:base] where [propa] = 'foo299'";
         assertEventually(() -> {
             assertThat(explain(propaQuery2), containsString("elasticsearch:test1"));
-
-            assertQuery(propaQuery2, singletonList("/test/a299"));
+            assertQuery(propaQuery2, List.of("/test/a299"));
         });
     }
 
@@ -87,9 +82,9 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
             assertThat(explain(propaQuery), containsString("elasticsearch:test1"));
             assertThat(explain("select [jcr:path] from [nt:base] where [propc] = 'foo'"), containsString("elasticsearch:test2"));
 
-            assertQuery(propaQuery, Arrays.asList("/test/a", "/test/b"));
-            assertQuery("select [jcr:path] from [nt:base] where [propa] = 'foo2'", singletonList("/test/c"));
-            assertQuery("select [jcr:path] from [nt:base] where [propc] = 'foo'", singletonList("/test/d"));
+            assertQuery(propaQuery, List.of("/test/a", "/test/b"));
+            assertQuery("select [jcr:path] from [nt:base] where [propa] = 'foo2'", List.of("/test/c"));
+            assertQuery("select [jcr:path] from [nt:base] where [propc] = 'foo'", List.of("/test/d"));
         });
     }
 
@@ -119,15 +114,15 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
             String explanation = explain(propabQuery);
             assertThat(explanation, containsString("elasticsearch:test1(/oak:index/test1) "));
             assertThat(explanation, containsString("{\"term\":{\":nodeName\":{\"value\":\"foo\""));
-            assertQuery(propabQuery, singletonList("/test/foo"));
+            assertQuery(propabQuery, List.of("/test/foo"));
 
-            assertQuery(queryPrefix + "LOCALNAME() = 'bar'", singletonList("/test/sc/bar"));
-            assertQuery(queryPrefix + "LOCALNAME() LIKE 'foo'", singletonList("/test/foo"));
-            assertQuery(queryPrefix + "LOCALNAME() LIKE 'camel%'", singletonList("/test/camelCase"));
+            assertQuery(queryPrefix + "LOCALNAME() = 'bar'", List.of("/test/sc/bar"));
+            assertQuery(queryPrefix + "LOCALNAME() LIKE 'foo'", List.of("/test/foo"));
+            assertQuery(queryPrefix + "LOCALNAME() LIKE 'camel%'", List.of("/test/camelCase"));
 
-            assertQuery(queryPrefix + "NAME() = 'bar'", singletonList("/test/sc/bar"));
-            assertQuery(queryPrefix + "NAME() LIKE 'foo'", singletonList("/test/foo"));
-            assertQuery(queryPrefix + "NAME() LIKE 'camel%'", singletonList("/test/camelCase"));
+            assertQuery(queryPrefix + "NAME() = 'bar'", List.of("/test/sc/bar"));
+            assertQuery(queryPrefix + "NAME() LIKE 'foo'", List.of("/test/foo"));
+            assertQuery(queryPrefix + "NAME() LIKE 'camel%'", List.of("/test/camelCase"));
         });
     }
 
@@ -157,7 +152,7 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
         root.commit();
         assertEventually(() -> {
             assertThat(explain(query), containsString("{\"terms\":{\"propa\":[\"a\",\"e\",\"i\"]}}"));
-            assertQuery(query, SQL2, ImmutableList.of("/test/node-a", "/test/node-e", "/test/node-i"));
+            assertQuery(query, SQL2, List.of("/test/node-a", "/test/node-e", "/test/node-i"));
         });
     }
 
@@ -174,7 +169,7 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
 
         assertEventually(() -> {
             assertThat(explain(query), containsString("{\"terms\":{\"propa\":[2,3,5,7]}}"));
-            assertQuery(query, SQL2, ImmutableList.of("/test/node-2", "/test/node-3", "/test/node-5", "/test/node-7"));
+            assertQuery(query, SQL2, List.of("/test/node-2", "/test/node-3", "/test/node-5", "/test/node-7"));
         });
     }
 
@@ -192,7 +187,7 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
 
         assertEventually(() -> {
             assertThat(explain(query), containsString("{\"terms\":{\"propa\":[2.0,3.0,5.0,7.0]}}"));
-            assertQuery(query, SQL2, ImmutableList.of("/test/node-2", "/test/node-3", "/test/node-5", "/test/node-7"));
+            assertQuery(query, SQL2, List.of("/test/node-2", "/test/node-3", "/test/node-5", "/test/node-7"));
         });
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
@@ -63,7 +63,7 @@ public class ElasticIndexWriterTest {
     }
 
     @Test
-    public void singleUpdateDocument() {
+    public void singleUpdateDocument() throws IOException {
         indexWriter.updateDocument("/foo", new ElasticDocument("/foo"));
 
         ArgumentCaptor<IndexRequest> acIndexRequest = ArgumentCaptor.forClass(IndexRequest.class);
@@ -75,7 +75,7 @@ public class ElasticIndexWriterTest {
     }
 
     @Test
-    public void singleDeleteDocument() {
+    public void singleDeleteDocument() throws IOException {
         indexWriter.deleteDocuments("/bar");
 
         ArgumentCaptor<DeleteRequest> acDeleteRequest = ArgumentCaptor.forClass(DeleteRequest.class);
@@ -87,7 +87,7 @@ public class ElasticIndexWriterTest {
     }
 
     @Test
-    public void multiRequests() {
+    public void multiRequests() throws IOException {
         indexWriter.updateDocument("/foo", new ElasticDocument("/foo"));
         indexWriter.updateDocument("/bar", new ElasticDocument("/bar"));
         indexWriter.deleteDocuments("/foo");
@@ -98,7 +98,7 @@ public class ElasticIndexWriterTest {
     }
 
     @Test
-    public void longDocumentPath() {
+    public void longDocumentPath() throws IOException {
         String generatedPath = randomString(1024);
 
         indexWriter.updateDocument(generatedPath, new ElasticDocument(generatedPath));


### PR DESCRIPTION
* changed bulk processor behavior to throw an exception when at least one intermediate bulk action fails
* `failOnErron` behavior can be disabled through the `failOnError` flag in the index definition or with the system property `elasticsearch.failOnError` (affects all elasticsearch indexes)
* intermediate failures are captured using [Java suppressed exceptions](https://marcelkliemannel.com/articles/2021/handling-multiple-thrown-exceptions-with-suppressed-exceptions/)
* since it's not that easy to simulate an intermediate failure, I have added the possibility to configure [strict mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html) for an elasticsearch index. This is not used by default but it's something we would like to enable in the future