### PR TITLE
OAK-10358 - Filter by path on MongoDB query when downloading repository in Indexing job

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -89,6 +89,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     // TODO: Revise this timeout. It is used to prevent the indexer from blocking forever if the queue is full.
     private static final Duration MONGO_QUEUE_OFFER_TIMEOUT = Duration.ofMinutes(30);
     private static final int MIN_INTERVAL_BETWEEN_DELAYED_ENQUEUING_MESSAGES = 10;
+    private final static BsonDocument NATURAL_HINT =  BsonDocument.parse("{ $natural:1}");
 
     private final int batchSize;
     private final BlockingQueue<BasicDBObject[]> mongoDocQueue;
@@ -277,7 +278,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             FindIterable<BasicDBObject> mongoIterable = dbCollection
                     .withReadPreference(readPreference)
                     .find()
-                    .hint(BsonDocument.parse("{ $natural:1}"));
+                    .hint(NATURAL_HINT);
             download(mongoIterable);
 
         } else {
@@ -295,7 +296,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             FindIterable<BasicDBObject> childrenIterable = dbCollection
                     .withReadPreference(readPreference)
                     .find(childrenQuery)
-                    .hint(BsonDocument.parse("{ $natural:1}"));
+                    .hint(NATURAL_HINT);
             download(childrenIterable);
         }
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -26,24 +26,31 @@ import com.mongodb.ReadPreference;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.Filters;
 import org.apache.jackrabbit.guava.common.base.Preconditions;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
+import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.document.Document;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Sorts.ascending;
 
 public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownloadTask.Result> {
@@ -72,6 +79,8 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     public static final boolean DEFAULT_OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS = true;
     public static final String OAK_INDEXER_PIPELINED_MONGO_CONNECTION_RETRY_SECONDS = "oak.indexer.pipelined.mongoConnectionRetrySeconds";
     public static final int DEFAULT_OAK_INDEXER_PIPELINED_MONGO_CONNECTION_RETRY_SECONDS = 300;
+    public static final String OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING = "oak.indexer.pipelined.mongoRegexPathFiltering";
+    public static final boolean DEFAULT_OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING = true;
     // Use a short initial retry interval. In most cases if the connection to a replica fails, there will be other
     // replicas available so a reconnection attempt will succeed immediately.
     private final static long retryInitialIntervalMillis = 100;
@@ -83,8 +92,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
 
     private final int batchSize;
     private final BlockingQueue<BasicDBObject[]> mongoDocQueue;
+    private final List<PathFilter> pathFilters;
     private final int retryDuringSeconds;
     private final boolean retryOnConnectionErrors;
+    private final boolean regexPathFiltering;
     private final Logger traversalLog = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class.getName() + ".traversal");
     private final MongoCollection<BasicDBObject> dbCollection;
     private final ReadPreference readPreference;
@@ -98,10 +109,12 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
 
     public PipelinedMongoDownloadTask(MongoCollection<BasicDBObject> dbCollection,
                                       int batchSize,
-                                      BlockingQueue<BasicDBObject[]> queue) {
+                                      BlockingQueue<BasicDBObject[]> queue,
+                                      List<PathFilter> pathFilters) {
         this.dbCollection = dbCollection;
         this.batchSize = batchSize;
         this.mongoDocQueue = queue;
+        this.pathFilters = pathFilters;
         // Default retries for 5 minutes.
         this.retryDuringSeconds = ConfigHelper.getSystemPropertyAsInt(
                 OAK_INDEXER_PIPELINED_MONGO_CONNECTION_RETRY_SECONDS,
@@ -111,6 +124,9 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         this.retryOnConnectionErrors = ConfigHelper.getSystemPropertyAsBoolean(
                 OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS,
                 DEFAULT_OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS);
+        this.regexPathFiltering = ConfigHelper.getSystemPropertyAsBoolean(
+                OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING,
+                DEFAULT_OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING);
 
         //TODO This may lead to reads being routed to secondary depending on MongoURI
         //So caller must ensure that its safe to read from secondary
@@ -127,67 +143,14 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             LOG.info("Starting to download from MongoDB.");
             //TODO This may lead to reads being routed to secondary depending on MongoURI
             //So caller must ensure that its safe to read from secondary
-
             this.nextLastModified = 0;
             this.lastIdDownloaded = null;
 
-
             downloadStartWatch.start();
-            if (!retryOnConnectionErrors) {
-                downloadAll();
+            if (retryOnConnectionErrors) {
+                downloadWithRetryOnConnectionErrors();
             } else {
-                Instant failuresStartTimestamp = null; // When the last series of failures started
-                long retryIntervalMs = retryInitialIntervalMillis;
-                int numberOfFailures = 0;
-                boolean downloadCompleted = false;
-                Map<String, Integer> exceptions = new HashMap<>();
-                while (!downloadCompleted) {
-                    try {
-                        if (lastIdDownloaded != null) {
-                            LOG.info("Recovering from broken connection, finishing downloading documents with _modified={}", nextLastModified);
-                            downloadRange(new DownloadRange(nextLastModified, nextLastModified + 1, lastIdDownloaded));
-                            // We have managed to reconnect, reset the failure timestamp
-                            failuresStartTimestamp = null;
-                            numberOfFailures = 0;
-                            // Continue downloading everything starting from the next _lastmodified value
-                            downloadRange(new DownloadRange(nextLastModified + 1, Long.MAX_VALUE, null));
-                        } else {
-                            downloadRange(new DownloadRange(nextLastModified, Long.MAX_VALUE, null));
-                        }
-                        downloadCompleted = true;
-                    } catch (MongoException e) {
-                        if (e instanceof MongoInterruptedException || e instanceof MongoIncompatibleDriverException) {
-                            // Non-recoverable exceptions
-                            throw e;
-                        }
-                        if (failuresStartTimestamp == null) {
-                            failuresStartTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-                        }
-                        LOG.warn("Connection error downloading from MongoDB.", e);
-                        long secondsSinceStartOfFailures = Duration.between(failuresStartTimestamp, Instant.now()).toSeconds();
-                        if (secondsSinceStartOfFailures > retryDuringSeconds) {
-                            // Give up. Get a string of all exceptions that were thrown
-                            StringBuilder summary = new StringBuilder();
-                            for (Map.Entry<String, Integer> entry : exceptions.entrySet()) {
-                                summary.append("\n\t").append(entry.getValue()).append("x: ").append(entry.getKey());
-                            }
-                            throw new RetryException(retryDuringSeconds, summary.toString(), e);
-                        } else {
-                            numberOfFailures++;
-                            LOG.warn("Retrying download in {} ms; number of times failed: {}; current series of failures started at: {} ({} seconds ago)",
-                                    retryIntervalMs, numberOfFailures, failuresStartTimestamp, secondsSinceStartOfFailures);
-                            exceptions.compute(e.getClass().getSimpleName() + " - " + e.getMessage(),
-                                    (key, val) -> val == null ? 1 : val + 1
-                            );
-                            try {
-                                Thread.sleep(retryIntervalMs);
-                            } catch (InterruptedException ignore) {
-                            }
-                            // simple exponential backoff mechanism
-                            retryIntervalMs = Math.min(retryMaxIntervalMillis, retryIntervalMs * 2);
-                        }
-                    }
-                }
+                downloadWithNaturalOrdering();
             }
             LOG.info("Terminating task. Downloaded {} Mongo documents in {}. Total enqueuing delay: {} ms ({}%)",
                     documentsRead, downloadStartWatch,
@@ -215,8 +178,88 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         traversalLog.trace(id);
     }
 
-    private void downloadRange(DownloadRange range) throws InterruptedException, TimeoutException {
-        BsonDocument findQuery = range.getFindQuery();
+
+    private void downloadWithRetryOnConnectionErrors() throws InterruptedException, TimeoutException {
+        // If regex filtering is enabled, start by downloading the ancestors of the path used for filtering.
+        // That is, download "/", "/content", "/content/dam" for a base path of "/content/dam". These nodes will not be
+        // matched by the regex used in the Mongo query, which assumes a prefix of "--:/content/dam"
+        Bson childrenFilter = null;
+        String regexBasePath = getPathForRegexFiltering();
+        if (regexBasePath != null) {
+            // Download the ancestors in a separate query. No retrials done on this query, as it will take only a few
+            // seconds and is done at the start of the job, so if it fails, the job can be retried without losing much work
+            LOG.info("Using regex filtering with path {}", regexBasePath);
+            Bson ancestorsQuery = ancestorsFilter(regexBasePath);
+            LOG.info("Downloading ancestors of {}", regexBasePath);
+            // Let Mongo decide which index to use for this query, it will return very few documents
+            FindIterable<BasicDBObject> mongoIterable = dbCollection
+                    .withReadPreference(readPreference)
+                    .find(ancestorsQuery);
+            download(mongoIterable);
+            childrenFilter = childrenFilter(regexBasePath);
+        }
+
+        Instant failuresStartTimestamp = null; // When the last series of failures started
+        long retryIntervalMs = retryInitialIntervalMillis;
+        int numberOfFailures = 0;
+        boolean downloadCompleted = false;
+        Map<String, Integer> exceptions = new HashMap<>();
+        this.nextLastModified = 0;
+        this.lastIdDownloaded = null;
+        while (!downloadCompleted) {
+            try {
+                if (lastIdDownloaded != null) {
+                    LOG.info("Recovering from broken connection, finishing downloading documents with _modified={}", nextLastModified);
+                    downloadRange(new DownloadRange(nextLastModified, nextLastModified + 1, lastIdDownloaded), childrenFilter);
+                    // We have managed to reconnect, reset the failure timestamp
+                    failuresStartTimestamp = null;
+                    numberOfFailures = 0;
+                    // Continue downloading everything starting from the next _lastmodified value
+                    downloadRange(new DownloadRange(nextLastModified + 1, Long.MAX_VALUE, null), childrenFilter);
+                } else {
+                    downloadRange(new DownloadRange(nextLastModified, Long.MAX_VALUE, null), childrenFilter);
+                }
+                downloadCompleted = true;
+            } catch (MongoException e) {
+                if (e instanceof MongoInterruptedException || e instanceof MongoIncompatibleDriverException) {
+                    // Non-recoverable exceptions
+                    throw e;
+                }
+                if (failuresStartTimestamp == null) {
+                    failuresStartTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+                }
+                LOG.warn("Connection error downloading from MongoDB.", e);
+                long secondsSinceStartOfFailures = Duration.between(failuresStartTimestamp, Instant.now()).toSeconds();
+                if (secondsSinceStartOfFailures > retryDuringSeconds) {
+                    // Give up. Get a string of all exceptions that were thrown
+                    StringBuilder summary = new StringBuilder();
+                    for (Map.Entry<String, Integer> entry : exceptions.entrySet()) {
+                        summary.append("\n\t").append(entry.getValue()).append("x: ").append(entry.getKey());
+                    }
+                    throw new RetryException(retryDuringSeconds, summary.toString(), e);
+                } else {
+                    numberOfFailures++;
+                    LOG.warn("Retrying download in {} ms; number of times failed: {}; current series of failures started at: {} ({} seconds ago)",
+                            retryIntervalMs, numberOfFailures, failuresStartTimestamp, secondsSinceStartOfFailures);
+                    exceptions.compute(e.getClass().getSimpleName() + " - " + e.getMessage(),
+                            (key, val) -> val == null ? 1 : val + 1
+                    );
+                    try {
+                        Thread.sleep(retryIntervalMs);
+                    } catch (InterruptedException ignore) {
+                    }
+                    // simple exponential backoff mechanism
+                    retryIntervalMs = Math.min(retryMaxIntervalMillis, retryIntervalMs * 2);
+                }
+            }
+        }
+    }
+
+    private void downloadRange(DownloadRange range, Bson filter) throws InterruptedException, TimeoutException {
+        Bson findQuery = range.getFindQuery();
+        if (filter != null) {
+            findQuery = Filters.and(findQuery, filter);
+        }
         LOG.info("Traversing: {}. Query: {}", range, findQuery);
         FindIterable<BasicDBObject> mongoIterable = dbCollection
                 .withReadPreference(readPreference)
@@ -225,12 +268,82 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         download(mongoIterable);
     }
 
-    private void downloadAll() throws InterruptedException, TimeoutException {
-        LOG.info("Traversing all documents");
-        FindIterable<BasicDBObject> mongoIterable = dbCollection
-                .withReadPreference(readPreference)
-                .find();
-        download(mongoIterable);
+    private void downloadWithNaturalOrdering() throws InterruptedException, TimeoutException {
+        // We are downloading potentially a large fraction of the repository, so using an index scan will be
+        // inefficient. So we pass the natural hint to force MongoDB to use natural ordering, that is, column scan
+        String regexBasePath = getPathForRegexFiltering();
+        if (regexBasePath == null) {
+            LOG.info("Downloading full repository using natural order");
+            FindIterable<BasicDBObject> mongoIterable = dbCollection
+                    .withReadPreference(readPreference)
+                    .find()
+                    .hint(BsonDocument.parse("{ $natural:1}"));
+            download(mongoIterable);
+
+        } else {
+            Bson ancestorQuery = ancestorsFilter(regexBasePath);
+            // Do not use natural order to download ancestors. The number of ancestors will always be small, likely less
+            // than 10, so let MongoDB use an index to find them.
+            LOG.info("Downloading using regex path filtering. Downloading ancestors: {}.", ancestorQuery);
+            FindIterable<BasicDBObject> ancestorsIterable = dbCollection
+                    .withReadPreference(readPreference)
+                    .find(ancestorQuery);
+            download(ancestorsIterable);
+
+            Bson childrenQuery = childrenFilter(regexBasePath);
+            LOG.info("Downloading using regex path filtering. Downloading children: {}.", childrenQuery);
+            FindIterable<BasicDBObject> childrenIterable = dbCollection
+                    .withReadPreference(readPreference)
+                    .find(childrenQuery)
+                    .hint(BsonDocument.parse("{ $natural:1}"));
+            download(childrenIterable);
+        }
+    }
+
+    private String getPathForRegexFiltering() {
+        if (!regexPathFiltering) {
+            LOG.info("Regex path filtering disabled.");
+            return null;
+        }
+        LOG.info("Creating regex filter from pathFilters: " + pathFilters);
+        if (pathFilters == null) {
+            return null;
+        }
+        if (pathFilters.size() != 1) {
+            return null;
+        }
+        PathFilter pathFilter = pathFilters.get(0);
+        List<String> includePaths = pathFilter.getIncludedPaths();
+        List<String> excludePaths = pathFilter.getExcludedPaths();
+
+        if (excludePaths.isEmpty() && includePaths.size() == 1) {
+            return includePaths.get(0);
+
+        } else {
+            return null;
+        }
+    }
+
+    private static Bson childrenFilter(String path) {
+        if (!path.endsWith("/")) {
+            path = path + "/";
+        }
+        String quotedPath = path.replace("/", "\\/");
+        return regex("_id", "^[0-9]{1,3}:" + quotedPath + ".*$");
+    }
+
+    private static Bson ancestorsFilter(String path) {
+        ArrayList<Bson> parentFilters = new ArrayList<>();
+        int depth = PathUtils.getDepth(path);
+        while (true) {
+            parentFilters.add(Filters.eq("_id", depth + ":" + path));
+            if (depth == 0) {
+                break;
+            }
+            path = PathUtils.getParentPath(path);
+            depth--;
+        }
+        return Filters.or(parentFilters);
     }
 
     private void download(FindIterable<BasicDBObject> mongoIterable) throws InterruptedException, TimeoutException {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -365,6 +365,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // Explicitly list all ancestors in a or query.
         while (true) {
             parentFilters.add(Filters.eq(NodeDocument.ID, depth + ":" + path));
+            parentFilters.add(Filters.eq(NodeDocument.PATH, path));
             if (depth == 0) {
                 break;
             }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -48,6 +48,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Sorts.ascending;
@@ -326,13 +327,13 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         if (!path.endsWith("/")) {
             path = path + "/";
         }
-        String quotedPath = path.replace("/", "\\/");
+        String quotedPath = Pattern.quote(path);
         // For entries with path sizes above a certain threshold, the _id field contains a hash instead of the path of
         // the entry. The path is stored instead in the _path field. Therefore, we have to include in the filter also
         // the documents with matching _path.
         return Filters.or(
-                regex(NodeDocument.ID, "^[0-9]{1,3}:" + quotedPath + ".*$"),
-                regex(NodeDocument.PATH, quotedPath + ".*$")
+                regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + quotedPath + ".*$")),
+                regex(NodeDocument.PATH, Pattern.compile(quotedPath + ".*$"))
         );
     }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -258,10 +258,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                     exceptions.compute(e.getClass().getSimpleName() + " - " + e.getMessage(),
                             (key, val) -> val == null ? 1 : val + 1
                     );
-                    try {
-                        Thread.sleep(retryIntervalMs);
-                    } catch (InterruptedException ignore) {
-                    }
+                    Thread.sleep(retryIntervalMs);
                     // simple exponential backoff mechanism
                     retryIntervalMs = Math.min(retryMaxIntervalMillis, retryIntervalMs * 2);
                 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -317,7 +317,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
 
         if (excludePaths.isEmpty() && includePaths.size() == 1) {
             return includePaths.get(0);
-
         } else {
             return null;
         }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -33,6 +33,7 @@ import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStoreHelper;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutionException;
@@ -193,6 +195,7 @@ public class PipelinedStrategy implements SortStrategy {
 
     private final PathElementComparator pathComparator;
     private final Compression algorithm;
+    private final List<PathFilter> pathFilters;
     private long entryCount;
     private final Predicate<String> pathPredicate;
 
@@ -203,7 +206,8 @@ public class PipelinedStrategy implements SortStrategy {
                              BlobStore blobStore,
                              File storeDir,
                              Compression algorithm,
-                             Predicate<String> pathPredicate) {
+                             Predicate<String> pathPredicate,
+                             List<PathFilter> pathFilters) {
         this.docStore = documentStore;
         this.documentNodeStore = documentNodeStore;
         this.rootRevision = rootRevision;
@@ -212,10 +216,10 @@ public class PipelinedStrategy implements SortStrategy {
         this.pathComparator = new PathElementComparator(preferredPathElements);
         this.pathPredicate = pathPredicate;
         this.algorithm = algorithm;
+        this.pathFilters = pathFilters;
 
         Preconditions.checkState(documentStore.isReadOnly(), "Traverser can only be used with readOnly store");
     }
-
 
     private int autodetectWorkingMemoryMB() {
         int maxHeapSizeMB = (int) (Runtime.getRuntime().maxMemory() / FileUtils.ONE_MB);
@@ -311,7 +315,7 @@ public class PipelinedStrategy implements SortStrategy {
 
             Stopwatch start = Stopwatch.createStarted();
             MongoCollection<BasicDBObject> dbCollection = MongoDocumentStoreHelper.getDBCollection(docStore, Collection.NODES);
-            PipelinedMongoDownloadTask downloadTask = new PipelinedMongoDownloadTask(dbCollection, mongoBatchSize, mongoDocQueue);
+            PipelinedMongoDownloadTask downloadTask = new PipelinedMongoDownloadTask(dbCollection, mongoBatchSize, mongoDocQueue, pathFilters);
             ecs.submit(downloadTask);
 
             File flatFileStore = null;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -199,6 +199,12 @@ public class PipelinedStrategy implements SortStrategy {
     private long entryCount;
     private final Predicate<String> pathPredicate;
 
+    /**
+     *
+     * @param pathPredicate Used by the transform stage to test if a node should be kept or discarded.
+     * @param pathFilters If non-empty, the download stage will use these filters to try to create a query that downloads
+     *                    only the matching MongoDB documents.
+     */
     public PipelinedStrategy(MongoDocumentStore documentStore,
                              DocumentNodeStore documentNodeStore,
                              RevisionVector rootRevision,

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.jetbrains.annotations.NotNull;
@@ -49,9 +50,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -71,6 +75,8 @@ public class PipelinedIT {
         Assume.assumeTrue(MongoUtils.isAvailable());
     }
 
+    private static final PathFilter contentDamPathFilter = new PathFilter(List.of("/content/dam"), List.of());
+
     @Before
     public void setup() throws IOException {
     }
@@ -78,40 +84,76 @@ public class PipelinedIT {
     @After
     public void tear() {
         MongoConnection c = connectionFactory.getConnection();
-        c.getDatabase().drop();
+        if (c != null) {
+            c.getDatabase().drop();
+        }
     }
 
     @Test
-    public void createFFSWithPipelinedStrategy() throws Exception {
+    public void createFFS_retryOnMongoFailures_noMongoFiltering() throws Exception {
+        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "true");
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "false");
+
+        Predicate<String> pathPredicate = s -> contentDamPathFilter.filter(s) != PathFilter.Result.EXCLUDE;
+        List<PathFilter> pathFilters = null;
+
+        testSuccessfulDownload(pathPredicate, pathFilters);
+    }
+
+    @Test
+    public void createFFS_retryOnMongoFailures_mongoFiltering() throws Exception {
+        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "true");
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");
+
+        Predicate<String> pathPredicate = s -> true;
+        List<PathFilter> pathFilters = List.of(contentDamPathFilter);
+
+        testSuccessfulDownload(pathPredicate, pathFilters);
+    }
+
+    @Test
+    public void createFFS_noRetryOnMongoFailures_mongoFiltering() throws Exception {
+        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "false");
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");
+
+        Predicate<String> pathPredicate = s -> true;
+        List<PathFilter> pathFilters = List.of(contentDamPathFilter);
+
+        testSuccessfulDownload(pathPredicate, pathFilters);
+    }
+
+    @Test
+    public void createFFS_noRetryOnMongoFailures_noMongoFiltering() throws Exception {
+        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "false");
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "false");
+
+        Predicate<String> pathPredicate = s -> contentDamPathFilter.filter(s) != PathFilter.Result.EXCLUDE;
+        List<PathFilter> pathFilters = null;
+
+        testSuccessfulDownload(pathPredicate, pathFilters);
+    }
+
+    private void testSuccessfulDownload(Predicate<String> pathPredicate, List<PathFilter> pathFilters) throws CommitFailedException, IOException {
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> rwStore = createNodeStore(false);
         createContent(rwStore.right);
 
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> roStore = createNodeStore(true);
-        Predicate<String> pathPredicate = s -> s.startsWith("/content/dam");
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate);
+
+        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
 
         File file = pipelinedStrategy.createSortedStoreFile();
         assertTrue(file.exists());
-        assertEquals(Arrays.asList(new String[] {"/content/dam|{}",
-                        "/content/dam/1000|{}",
-                        "/content/dam/1000/12|{\"p1\":\"v100012\"}",
-                        "/content/dam/2022|{}",
-                        "/content/dam/2022/02|{\"p1\":\"v202202\"}",
-                        "/content/dam/2023|{\"p2\":\"v2023\"}",
-                        "/content/dam/2023/01|{\"p1\":\"v202301\"}",
-                        "/content/dam/2023/02|{}",
-                        "/content/dam/2023/02/28|{\"p1\":\"v20230228\"}"}),
-                Files.readAllLines(file.toPath()));
+        assertEquals(EXPECTED_FFS, Files.readAllLines(file.toPath()));
     }
 
     @Test
-    public void createFFSWithPipelinedStrategy_pathPredicateDoesNotMatch() throws Exception {
+    public void createFFS_pathPredicateDoesNotMatch() throws Exception {
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> rwStore = createNodeStore(false);
         createContent(rwStore.right);
 
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> roStore = createNodeStore(true);
         Predicate<String> pathPredicate = s -> s.startsWith("/content/dam/does-not-exist");
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate);
+        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, null);
 
         File file = pipelinedStrategy.createSortedStoreFile();
 
@@ -120,7 +162,7 @@ public class PipelinedIT {
     }
 
     @Test
-    public void createFFSWithPipelinedStrategy_badNumberOfTransformThreads() throws CommitFailedException {
+    public void createFFS_badNumberOfTransformThreads() throws CommitFailedException {
         System.setProperty(PipelinedStrategy.OAK_INDEXER_PIPELINED_TRANSFORM_THREADS, "0");
 
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> rwStore = createNodeStore(false);
@@ -136,7 +178,7 @@ public class PipelinedIT {
     }
 
     @Test
-    public void createFFSWithPipelinedStrategy_badWorkingMemorySetting() throws CommitFailedException {
+    public void createFFS_badWorkingMemorySetting() throws CommitFailedException {
         System.setProperty(PipelinedStrategy.OAK_INDEXER_PIPELINED_WORKING_MEMORY_MB, "-1");
 
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> rwStore = createNodeStore(false);
@@ -161,16 +203,16 @@ public class PipelinedIT {
 
         ImmutablePair<MongoDocumentStore, DocumentNodeStore> roStore = createNodeStore(true);
         Predicate<String> pathPredicate = s -> s.startsWith("/content/dam");
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate);
+        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, null);
 
         pipelinedStrategy.createSortedStoreFile();
     }
 
     private PipelinedStrategy createStrategy(ImmutablePair<MongoDocumentStore, DocumentNodeStore> roStore) {
-        return createStrategy(roStore, s -> true);
+        return createStrategy(roStore, s -> true, null);
     }
 
-    private PipelinedStrategy createStrategy(ImmutablePair<MongoDocumentStore, DocumentNodeStore> roStore, Predicate<String> pathPredicate) {
+    private PipelinedStrategy createStrategy(ImmutablePair<MongoDocumentStore, DocumentNodeStore> roStore, Predicate<String> pathPredicate, List<PathFilter> pathFilters) {
         DocumentNodeStore readOnlyNodeStore = roStore.right;
         MongoDocumentStore readOnlyMongoDocStore = roStore.left;
 
@@ -184,8 +226,8 @@ public class PipelinedIT {
                 new MemoryBlobStore(),
                 sortFolder.getRoot(),
                 Compression.NONE,
-                pathPredicate
-        );
+                pathPredicate,
+                pathFilters);
     }
 
     private void createContent(NodeStore rwNodeStore) throws CommitFailedException {
@@ -197,8 +239,33 @@ public class PipelinedIT {
         contentDamBuilder.child("1000").child("12").setProperty("p1", "v100012");
         contentDamBuilder.child("2023").setProperty("p2", "v2023");
         contentDamBuilder.child("2023").child("02").child("28").setProperty("p1", "v20230228");
+
+        // Other subtrees, to exercise filtering
+        rootBuilder.child("jcr:system").child("jcr:versionStorage")
+                .child("42").child("41").child("1.0").child("jcr:frozenNode").child("nodes").child("node0");
+        rootBuilder.child("home").child("users").child("system").child("cq:services").child("internal")
+                .child("dam").child("foobar").child("rep:principalPolicy").child("entry2")
+                .child("rep:restrictions");
+        rootBuilder.child("etc").child("scaffolding").child("jcr:content").child("cq:dialog")
+                .child("content").child("items").child("tabs").child("items").child("basic")
+                .child("items");
+
         rwNodeStore.merge(rootBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
     }
+
+    private static final List<String> EXPECTED_FFS = Arrays.asList(
+            "/|{}",
+            "/content|{}",
+            "/content/dam|{}",
+            "/content/dam/1000|{}",
+            "/content/dam/1000/12|{\"p1\":\"v100012\"}",
+            "/content/dam/2022|{}",
+            "/content/dam/2022/02|{\"p1\":\"v202202\"}",
+            "/content/dam/2023|{\"p2\":\"v2023\"}",
+            "/content/dam/2023/01|{\"p1\":\"v202301\"}",
+            "/content/dam/2023/02|{}",
+            "/content/dam/2023/02/28|{\"p1\":\"v20230228\"}"
+    );
 
     private ImmutablePair<MongoDocumentStore, DocumentNodeStore> createNodeStore(boolean readOnly) {
         MongoConnection c = connectionFactory.getConnection();

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -85,7 +85,7 @@ public class PipelinedMongoDownloadTaskTest {
 
         int batchSize = 100;
         BlockingQueue<BasicDBObject[]> queue = new ArrayBlockingQueue<>(100);
-        PipelinedMongoDownloadTask task = new PipelinedMongoDownloadTask(dbCollection, batchSize, queue);
+        PipelinedMongoDownloadTask task = new PipelinedMongoDownloadTask(dbCollection, batchSize, queue, null);
 
         // Execute
         PipelinedMongoDownloadTask.Result result = task.call();

--- a/oak-run-commons/src/test/resources/logback-test.xml
+++ b/oak-run-commons/src/test/resources/logback-test.xml
@@ -32,13 +32,13 @@
     <!--
     <logger name="org.apache.jackrabbit.oak.index.IndexerSupport" level="TRACE"/>
     -->
-    <logger name="org.apache.jackrabbit.oak.index.indexer.document.flatfile" level="TRACE"/>
+<!--    <logger name="org.apache.jackrabbit.oak.index.indexer.document.flatfile" level="TRACE"/>-->
 
     <root level="INFO">
         <!--
-        <appender-ref ref="console"/>
-        -->
         <appender-ref ref="file"/>
+        -->
+        <appender-ref ref="console"/>
     </root>
 
 </configuration>

--- a/oak-run-commons/src/test/resources/logback-test.xml
+++ b/oak-run-commons/src/test/resources/logback-test.xml
@@ -32,13 +32,13 @@
     <!--
     <logger name="org.apache.jackrabbit.oak.index.IndexerSupport" level="TRACE"/>
     -->
-<!--    <logger name="org.apache.jackrabbit.oak.index.indexer.document.flatfile" level="TRACE"/>-->
+    <logger name="org.apache.jackrabbit.oak.index.indexer.document.flatfile" level="TRACE"/>
 
     <root level="INFO">
         <!--
-        <appender-ref ref="file"/>
-        -->
         <appender-ref ref="console"/>
+        -->
+        <appender-ref ref="file"/>
     </root>
 
 </configuration>

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
@@ -23,6 +23,7 @@ package org.apache.jackrabbit.oak.spi.filter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -72,13 +73,12 @@ public class PathFilter {
         TRAVERSE
     }
 
-    private static final PathFilter ALL = new PathFilter(INCLUDE_ROOT, Collections.<String>emptyList()) {
+    private static final PathFilter ALL = new PathFilter(INCLUDE_ROOT, Collections.emptyList()) {
         @Override
         public Result filter(@NotNull String path) {
             return Result.INCLUDE;
         }
     };
-
     private final String[] includedPaths;
     private final String[] excludedPaths;
 
@@ -99,7 +99,7 @@ public class PathFilter {
         }
         return new PathFilter(getStrings(defn, PROP_INCLUDED_PATHS,
                 INCLUDE_ROOT), getStrings(defn, PROP_EXCLUDED_PATHS,
-                Collections.<String> emptyList()));
+                Collections.emptyList()));
     }
 
     /**
@@ -108,8 +108,7 @@ public class PathFilter {
      * If both are empty then all paths would be considered to be included
      *
      * @param includes list of paths which should not be included
-     * @param excludes list of p
-     *                 aths which should be included
+     * @param excludes list of paths which should be included
      */
     public PathFilter(Iterable<String> includes, Iterable<String> excludes) {
         Set<String> includeCopy = newHashSet(includes);
@@ -147,6 +146,14 @@ public class PathFilter {
         }
 
         return Result.EXCLUDE;
+    }
+
+    public List<String> getIncludedPaths() {
+        return List.of(includedPaths);
+    }
+
+    public List<String> getExcludedPaths() {
+        return List.of(excludedPaths);
     }
 
     @Override

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
@@ -107,8 +107,8 @@ public class PathFilter {
      *
      * If both are empty then all paths would be considered to be included
      *
-     * @param includes list of paths which should not be included
-     * @param excludes list of paths which should be included
+     * @param includes list of paths which should be included
+     * @param excludes list of paths which should not be included
      */
     public PathFilter(Iterable<String> includes, Iterable<String> excludes) {
         Set<String> includeCopy = newHashSet(includes);


### PR DESCRIPTION
Use a [MongoDB regex query](https://www.mongodb.com/docs/manual/reference/operator/query/regex/) to download only the Mongo documents that are needed for a given index, based on the `includedPaths`/`excludedPaths` properties. 

This PR only applies filtering in the simple cases, where there is a single `includedPath` and no `excludedPaths`. This should be a common case. In the future, we may expand to filter on more complex combinations of these two properties.

The regex used to match a path is of the form `^[0-9]{1,3}:" + path + ".*$`. Since this regex starts with an wildcard, it cannot use the index on `_id`, so Mongo has to scan all documents, like when downloading without regex filtering. The gain in performance of regex filtering is from only sending to the indexing job the documents for the entries in the path being indexed. 