### PR TITLE
OAK-10263 Prevent inconsistent state in TarWriter

### DIFF
--- a/oak-segment-azure/pom.xml
+++ b/oak-segment-azure/pom.xml
@@ -229,7 +229,12 @@
             <version>1.0.9</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
+            <version>5.14.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistence.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistence.java
@@ -48,13 +48,17 @@ import org.slf4j.LoggerFactory;
 
 public class AzurePersistence implements SegmentNodeStorePersistence {
 
-    private static int RETRY_ATTEMPTS = Integer.getInteger("segment.azure.retry.attempts", 5);
+    private static final String RETRY_ATTEMPTS_PROP = "segment.azure.retry.attempts";
+    private static final int DEFAULT_RETRY_ATTEMPTS = 5;
 
-    private static int RETRY_BACKOFF_SECONDS = Integer.getInteger("segment.azure.retry.backoff", 5);
+    private static final String RETRY_BACKOFF_PROP = "segment.azure.retry.backoff";
+    private static final int DEFAULT_RETRY_BACKOFF_SECONDS = 5;
 
-    private static int TIMEOUT_EXECUTION = Integer.getInteger("segment.timeout.execution", 30);
+    private static final String TIMEOUT_EXECUTION_PROP = "segment.timeout.execution";
+    private static final int DEFAULT_TIMEOUT_EXECUTION = 30;
 
-    private static int TIMEOUT_INTERVAL = Integer.getInteger("segment.timeout.interval", 1);
+    private static final String TIMEOUT_INTERVAL_PROP = "segment.timeout.interval";
+    private static final int DEFAULT_TIMEOUT_INTERVAL = 1;
 
     private static final Logger log = LoggerFactory.getLogger(AzurePersistence.class);
 
@@ -65,18 +69,22 @@ public class AzurePersistence implements SegmentNodeStorePersistence {
 
         BlobRequestOptions defaultRequestOptions = segmentStoreDirectory.getServiceClient().getDefaultRequestOptions();
         if (defaultRequestOptions.getRetryPolicyFactory() == null) {
-            if (RETRY_ATTEMPTS > 0) {
-                defaultRequestOptions.setRetryPolicyFactory(new RetryLinearRetry((int) TimeUnit.SECONDS.toMillis(RETRY_BACKOFF_SECONDS), RETRY_ATTEMPTS));
+            int retryAttempts = Integer.getInteger(RETRY_ATTEMPTS_PROP, DEFAULT_RETRY_ATTEMPTS);
+            if (retryAttempts > 0) {
+                Integer retryBackoffSeconds = Integer.getInteger(RETRY_BACKOFF_PROP, DEFAULT_RETRY_BACKOFF_SECONDS);
+                defaultRequestOptions.setRetryPolicyFactory(new RetryLinearRetry((int) TimeUnit.SECONDS.toMillis(retryBackoffSeconds), retryAttempts));
             }
         }
         if (defaultRequestOptions.getMaximumExecutionTimeInMs() == null) {
-            if (TIMEOUT_EXECUTION > 0) {
-                defaultRequestOptions.setMaximumExecutionTimeInMs((int) TimeUnit.SECONDS.toMillis(TIMEOUT_EXECUTION));
+            int timeoutExecution = Integer.getInteger(TIMEOUT_EXECUTION_PROP, DEFAULT_TIMEOUT_EXECUTION);
+            if (timeoutExecution > 0) {
+                defaultRequestOptions.setMaximumExecutionTimeInMs((int) TimeUnit.SECONDS.toMillis(timeoutExecution));
             }
         }
         if (defaultRequestOptions.getTimeoutIntervalInMs() == null) {
-            if (TIMEOUT_INTERVAL > 0) {
-                defaultRequestOptions.setTimeoutIntervalInMs((int) TimeUnit.SECONDS.toMillis(TIMEOUT_INTERVAL));
+            int timeoutInterval = Integer.getInteger(TIMEOUT_INTERVAL_PROP, DEFAULT_TIMEOUT_INTERVAL);
+            if (timeoutInterval > 0) {
+                defaultRequestOptions.setTimeoutIntervalInMs((int) TimeUnit.SECONDS.toMillis(timeoutInterval));
             }
         }
     }

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureSegmentArchiveWriter.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureSegmentArchiveWriter.java
@@ -31,6 +31,7 @@ import com.microsoft.azure.storage.blob.CloudBlobDirectory;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
 
 import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.azure.util.Retrier;
 import org.apache.jackrabbit.oak.segment.remote.AbstractRemoteSegmentArchiveWriter;
 import org.apache.jackrabbit.oak.segment.remote.RemoteSegmentArchiveEntry;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
@@ -39,6 +40,11 @@ import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
 public class AzureSegmentArchiveWriter extends AbstractRemoteSegmentArchiveWriter {
 
     private final CloudBlobDirectory archiveDirectory;
+
+    private final Retrier retrier = Retrier.withParams(
+            Integer.getInteger("azure.segment.archive.writer.retries.max", 16),
+            Integer.getInteger("azure.segment.archive.writer.retries.intervalMs", 5000)
+    );
 
     public AzureSegmentArchiveWriter(CloudBlobDirectory archiveDirectory, IOMonitor ioMonitor, FileStoreMonitor monitor) {
         super(ioMonitor, monitor);
@@ -82,20 +88,24 @@ public class AzureSegmentArchiveWriter extends AbstractRemoteSegmentArchiveWrite
 
     @Override
     protected void doWriteDataFile(byte[] data, String extension) throws IOException {
-        try {
-            getBlob(getName() + extension).uploadFromByteArray(data, 0, data.length);
-        } catch (StorageException e) {
-            throw new IOException(e);
-        }
+        retrier.execute(() -> {
+            try {
+                getBlob(getName() + extension).uploadFromByteArray(data, 0, data.length);
+            } catch (StorageException e) {
+                throw new IOException(e);
+            }
+        });
     }
 
     @Override
     protected void afterQueueClosed() throws IOException {
-        try {
-            getBlob("closed").uploadFromByteArray(new byte[0], 0, 0);
-        } catch (StorageException e) {
-            throw new IOException(e);
-        }
+        retrier.execute(() -> {
+            try {
+                getBlob("closed").uploadFromByteArray(new byte[0], 0, 0);
+            } catch (StorageException e) {
+                throw new IOException(e);
+            }
+        });
     }
 
     @Override

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/SegmentCopy.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/SegmentCopy.java
@@ -19,7 +19,6 @@
 package org.apache.jackrabbit.oak.segment.azure.tool;
 
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
-import static org.apache.jackrabbit.oak.segment.azure.tool.SegmentStoreMigrator.runWithRetry;
 import static org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.newSegmentNodeStorePersistence;
 import static org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.printMessage;
 import static org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.printableStopwatch;
@@ -46,6 +45,7 @@ import java.util.concurrent.Future;
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.segment.azure.tool.SegmentStoreMigrator.Segment;
 import org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.SegmentStoreType;
+import org.apache.jackrabbit.oak.segment.azure.util.Retrier;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitorAdapter;
@@ -236,6 +236,8 @@ public class SegmentCopy {
 
     private static final int READ_THREADS = 20;
 
+    private static final Retrier RETRIER = Retrier.withParams(16, 5000);
+
     private final String source;
 
     private final String destination;
@@ -306,11 +308,11 @@ public class SegmentCopy {
 
                     List<Future<Segment>> futures = new ArrayList<>();
                     for (SegmentArchiveEntry entry : reader.listSegments()) {
-                        futures.add(executor.submit(() -> runWithRetry(() -> {
+                        futures.add(executor.submit(() -> RETRIER.execute(() -> {
                             Segment segment = new Segment(entry);
                             segment.read(reader);
                             return segment;
-                        }, 16, 5)));
+                        })));
                     }
 
                     File directory = new File(destination);
@@ -318,7 +320,7 @@ public class SegmentCopy {
 
                     for (Future<Segment> future : futures) {
                         Segment segment = future.get();
-                        runWithRetry(() -> {
+                        RETRIER.execute(() -> {
                             final byte[] array = segment.data.array();
                             String segmentId = new UUID(segment.entry.getMsb(), segment.entry.getLsb()).toString();
                             File segmentFile = new File(directory, segmentId);
@@ -348,8 +350,7 @@ public class SegmentCopy {
                                             segmentId, i);
                                 }
                             }
-                            return null;
-                        }, 16, 5);
+                        });
                     }
 
                     count++;

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/util/Retrier.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/util/Retrier.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.segment.azure.util;
+
+import org.apache.jackrabbit.oak.segment.spi.RepositoryNotReachableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class Retrier {
+    private static final Logger log = LoggerFactory.getLogger(Retrier.class);
+
+    private final int maxAttempts;
+    private final int intervalMs;
+
+    Retrier(int maxAttempts, int intervalMs) {
+        this.maxAttempts = maxAttempts;
+        this.intervalMs = intervalMs;
+    }
+
+    public static Retrier withParams(int maxAttempts, int intervalMs) {
+        return new Retrier(maxAttempts, intervalMs);
+    }
+
+    public <T> T execute(ThrowingSupplier<T> supplier) throws IOException {
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return supplier.get();
+            } catch (Exception e) {
+                // if last attempt fails or if unexpected exception, exit by throwing the last exception
+                if (attempt == maxAttempts) {
+                    log.error("Can't execute the operation (attempt {}/{}). Reason: {}", attempt, maxAttempts, e.getMessage());
+                    throw e;
+                } else if (!(e instanceof IOException || e instanceof RepositoryNotReachableException)) {
+                    throw new RuntimeException("Unexpected exception while executing the operation", e);
+                }
+                log.error("Can't execute the operation (attempt {}/{}). Retrying in {} ms...", attempt, maxAttempts, intervalMs, e);
+            }
+            try {
+                Thread.sleep(intervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // Restore the interrupted status
+                throw new RuntimeException("Retries interrupted");
+            }
+        }
+        throw new AssertionError("Should never reach here");
+    }
+
+    public void execute(ThrowingRunnable runnable) throws IOException {
+        execute(() -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    @FunctionalInterface
+    public interface ThrowingSupplier<T> {
+        T get() throws IOException;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+        void run() throws IOException;
+    }
+}

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureSegmentArchiveWriterTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureSegmentArchiveWriterTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.segment.azure;
+
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.BinaryBody;
+import org.mockserver.model.HttpRequest;
+import shaded_package.org.apache.http.client.utils.URIBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.verify.VerificationTimes.exactly;
+
+public class AzureSegmentArchiveWriterTest {
+    public static final String BASE_PATH = "/devstoreaccount1/oak-test";
+    public static final int MAX_ATTEMPTS = 3;
+
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(this);
+
+    @SuppressWarnings("unused")
+    private MockServerClient mockServerClient;
+
+    private CloudBlobContainer container;
+
+    @Before
+    public void setUp() throws Exception {
+        container = createCloudBlobContainer();
+
+        System.setProperty("azure.segment.archive.writer.retries.intervalMs", "100");
+        System.setProperty("azure.segment.archive.writer.retries.max", Integer.toString(MAX_ATTEMPTS));
+
+        // Disable Azure SDK own retry mechanism used by AzureSegmentArchiveWriter
+        System.setProperty("segment.azure.retry.attempts", "0");
+        System.setProperty("segment.timeout.execution", "1");
+    }
+
+    @Test
+    public void retryWhenFailureOnWriteBinaryReferences_eventuallySucceed() throws Exception {
+        SegmentArchiveWriter writer = createSegmentArchiveWriter();
+        writeAndFlushSegment(writer);
+
+        HttpRequest writeBinaryReferencesRequest = getWriteBinaryReferencesRequest();
+        // fail twice
+        mockServerClient
+                .when(writeBinaryReferencesRequest, Times.exactly(2))
+                .respond(response().withStatusCode(500));
+        // then succeed
+        mockServerClient
+                .when(writeBinaryReferencesRequest, Times.once())
+                .respond(response().withStatusCode(201));
+
+        writer.writeBinaryReferences(new byte[10]);
+
+        mockServerClient.verify(writeBinaryReferencesRequest, exactly(MAX_ATTEMPTS));
+    }
+
+    @Test
+    public void retryWhenFailureOnWriteGraph_eventuallySucceed() throws Exception {
+        SegmentArchiveWriter writer = createSegmentArchiveWriter();
+        writeAndFlushSegment(writer);
+
+        HttpRequest writeGraphRequest = getWriteGraphRequest();
+        // fail twice
+        mockServerClient
+                .when(writeGraphRequest, Times.exactly(2))
+                .respond(response().withStatusCode(500));
+        // then succeed
+        mockServerClient
+                .when(writeGraphRequest, Times.once())
+                .respond(response().withStatusCode(201));
+
+        writer.writeGraph(new byte[10]);
+
+        mockServerClient.verify(writeGraphRequest, exactly(MAX_ATTEMPTS));
+    }
+
+    @Test
+    public void retryWhenFailureOnClose_eventuallySucceed() throws Exception {
+        SegmentArchiveWriter writer = createSegmentArchiveWriter();
+        writeAndFlushSegment(writer);
+
+        HttpRequest closeArchiveRequest = getCloseArchiveRequest();
+        // fail twice
+        mockServerClient
+                .when(closeArchiveRequest, Times.exactly(2))
+                .respond(response().withStatusCode(500));
+        // then succeed
+        mockServerClient
+                .when(closeArchiveRequest, Times.once())
+                .respond(response().withStatusCode(201));
+
+        writer.close();
+
+        mockServerClient.verify(closeArchiveRequest, exactly(MAX_ATTEMPTS));
+    }
+
+    @Test
+    public void retryWhenFailureOnClose_failAfterLastRetryAttempt() throws Exception {
+        SegmentArchiveWriter writer = createSegmentArchiveWriter();
+        writeAndFlushSegment(writer);
+
+        HttpRequest closeArchiveRequest = getCloseArchiveRequest();
+        // always fail
+        mockServerClient
+                .when(closeArchiveRequest, Times.unlimited())
+                .respond(response().withStatusCode(500));
+
+
+        assertThrows(IOException.class, writer::close);
+
+        mockServerClient.verify(closeArchiveRequest, exactly(MAX_ATTEMPTS));
+    }
+
+
+    private void writeAndFlushSegment(SegmentArchiveWriter writer) throws IOException {
+        expectWriteRequests();
+        UUID u = UUID.randomUUID();
+        writer.writeSegment(u.getMostSignificantBits(), u.getLeastSignificantBits(), new byte[10], 0, 10, 0, 0, false);
+        writer.flush();
+    }
+
+    private void expectWriteRequests() {
+        mockServerClient
+                .when(getUploadSegmentDataRequest(), Times.once())
+                .respond(response().withStatusCode(201));
+
+        mockServerClient
+                .when(getUploadSegmentMetadataRequest(), Times.once())
+                .respond(response().withStatusCode(200));
+    }
+
+    @NotNull
+    private SegmentArchiveWriter createSegmentArchiveWriter() throws URISyntaxException, IOException {
+        SegmentArchiveManager manager = new AzurePersistence(container.getDirectoryReference("oak")).createArchiveManager(false, false, new IOMonitorAdapter(), new FileStoreMonitorAdapter(), new RemoteStoreMonitorAdapter());
+        SegmentArchiveWriter writer = manager.create("data00000a.tar");
+        return writer;
+    }
+
+    private static HttpRequest getCloseArchiveRequest() {
+        return request()
+                .withMethod("PUT")
+                .withPath(BASE_PATH + "/oak/data00000a.tar/closed");
+    }
+
+    private static HttpRequest getWriteBinaryReferencesRequest() {
+        return request()
+                .withMethod("PUT")
+                .withPath(BASE_PATH + "/oak/data00000a.tar/data00000a.tar.brf");
+    }
+
+    private static HttpRequest getWriteGraphRequest() {
+        return request()
+                .withMethod("PUT")
+                .withPath(BASE_PATH + "/oak/data00000a.tar/data00000a.tar.gph");
+    }
+
+    private static HttpRequest getUploadSegmentMetadataRequest() {
+        return request()
+                .withMethod("PUT")
+                .withPath(BASE_PATH + "/oak/data00000a.tar/.*")
+                .withQueryStringParameter("comp", "metadata");
+    }
+
+    private static HttpRequest getUploadSegmentDataRequest() {
+        return request()
+                .withMethod("PUT")
+                .withPath(BASE_PATH + "/oak/data00000a.tar/.*")
+                .withBody(new BinaryBody(new byte[10]));
+    }
+
+    @NotNull
+    private CloudBlobContainer createCloudBlobContainer() throws URISyntaxException, StorageException {
+        URI uri = new URIBuilder()
+                .setScheme("http")
+                .setHost(mockServerClient.remoteAddress().getHostName())
+                .setPort(mockServerClient.remoteAddress().getPort())
+                .setPath(BASE_PATH)
+                .build();
+
+        return new CloudBlobContainer(uri);
+    }
+}

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureTarWriterTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureTarWriterTest.java
@@ -16,17 +16,16 @@
  */
 package org.apache.jackrabbit.oak.segment.azure;
 
-import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.file.tar.TarWriterTest;
-import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
 
 public class AzureTarWriterTest extends TarWriterTest {
 
@@ -36,14 +35,29 @@ public class AzureTarWriterTest extends TarWriterTest {
     private CloudBlobContainer container;
 
     @Before
+    public void setUp() throws Exception {
+        container = azurite.getContainer("oak-test");
+    }
+
+    @NotNull
     @Override
-    public void setUp() throws IOException {
-        try {
-            monitor = new TestFileStoreMonitor();
-            container = azurite.getContainer("oak-test");
-            archiveManager = new AzurePersistence(container.getDirectoryReference("oak")).createArchiveManager(true, false, new IOMonitorAdapter(), monitor, new RemoteStoreMonitorAdapter());
-        } catch (StorageException | InvalidKeyException | URISyntaxException e) {
-            throw new IOException(e);
-        }
+    protected SegmentArchiveManager getSegmentArchiveManager() throws Exception {
+        return new AzureArchiveManager(container.getDirectoryReference("oak"), new IOMonitorAdapter(), monitor);
+    }
+
+    @NotNull
+    @Override
+    protected SegmentArchiveManager getFailingSegmentArchiveManager() throws Exception {
+        return new AzureArchiveManager(container.getDirectoryReference("oak"), new IOMonitorAdapter(), monitor) {
+            @Override
+            public SegmentArchiveWriter create(String archiveName) throws IOException {
+                return new AzureSegmentArchiveWriter(getDirectory(archiveName), ioMonitor, monitor) {
+                    @Override
+                    public void writeGraph(@NotNull byte[] data) throws IOException {
+                        throw new IOException("test");
+                    }
+                };
+            }
+        };
     }
 }

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/util/RetrierTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/util/RetrierTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.segment.azure.util;
+
+import org.apache.jackrabbit.oak.segment.spi.RepositoryNotReachableException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class RetrierTest {
+
+    @Test
+    public void succeedAtFirstAttempt() throws IOException {
+        Retrier retrier = Retrier.withParams(10, 1);
+        RetryTester execution = new RetryTester(1, "OK");
+
+        String result = retrier.execute(execution);
+
+        assertEquals("OK", result);
+        assertEquals(1, execution.attempts);
+    }
+
+    @Test
+    public void succeedAfterSeveralRetries() throws IOException {
+        Retrier retrier = Retrier.withParams(10, 1);
+        RetryTester execution = new RetryTester(5, "OK");
+
+        String result = retrier.execute(execution);
+
+        assertEquals("OK", result);
+        assertEquals(5, execution.attempts);
+    }
+
+    @Test
+    public void failAfterMaxRetries() {
+        Retrier retrier = Retrier.withParams(5, 1);
+        RetryTester execution = new RetryTester(10, "OK");
+
+        assertThrows(IOException.class, () -> retrier.execute(execution));
+        assertEquals(5, execution.attempts);
+    }
+
+    @Test
+    public void retryOnExpectedExceptions() {
+        Retrier retrier = Retrier.withParams(5, 1);
+
+        RetryTester throwingIOException = new RetryTester(10, "OK");
+        assertThrows(IOException.class, () -> retrier.execute(throwingIOException));
+        assertEquals(5, throwingIOException.attempts);
+
+        RetryTester throwingRepoNotReachableException = new RetryTester(10, "OK", () ->
+                new RepositoryNotReachableException(new RuntimeException()));
+        assertThrows(RepositoryNotReachableException.class, () -> retrier.execute(throwingRepoNotReachableException));
+        assertEquals(5, throwingRepoNotReachableException.attempts);
+    }
+
+    @Test
+    public void failWithoutRetryingOnUnexpectedExceptions() {
+        Retrier retrier = Retrier.withParams(5, 1);
+        RetryTester execution = new RetryTester(10, "OK", NullPointerException::new);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> retrier.execute(execution));
+        assertEquals("Unexpected exception while executing the operation", ex.getMessage());
+        assertEquals(NullPointerException.class, ex.getCause().getClass());
+        assertEquals(1, execution.attempts);
+    }
+
+    @Test
+    public void executeRunnable() throws IOException {
+        Retrier retrier = Retrier.withParams(10, 1);
+        RetryTesterRunnable execution = new RetryTesterRunnable(5);
+
+        retrier.execute(execution);
+
+        assertEquals(5, execution.attempts);
+    }
+
+    private static class RetryTester implements Retrier.ThrowingSupplier<String> {
+        private final int succeedAfterAttempts;
+        private final String result;
+        private final Supplier<RuntimeException> runtimeExceptionSupplier;
+
+        private int attempts = 0;
+
+        public RetryTester(int succeedAfterAttempts, String result, Supplier<RuntimeException> runtimeExceptionSupplier) {
+            this.succeedAfterAttempts = succeedAfterAttempts;
+            this.result = result;
+            this.runtimeExceptionSupplier = runtimeExceptionSupplier;
+        }
+
+        public RetryTester(int succeedAfterAttempts, String result) {
+            this(succeedAfterAttempts, result, () -> null);
+        }
+
+        @Override
+        public String get() throws IOException {
+            attempts++;
+            if (attempts == succeedAfterAttempts) {
+                return result;
+            }
+            RuntimeException runtimeException1 = runtimeExceptionSupplier.get();
+            if (runtimeException1 != null) {
+                throw runtimeException1;
+            }
+            throw new IOException("Fail at attempt " + attempts);
+        }
+    }
+
+    private static class RetryTesterRunnable implements Retrier.ThrowingRunnable {
+        private final int succeedAfterAttempts;
+
+        private int attempts = 0;
+
+        public RetryTesterRunnable(int succeedAfterAttempts) {
+            this.succeedAfterAttempts = succeedAfterAttempts;
+        }
+
+        @Override
+        public void run() throws IOException {
+            attempts++;
+            if (attempts == succeedAfterAttempts) {
+                return;
+            }
+            throw new IOException("Fail at attempt " + attempts);
+        }
+    }
+}

--- a/oak-segment-azure/src/test/resources/logback-test.xml
+++ b/oak-segment-azure/src/test/resources/logback-test.xml
@@ -15,14 +15,18 @@
    limitations under the License.
   -->
 <configuration>
-    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- Appenders -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %-5level %-40([%thread] %F:%L) %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
+    <!-- Root logger -->
     <root level="INFO">
-        <appender-ref ref="console"/>
+        <appender-ref ref="CONSOLE"/>
     </root>
+
+    <logger name="org.mockserver" level="WARN"/>
 </configuration>

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/FileStore.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/FileStore.java
@@ -359,6 +359,9 @@ public class FileStore extends AbstractFileStore {
                     stats.flushed();
                 });
             }
+        } catch (UnrecoverableArchiveException e) {
+            log.error("Critical failure while flushing pending changes. Shutting down the FileStore.", e);
+            close();
         } catch (IOException e) {
             log.warn("Failed to flush the TarMK at {}", directory, e);
         }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/UnrecoverableArchiveException.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/UnrecoverableArchiveException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.jackrabbit.oak.segment.file;
+
+import java.io.IOException;
+
+public class UnrecoverableArchiveException extends IOException {
+    public UnrecoverableArchiveException(String message, IOException cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public synchronized IOException getCause() {
+        return (IOException) super.getCause();
+    }
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriter.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import java.util.zip.CRC32;
 
 import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.file.UnrecoverableArchiveException;
 import org.apache.jackrabbit.oak.segment.file.tar.binaries.BinaryReferencesIndexWriter;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
@@ -219,10 +220,14 @@ class TarWriter implements Closeable {
         // to ensure that no concurrent thread is still flushing
         // the file when we close the file handle.
         synchronized (closeMonitor) {
-            writeBinaryReferences();
-            writeGraph();
+            try {
+                writeBinaryReferences();
+                writeGraph();
 
-            archive.close();
+                archive.close();
+            } catch (IOException e) {
+                throw new UnrecoverableArchiveException("Failed to close tar archive", e);
+            }
         }
     }
 

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/FileStoreTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/FileStoreTest.java
@@ -19,20 +19,36 @@
 
 package org.apache.jackrabbit.oak.segment.file;
 
+import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 
+import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.segment.SegmentId;
 import org.apache.jackrabbit.oak.segment.SegmentNodeBuilder;
 import org.apache.jackrabbit.oak.segment.SegmentNodeState;
-import org.junit.Assert;
+import org.apache.jackrabbit.oak.segment.file.tar.SegmentTarManager;
+import org.apache.jackrabbit.oak.segment.file.tar.SegmentTarWriter;
+import org.apache.jackrabbit.oak.segment.file.tar.TarPersistence;
+import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
+import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
+import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitor;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class FileStoreTest {
+    private  static final String FAILED_TO_WRITE_ON_CLOSE = "Failed to write to the archive on closing";
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File("target"));
@@ -43,27 +59,21 @@ public class FileStoreTest {
 
     @Test
     public void containsSegment() throws Exception {
-        FileStore fileStore = fileStoreBuilder(getFileStoreFolder()).build();
-        try {
-            SegmentId id = new SegmentId(fileStore, 0, 0);
+        try (FileStore fileStore = fileStoreBuilder(getFileStoreFolder()).build()) {
+            SegmentId id = getSegmentId(fileStore);
             if (fileStore.containsSegment(id)) {
                 fileStore.readSegment(id);
             }
-        } finally {
-            fileStore.close();
         }
     }
 
     @Test
-    public void overlapping() throws Exception {
-        FileStore fileStore = fileStoreBuilder(getFileStoreFolder()).build();
-        try {
-            fileStoreBuilder(getFileStoreFolder()).build();
-            Assert.fail("should not be able to open 2 stores on the same path");
+    public void overlapping() {
+        try (FileStore ignored1 = fileStoreBuilder(getFileStoreFolder()).build();
+             FileStore ignored2 = fileStoreBuilder(getFileStoreFolder()).build()) {
+            fail("should not be able to open 2 stores on the same path");
         } catch (Exception ex) {
             // expected
-        } finally {
-            fileStore.close();
         }
     }
 
@@ -84,5 +94,103 @@ public class FileStoreTest {
         }
     }
 
+    @Test
+    public void writeSegment_shouldThrowUnrecoverableExceptionWhenFailToCloseArchive() throws Exception {
+        File directory = getFileStoreFolder();
+        TarPersistence persistence = getPersistenceThrowingUnrecoverableExceptionOnClosingArchive(directory);
 
+        try(FileStore fileStore = fileStoreBuilder(directory)
+                .withMaxFileSize(1) // max archive size = 1 MB
+                .withCustomPersistence(persistence)
+                .build()) {
+
+
+            int size = 1024 * 1025; // Bigger than 1 MB to force closing the current archive and create a new one
+            byte[] dataExceedingMaxFileSize = new byte[size];
+
+            assertThrows(UnrecoverableArchiveException.class, () ->
+                    // write to the archive but fail to close it when it's full
+                    fileStore.writeSegment(getSegmentId(fileStore), dataExceedingMaxFileSize, 0, size)
+            );
+        }
+    }
+
+    @Test
+    public void tryFlush_shouldCloseFileStoreWhenFailToCloseArchive() throws Exception {
+        File directory = getFileStoreFolder();
+        TarPersistence failingPersistence = getPersistenceThrowingUnrecoverableExceptionOnClosingArchive(directory);
+
+        FileStore fileStore = fileStoreBuilder(directory)
+                .withMaxFileSize(1) // max archive size = 1 MB
+                .withCustomPersistence(failingPersistence)
+                .build();
+
+        // Write slightly less than 1MB
+        writeData(fileStore, 1024 * 1000);
+        // Write more data to exceed the archive max size, forcing to close the current archive and create a new one.
+        // Data is small enough to prevent auto-flushing, so it does not fail yet
+        writeData(fileStore, 1024 * 20);
+
+        // Execute tryFlush: now actually write to the archive, which will be closed because its size > maxFileSize
+        fileStore.tryFlush();
+
+        // FileStore should have been already shut down by tryFlush because of the UnrecoverableArchiveException
+        IllegalStateException closeEx = assertThrows("FileStore#tryFlush should have already shut down FileStore",
+                IllegalStateException.class, fileStore::close);
+        assertEquals("already shut down", closeEx.getMessage());
+    }
+
+    private static int counter = 0;
+
+    private static void writeData(FileStore fileStore, int size) throws IOException {
+        NodeBuilder nodeBuilder = EMPTY_NODE.builder();
+        Blob blob = nodeBuilder.createBlob(new ZeroStream(size));
+        int i = counter++;
+        nodeBuilder.child("node"+ i).setProperty("prop" + i, blob);
+        fileStore.getWriter().writeNode(nodeBuilder.getNodeState());
+    }
+
+    @NotNull
+    private static TarPersistence getPersistenceThrowingUnrecoverableExceptionOnClosingArchive(File directory) {
+        return new TarPersistence(directory) {
+            @Override
+            public SegmentArchiveManager createArchiveManager(boolean memoryMapping, boolean offHeapAccess, IOMonitor ioMonitor, FileStoreMonitor fileStoreMonitor, RemoteStoreMonitor remoteStoreMonitor) {
+                return new SegmentTarManager(directory, fileStoreMonitor, ioMonitor, memoryMapping, offHeapAccess) {
+                    @Override
+                    public SegmentArchiveWriter create(String archiveName) {
+                        return new SegmentTarWriter(new File(directory, archiveName), fileStoreMonitor, ioMonitor) {
+                            @Override
+                            public void writeGraph(byte[] data) throws IOException {
+                                throw new IOException(FAILED_TO_WRITE_ON_CLOSE);
+                            }
+                        };
+                    }
+                };
+            }
+        };
+    }
+
+    @NotNull
+    private static SegmentId getSegmentId(FileStore fileStore) {
+        return new SegmentId(fileStore, 0, 0);
+    }
+
+    private static class ZeroStream extends InputStream {
+        private final int size;
+
+        private int position = 0;
+
+        public ZeroStream(int size) {
+            this.size = size;
+        }
+
+        @Override
+        public int read() {
+            if (position < size) {
+                position++;
+                return 0;
+            }
+            return -1;
+        }
+    }
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriterTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriterTest.java
@@ -22,18 +22,22 @@ package org.apache.jackrabbit.oak.segment.file.tar;
 import static org.apache.jackrabbit.guava.common.base.Charsets.UTF_8;
 import static org.apache.jackrabbit.oak.segment.file.tar.GCGeneration.newGCGeneration;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
+import org.apache.jackrabbit.oak.segment.file.UnrecoverableArchiveException;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
 import org.apache.jackrabbit.oak.stats.NoopStats;
-import org.junit.Before;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -43,37 +47,66 @@ public class TarWriterTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File("target"));
 
-    protected SegmentArchiveManager archiveManager;
-
-    protected TestFileStoreMonitor monitor;
-
-    @Before
-    public void setUp() throws IOException {
-        monitor = new TestFileStoreMonitor();
-        archiveManager = new SegmentTarManager(folder.newFolder(), monitor, new IOMonitorAdapter(), false, false);
-    }
+    protected TestFileStoreMonitor monitor = new TestFileStoreMonitor();
 
     @Test
-    public void createNextGenerationTest() throws IOException {
+    public void createNextGenerationTest() throws Exception {
         int counter = 2222;
-        TarWriter t0 = new TarWriter(archiveManager, counter, NoopStats.INSTANCE);
+        TarWriter t0 = new TarWriter(getSegmentArchiveManager(), counter, NoopStats.INSTANCE);
 
         // not dirty, will not create a new writer
         TarWriter t1 = t0.createNextGeneration();
-        assertEquals(t0, t1);
-        assertTrue(t1.getFileName().contains("" + counter));
+        assertSame(t0, t1);
+        assertTrue(t1.getFileName().contains(String.valueOf(counter)));
 
         // dirty, will create a new writer
+        writeEntry(t1);
+
+        TarWriter t2 = t1.createNextGeneration();
+        assertNotSame(t1, t2);
+        assertTrue(t1.isClosed());
+        assertTrue(t2.getFileName().contains(String.valueOf(counter + 1)));
+    }
+
+    @Test
+    public void failToClose() throws Exception {
+        TarWriter tarWriter = new TarWriter(getFailingSegmentArchiveManager(), 2222, NoopStats.INSTANCE);
+
+        writeEntry(tarWriter);
+
+        assertThrows(UnrecoverableArchiveException.class, tarWriter::close);
+    }
+
+    private static void writeEntry(TarWriter writer) throws IOException {
         UUID id = UUID.randomUUID();
         long msb = id.getMostSignificantBits();
         long lsb = id.getLeastSignificantBits() & (-1 >>> 4); // OAK-1672
         byte[] data = "Hello, World!".getBytes(UTF_8);
-        t1.writeEntry(msb, lsb, data, 0, data.length, newGCGeneration(0, 0, false));
+        writer.writeEntry(msb, lsb, data, 0, data.length, newGCGeneration(0, 0, false));
+    }
 
-        TarWriter t2 = t1.createNextGeneration();
-        assertNotEquals(t1, t2);
-        assertTrue(t1.isClosed());
-        assertTrue(t2.getFileName().contains("" + (counter + 1)));
+    @NotNull
+    protected SegmentArchiveManager getSegmentArchiveManager() throws Exception {
+        IOMonitorAdapter ioMonitor = new IOMonitorAdapter();
+        File segmentstoreDir = folder.newFolder();
+        return new SegmentTarManager(segmentstoreDir, monitor, ioMonitor, false, false);
+    }
+
+    @NotNull
+    protected SegmentArchiveManager getFailingSegmentArchiveManager() throws Exception {
+        IOMonitorAdapter ioMonitor = new IOMonitorAdapter();
+        File segmentstoreDir = folder.newFolder();
+        return new SegmentTarManager(segmentstoreDir, monitor, ioMonitor, false, false) {
+            @Override
+            public @NotNull SegmentArchiveWriter create(String archiveName) {
+                return new SegmentTarWriter(new File(segmentstoreDir, archiveName), monitor, ioMonitor) {
+                    @Override
+                    public void writeGraph(byte[] data) throws IOException {
+                        throw new IOException("test");
+                    }
+                };
+            }
+        };
     }
 
     public static class TestFileStoreMonitor extends FileStoreMonitorAdapter {
@@ -89,7 +122,7 @@ public class TarWriterTest {
 
     @Test
     public void testFileStoreMonitor() throws Exception {
-        try (TarWriter writer = new TarWriter(archiveManager, 0, NoopStats.INSTANCE)) {
+        try (TarWriter writer = new TarWriter(getSegmentArchiveManager(), 0, NoopStats.INSTANCE)) {
             long sizeBefore = writer.fileLength();
             long writtenBefore = monitor.written;
             writer.writeEntry(0, 0, new byte[42], 0, 42, newGCGeneration(0, 0, false));


### PR DESCRIPTION
* Reduce the probability of transient Azure issues to break TarWriter, by retrying methods AzureSegmentArchiveWriter#doWriteDataFile and AzureSegmentArchiveWriter#afterQueueClosed, which are called on TarWriter#close.
* FileStore#tryFlush, which is called in a background thread, now closes the FileStore in case an unrecoverable exception is caught, to prevent it to continue while in an inconsistent state.
* Extracted & improved existing retry logic in its own class, org.apache.jackrabbit.oak.segment.azure.util.Retries.