### PR TITLE
OAK-9796: oak-segment-remote Redis tests fail with ARM processor

### DIFF
--- a/oak-segment-remote/pom.xml
+++ b/oak-segment-remote/pom.xml
@@ -151,9 +151,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <version>0.6</version>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCacheTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCacheTest.java
@@ -23,10 +23,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import redis.embedded.RedisExecProvider;
 import redis.embedded.RedisServer;
+import redis.embedded.core.ExecutableProviderBuilder;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -40,27 +41,26 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class PersistentRedisCacheTest extends AbstractPersistentCacheTest {
+
+    private static final String REDIS_HOST = "127.0.0.1";
 
     private RedisServer redisServer;
     private IOMonitorAdapter ioMonitorAdapter;
 
     @Before
     public void setUp() throws Exception {
-        Path redisTempExecutable = RedisExecProvider.defaultProvider().get().toPath();
+        Path redisTempExecutable = new ExecutableProviderBuilder().addProvidedVersions().build().get().toPath();
         Path redisTargetExecutable = new File("target", redisTempExecutable.getFileName().toString()).toPath();
         Files.copy(redisTempExecutable, redisTargetExecutable, StandardCopyOption.REPLACE_EXISTING);
-        RedisExecProvider execProvider = mock(RedisExecProvider.class);
-        when(execProvider.get()).thenReturn(redisTargetExecutable.toFile());
-        redisServer = RedisServer.builder().setting("maxmemory 768mb").redisExecProvider(execProvider).build();
+        redisServer = RedisServer.newRedisServer().setting("maxmemory 768mb").bind(REDIS_HOST).executableProvider(redisTargetExecutable::toFile).build();
         redisServer.start();
         int port = redisServer.ports().get(0);
         ioMonitorAdapter = mock(IOMonitorAdapter.class);
 
         persistentCache = new PersistentRedisCache(
-                "localhost",
+                REDIS_HOST,
                 port,
                 -1,
                 10000,
@@ -74,7 +74,7 @@ public class PersistentRedisCacheTest extends AbstractPersistentCacheTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         redisServer.stop();
     }
 


### PR DESCRIPTION
Switch to more recent version of embedded-redis