### PR TITLE
OAK-10384: Fix stripping of large indexed ordered properties

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -288,6 +288,8 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
                         new BytesRef(property.getValue(Type.BOOLEAN).toString()));
             } else if (tag == Type.STRING.tag()) {
                 String stringValue = property.getValue(Type.STRING);
+                // Truncate the value as lucene limits the length of a SortedDocValueField string to 
+                // STRING_PROPERTY_MAX_LENGTH(32766 bytes) and throws exception if over the limit
                 f = new SortedDocValuesField(name, getTruncatedBytesRef(name, stringValue, this.path,
                         STRING_PROPERTY_MAX_LENGTH));
             }
@@ -324,7 +326,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
      *
      * <p>Multi-byte sequences will be of the form {@code 11xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx}.
      * The method first truncates continuation bytes, which start with {@code 10} in binary. It then truncates the head byte, which
-     * starts with {@code 11}. Both truncation operations use a binary mask of {@code 11100000}.
+     * starts with {@code 11}. Both truncation operations use a binary mask of {@code 11000000}.
      *
      * @param prop      the name of the property
      * @param value     the string property value to convert into a {@code BytesRef} object

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneLargeStringPropertyTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneLargeStringPropertyTest.java
@@ -254,6 +254,8 @@ public class LuceneLargeStringPropertyTest extends AbstractQueryTest {
             String x = randomUnicodeString(r, 5);
             BytesRef ref = checkTruncateLength("x", x, "/x", 5);
             assertTrue(ref.length > 0 && ref.length <= 5);
+            //assert valid string
+            assertTrue(x.startsWith(ref.utf8ToString()));
         }
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneLargeStringPropertyTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneLargeStringPropertyTest.java
@@ -252,7 +252,8 @@ public class LuceneLargeStringPropertyTest extends AbstractQueryTest {
         String aVal ="abcd Mình nói tiếng Việt" + generatedString.substring(0, length);
         
         // Large String which ends with the unicode char `𐍈` represented by "\uD800\uDF48".
-        //This char is represented by 4 bytes in UTF-8 but only with 2 bytes in Java.
+        //This char is represented by 4 bytes in UTF-8 but only with 2 bytes in Java. The truncation will
+        // truncate the string `..xyz𐍈` to `..xyz`.
         String bVal = "abcd " + generatedString.substring(0, length - 6) + "\uD800\uDF48";
 
         test.addChild("a").setProperty("propa", aVal);


### PR DESCRIPTION
- Convert to BytesRef and then recheck and trim by the amount exceeding