### PR TITLE
OAK-10353: Elastic custom analyzer should ignore unsupported properties

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
@@ -173,6 +173,7 @@ public class ElasticCustomAnalyzer {
                                 .map(Map.Entry::getValue)
                                 .findFirst().orElseGet(Collections::emptyList);
                 Map<String, String> luceneArgs = StreamSupport.stream(child.getProperties().spliterator(), false)
+                        .filter(ElasticCustomAnalyzer::isPropertySupported)
                         .filter(ps -> !unsupportedParameters.contains(ps.getName()))
                         .collect(Collectors.toMap(PropertyState::getName, ps -> ps.getValue(Type.STRING)));
 
@@ -267,11 +268,7 @@ public class ElasticCustomAnalyzer {
 
     private static Map<String, Object> convertNodeState(NodeState state, List<ParameterTransformer> transformers, List<String> preloadedContent) {
         Map<String, Object> luceneParams = StreamSupport.stream(Spliterators.spliteratorUnknownSize(state.getProperties().iterator(), Spliterator.ORDERED), false)
-                .filter(ps -> ps.getType() != Type.BINARY &&
-                        !ps.isArray() &&
-                        !NodeStateUtils.isHidden(ps.getName()) &&
-                        !IGNORE_PROP_NAMES.contains(ps.getName())
-                )
+                .filter(ElasticCustomAnalyzer::isPropertySupported)
                 .collect(Collectors.toMap(PropertyState::getName, ps -> {
                     String value = ps.getValue(Type.STRING);
                     List<String> values = Arrays.asList(value.split(","));
@@ -290,6 +287,13 @@ public class ElasticCustomAnalyzer {
             lp1.putAll(lp2);
             return lp1;
         });
+    }
+
+    private static boolean isPropertySupported(PropertyState ps) {
+        return ps.getType() != Type.BINARY &&
+                !ps.isArray() &&
+                !NodeStateUtils.isHidden(ps.getName()) &&
+                !IGNORE_PROP_NAMES.contains(ps.getName());
     }
 
     /**

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
@@ -289,6 +289,9 @@ public class ElasticCustomAnalyzer {
         });
     }
 
+    /*
+     * See org.apache.jackrabbit.oak.plugins.index.lucene.NodeStateAnalyzerFactory#convertNodeState
+     */
     private static boolean isPropertySupported(PropertyState ps) {
         return ps.getType() != Type.BINARY &&
                 !ps.isArray() &&

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
@@ -104,7 +104,7 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            addFilter(filters, "Lowercase");
+            addFilter(filters, "LowerCase");
             Tree stemmer = addFilter(filters, "stemmer");
             stemmer.setProperty("language", "dutch_kp");
         });

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
@@ -104,8 +104,8 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            filters.addChild("LowerCase");
-            Tree stemmer = filters.addChild("stemmer");
+            addFilter(filters, "Lowercase");
+            Tree stemmer = addFilter(filters, "stemmer");
             stemmer.setProperty("language", "dutch_kp");
         });
 
@@ -126,7 +126,7 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            filters.addChild("Apostrophe");
+            addFilter(filters, "Apostrophe");
         });
 
         Tree test = root.getTree("/");
@@ -144,7 +144,7 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            Tree dd = filters.addChild("dictionary_decompounder");
+            Tree dd = addFilter(filters, "dictionary_decompounder");
             dd.setProperty("word_list", "words.txt");
             dd.addChild("words.txt").addChild(JcrConstants.JCR_CONTENT)
                     .setProperty(JcrConstants.JCR_DATA, "Donau\ndampf\nmeer\nschiff");
@@ -168,7 +168,7 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            Tree dd = filters.addChild("fingerprint");
+            Tree dd = addFilter(filters, "fingerprint");
             dd.setProperty("max_output_size", "10");
         });
 
@@ -190,7 +190,7 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            Tree kt = filters.addChild("keep_types");
+            Tree kt = addFilter(filters, "keep_types");
             kt.setProperty("types", "<NUM>");
         });
 
@@ -212,12 +212,12 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            Tree mh = filters.addChild("min_hash");
+            Tree mh = addFilter(filters, "min_hash");
             mh.setProperty("hash_count", "1");
             mh.setProperty("bucket_count", "512");
             mh.setProperty("hash_set_size", "1");
             mh.setProperty("with_rotation", "true");
-            Tree shingle = filters.addChild("shingle");
+            Tree shingle = addFilter(filters, "shingle");
             shingle.setProperty("min_shingle_size", "5");
             shingle.setProperty("max_shingle_size", "5");
             shingle.setProperty("output_unigrams", "false");
@@ -241,7 +241,7 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
             anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
 
             Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            Tree snowball = filters.addChild("SnowballPorter");
+            Tree snowball = addFilter(filters, "SnowballPorter");
             snowball.setProperty("language", "Italian");
         });
 


### PR DESCRIPTION
Examples: hidden, arrays, binaries, etc