### PR TITLE
OAK-10313: Identify revisions created by late-write scenario

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/document/check/ConsistencyCheck.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/document/check/ConsistencyCheck.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document.check;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.jackrabbit.oak.commons.json.JsopBuilder;
+import org.apache.jackrabbit.oak.plugins.document.Consistency;
+import org.apache.jackrabbit.oak.plugins.document.DocumentNodeState;
+import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.plugins.document.Path;
+import org.apache.jackrabbit.oak.plugins.document.Revision;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * <code>ConsistencyCheck</code>...
+ */
+public class ConsistencyCheck extends AsyncDocumentProcessor {
+
+    private final DocumentNodeStore ns;
+
+    private final DocumentNodeState root;
+
+    public ConsistencyCheck(DocumentNodeStore ns, ExecutorService executorService) {
+        super(executorService);
+        this.ns = ns;
+        this.root = ns.getRoot();
+    }
+
+    @Override
+    protected Optional<Callable<Void>> createTask(@NotNull NodeDocument document,
+                                                  @NotNull BlockingQueue<Result> results) {
+        if (document.isSplitDocument()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new CheckDocument(ns, root, document, results));
+        }
+    }
+
+    private static final class CheckDocument implements Callable<Void> {
+
+        private final DocumentNodeStore ns;
+
+        private final DocumentNodeState root;
+
+        private final NodeDocument doc;
+
+        private final BlockingQueue<Result> results;
+
+        public CheckDocument(DocumentNodeStore ns,
+                             DocumentNodeState root,
+                             NodeDocument doc,
+                             BlockingQueue<Result> results) {
+            this.ns = ns;
+            this.root = root;
+            this.doc = doc;
+            this.results = results;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            Set<Revision> revisions = new HashSet<>();
+            new Consistency(root, doc).check(ns, revisions::add);
+            for (Revision revision : revisions) {
+                results.put(new InconsistentState(doc.getPath(), revision));
+            }
+            return null;
+        }
+    }
+
+    private static final class InconsistentState implements Result {
+
+        final Path path;
+
+        final Revision revision;
+
+        public InconsistentState(Path path, Revision revision) {
+            this.path = path;
+            this.revision = revision;
+        }
+
+        @Override
+        public String toJson() {
+            JsopBuilder json = new JsopBuilder();
+            json.object();
+            json.key("type").value("inconsistent");
+            json.key("path").value(path.toString());
+            json.key("revision").value(revision.toString());
+            json.endObject();
+            return json.toString();
+        }
+    }
+}

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/document/check/DocumentStoreCheck.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/document/check/DocumentStoreCheck.java
@@ -87,6 +87,8 @@ public class DocumentStoreCheck {
 
     private final boolean uuid;
 
+    private final boolean consistency;
+
     private DocumentStoreCheck(DocumentNodeStore ns,
                                DocumentStore store,
                                Closer closer,
@@ -100,7 +102,8 @@ public class DocumentStoreCheck {
                                boolean versionHistory,
                                boolean predecessors,
                                boolean successors,
-                               boolean uuid) {
+                               boolean uuid,
+                               boolean consistency) {
         this.ns = ns;
         this.store = store;
         this.closer = closer;
@@ -121,6 +124,7 @@ public class DocumentStoreCheck {
         this.predecessors = predecessors;
         this.successors = successors;
         this.uuid = uuid;
+        this.consistency = consistency;
     }
 
     public void run() throws Exception {
@@ -208,6 +212,9 @@ public class DocumentStoreCheck {
         if (uuid) {
             processors.add(new ReferenceCheck(JCR_UUID, ns, ns.getHeadRevision(), executorService));
         }
+        if (consistency) {
+            processors.add(new ConsistencyCheck(ns, executorService));
+        }
         return CompositeDocumentProcessor.compose(processors);
     }
 
@@ -248,6 +255,8 @@ public class DocumentStoreCheck {
         private boolean successors;
 
         private boolean uuid;
+
+        private boolean consistency;
 
         public Builder(DocumentNodeStore ns,
                        DocumentStore store,
@@ -312,10 +321,15 @@ public class DocumentStoreCheck {
             return this;
         }
 
+        public Builder withConsistency(boolean enable) {
+            this.consistency = enable;
+            return this;
+        }
+
         public DocumentStoreCheck build() {
             return new DocumentStoreCheck(ns, store, closer, progress, silent,
                     summary, numThreads, output, orphan, baseVersion,
-                    versionHistory, predecessors, successors, uuid);
+                    versionHistory, predecessors, successors, uuid, consistency);
         }
     }
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DocumentStoreCheckCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DocumentStoreCheckCommand.java
@@ -68,6 +68,7 @@ class DocumentStoreCheckCommand implements Command {
                     .withPredecessors(options.withPredecessors())
                     .withSuccessors(options.withSuccessors())
                     .withUuid(options.withUuid())
+                    .withConsistency(options.withConsistency())
                     .withProgress(options.withProgress())
                     .isSilent(options.isSilent())
                     .withSummary(options.withSummary())
@@ -103,6 +104,8 @@ class DocumentStoreCheckCommand implements Command {
 
         final OptionSpec<Boolean> uuid;
 
+        final OptionSpec<Boolean> consistency;
+
         final OptionSpec<Integer> numThreads;
 
         public CheckOptions(String usage) {
@@ -126,6 +129,8 @@ class DocumentStoreCheckCommand implements Command {
             successors = parser.accepts("successors", "Check jcr:successors references")
                     .withOptionalArg().ofType(Boolean.class).defaultsTo(Boolean.TRUE);
             uuid = parser.accepts("uuid", "Check UUID index entry")
+                    .withOptionalArg().ofType(Boolean.class).defaultsTo(Boolean.TRUE);
+            consistency = parser.accepts("consistency", "Check node state consistency")
                     .withOptionalArg().ofType(Boolean.class).defaultsTo(Boolean.TRUE);
             numThreads = parser.accepts("numThreads", "Use this number of threads to check consistency")
                     .withRequiredArg().ofType(Integer.class).defaultsTo(Runtime.getRuntime().availableProcessors());
@@ -175,6 +180,10 @@ class DocumentStoreCheckCommand implements Command {
 
         public boolean withUuid() {
             return uuid.value(options);
+        }
+
+        public boolean withConsistency() {
+            return consistency.value(options);
         }
 
         public int getNumThreads() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Consistency.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Consistency.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.plugins.document.util.Utils;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Consistency check on a {@code NodeDocument}.
+ */
+public class Consistency {
+
+    private final DocumentNodeState root;
+
+    private final NodeDocument document;
+
+    /**
+     * Creates a new consistency check for the given {@code NodeDocument}.
+     *
+     * @param root the current root node state to use for the check.
+     * @param document the document to check.
+     */
+    public Consistency(@NotNull DocumentNodeState root,
+                       @NotNull NodeDocument document) {
+        this.root = requireNonNull(root);
+        this.document = requireNonNull(document);
+    }
+
+    public void check(@NotNull DocumentNodeStore ns,
+                      @NotNull Result collector) {
+        requireNonNull(ns);
+        requireNonNull(collector);
+
+        NodeState traversedState = root;
+        AbstractDocumentNodeState existingAncestorOrSelf = root;
+        for (String name : document.getPath().elements()) {
+            traversedState = traversedState.getChildNode(name);
+            if (traversedState instanceof DocumentNodeState) {
+                existingAncestorOrSelf = (DocumentNodeState) traversedState;
+            }
+        }
+        DocumentNodeState dns = document.getNodeAtRevision(ns, root.getRootRevision(), null);
+        if (traversedState.exists()) {
+            if (dns != null) {
+                if (!equalProperties(dns, traversedState)) {
+                    // both exist, but they are not equal
+                    identifyChanges(ns, traversedState, collector);
+                }
+            } else {
+                // exists when traversing to the node, getting node directly
+                // from document returned null
+                // document must have _deleted set to true after some _lastRev
+                identifyChanges(ns, traversedState, collector);
+            }
+        } else {
+            if (dns != null) {
+                // does not exist when traversing to node, but getting node
+                // directly returns it. node is orphaned
+                identifyChanges(ns, existingAncestorOrSelf, collector);
+            }
+        }
+    }
+
+    /**
+     * Callback interface for result of a consistency check.
+     */
+    public interface Result {
+
+        /**
+         * Called when the consistency check identified an inconsistency. The
+         * reported {@code Revision} identifies the associated change with
+         * the inconsistency.
+         *
+         * @param revision the revision of the change.
+         */
+        void inconsistent(Revision revision);
+    }
+
+    /**
+     * Compare the properties of both {@link NodeState}s and return {@code true}
+     * if they are equal, otherwise {@code false}.
+     *
+     * @param a a node state
+     * @param b another node state
+     * @return {@code true} if properties on both {@code NodeState}s are equal,
+     *      {@code false} otherwise.
+     */
+    private static boolean equalProperties(NodeState a, NodeState b) {
+        if (a.getPropertyCount() != b.getPropertyCount()) {
+            return false;
+        }
+        for (PropertyState property : a.getProperties()) {
+            if (!property.equals(b.getProperty(property.getName()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void identifyChanges(@NotNull RevisionContext context,
+                                 @NotNull NodeState state,
+                                 @NotNull Result result) {
+        if (state instanceof DocumentNodeState) {
+            DocumentNodeState traversedState = (DocumentNodeState) state;
+            // must not have any committed changes between lastRevision on
+            // traversed node state and root revision on this document
+            RevisionVector lastRevision = traversedState.getLastRevision();
+            RevisionVector rootRevision = traversedState.getRootRevision();
+            for (Revision r : document.getLocalCommitRoot().keySet()) {
+                if (!rootRevision.isRevisionNewer(r)
+                        && lastRevision.isRevisionNewer(r)
+                        && Utils.isCommitted(context.getCommitValue(r, document))) {
+                    // committed change after lastRevision, but not newer
+                    // than root revision
+                    result.inconsistent(r);
+                }
+            }
+        }
+    }
+}

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/FailingDocumentStore.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/FailingDocumentStore.java
@@ -16,6 +16,8 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -46,6 +48,8 @@ class FailingDocumentStore extends DocumentStoreWrapper {
     private Type exceptionType = Type.GENERIC;
 
     private List<Collection<? extends Document>> collectionIncludeList;
+
+    private List<FailedUpdateOpListener> listeners = new ArrayList<>();
 
     class Fail {
 
@@ -94,6 +98,11 @@ class FailingDocumentStore extends DocumentStoreWrapper {
         }
     }
 
+    public interface FailedUpdateOpListener {
+
+        void failed(UpdateOp op);
+    }
+
     FailingDocumentStore(DocumentStore store, long seed) {
         this(store, new Random(seed));
     }
@@ -109,6 +118,10 @@ class FailingDocumentStore extends DocumentStoreWrapper {
 
     Fail fail() {
         return new Fail();
+    }
+
+    void addListener(FailedUpdateOpListener listener) {
+        listeners.add(listener);
     }
 
     @Override
@@ -152,9 +165,11 @@ class FailingDocumentStore extends DocumentStoreWrapper {
     @Override
     public <T extends Document> boolean create(Collection<T> collection,
                                                List<UpdateOp> updateOps) {
+        List<UpdateOp> remaining = new ArrayList<>(updateOps);
+        int i = 0;
         // create individually
         for (UpdateOp op : updateOps) {
-            maybeFail(collection);
+            maybeFail(collection, remaining.subList(i++, remaining.size()));
             if (!super.create(collection, singletonList(op))) {
                 return false;
             }
@@ -165,17 +180,19 @@ class FailingDocumentStore extends DocumentStoreWrapper {
     @Override
     public <T extends Document> T createOrUpdate(Collection<T> collection,
                                                  UpdateOp update) {
-        maybeFail(collection);
+        maybeFail(collection, singletonList(update));
         return super.createOrUpdate(collection, update);
     }
 
     @Override
     public <T extends Document> List<T> createOrUpdate(Collection<T> collection,
                                                        List<UpdateOp> updateOps) {
+        List<UpdateOp> remaining = new ArrayList<>(updateOps);
         List<T> result = Lists.newArrayList();
-        // redirect to single document createOrUpdate
+        int i = 0;
         for (UpdateOp op : updateOps) {
-            result.add(createOrUpdate(collection, op));
+            maybeFail(collection, remaining.subList(i++, remaining.size()));
+            result.add(super.createOrUpdate(collection, op));
         }
         return result;
     }
@@ -183,16 +200,26 @@ class FailingDocumentStore extends DocumentStoreWrapper {
     @Override
     public <T extends Document> T findAndUpdate(Collection<T> collection,
                                                 UpdateOp update) {
-        maybeFail(collection);
+        maybeFail(collection, singletonList(update));
         return super.findAndUpdate(collection, update);
     }
 
     private <T extends Document> void maybeFail(Collection<T> collection) {
+        maybeFail(collection, Collections.emptyList());
+    }
+
+    private <T extends Document> void maybeFail(Collection<T> collection,
+                                                List<UpdateOp> remainingOps) {
         if ((collectionIncludeList == null || collectionIncludeList.contains(collection)) &&
                 (random.nextFloat() < p || failAfter.getAndDecrement() <= 0)) {
             if (numFailures.getAndDecrement() > 0) {
+                reportRemainingOps(remainingOps);
                 throw new DocumentStoreException("write operation failed", null, exceptionType);
             }
         }
+    }
+
+    private void reportRemainingOps(List<UpdateOp> remainingOps) {
+        listeners.forEach(listener -> remainingOps.forEach(listener::failed));
     }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/WriteAfterRecoveryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/WriteAfterRecoveryTest.java
@@ -1,0 +1,661 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.document.FailingDocumentStore.FailedUpdateOpListener;
+import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.stats.Clock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo.DEFAULT_LEASE_DURATION_MILLIS;
+import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
+import static org.apache.jackrabbit.oak.plugins.document.NodeDocument.isDeletedEntry;
+import static org.apache.jackrabbit.oak.plugins.document.TestUtils.childBuilder;
+import static org.apache.jackrabbit.oak.plugins.document.TestUtils.disposeQuietly;
+import static org.apache.jackrabbit.oak.plugins.document.UpdateOp.Operation.Type.SET_MAP_ENTRY;
+import static org.apache.jackrabbit.oak.plugins.document.util.Utils.getIdFromPath;
+import static org.apache.jackrabbit.oak.plugins.memory.StringPropertyState.stringProperty;
+import static org.apache.jackrabbit.oak.spi.state.NodeStateUtils.getNode;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that write after with a clusterId after the leased timed out and
+ * recovery was performed.
+ */
+public class WriteAfterRecoveryTest {
+
+    @Rule
+    public DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
+
+    private final FailingDocumentStore store = new FailingDocumentStore(new MemoryDocumentStore());
+
+    private final Clock clock = new Clock.Virtual();
+
+    private DocumentNodeStore ns1;
+
+    @Before
+    public void setUp() throws Exception {
+        clock.waitUntil(System.currentTimeMillis());
+        Revision.setClock(clock);
+        ClusterNodeInfo.setClock(clock);
+        ns1 = createNodeStore(1);
+    }
+
+    @After
+    public void cleanUp() {
+        ClusterNodeInfo.resetClockToDefault();
+        Revision.resetClockToDefault();
+    }
+
+    @Test
+    public void oneNodeAdded() throws Exception {
+        merge(ns1, createChild("/a"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, ADD_NODE_OPS));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, createChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertFalse(getNode(ns2.getRoot(), "/a/b").exists());
+        try {
+            merge(ns2, createChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("older than base"));
+        }
+
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void multipleNodesAdded() throws Exception {
+        merge(ns1, createChild("/a"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, ADD_NODE_OPS));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, createChild("/a/b/c"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertFalse(getNode(ns2.getRoot(), "/a/b/c").exists());
+        try {
+            merge(ns2, createChild("/a/b/c"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("older than base"));
+        }
+
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void orphanedNodesAdded() throws Exception {
+        merge(ns1, createChild("/a"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, ADD_NODE_OPS));
+        // let merge create some nodes
+        store.fail().after(2).eternally();
+        try {
+            merge(ns1, createChild("/a/b/c/d/e/f"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(1, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertFalse(getNode(ns2.getRoot(), "/a/b").exists());
+        // can create nodes that recovery removed ...
+        merge(ns2, createChild("/a/b/c"), false);
+        // ... but not those written after recovery
+        try {
+            merge(ns2, createChild("/a/b/c/d/e/f"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("older than base"));
+        }
+
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c", "/a/b/c/d", "/a/b/c/d/e", "/a/b/c/d/e/f");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void oneNodeRemoved() throws Exception {
+        merge(ns1, createChild("/a/b"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, REMOVE_NODE_OPS));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, removeChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertTrue(getNode(ns2.getRoot(), "/a/b").exists());
+        try {
+            merge(ns2, removeChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("already deleted"));
+        }
+
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void multipleNodesRemoved() throws Exception {
+        merge(ns1, createChild("/a/b/c"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, REMOVE_NODE_OPS));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, removeChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertTrue(getNode(ns2.getRoot(), "/a/b/c").exists());
+        try {
+            merge(ns2, removeChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("already deleted"));
+        }
+
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void orphanedNodesRemoved() throws Exception {
+        merge(ns1, createChild("/a/b/c/d/e/f"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, REMOVE_NODE_OPS));
+        // let merge remove some nodes and then fail
+        store.fail().after(2).eternally();
+        try {
+            merge(ns1, removeChild("/a/b"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(1, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertTrue(getNode(ns2.getRoot(), "/a/b/c/d/e/f").exists());
+        // add a node
+        try {
+            merge(ns2, createChild("/a/b/c/d/e/f/g"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("already deleted"));
+        }
+        // can set a property on a node where recovery reverted the delete ...
+        merge(ns2, setProperty("/a/b", "p", "v"), false);
+        // ... but cannot set a property on a node deleted after recovery
+        try {
+            merge(ns2, setProperty("/a/b/c/d/e/f", "p", "v"), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            assertThat(e.getMessage(), containsString("already deleted"));
+        }
+
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c", "/a/b/c/d", "/a/b/c/d/e", "/a/b/c/d/e/f", "/a/b/c/d/e/f/g");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void propertyChanged() throws Exception {
+        merge(ns1, compose(
+                createChild("/a/b"),
+                setProperty("/a/b", "p", "u")
+        ), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, setPropertyOps("p")));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, compose(
+                    setProperty("/a/b", "p", "v"),
+                    createChild("/a/b/c")
+            ), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+        assertEquals(stringProperty("p", "u"), getNode(ns1.getRoot(), "/a/b").getProperty("p"));
+        NodeDocument b = store.find(NODES, getIdFromPath("/a/b"));
+        assertNotNull(b);
+        assertNotNull(b.getNodeAtRevision(ns1, ns1.getHeadRevision(), null).getProperty("p"));
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertEquals(stringProperty("p", "u"), getNode(ns2.getRoot(), "/a/b").getProperty("p"));
+
+        // current implementation does not fail with conflict when property
+        // is overwritten, but consistency check can still detect it
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void propertyRemoved() throws Exception {
+        merge(ns1, compose(
+                createChild("/a/b"),
+                setProperty("/a/b", "p", "u")
+        ), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, setPropertyOps("p")));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, compose(
+                    removeProperty("/a/b", "p"),
+                    createChild("/a/b/c")
+            ), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+        assertEquals(stringProperty("p", "u"), getNode(ns1.getRoot(), "/a/b").getProperty("p"));
+        NodeDocument b = store.find(NODES, getIdFromPath("/a/b"));
+        assertNotNull(b);
+        assertNull(b.getNodeAtRevision(ns1, ns1.getHeadRevision(), null).getProperty("p"));
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertEquals(stringProperty("p", "u"), getNode(ns2.getRoot(), "/a/b").getProperty("p"));
+
+        // current implementation does not fail with conflict when property
+        // is overwritten, but consistency check can still detect it
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    @Test
+    public void propertySet() throws Exception {
+        merge(ns1, createChild("/a/b"), true);
+
+        List<UpdateOp> failed = new ArrayList<>();
+        store.addListener(filter(failed, setPropertyOps("p")));
+        store.fail().after(0).eternally();
+        try {
+            merge(ns1, compose(
+                    setProperty("/a/b", "p", "u"),
+                    createChild("/a/b/c")
+            ), false);
+            fail("merge must fail");
+        } catch (CommitFailedException e) {
+            // expected
+        }
+        disposeQuietly(ns1);
+        store.fail().never();
+
+        // wait until lease expires
+        clockWait(DEFAULT_LEASE_DURATION_MILLIS);
+
+        DocumentNodeStore ns2 = createNodeStore(2);
+        assertTrue(ns2.getLastRevRecoveryAgent().isRecoveryNeeded());
+        assertEquals(0, ns2.getLastRevRecoveryAgent().recover(1));
+
+        // 'late write'
+        store.createOrUpdate(NODES, failed);
+        Set<Revision> lateWriteRevisions = getRevisions(failed);
+
+        // revive clusterId 1
+        ns1 = createNodeStore(1);
+        merge(ns1, createChild("/d"), true);
+        assertNull(getNode(ns1.getRoot(), "/a/b").getProperty("p"));
+        NodeDocument b = store.find(NODES, getIdFromPath("/a/b"));
+        assertNotNull(b);
+        assertNotNull(b.getNodeAtRevision(ns1, ns1.getHeadRevision(), null).getProperty("p"));
+
+        ns2.runBackgroundOperations();
+        assertTrue(getNode(ns2.getRoot(), "/d").exists());
+        assertNull(getNode(ns2.getRoot(), "/a/b").getProperty("p"));
+
+        // current implementation does not fail with conflict when property
+        // is overwritten, but consistency check can still detect it
+        Set<Revision> inconsistent = checkConsistency(ns2, "/a/b", "/a/b/c");
+        assertEquals(lateWriteRevisions, inconsistent);
+    }
+
+    private static Change setProperty(String path,
+                                      String name,
+                                      String value) {
+        return root -> {
+            childBuilder(root, path).setProperty(name, value);
+            return root;
+        };
+    }
+
+    private static Change removeProperty(String path, String name) {
+        return root -> {
+            childBuilder(root, path).removeProperty(name);
+            return root;
+        };
+    }
+
+    private static Change createChild(String path) {
+        return root -> {
+            childBuilder(root, path);
+            return root;
+        };
+    }
+
+    private static Change removeChild(String path) {
+        return root -> {
+            NodeBuilder node = root;
+            for (String name : PathUtils.elements(path)) {
+                node = node.getChildNode(name);
+            }
+            if (node.exists()) {
+                node.remove();
+            }
+            return root;
+        };
+    }
+
+    private static NodeState merge(DocumentNodeStore store,
+                                   NodeBuilder builder,
+                                   boolean runBackgroundOps)
+            throws CommitFailedException {
+        NodeState root = TestUtils.merge(store, builder);
+        if (runBackgroundOps) {
+            store.runBackgroundOperations();
+        }
+        return root;
+    }
+
+    interface Change {
+
+        NodeBuilder apply(NodeBuilder root);
+    }
+
+    private static Change compose(Change... changes) {
+        return root -> {
+            Arrays.stream(changes).forEach(change -> change.apply(root));
+            return root;
+        };
+    }
+
+    public static NodeState merge(DocumentNodeStore store,
+                                  Change change,
+                                  boolean runBackgroundOps)
+            throws CommitFailedException {
+        return merge(store, change.apply(store.getRoot().builder()), runBackgroundOps);
+    }
+
+    private void clockWait(int durationMillis) throws InterruptedException {
+        clock.waitUntil(clock.getTime() + durationMillis);
+    }
+
+    private static FailedUpdateOpListener filter(List<UpdateOp> ops,
+                                                 Predicate<UpdateOp> predicate) {
+        return op -> {
+            if (predicate.test(op)) {
+                ops.add(op);
+            }
+        };
+    }
+
+    private static final Predicate<UpdateOp> ADD_NODE_OPS = updateOp -> {
+        for (UpdateOp.Key key : updateOp.getChanges().keySet()) {
+            if (isDeletedEntry(key.getName())
+                    && updateOp.getChanges().get(key).value.equals("false")) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    private static final Predicate<UpdateOp> REMOVE_NODE_OPS = updateOp -> {
+        for (UpdateOp.Key key : updateOp.getChanges().keySet()) {
+            if (isDeletedEntry(key.getName())
+                    && updateOp.getChanges().get(key).value.equals("true")) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    private static Predicate<UpdateOp> setPropertyOps(String propertyName) {
+        return updateOp -> {
+            for (UpdateOp.Key key : updateOp.getChanges().keySet()) {
+                if (propertyName.equals(key.getName())
+                        && updateOp.getChanges().get(key).type == SET_MAP_ENTRY) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    private DocumentNodeStore createNodeStore(int clusterId) {
+        return builderProvider.newBuilder()
+                .setDocumentStore(store)
+                .clock(clock)
+                .setClusterId(clusterId)
+                .setAsyncDelay(0)
+                .build();
+    }
+
+    private static Set<Revision> getRevisions(List<UpdateOp> failed) {
+        return failed.stream()
+                .flatMap(updateOp -> updateOp.getChanges().keySet().stream().map(UpdateOp.Key::getRevision))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<Revision> checkConsistency(DocumentNodeStore ns,
+                                           String... paths) {
+        Set<Revision> revisions = new HashSet<>();
+        DocumentNodeState root = ns.getRoot();
+        for (String path : paths) {
+            NodeDocument doc = ns.getDocumentStore().find(NODES, getIdFromPath(path));
+            if (doc != null) {
+                new Consistency(root, doc).check(ns, revisions::add);
+            }
+        }
+        return revisions;
+    }
+}


### PR DESCRIPTION
New tests
Consistency implementation to identify revisions
New consistency option for oak-run documentstore-check