### PR TITLE
OAK-10182: use streams to avoid buffer positioning issues leading to corrupted files

### DIFF
--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCopyCommandTest.java
@@ -274,6 +274,11 @@ public class DataStoreCopyCommandTest {
                             Path.of(cmd.getDestinationFromId(BLOB2)).getFileName().toString()),
                     files.map(f -> f.getFileName().toString()).collect(Collectors.toSet()));
         }
+
+        assertEquals(BLOBS_WITH_CONTENT.get(BLOB1),
+                IOUtils.toString(Path.of(cmd.getDestinationFromId(BLOB1)).toUri(), StandardCharsets.UTF_8));
+        assertEquals(BLOBS_WITH_CONTENT.get(BLOB2),
+                IOUtils.toString(Path.of(cmd.getDestinationFromId(BLOB2)).toUri(), StandardCharsets.UTF_8));
     }
 
     private CloudBlobContainer createBlobContainer() throws Exception {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexAggregationNtFileTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexAggregationNtFileTest.java
@@ -44,7 +44,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.JcrConstants.JCR_CONTENT;
 import static org.apache.jackrabbit.JcrConstants.JCR_DATA;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
@@ -99,8 +98,6 @@ public class ElasticIndexAggregationNtFileTest extends ElasticAbstractQueryTest 
 
     /**
      * convenience method for printing on logs the currently registered node types.
-     *
-     * @param builder
      */
     private static void printNodeTypes(NodeBuilder builder) {
         if (LOG.isDebugEnabled()) {
@@ -117,6 +114,7 @@ public class ElasticIndexAggregationNtFileTest extends ElasticAbstractQueryTest 
     protected void createTestIndexNode() throws Exception {
         Tree index = root.getTree("/");
         Tree indexDefn = createTestIndexNode(index, ElasticIndexDefinition.TYPE_ELASTICSEARCH);
+        indexDefn.setProperty(ElasticIndexDefinition.FAIL_ON_ERROR, false);
         indexDefn.setProperty(FulltextIndexConstants.COMPAT_MODE, IndexFormatVersion.V2.getVersion());
         Tree includeNtFileContent = indexDefn.addChild(FulltextIndexConstants.AGGREGATES)
                 .addChild(NT_TEST_ASSET).addChild("include10");
@@ -130,7 +128,6 @@ public class ElasticIndexAggregationNtFileTest extends ElasticAbstractQueryTest 
         setTraversalEnabled(false);
         final String statement = "//element(*, test:Asset)[ " +
                 "jcr:contains(jcr:content/renditions/dam.text.txt/jcr:content, 'quick') ]";
-        List<String> expected = newArrayList();
         Tree content = root.getTree("/").addChild("content");
         Tree page = content.addChild("asset");
         page.setProperty(JCR_PRIMARYTYPE, NT_TEST_ASSET, NAME);
@@ -144,10 +141,9 @@ public class ElasticIndexAggregationNtFileTest extends ElasticAbstractQueryTest 
         resource.setProperty(binaryProperty(JCR_DATA,
                 "the quick brown fox jumps over the lazy dog."));
         root.commit();
-        expected.add("/content/asset");
 
         assertEventually(()-> {
-            assertQuery(statement, "xpath", expected);
+            assertQuery(statement, "xpath", List.of("/content/asset"));
         });
     }
 }


### PR DESCRIPTION
#886 introduced a regression when checksum validation is enabled. The buffer mark is wrongly positioned when the destination file gets written leading to corrupted files. This also explains why the performance results with and without checksum validation were similar.

This PR uses streams and byte arrays instead of channels and ByteBuffers to perform write file operations and checksum. When the latter is enabled, the performance degradation is around 15%. 
