### PR TITLE
OAK-9705: fix explain output for elastic queries

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndex.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticIndex.java
@@ -90,7 +90,9 @@ class ElasticIndex extends FulltextIndex {
 
     @Override
     protected String getFulltextRequestString(IndexPlan plan, IndexNode indexNode, NodeState rootState) {
-        return queryIterator(plan, rootState).explain();
+        try (ElasticQueryIterator eqi = queryIterator(plan, rootState)) {
+            return eqi.explain();
+        }
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticQueryIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticQueryIterator.java
@@ -1,9 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jackrabbit.oak.plugins.index.elastic.query;
 
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex.FulltextResultRow;
 
 import java.util.Iterator;
 
-public interface ElasticQueryIterator extends Iterator<FulltextResultRow> {
+/**
+ * Iterator over the results of an elastic query. It is also possible to get an explanation of the query that would
+ * return the full payload of the query including options (eg: size, sort).
+ */
+public interface ElasticQueryIterator extends Iterator<FulltextResultRow>, AutoCloseable {
     String explain();
+
+    default void close() { /* do nothing by default */ }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticQueryIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticQueryIterator.java
@@ -1,0 +1,9 @@
+package org.apache.jackrabbit.oak.plugins.index.elastic.query;
+
+import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex.FulltextResultRow;
+
+import java.util.Iterator;
+
+public interface ElasticQueryIterator extends Iterator<FulltextResultRow> {
+    String explain();
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticSuggestIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticSuggestIterator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.query;
 
+import co.elastic.clients.json.JsonpUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNode;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
@@ -39,14 +40,14 @@ import java.util.stream.Collectors;
  * This class is in charge to extract suggestions for a given query. Suggestion is more like
  * a completion result.
  */
-class ElasticSuggestIterator implements Iterator<FulltextResultRow> {
+class ElasticSuggestIterator implements ElasticQueryIterator {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSuggestIterator.class);
 
     private final ElasticIndexNode indexNode;
     private final ElasticRequestHandler requestHandler;
     private final ElasticResponseHandler responseHandler;
-    private final String suggestQuery;
+    private final SearchRequest searchRequest;
 
     private Iterator<? extends FulltextResultRow> internalIterator;
     private boolean loaded;
@@ -57,7 +58,13 @@ class ElasticSuggestIterator implements Iterator<FulltextResultRow> {
         this.indexNode = indexNode;
         this.requestHandler = requestHandler;
         this.responseHandler = responseHandler;
-        this.suggestQuery = requestHandler.getPropertyRestrictionQuery().replace(ElasticRequestHandler.SUGGEST_PREFIX, "");
+
+        String suggestQuery = requestHandler.getPropertyRestrictionQuery().replace(ElasticRequestHandler.SUGGEST_PREFIX, "");
+        this.searchRequest = SearchRequest.of(s -> s
+                .index(indexNode.getDefinition().getIndexAlias())
+                .query(requestHandler.suggestionMatchQuery(suggestQuery))
+                .size(100)
+                .source(ss -> ss.filter(f -> f.includes(FieldNames.PATH))));
     }
 
     @Override
@@ -80,14 +87,7 @@ class ElasticSuggestIterator implements Iterator<FulltextResultRow> {
     }
     
     private void loadSuggestions() throws IOException {
-        Query suggestionQuery = requestHandler.suggestionMatchQuery(suggestQuery);
-        SearchRequest sReq = SearchRequest.of(s -> s
-                .index(indexNode.getDefinition().getIndexAlias())
-                .query(suggestionQuery)
-                .size(100)
-                .source(ss -> ss.filter(f -> f.includes(FieldNames.PATH))));
-
-        SearchResponse<ObjectNode> sRes = indexNode.getConnection().getClient().search(sReq, ObjectNode.class);
+        SearchResponse<ObjectNode> sRes = indexNode.getConnection().getClient().search(searchRequest, ObjectNode.class);
         this.internalIterator = sRes.hits().hits().stream()
                 .filter(hit -> responseHandler.isAccessible(responseHandler.getPath(hit)))
                 .map(hit -> hit.innerHits().get(FieldNames.SUGGEST).hits().hits())
@@ -95,6 +95,11 @@ class ElasticSuggestIterator implements Iterator<FulltextResultRow> {
                 .map(hit -> new ElasticSuggestion(hit.source().to(ObjectNode.class).get("value").asText(), hit.score()))
                 .collect(Collectors.toCollection(() -> new PriorityQueue<>((a, b) -> Double.compare(b.score, a.score))))
                 .stream().distinct().iterator();
+    }
+
+    @Override
+    public String explain() {
+        return JsonpUtils.toString(searchRequest, new StringBuilder()).toString();
     }
 
     private final static class ElasticSuggestion extends FulltextResultRow {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticSuggestIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticSuggestIterator.java
@@ -45,7 +45,6 @@ class ElasticSuggestIterator implements ElasticQueryIterator {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSuggestIterator.class);
 
     private final ElasticIndexNode indexNode;
-    private final ElasticRequestHandler requestHandler;
     private final ElasticResponseHandler responseHandler;
     private final SearchRequest searchRequest;
 
@@ -56,7 +55,6 @@ class ElasticSuggestIterator implements ElasticQueryIterator {
                            @NotNull ElasticRequestHandler requestHandler,
                            @NotNull ElasticResponseHandler responseHandler) {
         this.indexNode = indexNode;
-        this.requestHandler = requestHandler;
         this.responseHandler = responseHandler;
 
         String suggestQuery = requestHandler.getPropertyRestrictionQuery().replace(ElasticRequestHandler.SUGGEST_PREFIX, "");

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -57,6 +57,10 @@ import java.util.function.Predicate;
  * Class to iterate over Elastic results of a given {@link IndexPlan}.
  * The results are produced asynchronously into an internal unbounded {@link BlockingQueue}. To avoid too many calls to
  * Elastic the results are loaded in chunks (using search_after strategy) and loaded only when needed.
+ * <p>
+ * The resources held by this class are automatically released when the iterator is exhausted. In case the iterator is not
+ * exhausted, it is recommended for the caller to invoke {@link #close()} to release the resources.
+ * </p
  */
 public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, ElasticResponseListener.SearchHitListener {
 
@@ -179,6 +183,11 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
     @Override
     public String explain() {
         return JsonpUtils.toString(elasticQueryScanner.searchRequest, new StringBuilder()).toString();
+    }
+
+    @Override
+    public void close() {
+        elasticQueryScanner.close();
     }
 
     /**

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -180,6 +180,12 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
         return new ElasticQueryScanner(listeners);
     }
 
+    /*
+     * TODO: to return the explain output, the scanner gets created and an initial request to Elastic is sent. This could
+     * be avoided if we decouple the scanner creation from the first request to Elastic. This would require to change the
+     * way the scanner is created and the way the explain is retrieved. This is not a priority now and should not be an issue
+     * since the first request returns a small amount of data and the explain is a user debug feature.
+     */
     @Override
     public String explain() {
         return JsonpUtils.toString(elasticQueryScanner.searchRequest, new StringBuilder()).toString();

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticDynamicBoostTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticDynamicBoostTest.java
@@ -48,13 +48,13 @@ public class ElasticDynamicBoostTest extends DynamicBoostCommonTest {
 
     @Override
     protected String getTestQueryDynamicBoostBasicExplained() {
-        return "[dam:Asset] as [a] /* elasticsearch:test-index(/oak:index/test-index) {\"bool\":{\"must\":[{\"bool\":" +
-                "{\"must\":[{\"query_string\":{\"default_operator\":\"and\",\"fields\":[\"title^1.0\",\":dynamic-boost-ft^1.0E-4\",\":fulltext\"]," +
-                "\"query\":\"plant\",\"tie_breaker\":0.5,\"type\":\"cross_fields\"}}],\"should\":[{\"nested\":" +
-                "{\"path\":\"predictedTagsDynamicBoost\",\"query\":{\"function_score\":" +
-                "{\"boost\":9.999999747378752E-5,\"functions\":[{\"field_value_factor\":{\"field\":\"predictedTagsDynamicBoost.boost\"}}]," +
-                "\"query\":{\"match\":{\"predictedTagsDynamicBoost.value\":{\"query\":\"plant\"}}}}},\"score_mode\":\"avg\"}}]}}]}} " +
-                "ft:(\"plant\")\n" +
+        return "[dam:Asset] as [a] /* elasticsearch:test-index(/oak:index/test-index) {\"_source\":{\"includes\":[\":path\"]}," +
+                "\"query\":{\"bool\":{\"must\":[{\"bool\":{\"must\":[{\"query_string\":{\"default_operator\":\"and\"," +
+                "\"fields\":[\"title^1.0\",\":dynamic-boost-ft^1.0E-4\",\":fulltext\"],\"query\":\"plant\",\"tie_breaker\":0.5,\"type\":\"cross_fields\"}}]," +
+                "\"should\":[{\"nested\":{\"path\":\"predictedTagsDynamicBoost\",\"query\":{\"function_score\":{\"boost\":9.999999747378752E-5," +
+                "\"functions\":[{\"field_value_factor\":{\"field\":\"predictedTagsDynamicBoost.boost\"}}]," +
+                "\"query\":{\"match\":{\"predictedTagsDynamicBoost.value\":{\"query\":\"plant\"}}}}},\"score_mode\":\"avg\"}}]}}]}}," +
+                "\"size\":10,\"sort\":[{\"_score\":{\"order\":\"desc\"}},{\":path\":{\"order\":\"asc\"}}],\"track_total_hits\":10000} ft:(\"plant\")\n" +
                 "  where contains([a].[*], 'plant') */";
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
@@ -52,7 +52,7 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
         String query = "explain select [jcr:path] from [nt:base] where " +
                 "native('lucene', 'mlt?stream.body=/test/a&mlt.fl=:path&mlt.mindf=0&mlt.mintf=0')";
 
-        String explainWithoutSimilarityTags = "[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) {\"bool\":{\"must\":[{\"more_like_this\":{\"fields\":[\":dynamic-boost-ft\",\"*\"],\"include\":true,\"like\":[{\"_id\":\"/test/a\",\"per_field_analyzer\":{\"_ignored\":\"keyword\"}}],\"min_doc_freq\":0,\"min_term_freq\":0}}]}}" +
+        String explainWithoutSimilarityTags = "[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) {\"_source\":{\"includes\":[\":path\"]},\"query\":{\"bool\":{\"must\":[{\"more_like_this\":{\"fields\":[\":dynamic-boost-ft\",\"*\"],\"include\":true,\"like\":[{\"_id\":\"/test/a\",\"per_field_analyzer\":{\"_ignored\":\"keyword\"}}],\"min_doc_freq\":0,\"min_term_freq\":0}}]}},\"size\":10,\"sort\":[{\"_score\":{\"order\":\"desc\"}},{\":path\":{\"order\":\"asc\"}}],\"track_total_hits\":10000}" +
                 " where native([nt:base], [lucene], 'mlt?stream.body=/test/a&mlt.fl=:path&mlt.mindf=0&mlt.mintf=0') */";
 
         Tree test = root.getTree("/").addChild("test");
@@ -63,16 +63,16 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
         indexDefn.setProperty("similarityTagsEnabled", false);
         root.commit();
 
-        // similarity tags disabled, should not be present in the explain
+        // similarity tags disabled, should not be present in the explain output
         assertEventually(getAssertionForExplain(query, Query.JCR_SQL2, explainWithoutSimilarityTags, true));
 
         indexDefn.setProperty("similarityTagsEnabled", true);
         root.commit();
 
-        // similarity tags enabled, but no similarity tags properties configured, should not be present in the explain
+        // similarity tags enabled, but no similarity tags properties configured, should not be present in the explain output
         assertEventually(getAssertionForExplain(query, Query.JCR_SQL2, explainWithoutSimilarityTags, true));
 
-        String explainWithSimilarityTags = "[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) {\"bool\":{\"must\":[{\"more_like_this\":{\"fields\":[\":dynamic-boost-ft\",\"*\"],\"include\":true,\"like\":[{\"_id\":\"/test/a\",\"per_field_analyzer\":{\"_ignored\":\"keyword\"}}],\"min_doc_freq\":0,\"min_term_freq\":0}}],\"should\":[{\"more_like_this\":{\"boost\":0.5,\"fields\":[\":simTags\"],\"like\":[{\"_id\":\"/test/a\"}],\"min_doc_freq\":1,\"min_term_freq\":1}}]}}" +
+        String explainWithSimilarityTags = "[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) {\"_source\":{\"includes\":[\":path\"]},\"query\":{\"bool\":{\"must\":[{\"more_like_this\":{\"fields\":[\":dynamic-boost-ft\",\"*\"],\"include\":true,\"like\":[{\"_id\":\"/test/a\",\"per_field_analyzer\":{\"_ignored\":\"keyword\"}}],\"min_doc_freq\":0,\"min_term_freq\":0}}],\"should\":[{\"more_like_this\":{\"boost\":0.5,\"fields\":[\":simTags\"],\"like\":[{\"_id\":\"/test/a\"}],\"min_doc_freq\":1,\"min_term_freq\":1}}]}},\"size\":10,\"sort\":[{\"_score\":{\"order\":\"desc\"}},{\":path\":{\"order\":\"asc\"}}],\"track_total_hits\":10000}" +
                 " where native([nt:base], [lucene], 'mlt?stream.body=/test/a&mlt.fl=:path&mlt.mindf=0&mlt.mintf=0') */";
         Tree properties = indexDefn.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base").getChild("properties");
         Tree simProp = TestUtil.enableForFullText(properties, "simProp", false);
@@ -113,7 +113,7 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
     @Override
     public String getExplainValueForDescendantTestWithIndexTagExplain() {
         return "[nt:base] as [nt:base] /* elasticsearch:test-index(/oak:index/test-index) "
-                + "{\"bool\":{\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}}]}}"
+                + "{\"_source\":{\"includes\":[\":path\"]},\"query\":{\"bool\":{\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}}]}},\"size\":10,\"sort\":[{\"_score\":{\"order\":\"desc\"}},{\":path\":{\"order\":\"asc\"}}],\"track_total_hits\":10000}"
                 + " where isdescendantnode([nt:base], [/test]) */";
     }
 

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexQueryCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexQueryCommonTest.java
@@ -823,7 +823,7 @@ public abstract class IndexQueryCommonTest extends AbstractQueryTest {
             }
             ResultRow row = result.getRows().iterator().next();
             if (matchComplete) {
-                assertEquals(row.getValue("plan").toString(), expected);
+                assertEquals(expected, row.getValue("plan").toString());
             } else {
                 assertTrue(row.getValue("plan").toString().contains(expected));
             }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexSuggestionCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexSuggestionCommonTest.java
@@ -44,19 +44,18 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFIN
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.INDEX_RULES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
     protected TestRepository repositoryOptionsUtil;
     protected Node indexNode;
     protected IndexOptions indexOptions;
 
-    private JackrabbitSession session = null;
-    private Node root = null;
+    protected JackrabbitSession session = null;
+    protected Node root = null;
 
     @Before
-    public void settingup() throws RepositoryException {
+    public void setup() throws RepositoryException {
         session = (JackrabbitSession) adminSession;
         root = session.getRootNode();
     }
@@ -66,7 +65,7 @@ public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
         return createSuggestIndex(name, indexedNodeType, indexedPropertyName, false, false);
     }
 
-    private Node createSuggestIndex(String name, String indexedNodeType, String indexedPropertyName, boolean addFullText, boolean suggestAnalyzed)
+    protected Node createSuggestIndex(String name, String indexedNodeType, String indexedPropertyName, boolean addFullText, boolean suggestAnalyzed)
             throws Exception {
         Node def = root.getNode(INDEX_DEFINITIONS_NAME)
                 .addNode(name, INDEX_DEFINITIONS_NODE_TYPE);
@@ -75,7 +74,7 @@ public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
         def.setProperty("name", name);
         def.setProperty(FulltextIndexConstants.COMPAT_MODE, IndexFormatVersion.V2.getVersion());
         if (suggestAnalyzed) {
-            def.addNode(FulltextIndexConstants.SUGGESTION_CONFIG).setProperty("suggestAnalyzed", suggestAnalyzed);
+            def.addNode(FulltextIndexConstants.SUGGESTION_CONFIG).setProperty("suggestAnalyzed", true);
         }
         addPropertyDefinition(def, indexedNodeType, indexedPropertyName, addFullText);
         return def;
@@ -153,7 +152,7 @@ public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
         if (shouldSuggest) {
             assertEventually(() -> {
                 try {
-                    assertTrue("There should be some suggestion", getAllResults(queryManager, suggQuery).size() > 0);
+                    assertFalse("There should be some suggestion", getAllResults(queryManager, suggQuery).isEmpty());
                 } catch (RepositoryException e) {
                     throw new RuntimeException(e);
                 }
@@ -185,9 +184,8 @@ public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
         return value;
     }
 
-    private Node allow(Node node) throws RepositoryException {
+    private void allow(Node node) throws RepositoryException {
         AccessControlUtils.allow(node, "anonymous", Privilege.JCR_READ);
-        return node;
     }
 
     private String createSuggestQuery(String nodeTypeName, String suggestFor) {
@@ -367,13 +365,11 @@ public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
     public void emptySuggestWithNothingIndexed() throws Exception {
         final String nodeType = "nt:unstructured";
         final String indexPropName = "description";
-        final String indexPropValue = null;
-        final String suggestQueryText = null;
 
         checkSuggestions(nodeType,
-                indexPropName, indexPropValue,
+                indexPropName, null,
                 true, true,
-                suggestQueryText, false, false);
+                null, false, false);
     }
 
     @Test

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexSuggestionCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexSuggestionCommonTest.java
@@ -44,7 +44,9 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFIN
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.INDEX_RULES;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public abstract class IndexSuggestionCommonTest extends AbstractJcrTest {
     protected TestRepository repositoryOptionsUtil;

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/SpellcheckCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/SpellcheckCommonTest.java
@@ -50,7 +50,6 @@ public abstract class SpellcheckCommonTest extends AbstractJcrTest {
 
     @Before
     public void createIndex() throws RepositoryException {
-
         String indexName = UUID.randomUUID().toString();
         IndexDefinitionBuilder builder = indexOptions.createIndex(indexOptions.createIndexDefinitionBuilder(), false);
         builder.noAsync().evaluatePathRestrictions();
@@ -63,7 +62,6 @@ public abstract class SpellcheckCommonTest extends AbstractJcrTest {
 
         indexOptions.setIndex(adminSession, indexName, builder);
         indexNode = indexOptions.getIndexNode(adminSession, indexName);
-
     }
 
     @Test
@@ -154,7 +152,7 @@ public abstract class SpellcheckCommonTest extends AbstractJcrTest {
         });
     }
 
-    private Node allow(Node node) throws RepositoryException {
+    protected Node allow(Node node) throws RepositoryException {
         AccessControlUtils.allow(node, "anonymous", Privilege.JCR_READ);
         return node;
     }


### PR DESCRIPTION
Explanation of Elastic queries was just returning the base query, which has the following issues:
* only the `query{}` part gets returned. Options like sorting or size are not returned
* for `suggest` or `spellcheck` queries is not the correct output to return as explaination
