### PR TITLE
OAK-9459: ConstraintViolationException in VersionManagerImplRestore when target node has a property definition unknown by the frozen node

### DIFF
--- a/oak-jcr/pom.xml
+++ b/oak-jcr/pom.xml
@@ -85,7 +85,6 @@
       org.apache.jackrabbit.test.api.version.VersionHistoryTest#testMerge
       org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreLabel
       org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreLabelJcr2
-      org.apache.jackrabbit.test.api.version.RestoreTest#testRestoreRemovesMixin <!-- OAK-9459 -->
       org.apache.jackrabbit.test.api.version.WorkspaceRestoreTest
       org.apache.jackrabbit.test.api.version.MergeCancelMergeTest
       org.apache.jackrabbit.test.api.version.MergeCheckedoutSubNodeTest


### PR DESCRIPTION
Replacing https://github.com/apache/jackrabbit-oak/pull/1146 (see conversation there)