### PR TITLE
OAK-10171: datastore-copy cmd: add checksum validation 

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -170,8 +170,8 @@ public class DataStoreCopyCommand implements Command {
         OptionSpec<String> checksumOpt = parser.accepts("checksum", "The algorithm to compute the checksum (examples: SHA-256, MD5) or empty (the default) to skip checksum validation")
                 .withOptionalArg().ofType(String.class);
         OptionSpec<Integer> bufferSizeOpt = parser.accepts("buffer-size",
-                        "The buffer size for downloading and checksumming blobs (default 8192[8KB])")
-                .withRequiredArg().ofType(Integer.class).defaultsTo(8192);
+                        "The buffer size for downloading and checksumming blobs (default 16384[16KB])")
+                .withRequiredArg().ofType(Integer.class).defaultsTo(16384);
 
         OptionSet optionSet = parser.parse(args);
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommand.java
@@ -60,6 +60,7 @@ public class DataStoreCopyCommand implements Command {
     private boolean failOnError;
     private int slowLogThreshold;
     private String checksumAlgorithm;
+    private int bufferSize;
 
     @Override
     public void execute(String... args) throws Exception {
@@ -68,7 +69,7 @@ public class DataStoreCopyCommand implements Command {
 
         Stream<String> ids = null;
         try (Downloader downloader = new Downloader(concurrency, connectTimeout, readTimeout, maxRetries,
-                retryInitialInterval, failOnError, slowLogThreshold, checksumAlgorithm)) {
+                retryInitialInterval, failOnError, slowLogThreshold, checksumAlgorithm, bufferSize)) {
             if (fileIncludePath != null) {
                 ids = Files.lines(fileIncludePath);
             } else {
@@ -168,6 +169,9 @@ public class DataStoreCopyCommand implements Command {
                 .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
         OptionSpec<String> checksumOpt = parser.accepts("checksum", "The algorithm to compute the checksum (examples: SHA-256, MD5) or empty (the default) to skip checksum validation")
                 .withOptionalArg().ofType(String.class);
+        OptionSpec<Integer> bufferSizeOpt = parser.accepts("buffer-size",
+                        "The buffer size for downloading and checksumming blobs (default 8192[8KB])")
+                .withRequiredArg().ofType(Integer.class).defaultsTo(8192);
 
         OptionSet optionSet = parser.parse(args);
 
@@ -185,6 +189,7 @@ public class DataStoreCopyCommand implements Command {
         this.fileIncludePath = optionSet.valueOf(fileIncludePathOpt);
         this.failOnError = optionSet.valueOf(failOnErrorOpt);
         this.checksumAlgorithm = optionSet.valueOf(checksumOpt);
+        this.bufferSize = optionSet.valueOf(bufferSizeOpt);
     }
 
     protected static void setupLogging() throws IOException {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -69,7 +69,7 @@ public class Downloader implements Closeable {
     private final List<Future<ItemResponse>> responses;
 
     public Downloader(int concurrency, int connectTimeoutMs, int readTimeoutMs) {
-        this(concurrency, connectTimeoutMs, readTimeoutMs, 3, 100L, false, 10_000, null, 8192);
+        this(concurrency, connectTimeoutMs, readTimeoutMs, 3, 100L, false, 10_000, null, 16384);
     }
 
     public Downloader(int concurrency, int connectTimeoutMs, int readTimeoutMs, int maxRetries, long retryInitialInterval,

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Downloader.java
@@ -24,16 +24,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -174,7 +175,7 @@ public class Downloader implements Closeable {
             Files.createDirectories(destinationPath.getParent());
             long size = 0;
             try (ReadableByteChannel byteChannel = Channels.newChannel(sourceUrl.getInputStream());
-                 FileOutputStream outputStream = new FileOutputStream(destinationPath.toFile())) {
+                 FileChannel outputChannel = FileChannel.open(destinationPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
                 ByteBuffer buffer = ByteBuffer.allocate(1024);
                 int bytesRead;
                 while ((bytesRead = byteChannel.read(buffer)) != -1) {
@@ -183,7 +184,7 @@ public class Downloader implements Closeable {
                         md.update(buffer);
                     }
                     size += bytesRead;
-                    outputStream.getChannel().write(buffer);
+                    outputChannel.write(buffer);
                     buffer.clear();
                 }
             }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -34,7 +34,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -17,7 +17,6 @@
 package org.apache.jackrabbit.oak.run;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.SharedAccessBlobPermissions;
 import com.microsoft.azure.storage.blob.SharedAccessBlobPolicy;
@@ -35,10 +34,14 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.microsoft.azure.storage.blob.SharedAccessBlobPermissions.LIST;
@@ -52,9 +55,15 @@ public class DataStoreCopyCommandTest {
     @ClassRule
     public static AzuriteDockerRule AZURITE = new AzuriteDockerRule();
 
-    private static final String BLOB1 = "8897-b9025dc534d4a9fa5920569b373cd714c8cfe5d030ca3f5edb25004894a5";
-    private static final String BLOB2 = "c1f0-8893512e1e00910a9caff05487805632031f15a0bd8ee869c9205da59cb8";
-    private static final ImmutableSet<String> BLOBS = ImmutableSet.of(BLOB1, BLOB2);
+    private static final String BLOB1 = "290F-493C44F5D63D06B374D0A5ABD292FAE38B92CAB2FAE5EFEFE1B0E9347F56";
+    private static final String BLOB2 = "F73F-16EDE021D01EFECF627B5E658BE52293F167CFE06C6B8D0E591CB25B68C9";
+    private static final String BLOB3 = "A096-9499131919BEED06F508FF848DE3D49C227374702466E22D944EAD6ADB8E";
+
+    private static final Map<String, String> BLOBS_WITH_CONTENT = Map.of(
+            BLOB1, "some content",
+            BLOB2, "some other content",
+            BLOB3, "content with different checksum"
+    );
 
     @Rule
     public TemporaryFolder outDir = new TemporaryFolder(new File("target"));
@@ -120,13 +129,14 @@ public class DataStoreCopyCommandTest {
         assertTrue(thirdNode.exists() && thirdNode.isDirectory());
         File blob = new File(thirdNode, blobName);
         assertTrue(blob.exists() && blob.isFile());
-        assertEquals(BLOB1, IOUtils.toString(blob.toURI(), StandardCharsets.UTF_8));
+        assertEquals(BLOBS_WITH_CONTENT.get(BLOB1), IOUtils.toString(blob.toURI(), StandardCharsets.UTF_8));
     }
 
     @Test
     public void allBlobsWithFileIncludePath() throws Exception {
         Path blobs = Files.createTempFile("blobs", "txt");
-        IOUtils.write(BLOB1 + "\n" + BLOB2, Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        IOUtils.write(String.join("\n", BLOBS_WITH_CONTENT.keySet()),
+                Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
         DataStoreCopyCommand cmd = new DataStoreCopyCommand();
         cmd.execute(
                 "--source-repo",
@@ -140,14 +150,15 @@ public class DataStoreCopyCommandTest {
         );
 
         try (Stream<Path> files = Files.walk(outDir.getRoot().toPath()).filter(p -> p.toFile().isFile())) {
-            assertEquals(2, files.count());
+            assertEquals(3, files.count());
         }
     }
 
     @Test
     public void allBlobsPlusMissingOne() throws Exception {
         Path blobs = Files.createTempFile("blobs", "txt");
-        IOUtils.write(BLOB1 + "\n" + BLOB2 + "\n" + "foo", Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        IOUtils.write(String.join("\n", BLOBS_WITH_CONTENT.keySet()) + "\n" + "foo",
+                Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
         DataStoreCopyCommand cmd = new DataStoreCopyCommand();
         cmd.execute(
                 "--source-repo",
@@ -161,7 +172,7 @@ public class DataStoreCopyCommandTest {
         );
 
         try (Stream<Path> files = Files.walk(outDir.getRoot().toPath()).filter(p -> p.toFile().isFile())) {
-            assertEquals(2, files.count());
+            assertEquals(3, files.count());
         }
     }
 
@@ -185,7 +196,8 @@ public class DataStoreCopyCommandTest {
     @Test
     public void allBlobsPlusMissingOneWithFailOnError() throws Exception {
         Path blobs = Files.createTempFile("blobs", "txt");
-        IOUtils.write(BLOB1 + "\n" + BLOB2 + "\n" + "foo", Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        IOUtils.write(String.join("\n", BLOBS_WITH_CONTENT.keySet()) + "\n" + "foo",
+                Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
         DataStoreCopyCommand cmd = new DataStoreCopyCommand();
         assertThrows(RuntimeException.class, () -> cmd.execute(
                 "--source-repo",
@@ -212,16 +224,63 @@ public class DataStoreCopyCommandTest {
                 "--out-dir",
                 outDir.getRoot().getAbsolutePath()
         );
-        assertEquals(Joiner.on(File.separator).join(outDir.getRoot().getAbsolutePath(), "88",
-                        "97", "b9","8897b9025dc534d4a9fa5920569b373cd714c8cfe5d030ca3f5edb25004894a5"),
+        assertEquals(Joiner.on(File.separator).join(outDir.getRoot().getAbsolutePath(), "29",
+                        "0F", "49","290F493C44F5D63D06B374D0A5ABD292FAE38B92CAB2FAE5EFEFE1B0E9347F56"),
                 cmd.getDestinationFromId(BLOB1)
         );
     }
 
+    @Test
+    public void allBlobsWithBogusChecksumAlgorithm() throws Exception {
+        Path blobs = Files.createTempFile("blobs", "txt");
+        IOUtils.write(String.join("\n", BLOBS_WITH_CONTENT.keySet()),
+                Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        assertThrows(RuntimeException.class, () -> cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--file-include-path",
+                blobs.toString(),
+                "--sas-token",
+                container.generateSharedAccessSignature(policy(EnumSet.of(READ, LIST)), null),
+                "--out-dir",
+                outDir.getRoot().getAbsolutePath(),
+                "--checksum",
+                "SHA-foo"
+        ));
+    }
+
+    @Test
+    public void allBlobsWithChecksum() throws Exception {
+        Path blobs = Files.createTempFile("blobs", "txt");
+        IOUtils.write(String.join("\n", BLOBS_WITH_CONTENT.keySet()),
+                Files.newOutputStream(blobs.toFile().toPath()), StandardCharsets.UTF_8);
+        DataStoreCopyCommand cmd = new DataStoreCopyCommand();
+        cmd.execute(
+                "--source-repo",
+                container.getUri().toURL().toString(),
+                "--file-include-path",
+                blobs.toString(),
+                "--sas-token",
+                container.generateSharedAccessSignature(policy(EnumSet.of(READ, LIST)), null),
+                "--out-dir",
+                outDir.getRoot().getAbsolutePath(),
+                "--checksum",
+                "SHA-256"
+        );
+
+        try (Stream<Path> files = Files.walk(outDir.getRoot().toPath()).filter(p -> p.toFile().isFile())) {
+            assertEquals(
+                    Set.of(Path.of(cmd.getDestinationFromId(BLOB1)).getFileName().toString(),
+                            Path.of(cmd.getDestinationFromId(BLOB2)).getFileName().toString()),
+                    files.map(f -> f.getFileName().toString()).collect(Collectors.toSet()));
+        }
+    }
+
     private CloudBlobContainer createBlobContainer() throws Exception {
         container = AZURITE.getContainer("blobstore");
-        for (String blob : BLOBS) {
-            container.getBlockBlobReference(blob).uploadText(blob);
+        for (Map.Entry<String, String> blob : BLOBS_WITH_CONTENT.entrySet()) {
+            container.getBlockBlobReference(blob.getKey()).uploadText(blob.getValue());
         }
         return container;
     }


### PR DESCRIPTION
Performance tests executed with 1230 blobs (different sizes) for a total size of 22GB. The results are the median values across 10 executions.

|   |      Time  (sec)   |  Speed (MB/sec) |
|:---------|-------------:|------:|
| 1.46 |  55.30482299 | 379|
| 1.52-SNAPSHOT (8kb) | 58.71267322  |  357|
| 1.52-SNAPSHOT (8kb, SHA-256) | 54.7603119  |  383|
| 1.52-SNAPSHOT (16kb) | 56.6716487  |  370|
| 1.52-SNAPSHOT (16kb, SHA-256) | 54.61657572  |  384|
| 1.52-SNAPSHOT (32kb) | 56.27616847  |  373|
| 1.52-SNAPSHOT (32kb, SHA-256) | 56.10280934  |  374|
| 1.52-SNAPSHOT (64kb) | 57.10943102  |  367|
| 1.52-SNAPSHOT (64kb, SHA-256) | 55.37924649  |  379|
| 1.52-SNAPSHOT (87380b) | 56.00229955  |  374|
| 1.52-SNAPSHOT (87380b, SHA-256) | 53.95955522  |  389|

[OAK-10171.xlsx](https://github.com/apache/jackrabbit-oak/files/11140256/OAK-10171.xlsx)
