### PR TITLE
OAK-10147: Many move operations may consume a lot of memory

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -20,6 +20,7 @@ import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyMap;
+import static org.apache.jackrabbit.oak.spi.toggle.Feature.newFeature;
 import static org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils.registerMBean;
 
 import java.io.Closeable;
@@ -580,7 +581,7 @@ public class Oak {
         }
 
         if (queryEngineSettings != null) {
-            Feature prefetchFeature = Feature.newFeature(QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES, whiteboard);
+            Feature prefetchFeature = newFeature(QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES, whiteboard);
             LOG.info("Registered Prefetch feature: " + QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES);
             closer.register(prefetchFeature);
             queryEngineSettings.setPrefetchFeature(prefetchFeature);
@@ -801,7 +802,8 @@ public class Oak {
                 queryEngineSettings.unwrap(),
                 indexProvider,
                 securityProvider,
-                new AggregatingDescriptors(t)) {
+                new AggregatingDescriptors(t),
+                newFeature("OAK-10147", whiteboard)) {
             @Override
             public void close() throws IOException {
                 super.close();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ContentRepositoryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ContentRepositoryImpl.java
@@ -100,6 +100,7 @@ import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.spi.descriptors.GenericDescriptors;
 import org.apache.jackrabbit.oak.OakVersion;
+import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -116,6 +117,7 @@ public class ContentRepositoryImpl implements ContentRepository, Closeable {
     private final QueryIndexProvider indexProvider;
     private final QueryEngineSettings queryEngineSettings;
     private final Descriptors baseDescriptors;
+    private final Feature forceApplyPendingMoves;
 
     private GenericDescriptors descriptors;
     
@@ -128,6 +130,8 @@ public class ContentRepositoryImpl implements ContentRepository, Closeable {
      * @param defaultWorkspaceName the default workspace name;
      * @param indexProvider        index provider
      * @param securityProvider     The configured security provider.
+     * @param baseDescriptors      the base descriptors.
+     * @param forceApplyPendingMoves optional feature flag to force apply pending moves.
      */
     public ContentRepositoryImpl(@NotNull NodeStore nodeStore,
                                  @NotNull CommitHook commitHook,
@@ -135,7 +139,8 @@ public class ContentRepositoryImpl implements ContentRepository, Closeable {
                                  QueryEngineSettings queryEngineSettings,
                                  @Nullable QueryIndexProvider indexProvider,
                                  @NotNull SecurityProvider securityProvider,
-                                 @Nullable Descriptors baseDescriptors) {
+                                 @Nullable Descriptors baseDescriptors,
+                                 @Nullable Feature forceApplyPendingMoves) {
         this.nodeStore = checkNotNull(nodeStore);
         this.commitHook = checkNotNull(commitHook);
         this.defaultWorkspaceName = checkNotNull(defaultWorkspaceName);
@@ -143,6 +148,7 @@ public class ContentRepositoryImpl implements ContentRepository, Closeable {
         this.queryEngineSettings = queryEngineSettings != null ? queryEngineSettings : new QueryEngineSettings();
         this.indexProvider = indexProvider != null ? indexProvider : new CompositeQueryIndexProvider();
         this.baseDescriptors = baseDescriptors;
+        this.forceApplyPendingMoves = forceApplyPendingMoves;
     }
 
     @NotNull
@@ -163,7 +169,7 @@ public class ContentRepositoryImpl implements ContentRepository, Closeable {
         loginContext.login();
 
         return new ContentSessionImpl(loginContext, securityProvider, workspaceName, nodeStore,
-                commitHook, queryEngineSettings, indexProvider);
+                commitHook, queryEngineSettings, indexProvider, forceApplyPendingMoves);
     }
 
     @NotNull

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ContentSessionImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ContentSessionImpl.java
@@ -33,7 +33,9 @@ import org.apache.jackrabbit.oak.spi.security.SecurityProvider;
 import org.apache.jackrabbit.oak.spi.security.authentication.AuthInfoImpl;
 import org.apache.jackrabbit.oak.spi.security.authentication.LoginContext;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +58,7 @@ class ContentSessionImpl implements ContentSession {
     private final CommitHook hook;
     private final QueryEngineSettings queryEngineSettings;
     private final QueryIndexProvider indexProvider;
+    private final Feature forceApplyPendingMoves;
     private final String sessionName;
 
     /**
@@ -70,7 +73,8 @@ class ContentSessionImpl implements ContentSession {
                               @NotNull NodeStore store,
                               @NotNull CommitHook hook,
                               QueryEngineSettings queryEngineSettings,
-                              @NotNull QueryIndexProvider indexProvider) {
+                              @NotNull QueryIndexProvider indexProvider,
+                              @Nullable Feature forceApplyPendingMoves) {
         this.loginContext = loginContext;
         this.securityProvider = securityProvider;
         this.workspaceName = workspaceName;
@@ -78,6 +82,7 @@ class ContentSessionImpl implements ContentSession {
         this.hook = hook;
         this.queryEngineSettings = queryEngineSettings;
         this.indexProvider = indexProvider;
+        this.forceApplyPendingMoves = forceApplyPendingMoves;
         this.sessionName = "session-" + SESSION_COUNTER.incrementAndGet();
     }
 
@@ -103,7 +108,8 @@ class ContentSessionImpl implements ContentSession {
     public Root getLatestRoot() {
         checkLive();
         return new MutableRoot(store, hook, workspaceName, loginContext.getSubject(),
-                securityProvider, queryEngineSettings, indexProvider, this);
+                securityProvider, queryEngineSettings, indexProvider,
+                forceApplyPendingMoves, this);
     }
 
     //-----------------------------------------------------------< Closable >---

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableRoot.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableRoot.java
@@ -18,6 +18,7 @@
  */
 package org.apache.jackrabbit.oak.core;
 
+import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.synchronizedMap;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
@@ -31,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.WeakHashMap;
 
 import javax.security.auth.Subject;
@@ -126,7 +129,7 @@ class MutableRoot implements Root, PermissionAware {
      */
     private final MoveTracker moveTracker = new MoveTracker();
 
-    private final Map<MutableTree, Object> trees = synchronizedMap(new WeakHashMap<>());
+    private final Set<MutableTree> trees = newSetFromMap(synchronizedMap(new WeakHashMap<>()));
 
     /**
      * Number of {@link #updated} occurred.
@@ -376,7 +379,7 @@ class MutableRoot implements Root, PermissionAware {
      */
     void created(MutableTree t) {
         if (forceApplyPendingMoves()) {
-            trees.put(t, null);
+            trees.add(t);
         }
     }
 
@@ -407,7 +410,7 @@ class MutableRoot implements Root, PermissionAware {
 
     private void applyPendingMovesToKnownTrees() {
         if (forceApplyPendingMoves()) {
-            trees.forEach((t, o) -> { if (t != null) t.getName(); });
+            trees.stream().filter(Objects::nonNull).forEach(MutableTree::getName);
         }
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableTree.java
@@ -66,6 +66,7 @@ final class MutableTree extends AbstractMutableTree {
         this.name = checkNotNull(name);
         this.nodeBuilder = nodeBuilder;
         this.pendingMoves = checkNotNull(pendingMoves);
+        this.root.created(this);
     }
 
     //------------------------------------------------------------< AbstractMutableTree >---

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/SystemRoot.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/SystemRoot.java
@@ -72,7 +72,7 @@ public class SystemRoot extends MutableRoot {
         this(store, hook, workspaceName, securityProvider, queryEngineSettings, indexProvider,
                 new ContentSessionImpl(
                         LOGIN_CONTEXT, securityProvider, workspaceName,
-                        store, hook, queryEngineSettings, indexProvider) {
+                        store, hook, queryEngineSettings, indexProvider, null) {
                     @NotNull
                     @Override
                     public Root getLatestRoot() {
@@ -90,7 +90,7 @@ public class SystemRoot extends MutableRoot {
             @NotNull QueryIndexProvider indexProvider,
             @NotNull ContentSessionImpl session) {
         super(store, hook, workspaceName, SystemSubject.INSTANCE,
-                securityProvider, queryEngineSettings, indexProvider, session);
+                securityProvider, queryEngineSettings, indexProvider, null, session);
     }
     
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MoveTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MoveTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.core;
+
+import java.lang.reflect.Field;
+
+import javax.jcr.AccessDeniedException;
+
+import org.apache.jackrabbit.oak.AbstractSecurityTest;
+import org.apache.jackrabbit.oak.api.Root;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
+import static org.apache.jackrabbit.oak.commons.PathUtils.concat;
+import static org.apache.jackrabbit.oak.plugins.tree.TreeUtil.addChild;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests related to OAK-10147
+ */
+public class MoveTest extends AbstractSecurityTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MoveTest.class);
+
+    @Test
+    public void move() throws Exception {
+        Root r = adminSession.getLatestRoot();
+        Tree base = getOrCreateTree(r.getTree("/"), "/content/en/foo");
+        Tree unrelated = getOrCreateTree(base, "unrelated");
+        Tree source = getOrCreateTree(base, "source");
+        Tree target = getOrCreateTree(base, "target");
+        Tree n = getOrCreateTree(source, "node");
+        r.commit();
+
+        String basePath = base.getPath();
+        String unrelatedPath = unrelated.getPath();
+        String sourcePath = concat(source.getPath(), n.getName());
+        String targetPath = concat(target.getPath(), n.getName());
+        String nodePath = n.getPath();
+
+        for (int i = 0; i < 100; i++) {
+            assertTrue(r.move(sourcePath, targetPath));
+            r.commit();
+            assertTrue(r.move(targetPath, sourcePath));
+            r.commit();
+            source.getPath();
+            target.getPath();
+        }
+
+        LOG.info("pendingMoves for " + basePath + ": " + countMoves(base));
+        LOG.info("pendingMoves for " + unrelatedPath + ": " + countMoves(unrelated));
+        LOG.info("pendingMoves for " + nodePath + ": " + countMoves(n));
+
+        // number of pendingMoves drops to 1 after a read operation
+        unrelated.getPath();
+        assertEquals(1, countMoves(unrelated));
+    }
+
+    @Test
+    public void readMany() throws Exception {
+        Root r = adminSession.getLatestRoot();
+        Tree t = r.getTree("/");
+        // warming up
+        for (int i = 0; i < 100_000; i++) {
+            getOrCreateTree(t, "/content/en/foo/bar");
+        }
+        long time = System.currentTimeMillis();
+        // measure
+        for (int i = 0; i < 1_000_000; i++) {
+            getOrCreateTree(t, "/content/en/foo/bar");
+        }
+        time = System.currentTimeMillis() - time;
+        LOG.info("time to read: " + time + " ms.");
+    }
+
+    private Tree getOrCreateTree(Tree t, String path)
+            throws AccessDeniedException {
+        for (String name : PathUtils.elements(path)) {
+            if (t.hasChild(name)) {
+                t = t.getChild(name);
+            } else {
+                t = addChild(t, name, NT_UNSTRUCTURED);
+            }
+        }
+        return t;
+    }
+
+    private int countMoves(Tree t) throws Exception {
+        Field pendingMoves = MutableTree.class.getDeclaredField("pendingMoves");
+        pendingMoves.setAccessible(true);
+        return countMoves(pendingMoves.get(t));
+    }
+
+    private int countMoves(Object move) throws Exception {
+        Field m = MutableRoot.Move.class.getDeclaredField("next");
+        m.setAccessible(true);
+        int i = 0;
+        while (move != null) {
+            i++;
+            move = m.get(move);
+        }
+        return i;
+    }
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MoveTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MoveTest.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.AbstractSecurityTest;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.core.MutableRoot.Move;
 import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
 import org.apache.jackrabbit.oak.spi.whiteboard.Tracker;
 import org.junit.Before;
@@ -31,6 +32,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.commons.lang3.reflect.FieldUtils.getDeclaredField;
+import static org.apache.commons.lang3.reflect.FieldUtils.readDeclaredField;
 import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
 import static org.apache.jackrabbit.oak.commons.PathUtils.concat;
 import static org.apache.jackrabbit.oak.plugins.tree.TreeUtil.addChild;
@@ -118,14 +121,11 @@ public class MoveTest extends AbstractSecurityTest {
     }
 
     private int countMoves(Tree t) throws Exception {
-        Field pendingMoves = MutableTree.class.getDeclaredField("pendingMoves");
-        pendingMoves.setAccessible(true);
-        return countMoves(pendingMoves.get(t));
+        return countMoves(readDeclaredField(t, "pendingMoves", true));
     }
 
     private int countMoves(Object move) throws Exception {
-        Field m = MutableRoot.Move.class.getDeclaredField("next");
-        m.setAccessible(true);
+        Field m = getDeclaredField(Move.class, "next", true);
         int i = 0;
         while (move != null) {
             i++;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MoveTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MoveTest.java
@@ -24,6 +24,9 @@ import org.apache.jackrabbit.oak.AbstractSecurityTest;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
+import org.apache.jackrabbit.oak.spi.whiteboard.Tracker;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +43,16 @@ import static org.junit.Assert.assertTrue;
 public class MoveTest extends AbstractSecurityTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(MoveTest.class);
+
+    @Before
+    public void setFeatureToggle() {
+        Tracker<FeatureToggle> toggleTracker = whiteboard.track(FeatureToggle.class);
+        for (FeatureToggle ft : toggleTracker.getServices()) {
+            if ("OAK-10147".equals(ft.getName())) {
+                ft.setEnabled(true);
+            }
+        }
+    }
 
     @Test
     public void move() throws Exception {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MutableRootTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/core/MutableRootTest.java
@@ -23,7 +23,6 @@ import javax.security.auth.Subject;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.commons.LazyValue;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
@@ -81,7 +80,7 @@ public class MutableRootTest {
         when(cs.toString()).thenReturn("contentSession");
         when(cs.getAuthInfo()).thenReturn(AuthInfoImpl.EMPTY);
         when(cs.getWorkspaceName()).thenReturn("default");
-        root = new MutableRoot(store, new EmptyHook(), "default", new Subject(), sp, null, null, cs);
+        root = new MutableRoot(store, new EmptyHook(), "default", new Subject(), sp, null, null, null, cs);
     }
 
     /**


### PR DESCRIPTION
Quick and dirty proof of concept. Pending moves are applied to all known MutableTrees on commit. Keeping track of MutableTrees with weak references comes with overhead and should probably go behind a feature flag.