### PR TITLE
OAK-10608 - [Indexing job] Improve regex expression used to download from Mongo to make better used of Mongo indexes

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -143,15 +143,15 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     /**
      * Creates the filter to be used in the Mongo query
      *
-     * @param mongoFilterPaths         The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
-     *                                 (see {@link MongoFilterPaths} for details)
+     * @param mongoFilterPaths          The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
+     *                                  (see {@link MongoFilterPaths} for details)
      * @param customExcludeEntriesRegex Documents with paths matching this regex are excluded from download
      * @return The filter to be used in the Mongo query, or null if no filter is required
      */
-    static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex) {
+    static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex, boolean queryUsesIndexTraversal) {
         var filters = new ArrayList<Bson>(4);
         if (mongoFilterPaths != MongoFilterPaths.DOWNLOAD_ALL) {
-            filters.add(descendantsFilter(mongoFilterPaths.included));
+            filters.add(descendantsFilter(mongoFilterPaths.included, queryUsesIndexTraversal));
             if (!mongoFilterPaths.excluded.isEmpty()) {
                 // The Mongo filter returned here will download the top level path of each excluded subtree, which in theory
                 // should be excluded. That is, if the tree /a/b/c is excluded, the filter will download /a/b/c but none of
@@ -159,7 +159,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                 // This is done because excluding also the top level path would add extra complexity to the filter and
                 // would not have any measurable impact on performance because it only downloads a few extra documents, one
                 // for each excluded subtree. The transform stage will anyway filter out these paths.
-                Bson excludedFilter = descendantsFilter(mongoFilterPaths.excluded);
+                Bson excludedFilter = descendantsFilter(mongoFilterPaths.excluded, queryUsesIndexTraversal);
                 if (excludedFilter != null) {
                     filters.add(Filters.nor(excludedFilter));
                 }
@@ -167,7 +167,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
 
         // Custom regex filter to exclude paths
-        Bson customExcludedPathsFilter = createCustomExcludedEntriesFilter(customExcludeEntriesRegex);
+        Bson customExcludedPathsFilter = createCustomExcludedEntriesFilter(customExcludeEntriesRegex, queryUsesIndexTraversal);
         if (customExcludedPathsFilter != null) {
             filters.add(customExcludedPathsFilter);
         }
@@ -180,24 +180,19 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
     }
 
-    static Bson createCustomExcludedEntriesFilter(String customRegexPattern) {
+    static Bson createCustomExcludedEntriesFilter(String customRegexPattern, boolean queryUsesIndexTraversal) {
         if (customRegexPattern == null || customRegexPattern.trim().isEmpty()) {
             LOG.info("Mongo custom regex is disabled");
             return null;
         } else {
             LOG.info("Excluding nodes with paths matching regex: {}", customRegexPattern);
             var pattern = Pattern.compile(customRegexPattern);
-            return Filters.nor(
-                    Filters.regex(NodeDocument.ID, pattern),
-                    Filters.and(
-                            Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
-                            Filters.regex(NodeDocument.PATH, pattern)
-                    )
-            );
+            Bson pathFilter = createPathFilter(List.of(pattern), queryUsesIndexTraversal);
+            return Filters.nor(Filters.regex(NodeDocument.ID, pattern), pathFilter);
         }
     }
 
-    private static Bson descendantsFilter(List<String> paths) {
+    private static Bson descendantsFilter(List<String> paths, boolean queryUsesIndexTraversal) {
         if (paths.isEmpty()) {
             return null;
         }
@@ -220,13 +215,28 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             idPatterns.add(Pattern.compile("^[0-9]{1,3}:" + quotedPath + ".*$"));
             pathPatterns.add(Pattern.compile(quotedPath + ".*$"));
         }
-        return Filters.or(
-                Filters.in(NodeDocument.ID, idPatterns),
-                Filters.and(
-                        Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
-                        Filters.in(NodeDocument.PATH, pathPatterns)
-                )
-        );
+
+        Bson pathFilter = createPathFilter(pathPatterns, queryUsesIndexTraversal);
+        return Filters.or(Filters.in(NodeDocument.ID, idPatterns), pathFilter);
+    }
+
+    private static Bson createPathFilter(List<Pattern> pattern, boolean queryUsesIndexTraversal) {
+        // For the case of long path document, the _id does not contain the path of the document, so we need to check
+        // the _path field. When doing an index scan, it may be more efficient to check that the _id starts is in the format
+        // of a long path id (that is, numeric prefix followed by ":h") first, before checking the _path field. The _id
+        // is available from the index while the _path field is only available on the document itself, so checking the
+        // _path will force an expensive retrieval of the full document. It is not guranteed that Mongo will implement
+        // this optimization, but it is worth trying.
+        // If the query is doing a simple column scan, then Mongo already has to retrieve the full document, so we can
+        // check the _path directly, which simplified a bit the query.
+        if (queryUsesIndexTraversal) {
+            return Filters.and(
+                    Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
+                    Filters.in(NodeDocument.PATH, pattern)
+            );
+        } else {
+            return Filters.in(NodeDocument.PATH, pattern);
+        }
     }
 
     /**
@@ -396,7 +406,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // That is, download "/", "/content", "/content/dam" for a base path of "/content/dam". These nodes will not be
         // matched by the regex used in the Mongo query, which assumes a prefix of "???:/content/dam"
         MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
-        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
+        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex, true);
         if (mongoFilter == null) {
             LOG.info("Downloading full repository");
         } else {
@@ -491,7 +501,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // We are downloading potentially a large fraction of the repository, so using an index scan will be
         // inefficient. So we pass the natural hint to force MongoDB to use natural ordering, that is, column scan
         MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
-        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
+        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex, false);
         if (mongoFilter == null) {
             LOG.info("Downloading full repository from Mongo with natural order");
             FindIterable<NodeDocument> mongoIterable = dbCollection

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -143,8 +143,8 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     /**
      * Creates the filter to be used in the Mongo query
      *
-     * @param mongoFilterPaths          The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
-     *                                  (see {@link MongoFilterPaths} for details)
+     * @param mongoFilterPaths         The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
+     *                                 (see {@link MongoFilterPaths} for details)
      * @param customExcludeEntriesRegex Documents with paths matching this regex are excluded from download
      * @return The filter to be used in the Mongo query, or null if no filter is required
      */
@@ -189,7 +189,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             var pattern = Pattern.compile(customRegexPattern);
             return Filters.nor(
                     Filters.regex(NodeDocument.ID, pattern),
-                    Filters.regex(NodeDocument.PATH, pattern)
+                    Filters.and(
+                            Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
+                            Filters.regex(NodeDocument.PATH, pattern)
+                    )
             );
         }
     }
@@ -219,7 +222,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
         return Filters.or(
                 Filters.in(NodeDocument.ID, idPatterns),
-                Filters.in(NodeDocument.PATH, pathPatterns)
+                Filters.and(
+                        Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
+                        Filters.in(NodeDocument.PATH, pathPatterns)
+                )
         );
     }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -126,6 +126,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     private static final int MIN_INTERVAL_BETWEEN_DELAYED_ENQUEUING_MESSAGES = 10;
     private final static BsonDocument NATURAL_HINT = BsonDocument.parse("{ $natural: 1 }");
     private final static BsonDocument ID_INDEX_HINT = BsonDocument.parse("{ _id: 1 }");
+    private final static Pattern LONG_PATH_ID_PATTERN = Pattern.compile("^[0-9]{1,3}:h.*$");
 
     private static final String THREAD_NAME = "mongo-dump";
 
@@ -444,7 +445,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
         return Filters.or(
                 Filters.in(NodeDocument.ID, idPatterns),
-                Filters.in(NodeDocument.PATH, pathPatterns)
+                Filters.and(
+                        Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
+                        Filters.in(NodeDocument.PATH, pathPatterns)
+                )
         );
     }
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -301,7 +301,7 @@ public class PipelinedMongoDownloadTaskTest {
         var expectedBson = Filters.nor(
                 Filters.regex(NodeDocument.ID, p),
                 Filters.and(
-                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
+                        Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN),
                         Filters.in(NodeDocument.PATH, p)
                 )
         );
@@ -335,8 +335,8 @@ public class PipelinedMongoDownloadTaskTest {
         var expected = Filters.or(
                 Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$")),
                 Filters.and(
-                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
-                        Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
+                        Filters.in(NodeDocument.PATH, Pattern.compile("^" + Pattern.quote("/parent/") + ".*$")),
+                        Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN)
                 )
         );
         assertBsonEquals(expected, actual);
@@ -349,13 +349,13 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$",
                 true
         );
-        Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
         assertBsonEquals(
                 Filters.nor(
-                        Filters.regex(NodeDocument.ID, p),
+                        Filters.regex(NodeDocument.ID, excludePattern),
                         Filters.and(
-                                Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
-                                Filters.in(NodeDocument.PATH, p)
+                                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN),
+                                Filters.in(NodeDocument.PATH, excludePattern)
                         )
                 ),
                 actual
@@ -370,23 +370,24 @@ public class PipelinedMongoDownloadTaskTest {
                 true
         );
 
-        Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludesPattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
         var expected =
                 Filters.and(
-                        Filters.nor(
-                                Filters.regex(NodeDocument.ID, p),
-                                Filters.and(
-                                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
-                                        Filters.in(NodeDocument.PATH, p)
-                                )
-                        ),
                         Filters.or(
                                 Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$")),
                                 Filters.and(
-                                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
-                                        Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
+                                        Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN),
+                                        Filters.in(NodeDocument.PATH, Pattern.compile("^" + Pattern.quote("/parent/") + ".*$"))
                                 )
-                        ));
+                        ),
+                        Filters.nor(
+                                Filters.regex(NodeDocument.ID, excludesPattern),
+                                Filters.and(
+                                        Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN),
+                                        Filters.in(NodeDocument.PATH, excludesPattern)
+                                )
+                        )
+                );
         assertBsonEquals(expected, actual);
     }
 
@@ -398,17 +399,18 @@ public class PipelinedMongoDownloadTaskTest {
                 false
         );
 
-        Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
         var expected =
                 Filters.and(
-                        Filters.nor(
-                                Filters.regex(NodeDocument.ID, p),
-                                Filters.in(NodeDocument.PATH, p)
-                        ),
                         Filters.or(
                                 Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$")),
-                                Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
-                        ));
+                                Filters.in(NodeDocument.PATH, Pattern.compile("^" + Pattern.quote("/parent/") + ".*$"))
+                        ),
+                        Filters.nor(
+                                Filters.regex(NodeDocument.ID, excludePattern),
+                                Filters.in(NodeDocument.PATH, excludePattern)
+                        )
+                );
         assertBsonEquals(expected, actual);
     }
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -300,8 +300,13 @@ public class PipelinedMongoDownloadTaskTest {
         Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
         var expectedBson = Filters.nor(
                 Filters.regex(NodeDocument.ID, p),
-                Filters.regex(NodeDocument.PATH, p)
+                Filters.and(
+                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
+                        Filters.regex(NodeDocument.PATH, p)
+                )
         );
+
+
         var actualBson = PipelinedMongoDownloadTask.createCustomExcludedEntriesFilter("^[0-9]{1,3}:/a/b.*$");
 
         assertBsonEquals(expectedBson, actualBson);
@@ -327,7 +332,10 @@ public class PipelinedMongoDownloadTaskTest {
         );
         var expected = Filters.or(
                 Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$")),
-                Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
+                Filters.and(
+                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
+                        Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
+                )
         );
         assertBsonEquals(expected, actual);
     }
@@ -340,7 +348,13 @@ public class PipelinedMongoDownloadTaskTest {
         );
         Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
         assertBsonEquals(
-                Filters.nor(Filters.regex(NodeDocument.ID, p), Filters.regex(NodeDocument.PATH, p)),
+                Filters.nor(
+                        Filters.regex(NodeDocument.ID, p),
+                        Filters.and(
+                                Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
+                                Filters.regex(NodeDocument.PATH, p)
+                        )
+                ),
                 actual
         );
     }
@@ -355,10 +369,19 @@ public class PipelinedMongoDownloadTaskTest {
         Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
         var expected =
                 Filters.and(
-                        Filters.nor(Filters.regex(NodeDocument.ID, p), Filters.regex(NodeDocument.PATH, p)),
+                        Filters.nor(
+                                Filters.regex(NodeDocument.ID, p),
+                                Filters.and(
+                                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
+                                        Filters.regex(NodeDocument.PATH, p)
+                                )
+                        ),
                         Filters.or(
                                 Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$")),
-                                Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
+                                Filters.and(
+                                        Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:h.*$")),
+                                        Filters.in(NodeDocument.PATH, Pattern.compile(Pattern.quote("/parent/") + ".*$"))
+                                )
                         ));
         assertBsonEquals(expected, actual);
     }


### PR DESCRIPTION
The current regex expression used to filter from Mongo the included/excluded paths has conditions on both the fields `_id` and `_path`. In most cases, the `_id` field contains the path of the node, but when the path is too long, the `_id` is replaced by an hash of the path and the full path is added to the document as an additional `_path` field. For these cases, the regex expression must also check the `_path` field.

When running an ordered traversal, we use a Mongo index on `(_modified, _id)`. So checks on `_id` can be done with just the data retrieved from the index. But for the check on `_path`, Mongo needs to read the full document from the column store, which slows down significantly the traversal.

Currently, if `_id` does not match, the regex expression will always check `_path`, forcing a retrieval of the document. But we only need to check `_path` if the `_id` is of the form of a long path id, that is, of the pattern `4:h<hash>...`, otherwise, if the `_id` is not a long path, then if it does not match the regex, we can be sure that the document is not needed. The check that `_id` is an hash can be done without retrieving the full document from the column store, so it will be fast. And in the common case, the document is not a long path, so this simple check will avoid retrieving the document from the column store.

This optimization will have a big impact when the regex expression matches a small fraction of the repository. In the current implementation, Mongo has to traverse both the index and the column store for all possible regex filters. But with the additional check for long paths, Mongo has still to traverse the full index but it will only retrieve from the column store the documents that match the filter or the long path documents. And since the index is much smaller than the column store and can more easily be cached, this will significantly improve performance.

In a test environment, with an index job that downloads 12M out of 230M mongo documents, I got the following results:
- regex filtering, without long path optimization: 1h45
- regex filtering with long path optimization: 0h45m