### PR TITLE
OAK-10475 - Expose the Mongo client connection in MongoDocumentNodeStoreBuilderBase

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -47,6 +47,7 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     private String uri;
     private String name;
     private String collectionCompressionType;
+    private MongoClient mongoClient;
 
     /**
      * Uses the given information to connect to to MongoDB as backend
@@ -212,6 +213,15 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         return mongoStatus;
     }
 
+    /**
+     * Returns the MongoDB client configured in the {@link #setMongoDB(String, String, int)} method.
+     *
+     * @return the client or null if the {@link #setMongoDB(String, String, int)} method hasn't been called.
+     */
+    public MongoClient getMongoClient() {
+        return mongoClient;
+    }
+
     long getMaxReplicationLagMillis() {
         return maxReplicationLagMillis;
     }
@@ -227,16 +237,17 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
         return newMongoDBConnection(uri, name, mongoClock, socketTimeout, socketKeepAlive);
     }
 
-    private T setMongoDB(@NotNull MongoDBConnection client,
+    private T setMongoDB(@NotNull MongoDBConnection mongoDBConnection,
                          int blobCacheSizeMB) {
-        client.checkReadWriteConcern();
-        this.mongoStatus = client.getStatus();
+        mongoDBConnection.checkReadWriteConcern();
+        this.mongoStatus = mongoDBConnection.getStatus();
+        this.mongoClient = mongoDBConnection.getClient();
         this.documentStoreSupplier = memoize(() -> new MongoDocumentStore(
-                client.getClient(), client.getDatabase(), MongoDocumentNodeStoreBuilderBase.this));
+                mongoDBConnection.getClient(), mongoDBConnection.getDatabase(), MongoDocumentNodeStoreBuilderBase.this));
 
         if (this.blobStoreSupplier == null) {
             this.blobStoreSupplier = memoize(
-                    () -> new MongoBlobStore(client.getDatabase(), blobCacheSizeMB * 1024 * 1024L, MongoDocumentNodeStoreBuilderBase.this));
+                    () -> new MongoBlobStore(mongoDBConnection.getDatabase(), blobCacheSizeMB * 1024 * 1024L, MongoDocumentNodeStoreBuilderBase.this));
         }
 
         return thisBuilder();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderBase.java
@@ -240,8 +240,8 @@ public abstract class MongoDocumentNodeStoreBuilderBase<T extends MongoDocumentN
     private T setMongoDB(@NotNull MongoDBConnection mongoDBConnection,
                          int blobCacheSizeMB) {
         mongoDBConnection.checkReadWriteConcern();
-        this.mongoStatus = mongoDBConnection.getStatus();
         this.mongoClient = mongoDBConnection.getClient();
+        this.mongoStatus = mongoDBConnection.getStatus();
         this.documentStoreSupplier = memoize(() -> new MongoDocumentStore(
                 mongoDBConnection.getClient(), mongoDBConnection.getDatabase(), MongoDocumentNodeStoreBuilderBase.this));
 


### PR DESCRIPTION
This is a follow up of OAK-10453, which changed the indexing job to use custom codecs when downloading from Mongo. For this, the indexing logic needs access to the Mongo Connection to register the codec. If a library client uses MongoDocumentNodeStoreBuilderBase to build a MongoDocumentStore instance, then it may also need access to the Mongo connection to pass it to the indexing logic.