### PR TITLE
OAK-10425: Ability to remove mixin type without read permission on jc…

### DIFF
--- a/oak-jcr/pom.xml
+++ b/oak-jcr/pom.xml
@@ -149,6 +149,9 @@
       org.apache.jackrabbit.core.query.ShareableNodeTest#testName                                    <!-- OAK-118 -->
       org.apache.jackrabbit.core.query.ShareableNodeTest#testPathConstraint                          <!-- OAK-118 -->
       org.apache.jackrabbit.oak.jcr.query.QueryTest#fnNameEncoding                                   <!-- OAK-1000 -->
+
+      <!-- node type -->
+      org.apache.jackrabbit.oak.jcr.security.authorization.ReadPropertyTest#testRemoveMixinType      <!-- OAK-10425 -->
     </known.issues>
   </properties>
 


### PR DESCRIPTION
…r:mixinTypes property

Add ignored test