### PR TITLE
OAK-10590 - If includedPaths and excludedPaths are specified as a String instead of array of String, interpret them as a one-element array of Strings

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/NodeCounterMBeanEstimator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/NodeCounterMBeanEstimator.java
@@ -92,8 +92,8 @@ public class NodeCounterMBeanEstimator implements NodeCountEstimator {
                     return;
                 }
 
-                Iterables.addAll(includes, PathFilter.getStringsLenient(idxState, PROP_INCLUDED_PATHS));
-                Iterables.addAll(excludes, PathFilter.getStringsLenient(idxState, PROP_EXCLUDED_PATHS));
+                Iterables.addAll(includes, PathFilter.getStrings(idxState.getProperty(PROP_INCLUDED_PATHS), Set.of()));
+                Iterables.addAll(excludes, PathFilter.getStrings(idxState.getProperty(PROP_EXCLUDED_PATHS), Set.of()));
             }
 
             if (includes.isEmpty()) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/NodeCounterMBeanEstimator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/NodeCounterMBeanEstimator.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.counter.jmx.NodeCounter;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
@@ -86,14 +87,13 @@ public class NodeCounterMBeanEstimator implements NodeCountEstimator {
                 NodeState idxState = NodeStateUtils.getNode(root, indexPath);
 
                 //No include exclude specified so include all
-                if (!idxState.hasProperty(PROP_INCLUDED_PATHS)
-                        && !idxState.hasProperty(PROP_EXCLUDED_PATHS)) {
+                if (!idxState.hasProperty(PROP_INCLUDED_PATHS) && !idxState.hasProperty(PROP_EXCLUDED_PATHS)) {
                     includeAll = true;
                     return;
                 }
 
-                Iterables.addAll(includes, idxState.getStrings(PROP_INCLUDED_PATHS));
-                Iterables.addAll(excludes, idxState.getStrings(PROP_EXCLUDED_PATHS));
+                Iterables.addAll(includes, PathFilter.getStringsLenient(idxState, PROP_INCLUDED_PATHS));
+                Iterables.addAll(excludes, PathFilter.getStringsLenient(idxState, PROP_EXCLUDED_PATHS));
             }
 
             if (includes.isEmpty()) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/importer/JsonDeserializationTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/importer/JsonDeserializationTest.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.oak.json.BlobSerializer;
 import org.apache.jackrabbit.oak.json.JsonDeserializer;
 import org.apache.jackrabbit.oak.json.JsonSerializer;
 import org.apache.jackrabbit.oak.plugins.tree.factories.TreeFactory;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.EqualsDiff;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -40,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 public class JsonDeserializationTest {
 
     @Test
-    public void deserialize() throws Exception{
+    public void deserialize() {
         String json = "{\n" +
                 "    \"evaluatePathRestrictions\": true,\n" +
                 "    \"compatVersion\": 2,\n" +
@@ -86,8 +87,8 @@ public class JsonDeserializationTest {
         tree.setProperty("evaluatePathRestrictions", true);
         tree.setProperty("compatVersion", 2);
         tree.setProperty("type", "lucene");
-        tree.setProperty("includedPaths", Collections.singletonList("/content"), Type.STRINGS);
-        tree.setProperty("excludedPaths", Collections.singletonList("/jcr:system"), Type.STRINGS);
+        tree.setProperty(PathFilter.PROP_INCLUDED_PATHS, Collections.singletonList("/content"), Type.STRINGS);
+        tree.setProperty(PathFilter.PROP_EXCLUDED_PATHS, Collections.singletonList("/jcr:system"), Type.STRINGS);
         tree.setProperty("async", "async");
         tree.setProperty("jcr:primaryType", "oak:QueryIndexDefinition", Type.NAME);
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTest.java
@@ -28,8 +28,8 @@ import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_COU
 import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.createIndexDefinition;
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import javax.jcr.query.Query;
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreQueryTest.java
@@ -51,8 +51,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
-import org.apache.jackrabbit.guava.common.collect.Lists;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Tests indexing and queries when using the composite node store.
@@ -70,12 +70,10 @@ public class CompositeNodeStoreQueryTest extends CompositeNodeStoreQueryTestBase
         NodeBuilder b;
         NodeBuilder readOnlyBuilder = readOnlyStore.getRoot().builder();
         b = createIndexDefinition(readOnlyBuilder.child(INDEX_DEFINITIONS_NAME), "foo",
-                true, false, ImmutableSet.of("foo"), null);
-        b.setProperty("excludedPaths", "/jcr:system");
+                true, false, Set.of("foo"), null);
         NodeBuilder globalBuilder = globalStore.getRoot().builder();
         b = createIndexDefinition(globalBuilder.child(INDEX_DEFINITIONS_NAME), "foo",
-                true, false, ImmutableSet.of("foo"), null);
-        b.setProperty("excludedPaths", "/jcr:system");
+                true, false, Set.of("foo"), null);
         EditorHook hook = new EditorHook(
                 new IndexUpdateProvider(new PropertyIndexEditorProvider().with(mip)));
         readOnlyStore.merge(readOnlyBuilder, hook, CommitInfo.EMPTY);
@@ -184,8 +182,7 @@ public class CompositeNodeStoreQueryTest extends CompositeNodeStoreQueryTestBase
         b.setProperty(TYPE_PROPERTY_NAME, LuceneIndexConstants.TYPE_LUCENE);
         b.setProperty(FulltextIndexConstants.COMPAT_MODE, IndexFormatVersion.V2.getVersion());
         b.setProperty(IndexConstants.ASYNC_PROPERTY_NAME,
-                Lists.newArrayList("async", "nrt"), Type.STRINGS);
-        b.setProperty("excludedPaths", "/jcr:system");
+                List.of("async", "nrt"), Type.STRINGS);
         NodeBuilder foo = b.child(FulltextIndexConstants.INDEX_RULES)
                 .child("nt:base")
                 .child(FulltextIndexConstants.PROP_NODE)

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/composite/blueGreen/IndexUtils.java
@@ -70,7 +70,7 @@ public class IndexUtils {
         index.setProperty(IndexConstants.ASYNC_PROPERTY_NAME,
                 new String[] { "async", "nrt" });
         index.setProperty(FulltextIndexConstants.COST_PER_EXECUTION, cost);
-        // index.setProperty("excludedPaths", "/jcr:system");
+//        index.setProperty(PathFilter.PROP_EXCLUDED_PATHS, "/jcr:system");
         Node indexRules = index.addNode(FulltextIndexConstants.INDEX_RULES);
         Node ntBase = indexRules.addNode("nt:base");
         Node props = ntBase.addNode(FulltextIndexConstants.PROP_NODE);
@@ -99,7 +99,6 @@ public class IndexUtils {
      * @param xpath the xpath query
      * @param expectedIndex the index that is expected to be used
      * @param expectedResult the expected list of results
-     * @return the index name used
      */
     public static void assertQueryUsesIndexAndReturns(Persistence p, String xpath, String expectedIndex,
             String expectedResult) throws RepositoryException {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -397,7 +397,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             return Set.of();
         }
 
-        // Keep only unique include paths. That is, if paths "/a/b" and "/a/b/c" are both in the list, keep only "/a/b"
+        // Keep only unique included paths. That is, if paths "/a/b" and "/a/b/c" are both in the list, keep only "/a/b"
         HashSet<String> includedPathsRoots = new HashSet<>();
         for (String path : sortedIncludedPaths) {
             if (includedPathsRoots.stream().noneMatch(ancestor -> PathUtils.isAncestor(ancestor, path))) {

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -136,6 +136,10 @@ public class PipelinedMongoDownloadTaskTest {
         return Arrays.stream(paths).map(path -> new PathFilter(List.of(path), List.of())).collect(Collectors.toList());
     }
 
+    private List<PathFilter> createPathFilters(Set<String> included, Set<String> excluded) {
+        return List.of(new PathFilter(included, excluded));
+    }
+
     @Test
     public void ancestorsFilters() {
         assertEquals(Set.of(), PipelinedMongoDownloadTask.getAncestors(Set.of()));
@@ -175,5 +179,12 @@ public class PipelinedMongoDownloadTaskTest {
                 new PathFilter(List.of("/"), List.of("/var"))
         );
         assertEquals(Set.of(), PipelinedMongoDownloadTask.extractIncludedPaths(withExcludeFilter));
+    }
+
+    @Test
+    public void pathFilters_onlyExcludedPaths() {
+        List<PathFilter> pathFilters = createPathFilters(Set.of(), Set.of("/exclude/1", "/exclude/2"));
+
+        assertEquals(Set.of(), PipelinedMongoDownloadTask.extractIncludedPaths(pathFilters));
     }
 }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -136,10 +136,6 @@ public class PipelinedMongoDownloadTaskTest {
         return Arrays.stream(paths).map(path -> new PathFilter(List.of(path), List.of())).collect(Collectors.toList());
     }
 
-    private List<PathFilter> createPathFilters(Set<String> included, Set<String> excluded) {
-        return List.of(new PathFilter(included, excluded));
-    }
-
     @Test
     public void ancestorsFilters() {
         assertEquals(Set.of(), PipelinedMongoDownloadTask.getAncestors(Set.of()));
@@ -179,12 +175,5 @@ public class PipelinedMongoDownloadTaskTest {
                 new PathFilter(List.of("/"), List.of("/var"))
         );
         assertEquals(Set.of(), PipelinedMongoDownloadTask.extractIncludedPaths(withExcludeFilter));
-    }
-
-    @Test
-    public void pathFilters_onlyExcludedPaths() {
-        List<PathFilter> pathFilters = createPathFilters(Set.of(), Set.of("/exclude/1", "/exclude/2"));
-
-        assertEquals(Set.of(), PipelinedMongoDownloadTask.extractIncludedPaths(pathFilters));
     }
 }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FunctionIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FunctionIndexCommonTest.java
@@ -42,6 +42,7 @@ import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
 import org.apache.jackrabbit.oak.query.AbstractQueryTest;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.event.Level;
@@ -91,7 +92,7 @@ public abstract class FunctionIndexCommonTest extends AbstractQueryTest {
     @Test
     public void lowerCaseLocalName() throws Exception {
         Tree luceneIndex = createIndex("lowerLocalName", Collections.emptySet());
-        luceneIndex.setProperty("excludedPaths",
+        luceneIndex.setProperty(PathFilter.PROP_EXCLUDED_PATHS,
                 List.of("/jcr:system", "/oak:index"), Type.STRINGS);
         Tree func = luceneIndex.addChild(FulltextIndexConstants.INDEX_RULES)
                 .addChild("nt:base")
@@ -130,7 +131,7 @@ public abstract class FunctionIndexCommonTest extends AbstractQueryTest {
     @Test
     public void lengthName() throws Exception {
         Tree luceneIndex = createIndex("lengthName", Collections.emptySet());
-        luceneIndex.setProperty("excludedPaths",
+        luceneIndex.setProperty(PathFilter.PROP_EXCLUDED_PATHS,
                 List.of("/jcr:system", "/oak:index"), Type.STRINGS);
         Tree func = luceneIndex.addChild(FulltextIndexConstants.INDEX_RULES)
                 .addChild("nt:base")
@@ -165,7 +166,7 @@ public abstract class FunctionIndexCommonTest extends AbstractQueryTest {
     @Test
     public void length() throws Exception {
         Tree luceneIndex = createIndex("length", Collections.emptySet());
-        luceneIndex.setProperty("excludedPaths", List.of("/jcr:system", "/oak:index"), Type.STRINGS);
+        luceneIndex.setProperty(PathFilter.PROP_EXCLUDED_PATHS, List.of("/jcr:system", "/oak:index"), Type.STRINGS);
         Tree func = luceneIndex.addChild(FulltextIndexConstants.INDEX_RULES)
                 .addChild("nt:base")
                 .addChild(FulltextIndexConstants.PROP_NODE)

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/secondary/SecondaryStoreCacheServiceTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/secondary/SecondaryStoreCacheServiceTest.java
@@ -99,7 +99,7 @@ public class SecondaryStoreCacheServiceTest {
     @Test
     public void configurePathFilter() throws Exception{
         Map<String, Object> config = new HashMap<>();
-        config.put("includedPaths", new String[] {"/a"});
+        config.put(PathFilter.PROP_INCLUDED_PATHS, new String[] {"/a"});
         MockOsgi.activate(cacheService, context.bundleContext(), config);
 
         assertEquals(PathFilter.Result.INCLUDE, cacheService.getPathFilter().filter("/a"));

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
@@ -29,7 +29,9 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,8 +175,8 @@ public class PathFilter {
      *
      * @return the value of the property if the property is set and is of type Strings or String, otherwise the default value
      */
-    private static Iterable<String> getStringsLenient(NodeBuilder builder, String propertyName, Collection<String> defaultVal) {
-        PropertyState property = builder.getProperty(propertyName);
+    public static Iterable<String> getStringsLenient(NodeBuilder builder, String propertyName, Collection<String> defaultVal) {
+        @Nullable PropertyState property = builder.getProperty(propertyName);
         if (property != null && property.getType() == Type.STRINGS) {
             return property.getValue(Type.STRINGS);
         } else if (property != null && property.getType() == Type.STRING) {
@@ -185,6 +187,18 @@ public class PathFilter {
             return List.of(value);
         } else {
             return defaultVal;
+        }
+    }
+
+    public static Iterable<String> getStringsLenient(NodeState idxState, String propertyName) {
+        @Nullable PropertyState property = idxState.getProperty(propertyName);
+        if (property != null && property.getType() == Type.STRINGS) {
+            return idxState.getStrings(propertyName);
+        } else if (property != null && property.getType() == Type.STRING) {
+            @NotNull String singleValue = property.getValue(Type.STRING);
+            return List.of(singleValue);
+        } else {
+            return idxState.getStrings(propertyName);
         }
     }
 

--- a/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
+++ b/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.fail;
 public class PathFilterTest {
 
     @Test
-    public void exclude() throws Exception {
+    public void exclude() {
         PathFilter p = new PathFilter(Set.of("/"), Set.of("/etc"));
         assertEquals(PathFilter.Result.INCLUDE, p.filter("/"));
         assertEquals(PathFilter.Result.INCLUDE, p.filter("/a"));
@@ -44,7 +44,7 @@ public class PathFilterTest {
     }
 
     @Test
-    public void include() throws Exception {
+    public void include() {
         PathFilter p = new PathFilter(Set.of("/content", "/etc"), Set.of("/etc/workflow/instance"));
         assertEquals(PathFilter.Result.TRAVERSE, p.filter("/"));
         assertEquals(PathFilter.Result.EXCLUDE, p.filter("/var"));
@@ -68,7 +68,7 @@ public class PathFilterTest {
     }
 
     @Test
-    public void config() throws Exception {
+    public void config() {
         NodeBuilder root = EMPTY_NODE.builder();
         root.setProperty(createProperty(PROP_INCLUDED_PATHS, Set.of("/etc"), Type.STRINGS));
         root.setProperty(createProperty(PROP_EXCLUDED_PATHS, Set.of("/etc/workflow"), Type.STRINGS));
@@ -106,7 +106,7 @@ public class PathFilterTest {
     }
 
     @Test
-    public void invalid() throws Exception {
+    public void invalid() {
         try {
             new PathFilter(Set.of(), Set.of("/etc"));
             fail();

--- a/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
+++ b/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
@@ -135,34 +135,34 @@ public class PathFilterTest {
     public void getStringsLenientNodeBuilder_MultipleValues() {
         NodeBuilder root = EMPTY_NODE.builder();
         @NotNull NodeBuilder b1 = root.setProperty(createProperty("propMultiple", Set.of("/p1", "/p2"), Type.STRINGS));
-        assertEquals(Set.of("/p1", "/p2"), toSet(PathFilter.getStringsLenient(b1, "propMultiple", Set.of("default"))));
+        assertEquals(Set.of("/p1", "/p2"), toSet(PathFilter.getStrings(b1.getProperty("propMultiple"), Set.of("default"))));
     }
 
     @Test
     public void getStringsLenientNodeBuilder_SingleValueAsSet() {
         NodeBuilder root = EMPTY_NODE.builder();
         @NotNull NodeBuilder b1 = root.setProperty(createProperty("propMultiple", Set.of("/p1"), Type.STRINGS));
-        assertEquals(Set.of("/p1"), toSet(PathFilter.getStringsLenient(b1, "propMultiple", Set.of("default"))));
+        assertEquals(Set.of("/p1"), toSet(PathFilter.getStrings(b1.getProperty("propMultiple"), Set.of("default"))));
     }
 
     @Test
     public void getStringsLenientNodeBuilder_SingleValueAsString() {
         NodeBuilder root = EMPTY_NODE.builder();
         @NotNull NodeBuilder b1 = root.setProperty(createProperty("propMultiple", "/p1", Type.STRING));
-        assertEquals(Set.of("/p1"), toSet(PathFilter.getStringsLenient(b1, "propMultiple", Set.of("default"))));
+        assertEquals(Set.of("/p1"), toSet(PathFilter.getStrings(b1.getProperty("propMultiple"), Set.of("default"))));
     }
 
     @Test
     public void getStringsLenientNodeBuilder_NoValue() {
         NodeBuilder root = EMPTY_NODE.builder();
-        assertEquals(Set.of("default"), toSet(PathFilter.getStringsLenient(root, "propMultiple", Set.of("default"))));
+        assertEquals(Set.of("default"), toSet(PathFilter.getStrings(root.getProperty("propMultiple"), Set.of("default"))));
     }
 
     @Test
     public void getStringsLenientNodeBuilder_WrongType() {
         NodeBuilder root = EMPTY_NODE.builder();
         @NotNull NodeBuilder b1 = root.setProperty(createProperty("propMultiple", 1L, Type.LONG));
-        assertEquals(Set.of("default"), toSet(PathFilter.getStringsLenient(root, "propMultiple", Set.of("default"))));
+        assertEquals(Set.of("default"), toSet(PathFilter.getStrings(root.getProperty("propMultiple"), Set.of("default"))));
     }
 
     static private <T> Set<T> toSet(Iterable<T> iterable) {


### PR DESCRIPTION
The includedPaths property of an index definition should be an array of strings. But a common mistake made by users is to define it as a String when it has a single element. That is, instead of:
```
        "includedPaths": [ "/a/b"] , 
```
it is defined as:
```
        "includedPaths": "/a/b", 
```

If `includedPaths` is defined as a String, the indexing job would ignore its value and instead default to use the root as the `includedPaths`, which results in downloading the full node store and creating an FFS containing everything (except hidden paths). This will slow down significantly the indexing job, as it will negate any benefits from using regex filtering. And even if regex filtering is not enabled or cannot be used, using `/` as `includedPaths` will also result in the FFS containing more nodes than it should, which will once again slow down the indexing job.

The same is true for `excludedPaths`, but in this case, the default value is an empty list of `excludedPaths`, so it will ignore the value of this property and will not exclude anything. This may result in parts of the node store being indexed that should not be indexed.

The handling of `includedPaths` and `excludedPaths` is also inconsistent with the handling of `queryPaths`, which is being interpreted as a one-element array if it is defined as a String.

This PR makes the logic that reads the `includedPaths` and `excludedPaths` properties more lenient, by treating Strings as one-element arrays and issuing a warning with a suggested fix.

Additionally, the PR makes some minor cleanups in the files that had to be modified (remove usages of Guava and fix some compilation warnings).