### PR TITLE
OAK-10491 - Indexing: pass a MongoDatabase instance instead of MongoConnection to indexing logic

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -344,10 +344,6 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
         }
     }
 
-    private MongoConnection getMongoConnection() {
-        return checkNotNull(indexHelper.getService(MongoConnection.class));
-    }
-
     private MongoDocumentStore getMongoDocumentStore() {
         return checkNotNull(indexHelper.getService(MongoDocumentStore.class));
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -20,6 +20,7 @@
 package org.apache.jackrabbit.oak.index.indexer.document;
 
 import com.codahale.metrics.MetricRegistry;
+import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.io.Closer;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -170,7 +171,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
                         .withRootRevision(rootDocumentState.getRootRevision())
                         .withNodeStore(nodeStore)
                         .withMongoDocumentStore(getMongoDocumentStore())
-                        .withMongoConnection(getMongoConnection())
+                        .withMongoDatabase(getMongoDatabase())
                         .withNodeStateEntryTraverserFactory(new MongoNodeStateEntryTraverserFactory(rootDocumentState.getRootRevision(),
                                 nodeStore, getMongoDocumentStore(), traversalLog))
                         .withCheckpoint(indexerSupport.getCheckpoint());
@@ -349,6 +350,10 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
 
     private MongoDocumentStore getMongoDocumentStore() {
         return checkNotNull(indexHelper.getService(MongoDocumentStore.class));
+    }
+
+    private MongoDatabase getMongoDatabase() {
+        return checkNotNull(indexHelper.getService(MongoDatabase.class));
     }
 
     private void configureEstimators(IndexingProgressReporter progressReporter) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -19,6 +19,7 @@
 
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
+import com.mongodb.client.MongoDatabase;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -33,7 +34,6 @@ import org.apache.jackrabbit.oak.index.indexer.document.indexstore.IndexStoreUti
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.query.NodeStateNodeTypeInfoProvider;
@@ -138,7 +138,7 @@ public class FlatFileNodeStoreBuilder {
     private RevisionVector rootRevision = null;
     private DocumentNodeStore nodeStore = null;
     private MongoDocumentStore mongoDocumentStore = null;
-    private MongoConnection mongoConnection = null;
+    private MongoDatabase mongoDatabase = null;
     private Set<IndexDefinition> indexDefinitions = null;
     private String checkpoint;
 
@@ -235,8 +235,8 @@ public class FlatFileNodeStoreBuilder {
         return this;
     }
 
-    public FlatFileNodeStoreBuilder withMongoConnection(MongoConnection mongoConnection) {
-        this.mongoConnection = mongoConnection;
+    public FlatFileNodeStoreBuilder withMongoDatabase(MongoDatabase mongoDatabase) {
+        this.mongoDatabase = mongoDatabase;
         return this;
     }
 
@@ -370,7 +370,7 @@ public class FlatFileNodeStoreBuilder {
             case PIPELINED:
                 log.info("Using PipelinedStrategy");
                 List<PathFilter> pathFilters = indexDefinitions.stream().map(IndexDefinition::getPathFilter).collect(Collectors.toList());
-                return new PipelinedStrategy(mongoDocumentStore, mongoConnection, nodeStore, rootRevision,
+                return new PipelinedStrategy(mongoDocumentStore, mongoDatabase, nodeStore, rootRevision,
                         preferredPathElements, blobStore, dir, algorithm, pathPredicate, pathFilters, checkpoint);
 
         }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -26,6 +26,7 @@ import com.mongodb.ReadPreference;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.guava.common.base.Preconditions;
@@ -34,7 +35,6 @@ import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;
@@ -136,7 +136,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     private String lastIdDownloaded = null;
 
 
-    public PipelinedMongoDownloadTask(MongoConnection mongoConnection,
+    public PipelinedMongoDownloadTask(MongoDatabase mongoDatabase,
                                       MongoDocumentStore mongoDocStore,
                                       int maxBatchSizeBytes,
                                       int maxBatchNumberOfDocuments,
@@ -147,7 +147,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                 CodecRegistries.fromProviders(nodeDocumentCodecProvider),
                 MongoClientSettings.getDefaultCodecRegistry()
         );
-        this.dbCollection = mongoConnection.getDatabase()
+        this.dbCollection = mongoDatabase
                 .withCodecRegistry(nodeDocumentCodecRegistry)
                 .getCollection(Collection.NODES.toString(), NodeDocument.class);
         this.maxBatchSizeBytes = maxBatchSizeBytes;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/DocumentFixtureProvider.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/DocumentFixtureProvider.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import javax.sql.DataSource;
 
+import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.guava.common.io.Closer;
 import com.mongodb.MongoClientURI;
 import org.apache.commons.io.FileUtils;
@@ -109,6 +110,7 @@ class DocumentFixtureProvider {
             }
             MongoConnection mongo = new MongoConnection(uri.getURI());
             wb.register(MongoConnection.class, mongo, emptyMap());
+            wb.register(MongoDatabase.class, mongo.getDatabase(), emptyMap());
             closer.register(mongo::close);
             ((MongoDocumentNodeStoreBuilder) builder).setMongoDB(mongo.getMongoClient(), mongo.getDBName());
             dns = builder.build();

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -48,8 +48,8 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -48,8 +48,8 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -48,6 +48,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
+import com.mongodb.client.MongoDatabase;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -306,7 +307,7 @@ public class PipelinedIT {
         RevisionVector rootRevision = backend.documentNodeStore.getRoot().getRootRevision();
         return new PipelinedStrategy(
                 backend.mongoDocumentStore,
-                backend.mongoConnection,
+                backend.mongoDatabase,
                 backend.documentNodeStore,
                 rootRevision,
                 preferredPathElements,
@@ -369,18 +370,18 @@ public class PipelinedIT {
         }
         builder.setAsyncDelay(1);
         DocumentNodeStore documentNodeStore = builder.getNodeStore();
-        return new Backend((MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c);
+        return new Backend((MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase());
     }
 
     static class Backend {
         final MongoDocumentStore mongoDocumentStore;
         final DocumentNodeStore documentNodeStore;
-        final MongoConnection mongoConnection;
+        final MongoDatabase mongoDatabase;
 
-        public Backend(MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoConnection mongoConnection) {
+        public Backend(MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoDatabase mongoDatabase) {
             this.mongoDocumentStore = mongoDocumentStore;
             this.documentNodeStore = documentNodeStore;
-            this.mongoConnection = mongoConnection;
+            this.mongoDatabase = mongoDatabase;
         }
     }
 }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -65,6 +65,10 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class PipelinedIT {
+    private static final PathFilter contentDamPathFilter = new PathFilter(List.of("/content/dam"), List.of());
+    private static final int LONG_PATH_TEST_LEVELS = 30;
+    private static final String LONG_PATH_LEVEL_STRING = "Z12345678901234567890-Level_";
+
     @Rule
     public final MongoConnectionFactory connectionFactory = new MongoConnectionFactory();
     @Rule
@@ -73,11 +77,6 @@ public class PipelinedIT {
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
     @Rule
     public final TemporaryFolder sortFolder = new TemporaryFolder();
-
-    private static final PathFilter contentDamPathFilter = new PathFilter(List.of("/content/dam"), List.of());
-
-    private static final int LONG_PATH_TEST_LEVELS = 30;
-    private static final String LONG_PATH_LEVEL_STRING = "Z12345678901234567890-Level_";
 
     @BeforeClass
     public static void setup() throws IOException {

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -48,7 +48,6 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -28,7 +28,6 @@ import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
@@ -64,10 +63,8 @@ public class PipelinedMongoDownloadTaskTest {
         @SuppressWarnings("unchecked")
         MongoCollection<NodeDocument> dbCollection = mock(MongoCollection.class);
 
-        MongoConnection mongoConnection = mock(MongoConnection.class);
         MongoDatabase mongoDatabase = mock(MongoDatabase.class);
         when(mongoDatabase.withCodecRegistry(any())).thenReturn(mongoDatabase);
-        when(mongoConnection.getDatabase()).thenReturn(mongoDatabase);
         when(mongoDatabase.getCollection(eq(Collection.NODES.toString()), eq(NodeDocument.class))).thenReturn(dbCollection);
 
         DocumentStore docStore = mock(DocumentStore.class);
@@ -103,7 +100,7 @@ public class PipelinedMongoDownloadTaskTest {
         BlockingQueue<NodeDocument[]> queue = new ArrayBlockingQueue<>(100);
         MongoDocumentStore mongoDocumentStore = mock(MongoDocumentStore.class);
 
-        PipelinedMongoDownloadTask task = new PipelinedMongoDownloadTask(mongoConnection, mongoDocumentStore, batchMaxMemorySize, batchMaxElements, queue, null);
+        PipelinedMongoDownloadTask task = new PipelinedMongoDownloadTask(mongoDatabase, mongoDocumentStore, batchMaxMemorySize, batchMaxElements, queue, null);
 
         // Execute
         PipelinedMongoDownloadTask.Result result = task.call();

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/incrementalstore/IncrementalStoreIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/incrementalstore/IncrementalStoreIT.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.index.indexer.document.incrementalstore;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoDatabase;
 import org.apache.commons.collections4.set.ListOrderedSet;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.commons.Compression;
@@ -299,7 +300,7 @@ public class IncrementalStoreIT {
         RevisionVector rootRevision = backend.documentNodeStore.getRoot().getRootRevision();
         return new PipelinedStrategy(
                 backend.mongoDocumentStore,
-                backend.mongoConnection,
+                backend.mongoDatabase,
                 backend.documentNodeStore,
                 rootRevision,
                 preferredPathElements,
@@ -477,19 +478,19 @@ public class IncrementalStoreIT {
         }
         builder.setAsyncDelay(1);
         DocumentNodeStore documentNodeStore = builder.getNodeStore();
-        return new Backend((MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c);
+        return new Backend((MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase());
     }
 
 
     static class Backend {
         final MongoDocumentStore mongoDocumentStore;
         final DocumentNodeStore documentNodeStore;
-        final MongoConnection mongoConnection;
+        final MongoDatabase mongoDatabase;
 
-        public Backend(MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoConnection mongoConnection) {
+        public Backend(MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoDatabase mongoDatabase) {
             this.mongoDocumentStore = mongoDocumentStore;
             this.documentNodeStore = documentNodeStore;
-            this.mongoConnection = mongoConnection;
+            this.mongoDatabase = mongoDatabase;
         }
     }
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/DocumentStoreIndexerIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/DocumentStoreIndexerIT.java
@@ -19,6 +19,7 @@
 
 package org.apache.jackrabbit.oak.index;
 
+import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -306,7 +307,7 @@ public class DocumentStoreIndexerIT extends LuceneAbstractIndexCommandTest {
         MongoDocumentStore ds = (MongoDocumentStore) docBuilder.getDocumentStore();
         Registration r1 = wb.register(MongoDocumentStore.class, ds, emptyMap());
         wb.register(StatisticsProvider.class, StatisticsProvider.NOOP, emptyMap());
-        Registration c1Registration = wb.register(MongoConnection.class, c1, emptyMap());
+        Registration c1Registration = wb.register(MongoDatabase.class, c1.getDatabase(), emptyMap());
 
         configureIndex(store);
         configureBundling(store);
@@ -342,7 +343,7 @@ public class DocumentStoreIndexerIT extends LuceneAbstractIndexCommandTest {
         ds = (MongoDocumentStore) docBuilderRO.getDocumentStore();
         store = docBuilderRO.build();
         wb.register(MongoDocumentStore.class, ds, emptyMap());
-        wb.register(MongoConnection.class, c2, emptyMap());
+        wb.register(MongoDatabase.class, c2.getDatabase(), emptyMap());
 
         ExtendedIndexHelper helper = new ExtendedIndexHelper(store, store.getBlobStore(), wb, temporaryFolder.newFolder(),
                 temporaryFolder.newFolder(), List.of(TEST_INDEX_PATH));


### PR DESCRIPTION
Refactor Indexing logic to take only a MongoDatabase instance instead of a MongoConnection, which is a more complex object with more fields other than the MongoDatabase.

The pipeline indexing strategy needs to have access to a MongoDatabase object to register a custom codec to deserialize the responses from Mongo. Previously we were passing a MongoConnection object which contained a reference to MongoDatabase. But the indexing job does not need any other fields from MongoConnection other than MongoDatabase. But requiring MongoConnection makes it harder for users of Oak to call this API.