### PR TITLE
OAK-10487: replaced lsm estimator with cacheable count

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -285,17 +285,19 @@ public class ElasticIndexStatistics implements IndexStatistics {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             StatsRequestDescriptor that = (StatsRequestDescriptor) o;
-            String thisInternalQuery = query != null ? query.toString() : null;
-            String thatInternalQuery = that.query != null ? that.query.toString() : null;
             return index.equals(that.index) &&
                     Objects.equals(field, that.field) &&
                     // ES Query objects are not comparable, so we need to compare their string representations
-                    Objects.equals(thisInternalQuery, thatInternalQuery);
+                    Objects.equals(internalQuery(), that.internalQuery());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(index, field, query != null ? query.toString() : null);
+            return Objects.hash(index, field, internalQuery());
+        }
+
+        private String internalQuery() {
+            return query != null ? query.toString() : null;
         }
     }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -191,12 +191,12 @@ public class ElasticIndexStatistics implements IndexStatistics {
     static class CountCacheLoader extends CacheLoader<StatsRequestDescriptor, Integer> {
 
         @Override
-        public Integer load(@NotNull StatsRequestDescriptor countRequestDescriptor) throws IOException {
+        public @NotNull Integer load(@NotNull StatsRequestDescriptor countRequestDescriptor) throws IOException {
             return count(countRequestDescriptor);
         }
 
         @Override
-        public ListenableFuture<Integer> reload(@NotNull StatsRequestDescriptor crd, @NotNull Integer oldValue) {
+        public @NotNull ListenableFuture<Integer> reload(@NotNull StatsRequestDescriptor crd, @NotNull Integer oldValue) {
             ListenableFutureTask<Integer> task = ListenableFutureTask.create(() -> count(crd));
             REFRESH_EXECUTOR.execute(task);
             return task;
@@ -220,12 +220,12 @@ public class ElasticIndexStatistics implements IndexStatistics {
     static class StatsCacheLoader extends CacheLoader<StatsRequestDescriptor, StatsResponse> {
 
         @Override
-        public StatsResponse load(@NotNull StatsRequestDescriptor countRequestDescriptor) throws IOException {
+        public @NotNull StatsResponse load(@NotNull StatsRequestDescriptor countRequestDescriptor) throws IOException {
             return stats(countRequestDescriptor);
         }
 
         @Override
-        public ListenableFuture<StatsResponse> reload(@NotNull StatsRequestDescriptor crd, @NotNull StatsResponse oldValue) {
+        public @NotNull ListenableFuture<StatsResponse> reload(@NotNull StatsRequestDescriptor crd, @NotNull StatsResponse oldValue) {
             ListenableFutureTask<StatsResponse> task = ListenableFutureTask.create(() -> stats(crd));
             REFRESH_EXECUTOR.execute(task);
             return task;
@@ -237,7 +237,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
                             .bytes(Bytes.Bytes))
                     .valueBody();
             if (records.isEmpty()) {
-                return null;
+                throw new IllegalStateException("Cannot retrieve stats for index " + crd.index + " as it does not exist");
             }
             // Assuming a single index matches crd.index
             IndicesRecord record = records.get(0);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -295,7 +295,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
 
         @Override
         public int hashCode() {
-            return Objects.hash(index, field);
+            return Objects.hash(index, field, query != null ? query.toString() : null);
         }
     }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -286,8 +286,12 @@ public class ElasticIndexStatistics implements IndexStatistics {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             StatsRequestDescriptor that = (StatsRequestDescriptor) o;
+            String thisInternalQuery = query != null ? query.toString() : null;
+            String thatInternalQuery = that.query != null ? that.query.toString() : null;
             return index.equals(that.index) &&
-                    Objects.equals(field, that.field);
+                    Objects.equals(field, that.field) &&
+                    // ES Query objects are not comparable, so we need to compare their string representations
+                    Objects.equals(thisInternalQuery, thatInternalQuery);
         }
 
         @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -207,8 +207,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
             cBuilder.index(crd.index);
             if (crd.query != null) {
                 cBuilder.query(crd.query);
-            }
-            else if (crd.field != null) {
+            } else if (crd.field != null) {
                 cBuilder.query(q -> q.exists(e -> e.field(crd.field)));
             } else {
                 cBuilder.query(q -> q.matchAll(m -> m));

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndex.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndex.java
@@ -19,21 +19,19 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.query;
 import co.elastic.clients.json.JsonpUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNode;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.ElasticResultRowAsyncIterator;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexNode;
 import org.apache.jackrabbit.oak.plugins.index.search.SizeEstimator;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndexPlanner;
-import org.apache.jackrabbit.oak.plugins.index.search.util.LMSEstimator;
 import org.apache.jackrabbit.oak.spi.query.Cursor;
 import org.apache.jackrabbit.oak.spi.query.Filter;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
@@ -43,7 +41,6 @@ import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefini
 class ElasticIndex extends FulltextIndex {
     private static final Predicate<NodeState> ELASTICSEARCH_INDEX_DEFINITION_PREDICATE =
             state -> TYPE_ELASTICSEARCH.equals(state.getString(TYPE_PROPERTY_NAME));
-    private static final Map<String, LMSEstimator> ESTIMATORS = new WeakHashMap<>();
 
     // no concept of rewound in ES (even if it might be doing it internally, we can't do much about it
     private static final IteratorRewoundStateProvider REWOUND_STATE_PROVIDER_NOOP = () -> 0;
@@ -66,7 +63,10 @@ class ElasticIndex extends FulltextIndex {
 
     @Override
     protected SizeEstimator getSizeEstimator(IndexPlan plan) {
-        return () -> getEstimator(plan.getPlanName()).estimate(plan.getFilter());
+        return () -> {
+            ElasticIndexStatistics indexStatistics = acquireIndexNode(plan).getIndexStatistics();
+            return indexStatistics.getDocCountFor(new ElasticRequestHandler(plan, getPlanResult(plan), null).baseQuery());
+        };
     }
 
     @Override
@@ -122,7 +122,6 @@ class ElasticIndex extends FulltextIndex {
                         responseHandler,
                         plan,
                         partialShouldInclude.apply(getPathRestriction(plan), filter.getPathRestriction()),
-                        getEstimator(plan.getPlanName()),
                         elasticIndexTracker.getElasticMetricHandler()
                 );
 
@@ -131,11 +130,6 @@ class ElasticIndex extends FulltextIndex {
             indexNode.release();
         }
         return new FulltextPathCursor(itr, REWOUND_STATE_PROVIDER_NOOP, plan, filter.getQueryLimits(), getSizeEstimator(plan));
-    }
-
-    private LMSEstimator getEstimator(String path) {
-        ESTIMATORS.putIfAbsent(path, new LMSEstimator());
-        return ESTIMATORS.get(path);
     }
 
     private static boolean shouldInclude(String path, Filter.PathRestriction pathRestriction, String docPath) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -730,7 +730,7 @@ public class ElasticRequestHandler {
         int length = QueryConstants.REP_EXCERPT.length();
         if (name.length() > length) {
             String field = name.substring(length + 1, name.length() - 1);
-            if (field.length() > 0 && !field.equals(".")) {
+            if (!field.isEmpty() && !field.equals(".")) {
                 return field;
             }
         }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -32,7 +32,6 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticRequestHandl
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticResponseHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.facets.ElasticFacetProvider;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex.FulltextResultRow;
-import org.apache.jackrabbit.oak.plugins.index.search.util.LMSEstimator;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex.IndexPlan;
 import org.jetbrains.annotations.NotNull;
@@ -71,7 +70,6 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
     private final IndexPlan indexPlan;
     private final Predicate<String> rowInclusionPredicate;
     private final ElasticMetricHandler metricHandler;
-    private final LMSEstimator estimator;
     private final ElasticQueryScanner elasticQueryScanner;
     private final ElasticRequestHandler elasticRequestHandler;
     private final ElasticResponseHandler elasticResponseHandler;
@@ -85,13 +83,12 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                                          @NotNull ElasticResponseHandler elasticResponseHandler,
                                          @NotNull QueryIndex.IndexPlan indexPlan,
                                          Predicate<String> rowInclusionPredicate,
-                                         LMSEstimator estimator, ElasticMetricHandler metricHandler) {
+                                         ElasticMetricHandler metricHandler) {
         this.indexNode = indexNode;
         this.elasticRequestHandler = elasticRequestHandler;
         this.elasticResponseHandler = elasticResponseHandler;
         this.indexPlan = indexPlan;
         this.rowInclusionPredicate = rowInclusionPredicate;
-        this.estimator = estimator;
         this.metricHandler = metricHandler;
         this.elasticFacetProvider = elasticRequestHandler.getAsyncFacetProvider(elasticResponseHandler);
         this.elasticQueryScanner = initScanner();
@@ -293,7 +290,6 @@ public class ElasticResultRowAsyncIterator implements Iterator<FulltextResultRow
                 } else {
                     anyDataLeft.set(true);
                 }
-                estimator.update(indexPlan.getFilter(), totalHits);
 
                 // now that we got the last hit we can release the semaphore to potentially unlock other requests
                 semaphore.release();


### PR DESCRIPTION
The ES size estimator is currently implemented with a simple linear regression function. This could lead to quite inaccurate results. Replaced with an estimator that performs a count query. The results are cached using the existing ES cached statistics capabilities.