### PR TITLE
OAK-9459: ConstraintViolationException in VersionManagerImplRestore w…

### DIFF
--- a/oak-jcr/pom.xml
+++ b/oak-jcr/pom.xml
@@ -85,7 +85,6 @@
       org.apache.jackrabbit.test.api.version.VersionHistoryTest#testMerge
       org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreLabel
       org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreLabelJcr2
-      org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreRemovesMixin <!-- OAK-9459 -->
       org.apache.jackrabbit.test.api.version.WorkspaceRestoreTest
       org.apache.jackrabbit.test.api.version.MergeCancelMergeTest
       org.apache.jackrabbit.test.api.version.MergeCheckedoutSubNodeTest


### PR DESCRIPTION
…hen target node has a property definition unknown by the frozen node

Fixed by retrieving the property definitions before setting the node types.