### PR TITLE
OAK-10450: bump testcontainers

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -63,7 +63,7 @@
     <tika.version>1.28.5</tika.version>
     <derby.version>10.15.2.0</derby.version>
     <jackson.version>2.15.2</jackson.version>
-    <testcontainers.version>1.18.3</testcontainers.version>
+    <testcontainers.version>1.19.0</testcontainers.version>
     <pax-exam.version>4.13.1</pax-exam.version>
     <groovy.version>2.5.22</groovy.version>
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
@@ -103,6 +103,7 @@ public class ElasticTestServer implements AutoCloseable {
                         MountableFile.forHostPath(localPluginPath),
                         "/tmp/plugins/elastiknn.zip")
                 .withNetwork(network)
+                .withNetworkAliases("elasticsearch")
                 .withStartupAttempts(3);
         CONTAINER.start();
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDockerRule.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDockerRule.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.arakelian.docker.junit.DockerRule;
 import com.arakelian.docker.junit.model.ImmutableDockerConfig;
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.PullImageResultCallback;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.auth.FixedRegistryAuthSupplier;
 
 import org.junit.Assume;
 import org.junit.rules.TestRule;
@@ -30,7 +30,6 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.DockerClientFactory;
 
 /**
  * A MongoDB {@link DockerRule}.
@@ -49,12 +48,14 @@ public class MongoDockerRule implements TestRule {
 
     static {
         boolean available = false;
-        try {
-            DockerClient client = DockerClientFactory.instance().client();
-            client.pingCmd().exec();
-            client.pullImageCmd(IMAGE).exec(new PullImageResultCallback()).awaitCompletion();
+        try (DefaultDockerClient client = DefaultDockerClient.fromEnv()
+                .connectTimeoutMillis(5000L).readTimeoutMillis(20000L)
+                .registryAuthSupplier(new FixedRegistryAuthSupplier())
+                .build()) {
+            client.ping();
+            client.pull(IMAGE);
             available = true;
-        } catch (Exception t) {
+        } catch (Throwable t) {
             LOG.info("Cannot connect to docker or pull image", t);
         }
         DOCKER_AVAILABLE = available;


### PR DESCRIPTION
+ use of latest toxiproxy image (2.6.0) which has multi arch support