### PR TITLE
OAK-10556: Fix two order-dependent flaky tests by resetting hit count

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProvider.java
@@ -51,6 +51,14 @@ public class OrderedPropertyIndexProvider implements QueryIndexProvider {
     
     /**
      * used only for testing purposes. Not thread safe.
+     *
+     */
+    static void resetHits() {
+        hits = 0;
+    }
+    
+    /**
+     * used only for testing purposes. Not thread safe.
      * 
      * @param t
      */

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java
@@ -56,6 +56,7 @@ public class OrderedPropertyIndexProviderTest extends AbstractQueryTest {
     
     @Test
     public void singleQueryRun() {
+        OrderedPropertyIndexProvider.resetHits();
         custom.starting();
         executeQuery("SELECT * FROM [oak:Unstructured]", SQL2);
         List<String> logs = custom.getLogs();
@@ -68,7 +69,8 @@ public class OrderedPropertyIndexProviderTest extends AbstractQueryTest {
     public void multipleQueryRuns() {
         final int executions = 16;
         final int trackEvery = 5;
-        final int numTraces = executions / trackEvery;
+        final int numTraces = executions / trackEvery + 1;
+        OrderedPropertyIndexProvider.resetHits();
         OrderedPropertyIndexProvider.setThreshold(trackEvery);
         List<String> expectedLogs = Collections.nCopies(numTraces, OrderedIndex.DEPRECATION_MESSAGE);
         custom.starting();


### PR DESCRIPTION
fix two order-dependent tests by resetting hit count.

Related test:
[org.apache.jackrabbit.oak.plugins.index.property.OrderedPropertyIndexProviderTest.singleQueryRun](https://github.com/lxb007981/jackrabbit-oak/blob/0440e096dc7a460d206c77a5f178796db31a0ef4/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java#L58)
[org.apache.jackrabbit.oak.plugins.index.property.OrderedPropertyIndexProviderTest.multipleQueryRuns](https://github.com/lxb007981/jackrabbit-oak/blob/0440e096dc7a460d206c77a5f178796db31a0ef4/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java#L68)


These two tests modify the [hit count](https://github.com/lxb007981/jackrabbit-oak/blob/0440e096dc7a460d206c77a5f178796db31a0ef4/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProvider.java#L37) of `OrderedPropertyIndexProvider` without resetting it after the test, but the assertion in the test [multipleQueryRuns](https://github.com/lxb007981/jackrabbit-oak/blob/0440e096dc7a460d206c77a5f178796db31a0ef4/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java#L68) relies on this hit count. The test [multipleQueryRuns](https://github.com/lxb007981/jackrabbit-oak/blob/0440e096dc7a460d206c77a5f178796db31a0ef4/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java#L68) implicitly assumes [singleQueryRun](https://github.com/lxb007981/jackrabbit-oak/blob/0440e096dc7a460d206c77a5f178796db31a0ef4/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/OrderedPropertyIndexProviderTest.java#L58) has already run before, which makes the test order-dependent.

### Describe how you did it

The fix introduces a method `resetHits()` to reset the hit count before each test starts.