### PR TITLE
OAK-10465 : added io.netty netty-transport-native-unix-common embedded dependency for oak-segment-tar

### DIFF
--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -326,6 +326,12 @@
             <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <version>${netty.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
 		<!-- ConcurrentLinkedHashMap -->
 


### PR DESCRIPTION
…d dependency for oak-segment-tar