### PR TITLE
OAK-10497 Properties order in FFS can be different across runs: option to sort

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -86,10 +86,6 @@ public class NodeStateEntryWriter {
     }
 
     public String asJson(NodeState nodeState) {
-        return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false));
-    }
-
-    String asSortedJson(NodeState nodeState) {
         return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false)
                 .sorted(Comparator.comparing(PropertyState::getName)));
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -38,7 +38,7 @@ import java.util.stream.StreamSupport;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 
 public class NodeStateEntryWriter {
-    private static final boolean UNSORTED_PROPERTIES = Boolean.getBoolean("oak.NodeStateEntryWriter.unsortedProps");
+    private static final boolean SORTED_PROPERTIES = Boolean.getBoolean("oak.NodeStateEntryWriter.sort");
     private static final String OAK_CHILD_ORDER = ":childOrder";
     public static final String DELIMITER = "|";
     private final JsopBuilder jw = new JsopBuilder();
@@ -87,11 +87,11 @@ public class NodeStateEntryWriter {
     }
 
     public String asJson(NodeState nodeState) {
-        if (UNSORTED_PROPERTIES) {
-            return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false));
+        if (SORTED_PROPERTIES) {
+            return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false)
+                    .sorted(Comparator.comparing(PropertyState::getName)));
         }
-        return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false)
-                .sorted(Comparator.comparing(PropertyState::getName)));
+        return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false));
     }
 
     private String asJson(Stream<? extends PropertyState> stream) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -38,6 +38,7 @@ import java.util.stream.StreamSupport;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 
 public class NodeStateEntryWriter {
+    private static final boolean UNSORTED_PROPERTIES = Boolean.getBoolean("oak.NodeStateEntryWriter.unsortedProps");
     private static final String OAK_CHILD_ORDER = ":childOrder";
     public static final String DELIMITER = "|";
     private final JsopBuilder jw = new JsopBuilder();
@@ -86,6 +87,9 @@ public class NodeStateEntryWriter {
     }
 
     public String asJson(NodeState nodeState) {
+        if (UNSORTED_PROPERTIES) {
+            return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false));
+        }
         return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false)
                 .sorted(Comparator.comparing(PropertyState::getName)));
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/SimpleFlatFileUtil.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/SimpleFlatFileUtil.java
@@ -92,7 +92,7 @@ public class SimpleFlatFileUtil {
             // skip
             return;
         }
-        String jsonText = entryWriter.asSortedJson(e.getNodeState());
+        String jsonText = entryWriter.asJson(e.getNodeState());
         String line = entryWriter.toString(copyOf(elements(path)), jsonText);
         writer.append(line);
         writer.append(LINE_SEPARATOR);


### PR DESCRIPTION
I think it's easier to sort.
Performance-wise, it doesn't have a big impact, according to a micro-branchmark I wrote (a few percent slower per serialized node). Anyway writing is not on the critical path if the flat file store is generated in a separate job.

If we want to speed up things, we should not use JSON.

