### PR TITLE
OAK-10372: oak-search-elastic: similarity queries produce no relevant results

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -136,6 +136,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
     private final Map<String, List<PropertyDefinition>> propertiesByName;
     private final List<PropertyDefinition> dynamicBoostProperties;
     private final List<PropertyDefinition> similarityProperties;
+    private final List<PropertyDefinition> similarityTagsProperties;
 
     public ElasticIndexDefinition(NodeState root, NodeState defn, String indexPath, String indexPrefix) {
         super(root, defn, determineIndexFormatVersion(defn), determineUniqueId(defn), indexPath);
@@ -181,6 +182,10 @@ public class ElasticIndexDefinition extends IndexDefinition {
                 .stream()
                 .flatMap(rule -> rule.getSimilarityProperties().stream())
                 .collect(Collectors.toList());
+
+        this.similarityTagsProperties = propertiesByName.values().stream()
+                .flatMap(List::stream)
+                .filter(pd -> pd.similarityTags).collect(Collectors.toList());
     }
 
     @Nullable
@@ -211,6 +216,10 @@ public class ElasticIndexDefinition extends IndexDefinition {
 
     public List<PropertyDefinition> getSimilarityProperties() {
         return similarityProperties;
+    }
+
+    public List<PropertyDefinition> getSimilarityTagsProperties() {
+        return similarityTagsProperties;
     }
 
     public boolean areSimilarityTagsEnabled() {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -104,6 +104,17 @@ public class ElasticIndexDefinition extends IndexDefinition {
     private static final String SIMILARITY_TAGS_ENABLED = "similarityTagsEnabled";
     private static final boolean SIMILARITY_TAGS_ENABLED_DEFAULT = true;
 
+    private static final String SIMILARITY_TAGS_FIELDS = "similarityTagsFields";
+
+    // MLT queries, when no fields are specified, do not use the entire document but only a maximum of
+    // max_query_terms (default 25). Even increasing this value, the query could produce not so relevant
+    // results (eg: based on the :fulltext content). To work this around, we can specify DYNAMIC_BOOST_FULLTEXT
+    // field as first field since it usually contains relevant terms. This will make sure that the MLT queries
+    // give more priority to the terms in this field while the rest (*) are considered secondary.
+    private static final String[] SIMILARITY_TAGS_FIELDS_DEFAULT = new String[] {
+            DYNAMIC_BOOST_FULLTEXT, "*"
+    };
+
     private static final String SIMILARITY_TAGS_BOOST = "similarityTagsBoost";
     private static final float SIMILARITY_TAGS_BOOST_DEFAULT = 0.5f;
 
@@ -137,6 +148,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
     private final List<PropertyDefinition> dynamicBoostProperties;
     private final List<PropertyDefinition> similarityProperties;
     private final List<PropertyDefinition> similarityTagsProperties;
+    private final String[] similarityTagsFields;
 
     public ElasticIndexDefinition(NodeState root, NodeState defn, String indexPath, String indexPrefix) {
         super(root, defn, determineIndexFormatVersion(defn), determineUniqueId(defn), indexPath);
@@ -158,6 +170,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
         this.failOnError = getOptionalValue(defn, FAIL_ON_ERROR,
                 Boolean.parseBoolean(System.getProperty(TYPE_ELASTICSEARCH + "." + FAIL_ON_ERROR, Boolean.toString(FAIL_ON_ERROR_DEFAULT)))
         );
+        this.similarityTagsFields = getOptionalValues(defn, SIMILARITY_TAGS_FIELDS, Type.STRINGS, String.class, SIMILARITY_TAGS_FIELDS_DEFAULT);
 
         this.propertiesByName = getDefinedRules()
                 .stream()
@@ -220,6 +233,10 @@ public class ElasticIndexDefinition extends IndexDefinition {
 
     public List<PropertyDefinition> getSimilarityTagsProperties() {
         return similarityTagsProperties;
+    }
+
+    public String[] getSimilarityTagsFields() {
+        return similarityTagsFields;
     }
 
     public boolean areSimilarityTagsEnabled() {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -396,12 +397,8 @@ public class ElasticRequestHandler {
                     // this is needed to workaround https://github.com/elastic/elasticsearch/pull/94518 that causes empty
                     // results when the _ignored metadata field is part of the input document
                     .perFieldAnalyzer("_ignored", "keyword")));
-            // MLT queries, when no fields are specified, do not use the entire document but only a maximum of
-            // max_query_terms (default 25). Even increasing this value, the query could produce not so relevant
-            // results (eg: based on the :fulltext content). To work this around, we can specify DYNAMIC_BOOST_FULLTEXT
-            // field as first field since it usually contains relevant terms. This will make sure that the MLT queries
-            // give more priority to the terms in this field while the rest (*) are considered secondary.
-            mlt.fields(ElasticIndexDefinition.DYNAMIC_BOOST_FULLTEXT, "*");
+            // when no fields are specified, we set the ones from the index definition
+            mlt.fields(Arrays.asList(elasticIndexDefinition.getSimilarityTagsFields()));
         } else {
             // This is for native queries if someone sends additional fields via
             // mlt.fl=field1,field2

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -397,9 +397,9 @@ public class ElasticRequestHandler {
                     // results when the _ignored metadata field is part of the input document
                     .perFieldAnalyzer("_ignored", "keyword")));
             // MLT queries, when no fields are specified, do not use the entire document but only a maximum of
-            // max_query_terms (default 25). Even increasing this value to a greater number could produce not so relevant
+            // max_query_terms (default 25). Even increasing this value, the query could produce not so relevant
             // results (eg: based on the :fulltext content). To work this around, we can specify DYNAMIC_BOOST_FULLTEXT
-            // field as first field since it usually contains relevant terms. This will make sure that the MLT query
+            // field as first field since it usually contains relevant terms. This will make sure that the MLT queries
             // give more priority to the terms in this field while the rest (*) are considered secondary.
             mlt.fields(ElasticIndexDefinition.DYNAMIC_BOOST_FULLTEXT, "*");
         } else {

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexQueryCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexQueryCommonTest.java
@@ -57,7 +57,7 @@ import static org.junit.Assert.fail;
  */
 public abstract class IndexQueryCommonTest extends AbstractQueryTest {
 
-    private Tree indexDefn;
+    protected Tree indexDefn;
     protected IndexOptions indexOptions;
     protected TestRepository repositoryOptionsUtil;
     private LogCustomizer logCustomizer;
@@ -813,7 +813,7 @@ public abstract class IndexQueryCommonTest extends AbstractQueryTest {
 
     public abstract String getExplainValueForDescendantTestWithIndexTagExplain();
 
-    private Runnable getAssertionForExplain(String query, String language, String expected, boolean matchComplete) {
+    protected Runnable getAssertionForExplain(String query, String language, String expected, boolean matchComplete) {
         return () -> {
             Result result = null;
             try {
@@ -830,7 +830,7 @@ public abstract class IndexQueryCommonTest extends AbstractQueryTest {
         };
     }
 
-    private static void assertEventually(Runnable r) {
+    protected static void assertEventually(Runnable r) {
         TestUtil.assertEventually(r, 3000 * 3);
     }
 }


### PR DESCRIPTION
MLT queries, when no fields are specified, do not use the entire document but only a maximum of max_query_terms (default 25). Even increasing this value to a greater number could produce not so relevant results (eg: based on the `:fulltext` content). To work this around, we can specify DYNAMIC_BOOST_FULLTEXT field as the first field since it usually contains relevant terms. This will make sure that the MLT queries give more priority to the terms in this field while the rest (*) are considered secondary.