### PR TITLE
OAK-10345 - Add debug log message if larger blob is compared byte-wise.

### DIFF
--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
@@ -26,6 +26,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
 
 import org.apache.jackrabbit.oak.api.Blob;
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -40,8 +41,17 @@ public abstract class AbstractBlob implements Blob {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractBlob.class);
 
-    private static final boolean DEBUG_BLOB_EQUAL_LOG = Boolean.getBoolean("oak.abstractblob.equal.log");
-    private static final long DEBUG_BLOB_EQUAL_LOG_LIMIT = Long.getLong("oak.abstractblob.equal.log.limit", 100_000_000L);
+    private static final boolean DEBUG_BLOB_EQUAL_LOG = SystemPropertySupplier
+            .create("oak.abstractblob.equal.log", false)
+            .loggingTo(LOG)
+            .formatSetMessage( (name, value) -> String.format("%s set to: %s", name, value) )
+            .get();
+
+    private static final long DEBUG_BLOB_EQUAL_LOG_LIMIT = SystemPropertySupplier
+            .create("oak.abstractblob.equal.log.limit", 100_000_000L)
+            .loggingTo(LOG)
+            .formatSetMessage( (name, value) -> String.format("%s set to: %s", name, value) )
+            .get();
 
     private static ByteSource supplier(final Blob blob) {
         return new ByteSource() {

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
@@ -28,6 +28,8 @@ import com.google.common.io.ByteSource;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for {@link Blob} implementations.
@@ -35,6 +37,10 @@ import org.jetbrains.annotations.Nullable;
  * {@code hashCode} and {@code equals}.
  */
 public abstract class AbstractBlob implements Blob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBlob.class);
+
+    private static final long DEBUG_BLOB_EQUAL_LOG_LIMIT = Long.getLong("oak.abstractblob.equal.log.limit", 100_000_000L);
 
     private static ByteSource supplier(final Blob blob) {
         return new ByteSource() {
@@ -60,6 +66,10 @@ public abstract class AbstractBlob implements Blob {
         //definitely same blob. If not we need to check further.
         if (ai != null && bi != null && ai.equals(bi)){
             return true;
+        }
+
+        if (al > DEBUG_BLOB_EQUAL_LOG_LIMIT) {
+            LOG.debug("Blobs have the same length of {} and we're falling back to byte-wise comparison.", al);
         }
 
         try {

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
@@ -40,6 +40,7 @@ public abstract class AbstractBlob implements Blob {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractBlob.class);
 
+    private static final boolean DEBUG_BLOB_EQUAL_LOG = Boolean.getBoolean("oak.abstractblob.equal.log");
     private static final long DEBUG_BLOB_EQUAL_LOG_LIMIT = Long.getLong("oak.abstractblob.equal.log.limit", 100_000_000L);
 
     private static ByteSource supplier(final Blob blob) {
@@ -68,7 +69,7 @@ public abstract class AbstractBlob implements Blob {
             return true;
         }
 
-        if (al > DEBUG_BLOB_EQUAL_LOG_LIMIT) {
+        if (DEBUG_BLOB_EQUAL_LOG && al > DEBUG_BLOB_EQUAL_LOG_LIMIT) {
             LOG.debug("Blobs have the same length of {} and we're falling back to byte-wise comparison.", al);
         }
 


### PR DESCRIPTION
We want to be able to assess how often it happens that large blobs are compared byte-by-byte.