### PR TITLE
OAK-10249: Reduce logging in the datastore check and gc process

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/MarkSweepGarbageCollector.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/MarkSweepGarbageCollector.java
@@ -421,7 +421,7 @@ public class MarkSweepGarbageCollector implements BlobGarbageCollector {
             lineIterator.forEachRemaining(line -> {
                 String id = line.split(DELIM)[0];
                 long length = DataStoreBlobStore.BlobId.of(id).getLength();
-                LOG.info("Blob {} has size {}", id, length);
+                LOG.debug("Blob {} has size {}", id, length);
 
                 stats.getCollector().updateNumBlobReferences(1);
 
@@ -662,7 +662,7 @@ public class MarkSweepGarbageCollector implements BlobGarbageCollector {
                                     saveBatchToFile(idBatch, writer);
                                 }
 
-                                if (count.get() % getBatchCount() == 0) {
+                                if (count.get() > 0 && count.get() % getBatchCount() == 0) {
                                     LOG.info("Collected ({}) blob references", count.get());
                                 }
                             } catch (Exception e) {

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/FileIOUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/FileIOUtils.java
@@ -257,7 +257,7 @@ public final class FileIOUtils {
                 writeAsLine(writer, transformer.apply(iterator.next()), escape);
                 count++;
                 if (logger != null) {
-                    if (count % 1000 == 0) {
+                    if (count % 100000 == 0) {
                         logger.info(Strings.nullToEmpty(message) + count);
                     }
                 }


### PR DESCRIPTION
- only log sizes for individual files to debug
- log blob ids only at 100k
- ignore in memory blobs as anyways not relevant