### PR TITLE
OAK-10170 : simplify usage of authorizableiterator

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/AuthorizableImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/AuthorizableImpl.java
@@ -288,9 +288,13 @@ abstract class AuthorizableImpl implements Authorizable, UserConstants, TreeAwar
         
         MembershipProvider mMgr = getMembershipProvider();
         Iterator<Tree> trees = mMgr.getMembership(getTree(), includeInherited);
-        
-        AuthorizableIterator groups = (!trees.hasNext()) ? AuthorizableIterator.empty() : AuthorizableIterator.create(trees, userManager, AuthorizableType.GROUP);
-        AuthorizableIterator allGroups = AuthorizableIterator.create(true, dynamicGroups, groups);
-        return new RangeIteratorAdapter(allGroups);
+
+        if (!trees.hasNext()) {
+            return new RangeIteratorAdapter(AuthorizableIterator.create(true, dynamicGroups));
+        } else {
+            AuthorizableIterator groups = AuthorizableIterator.create(trees, userManager, AuthorizableType.GROUP);
+            AuthorizableIterator allGroups = AuthorizableIterator.create(true, dynamicGroups, groups);
+            return new RangeIteratorAdapter(allGroups);
+        }
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/AuthorizableIterator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/AuthorizableIterator.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import javax.jcr.RangeIterator;
 import javax.jcr.RepositoryException;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
@@ -43,12 +42,10 @@ final class AuthorizableIterator implements Iterator<Authorizable> {
 
     private static final Logger log = LoggerFactory.getLogger(AuthorizableIterator.class);
 
-    private final Iterator<Authorizable> authorizables;
+    private final Iterator<? extends Authorizable> authorizables;
     private final long size;
     private final Set<String> servedIds;
-
-    private static AuthorizableIterator EMPTY = new AuthorizableIterator(Collections.emptyIterator(), 0, false);
-
+    
     @NotNull
     static AuthorizableIterator create(@NotNull Iterator<Tree> authorizableTrees,
                                        @NotNull UserManagerImpl userManager,
@@ -56,6 +53,12 @@ final class AuthorizableIterator implements Iterator<Authorizable> {
         Iterator<Authorizable> it = Iterators.transform(authorizableTrees, new TreeToAuthorizable(userManager, authorizableType));
         long size = getSize(authorizableTrees);
         return new AuthorizableIterator(it, size, false);
+    }
+
+    @NotNull
+    static AuthorizableIterator create(boolean filterDuplicates, @NotNull Iterator<? extends Authorizable> it1) {
+        long size = getSize(it1);
+        return new AuthorizableIterator(it1, size, filterDuplicates);
     }
     
     @NotNull
@@ -72,13 +75,8 @@ final class AuthorizableIterator implements Iterator<Authorizable> {
         }
         return new AuthorizableIterator(Iterators.concat(it1, it2), size, filterDuplicates);
     }
-    
-    @NotNull
-    static AuthorizableIterator empty() {
-        return EMPTY;
-    }
 
-    private AuthorizableIterator(Iterator<Authorizable> authorizables, long size, boolean filterDuplicates) {
+    private AuthorizableIterator(Iterator<? extends Authorizable> authorizables, long size, boolean filterDuplicates) {
         if (filterDuplicates)  {
             this.servedIds = new HashSet<>();
             this.authorizables = Iterators.filter(authorizables, authorizable -> {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/GroupImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/GroupImpl.java
@@ -213,13 +213,13 @@ class GroupImpl extends AuthorizableImpl implements Group {
         DynamicMembershipProvider dmp = getUserManager().getDynamicMembershipProvider();
         Iterator<Authorizable> dynamicMembers = dmp.getMembers(this, includeInherited);
         if (dmp.coversAllMembers(this)) {
-            return AuthorizableIterator.create(true, dynamicMembers, AuthorizableIterator.empty());
+            return AuthorizableIterator.create(true, dynamicMembers);
         }
 
         // dynamic membership didn't cover all members -> extract from group-tree
         Iterator<Tree> trees = getMembershipProvider().getMembers(getTree(), includeInherited);
         if (!trees.hasNext()) {
-            return AuthorizableIterator.create(true, dynamicMembers, AuthorizableIterator.empty());
+            return AuthorizableIterator.create(true, dynamicMembers);
         }
         
         Iterator<Authorizable> members = AuthorizableIterator.create(trees, userMgr, AuthorizableType.AUTHORIZABLE);


### PR DESCRIPTION
@reschke , as discussed. in a next step i will also adjust the size-calculation such that it returns -1 if duplicates are filtered.