### PR TITLE
OAK-10547 - Fix: Indexing job fails at the end of reindexing if it took more than 24h to run

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
@@ -18,18 +18,28 @@ package org.apache.jackrabbit.oak.plugins.index;
 
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 
 public class FormattingUtils {
     public static String formatToSeconds(Stopwatch stopwatch) {
-        LocalTime seconds = LocalTime.ofSecondOfDay(stopwatch.elapsed(TimeUnit.SECONDS));
-        return DateTimeFormatter.ISO_TIME.format(seconds);
+        long seconds = stopwatch.elapsed(TimeUnit.SECONDS);
+        long absSeconds = Math.abs(seconds);
+        return String.format(
+                "%02d:%02d:%02d",
+                absSeconds / 3600,
+                (absSeconds % 3600) / 60,
+                absSeconds % 60);
     }
 
     public static String formatToMillis(Stopwatch stopwatch) {
-        LocalTime nanoSeconds = LocalTime.ofNanoOfDay(stopwatch.elapsed(TimeUnit.MILLISECONDS)*1000000);
-        return DateTimeFormatter.ISO_TIME.format(nanoSeconds);
+        long millis = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+        long absMillis = Math.abs(millis);
+        return String.format(
+                "%02d:%02d:%02d.%03d",
+                absMillis / 3_600_000,
+                (absMillis % 3_600_000) / 60_000,
+                absMillis % 60_000/1_000,
+                absMillis % 1_000
+                );
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
@@ -24,22 +24,21 @@ public class FormattingUtils {
     public static String formatToSeconds(Stopwatch stopwatch) {
         long seconds = stopwatch.elapsed(TimeUnit.SECONDS);
         long absSeconds = Math.abs(seconds);
-        return String.format(
-                "%02d:%02d:%02d",
-                absSeconds / 3600,
-                (absSeconds % 3600) / 60,
-                absSeconds % 60);
+        long hoursPart = TimeUnit.SECONDS.toHours(absSeconds);
+        long minutesPart = TimeUnit.SECONDS.toMinutes(absSeconds) % 60;
+        long secondsPart = TimeUnit.SECONDS.toSeconds(absSeconds) % 60;
+        String sign = seconds < 0 ? "-" : "";
+        return String.format("%s%02d:%02d:%02d", sign, hoursPart, minutesPart, secondsPart);
     }
 
     public static String formatToMillis(Stopwatch stopwatch) {
         long millis = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         long absMillis = Math.abs(millis);
-        return String.format(
-                "%02d:%02d:%02d.%03d",
-                absMillis / 3_600_000,
-                (absMillis % 3_600_000) / 60_000,
-                absMillis % 60_000/1_000,
-                absMillis % 1_000
-                );
+        long hoursPart = TimeUnit.MILLISECONDS.toHours(absMillis);
+        long minutesPart = TimeUnit.MILLISECONDS.toMinutes(absMillis) % 60;
+        long secondsPart = TimeUnit.MILLISECONDS.toSeconds(absMillis) % 60;
+        long millisPart = TimeUnit.MILLISECONDS.toMillis(absMillis) % 1000;
+        String sign = millis < 0 ? "-" : "";
+        return String.format("%s%02d:%02d:%02d.%03d", sign, hoursPart, minutesPart, secondsPart, millisPart);
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
@@ -54,6 +54,7 @@ public class FormattingUtilsTest {
                 TimeUnit.SECONDS.toNanos(59) +
                 TimeUnit.MILLISECONDS.toNanos(999)
         );
+        testFormatToSeconds("-00:01:00", -TimeUnit.SECONDS.toNanos(60));
     }
 
     private void testFormatToSeconds(String expected, long nanos) {
@@ -76,7 +77,7 @@ public class FormattingUtilsTest {
                 TimeUnit.SECONDS.toNanos(59) +
                 TimeUnit.MILLISECONDS.toNanos(999)
         );
-
+        testFormatToMillis("-00:01:00.000", -TimeUnit.SECONDS.toNanos(60));
     }
 
     private void testFormatToMillis(String expected, long nanos) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jackrabbit.oak.plugins.index;
 
 import org.apache.jackrabbit.guava.common.base.Stopwatch;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
@@ -1,0 +1,70 @@
+package org.apache.jackrabbit.oak.plugins.index;
+
+import org.apache.jackrabbit.guava.common.base.Stopwatch;
+import org.apache.jackrabbit.guava.common.base.Ticker;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class FormattingUtilsTest {
+
+    private static class TestTicker extends Ticker {
+        private long time = 0;
+        @Override
+        public long read() {
+            return time;
+        }
+        public void set(long nanos) {
+            time = nanos;
+        }
+    }
+    private final TestTicker ticker = new TestTicker();
+    private final Stopwatch sw = Stopwatch.createStarted(ticker);
+
+    @Test
+    public void formatToSeconds() {
+        testFormatToSeconds("00:00:00", 0);
+        testFormatToSeconds("00:00:59", TimeUnit.MILLISECONDS.toNanos(59_567));
+        testFormatToSeconds("00:01:00", TimeUnit.MILLISECONDS.toNanos(60_567));
+        testFormatToSeconds("00:59:00", TimeUnit.MINUTES.toNanos(59));
+        testFormatToSeconds("01:00:00", TimeUnit.MINUTES.toNanos(60));
+        testFormatToSeconds("23:00:00", TimeUnit.HOURS.toNanos(23));
+        testFormatToSeconds("24:00:00", TimeUnit.HOURS.toNanos(24));
+        testFormatToSeconds("48:00:00", TimeUnit.HOURS.toNanos(48));
+        testFormatToSeconds("23:59:59", TimeUnit.HOURS.toNanos(23) +
+                TimeUnit.MINUTES.toNanos(59) +
+                TimeUnit.SECONDS.toNanos(59) +
+                TimeUnit.MILLISECONDS.toNanos(999)
+        );
+    }
+
+    private void testFormatToSeconds(String expected, long nanos) {
+        ticker.set(nanos);
+        assertEquals(expected, FormattingUtils.formatToSeconds(sw));
+    }
+
+    @Test
+    public void formatToMillis() {
+        testFormatToMillis("00:00:00.000", 0);
+        testFormatToMillis("00:00:59.567", TimeUnit.MILLISECONDS.toNanos(59_567));
+        testFormatToMillis("00:01:00.567", TimeUnit.MILLISECONDS.toNanos(60_567));
+        testFormatToMillis("00:59:00.000", TimeUnit.MINUTES.toNanos(59));
+        testFormatToMillis("01:00:00.000", TimeUnit.MINUTES.toNanos(60));
+        testFormatToMillis("23:00:00.000", TimeUnit.HOURS.toNanos(23));
+        testFormatToMillis("24:00:00.000", TimeUnit.HOURS.toNanos(24));
+        testFormatToMillis("48:00:00.000", TimeUnit.HOURS.toNanos(48));
+        testFormatToMillis("23:59:59.999", TimeUnit.HOURS.toNanos(23) +
+                TimeUnit.MINUTES.toNanos(59) +
+                TimeUnit.SECONDS.toNanos(59) +
+                TimeUnit.MILLISECONDS.toNanos(999)
+        );
+
+    }
+
+    private void testFormatToMillis(String expected, long nanos) {
+        ticker.set(nanos);
+        assertEquals(expected, FormattingUtils.formatToMillis(sw));
+    }
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
@@ -22,7 +22,8 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 
 public class FormattingUtilsTest {
 


### PR DESCRIPTION
Fix support formatting durations longer than 24h.