### PR TITLE
OAK-10273: Index-definition json created during oak-run reindex should not serialise index data

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/IndexerSupport.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/IndexerSupport.java
@@ -111,7 +111,7 @@ public class IndexerSupport {
 
     private void dumpIndexDefinitions(NodeStore nodeStore) throws IOException, CommitFailedException {
         IndexDefinitionPrinter printer = new IndexDefinitionPrinter(nodeStore, indexHelper.getIndexPathService());
-        printer.setFilter("{\"properties\":[\"*\", \"-:childOrder\"],\"nodes\":[\"*\", \"-:index-definition\"]}");
+        printer.setFilter("{\"properties\":[\"*\", \"-:childOrder\"],\"nodes\":[\"*\", \"-:index-definition\", \"-:data\", \"-:suggest-data\"]}");
         PrinterDumper dumper = new PrinterDumper(getLocalIndexDir(), IndexDefinitionUpdater.INDEX_DEFINITIONS_JSON,
                 false, Format.JSON, printer);
         dumper.dump();

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/AbstractIndexCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/AbstractIndexCommandTest.java
@@ -60,7 +60,7 @@ public class AbstractIndexCommandTest {
     protected void addTestContent(RepositoryFixture fixture, String basePath, String propName, int count) throws IOException, RepositoryException {
         Session session = fixture.getAdminSession();
         for (int i = 0; i < count; i++) {
-            getOrCreateByPath(basePath+i,
+            getOrCreateByPath(basePath + i,
                     "oak:Unstructured", session).setProperty(propName, "bar");
         }
         session.save();
@@ -82,13 +82,13 @@ public class AbstractIndexCommandTest {
         if (!asyncIndex) {
             idxBuilder.noAsync();
         }
-        idxBuilder.indexRule("nt:base").property("foo").propertyIndex();
+        idxBuilder.indexRule("nt:base").property("foo").propertyIndex().useInSuggest().analyzed();
 
         Session session = fixture.getAdminSession();
         Node fooIndex = getOrCreateByPath(TEST_INDEX_PATH,
                 "oak:QueryIndexDefinition", session);
-
         idxBuilder.build(fooIndex);
+        fooIndex.addNode("suggestion").setProperty("suggestUpdateFrequencyMinutes", 0);
         session.save();
         session.logout();
     }


### PR DESCRIPTION
…d not serialise index data