### PR TITLE
OAK-10371: oak-segment-azure/oak-blob-cloud-azure require provided Guava, embed it instead

### DIFF
--- a/oak-blob-cloud-azure/pom.xml
+++ b/oak-blob-cloud-azure/pom.xml
@@ -36,10 +36,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
-                    <instructions>
+                    <instructions combine.self="override">
                         <Import-Package>
-                            <!-- OAK-10369 -->${guava.osgi.import},
-                            *
+                          !com.google.*,
+                          !org.checkerframework.*,
+                          *
                         </Import-Package>
                         <Export-Package>
                             org.apache.jackrabbit.oak.blob.cloud.azure.blobstorage
@@ -47,8 +48,11 @@
                         <DynamicImport-Package>sun.io</DynamicImport-Package>
                         <Embed-Dependency>
                             azure-storage,
-                            azure-keyvault-core
+                            azure-keyvault-core,
+                            guava
                         </Embed-Dependency>
+                        <!-- needed to override value from oak-parent; can be removed when OAK-6741 is resolved -->
+                        <_plugin/>
                     </instructions>
                 </configuration>
             </plugin>
@@ -137,6 +141,12 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault-core</artifactId>
+        </dependency>
+        <!-- Azure Guava dependency -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>24.1.1-jre</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/oak-it-osgi/pom.xml
+++ b/oak-it-osgi/pom.xml
@@ -217,13 +217,6 @@
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- to be removed when OAK-10371 is resolved -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>

--- a/oak-it-osgi/test-bundles.xml
+++ b/oak-it-osgi/test-bundles.xml
@@ -30,8 +30,6 @@
       <includes>
         <include>javax.jcr:jcr</include>
         <include>javax.servlet:javax.servlet-api</include>
-        <!-- to be removed when OAK-10371 is resolved -->
-        <include>com.google.guava:guava</include>
         <include>org.slf4j:slf4j-api</include>
         <include>ch.qos.logback:logback-core</include>
         <include>ch.qos.logback:logback-classic</include>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -61,7 +61,6 @@
     <logback.version>1.2.10</logback.version>
     <h2.version>2.1.214</h2.version>
     <tika.version>1.28.5</tika.version>
-    <!-- OAK-10369 --><guava.osgi.import>com.google.common.*;version="[15.0,20)"</guava.osgi.import>
     <derby.version>10.15.2.0</derby.version>
     <jackson.version>2.13.5</jackson.version>
     <testcontainers.version>1.18.3</testcontainers.version>

--- a/oak-segment-azure/pom.xml
+++ b/oak-segment-azure/pom.xml
@@ -38,12 +38,13 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
-                    <instructions>
+                    <instructions combine.self="override">
                         <Import-Package>
-                            <!-- OAK-10369 -->${guava.osgi.import},
                             org.apache.jackrabbit.oak.segment.spi*,
                             org.apache.jackrabbit.oak.segment.remote*,
                             !org.apache.jackrabbit.oak.segment*,
+                            !com.google.*,
+                            !org.checkerframework.*,
                             *
                         </Import-Package>
                         <Export-Package>
@@ -56,8 +57,11 @@
                         </Export-Package>
                         <Embed-Dependency>
                             azure-storage,
-                            azure-keyvault-core
+                            azure-keyvault-core,
+                            guava
                         </Embed-Dependency>
+                        <!-- needed to override value from oak-parent; can be removed when OAK-6741 is resolved -->
+                        <_plugin/>
                     </instructions>
                 </configuration>
             </plugin>
@@ -139,6 +143,12 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault-core</artifactId>
+        </dependency>
+        <!-- Azure Guava dependency -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>24.1.1-jre</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
* OAK-10371: embed Guava in oak*azure bundles

* OAK-10371: remove provided Guava from OSGi tests

* OAK-10371: embed Guava in oak*azure bundles

Override _plugin instruction with an empty value.

* OAK-10371: embed Guava in oak*azure bundles 

Override _plugin instruction with an empty value.

* OAK-10371: embed Guava in oak*azure bundles

 Override _plugin instruction with an empty value.

* OAK-10371: embed Guava in oak*azure bundles

Re-added comment.

* OAK-10371: embed Guava in oak*azure bundles

Re-added comment.

* OAK-10371: use Guava version used by the SDK (for now)

* OAK-10371: suppress a few imports

---------