### PR TITLE
OAK-10413: DocumentStoreIndexerIT hanging

### DIFF
--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersionIT.java
@@ -81,6 +81,7 @@ public class PurgeOldIndexVersionIT {
         Assert.assertTrue(IndexUtils.isIndexDisabledAndHiddenNodesDeleted(n, "/oak:index/test-1"));
         Assert.assertTrue(IndexUtils.isIndexDisabledAndHiddenNodesDeleted(n, "/oak:index/test-2"));
         Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPresent(n, "/oak:index/test-2-custom-1"));
+        p.close();
     }
 
     @Test
@@ -105,6 +106,7 @@ public class PurgeOldIndexVersionIT {
         Assert.assertTrue(IndexUtils.isIndexDisabledAndHiddenNodesDeleted(n, "/oak:index/test-1"));
         Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPresent(n, "/oak:index/test-2"));
         Assert.assertTrue(IndexUtils.isIndexEnabledAndHiddenNodesPresent(n, "/oak:index/test-2-custom-1"));
+        p.close();
     }
 
     private void initGlobal() throws Exception {


### PR DESCRIPTION
Release resources held by Persistence