### PR TITLE
OAK-10441: exclude snakeyaml from oak-search-elastic

### DIFF
--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <elasticsearch.hlrc.version>7.17.13</elasticsearch.hlrc.version>
-    <elasticsearch.java.client.version>8.7.0</elasticsearch.java.client.version>
+    <elasticsearch.java.client.version>8.7.1</elasticsearch.java.client.version>
   </properties>
 
   <build>

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -33,7 +33,7 @@
   <description>Oak Elasticsearch integration subproject</description>
 
   <properties>
-    <elasticsearch.hlrc.version>7.17.9</elasticsearch.hlrc.version>
+    <elasticsearch.hlrc.version>7.17.13</elasticsearch.hlrc.version>
     <elasticsearch.java.client.version>8.7.0</elasticsearch.java.client.version>
   </properties>
 
@@ -193,6 +193,17 @@
         <exclusion>
           <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-suggest</artifactId>
+        </exclusion>
+        <!--
+          elasticsearch-xcontent depends on snakeyaml 1.33 which is vulnerable to remote code execution
+          (https://nvd.nist.gov/vuln/detail/CVE-2022-1471)
+          elasticsearch-xcontent is used in this module but only with the json parser which does not use snakeyaml
+          so we can safely exclude it.
+          This exclusion, like the others above, can be removed once we will remove the elasticsearch high level rest client
+        -->
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
@@ -50,7 +50,8 @@ public class ElasticTestServer implements AutoCloseable {
             "8.4.2.0", "5ce81ad043816900a496ad5b3cce7de1d99547ebf92aa1f9856343e48580c71c",
             "8.4.3.0", "5c00d43cdd56c5c5d8e9032ad507acea482fb5ca9445861c5cc12ad63af66425",
             "8.5.3.0", "d4c13f68650f9df5ff8c74ec83abc2e416de9c45f991d459326e0e2baf7b0e3f",
-            "8.7.0.0", "7aeac9b7ac4dea1ded3f8e477e26bcc7fe62e313edf6352f4bdf973c43d25819");
+            "8.7.0.0", "7aeac9b7ac4dea1ded3f8e477e26bcc7fe62e313edf6352f4bdf973c43d25819",
+            "8.7.1.0", "80c8d34334b0cf4def79835ea6dab78b59ba9ee54c8f5f3cba0bde53123d7820");
 
     private static final ElasticTestServer SERVER = new ElasticTestServer();
     private static volatile ElasticsearchContainer CONTAINER;


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-1471

snakeyaml 1.33 is vulnerable to remote code execution. A better solution would be to get rid of the es high-level client completely. This would require more time because of the changes needed to replace the bulk processor.

We can safely exclude this dependency since it's not used in our codebase.

As part of this PR, the es clients have been updated to the latest patch release.
