### PR TITLE
OAK-10259: oak-core tests running out of memory

### DIFF
--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/AbstractSecurityTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/AbstractSecurityTest.java
@@ -129,10 +129,6 @@ public abstract class AbstractSecurityTest {
             }
             Configuration.setConfiguration(null);
         }
-    }
-
-    @After
-    public void clearMocks() {
         Mockito.framework().clearInlineMocks();
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/AbstractSecurityTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/AbstractSecurityTest.java
@@ -70,6 +70,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mockito;
 
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 
@@ -128,6 +129,11 @@ public abstract class AbstractSecurityTest {
             }
             Configuration.setConfiguration(null);
         }
+    }
+
+    @After
+    public void clearMocks() {
+        Mockito.framework().clearInlineMocks();
     }
 
     protected ContentRepository getContentRepository() {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/user/LoginModuleImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/user/LoginModuleImplTest.java
@@ -86,7 +86,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,7 +105,6 @@ public class LoginModuleImplTest extends AbstractSecurityTest {
     @Override
     public void after() throws Exception {
         try {
-            clearInvocations(monitor);
             if (user != null) {
                 user.remove();
                 root.commit();

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/user/LoginModuleImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/user/LoginModuleImplTest.java
@@ -86,6 +86,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -105,6 +106,7 @@ public class LoginModuleImplTest extends AbstractSecurityTest {
     @Override
     public void after() throws Exception {
         try {
+            clearInvocations(monitor);
             if (user != null) {
                 user.remove();
                 root.commit();


### PR DESCRIPTION
Clear inline mocks at the end of a test