### PR TITLE
OAK-10538 - Pipeline strategy: eliminate unnecessary intermediate copy of entries in transform stage

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -28,12 +28,9 @@ import org.apache.jackrabbit.oak.plugins.blob.serializer.BlobIdSerializer;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
-import java.io.IOException;
-import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 
@@ -67,16 +64,6 @@ public class NodeStateEntryWriter {
         return path + DELIMITER + nodeStateAsJson;
     }
 
-    public void writeTo(Writer writer, NodeStateEntry nse) throws IOException {
-        writeTo(writer, nse.getPath(), asJson(nse.getNodeState()));
-    }
-
-    public void writeTo(Writer writer, String path, String value) throws IOException {
-        writer.write(path);
-        writer.write(DELIMITER);
-        writer.write(value);
-    }
-
     public String toString(List<String> pathElements, String nodeStateAsJson) {
         int pathStringSize = pathElements.stream().mapToInt(String::length).sum();
         StringBuilder sb = new StringBuilder(nodeStateAsJson.length() + pathStringSize + pathElements.size() + 1);
@@ -90,18 +77,21 @@ public class NodeStateEntryWriter {
         if (SORTED_PROPERTIES) {
             return asSortedJson(nodeState);
         }
-        return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false));
+        return asJson(nodeState.getProperties());
+
     }
 
     String asSortedJson(NodeState nodeState) {
-        return asJson(StreamSupport.stream(nodeState.getProperties().spliterator(), false)
-                .sorted(Comparator.comparing(PropertyState::getName)));
+        List<PropertyState> result = new ArrayList<>();
+        nodeState.getProperties().forEach(result::add);
+        result.sort(Comparator.comparing(PropertyState::getName));
+        return asJson(result);
     }
 
-    private String asJson(Stream<? extends PropertyState> stream) {
+    private String asJson(Iterable<? extends PropertyState> properties) {
         jw.resetWriter();
         jw.object();
-        stream.forEach(ps -> {
+        properties.forEach(ps -> {
             String name = ps.getName();
             if (include(name)) {
                 jw.key(name);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -78,14 +78,13 @@ public class NodeStateEntryWriter {
             return asSortedJson(nodeState);
         }
         return asJson(nodeState.getProperties());
-
     }
 
     String asSortedJson(NodeState nodeState) {
-        List<PropertyState> result = new ArrayList<>();
-        nodeState.getProperties().forEach(result::add);
-        result.sort(Comparator.comparing(PropertyState::getName));
-        return asJson(result);
+        List<PropertyState> properties = new ArrayList<>();
+        nodeState.getProperties().forEach(properties::add);
+        properties.sort(Comparator.comparing(PropertyState::getName));
+        return asJson(properties);
     }
 
     private String asJson(Iterable<? extends PropertyState> properties) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 
 public class NodeStateEntryBatch {
     public static class BufferFullException extends RuntimeException {
-
         public BufferFullException(String message) {
             super(message);
         }
@@ -34,6 +33,7 @@ public class NodeStateEntryBatch {
             super(message, cause);
         }
     }
+
     public static final byte DELIMITER = '|';
 
     // Must be large enough to hold a full node state entry

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 public class NodeStateEntryBatch {
+
     public static class BufferFullException extends RuntimeException {
         public BufferFullException(String message) {
             super(message);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
@@ -18,12 +18,27 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 public class NodeStateEntryBatch {
+    public static class BufferFullException extends RuntimeException {
+
+        public BufferFullException(String message) {
+            super(message);
+        }
+
+        public BufferFullException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+    public static final byte DELIMITER = '|';
+
     // Must be large enough to hold a full node state entry
     static final int MIN_BUFFER_SIZE = 256 * 1024;
+
     public static NodeStateEntryBatch createNodeStateEntryBatch(int bufferSizeBytes, int maxNumEntries) {
         if (bufferSizeBytes < MIN_BUFFER_SIZE) {
             throw new IllegalArgumentException("Buffer size must be at least " + MIN_BUFFER_SIZE + " bytes");
@@ -53,15 +68,25 @@ public class NodeStateEntryBatch {
         return buffer;
     }
 
-    public void addEntry(String path, byte[] entryData) {
+    public int addEntry(String path, byte[] entryData) throws BufferFullException {
         if (numberOfEntries() == maxEntries) {
-            throw new IllegalStateException("Sort buffer size exceeded max entries: " + sortBuffer.size() + " > " + maxEntries);
+            throw new BufferFullException("Sort buffer size is full, reached max entries: " + sortBuffer.size());
         }
         int bufferPos = buffer.position();
-        buffer.putInt(entryData.length);
-        buffer.put(entryData);
-        String[] key = SortKey.genSortKeyPathElements(path);
-        sortBuffer.add(new SortKey(key, bufferPos));
+        byte[] pathBytes = path.getBytes(StandardCharsets.UTF_8);
+        int entrySize = pathBytes.length + 1 + entryData.length;
+        try {
+            buffer.putInt(entrySize);
+            buffer.put(pathBytes);
+            buffer.put(DELIMITER);
+            buffer.put(entryData);
+            String[] key = SortKey.genSortKeyPathElements(path);
+            sortBuffer.add(new SortKey(key, bufferPos));
+            return entrySize;
+        } catch (BufferOverflowException e) {
+            buffer.position(bufferPos);
+            throw new BufferFullException("Buffer full while adding entry: " + path + " size: " + entrySize, e);
+        }
     }
 
     public boolean isAtMaxEntries() {
@@ -69,10 +94,6 @@ public class NodeStateEntryBatch {
             throw new AssertionError("Sort buffer size exceeded max entries: " + sortBuffer.size() + " > " + maxEntries);
         }
         return sortBuffer.size() == maxEntries;
-    }
-
-    public boolean hasSpaceForEntry(byte[] entryData) {
-        return !isAtMaxEntries() && entryData.length + 4 <= buffer.remaining();
     }
 
     public void flip() {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/NodeStateEntryBatch.java
@@ -35,7 +35,6 @@ public class NodeStateEntryBatch {
     }
 
     public static final byte DELIMITER = '|';
-
     // Must be large enough to hold a full node state entry
     static final int MIN_BUFFER_SIZE = 256 * 1024;
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedSortBatchTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedSortBatchTaskTest.java
@@ -19,18 +19,13 @@
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import org.apache.jackrabbit.oak.commons.Compression;
-import org.apache.jackrabbit.oak.index.indexer.document.flatfile.NodeStateEntryWriter;
-import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -65,7 +60,6 @@ public class PipelinedSortBatchTaskTest {
 
     private final PathElementComparator pathComparator = new PathElementComparator(Set.of());
     private final Compression algorithm = Compression.NONE;
-    private final NodeStateEntryWriter nodeStateEntryWriter = new NodeStateEntryWriter(new MemoryBlobStore());
 
     @Test
     public void noBatch() throws Exception {
@@ -154,12 +148,8 @@ public class PipelinedSortBatchTaskTest {
         );
     }
 
-    private void addEntry(NodeStateEntryBatch batch, String path, String entry) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Writer writer = new OutputStreamWriter(baos);
-        nodeStateEntryWriter.writeTo(writer, path, entry);
-        writer.close();
-        batch.addEntry(path, baos.toByteArray());
+    private void addEntry(NodeStateEntryBatch batch, String path, String entry) {
+        batch.addEntry(path, entry.getBytes(StandardCharsets.UTF_8));
     }
 
     private TestResult runTest(NodeStateEntryBatch... nodeStateEntryBatches) throws Exception {


### PR DESCRIPTION
Remove intermediate buffer used to serialize entries in transform thread. 
Removing this buffer eliminates the creation of a few objects for each node state entry processed, and eliminates a full in-memory copy of all the data processed.

Additionally, do not use Streams to serialize NodeStateEntries to Json, this is unnecessary as the code is equally simple using Iterables. By using directly the Iterable that is returned by the NodeStateEntry API, we avoid the creation of a couple of Stream wrappers for each entry processed.