### PR TITLE
OAK-10452 - Mongo query that downloads ancestors of base path for regex filtering is doing a column scan

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -287,7 +287,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
 
     private void downloadAncestors(String basePath) throws InterruptedException, TimeoutException {
         Bson ancestorQuery = ancestorsFilter(basePath);
-        LOG.info("Downloading using regex path filtering. Base path: {}, Ancestors: {}.", basePath, ancestorQuery);
+        LOG.info("Downloading using regex path filtering. Base path: {}, Ancestors query: {}.", basePath, ancestorQuery);
         FindIterable<BasicDBObject> ancestorsIterable = dbCollection
                 .withReadPreference(readPreference)
                 .find(ancestorQuery)


### PR DESCRIPTION
Use Oak [Utils.getIdFromPath](https://github.com/apache/jackrabbit-oak/blob/59f62bafa5ceb0cbedfed285bff31c2db8d48355/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java#L281-L289) to compute the correct Mongo document id based on the path of the node. This deals with long paths transparently and does not require matching on the `_path` field. Doing a query with a condition on the `_path` field was forcing a full column scan because the `_path` field is not indexed. 

To ensure that the query on the ancestors uses the index on _id field, provide an hint to this query to request this index.