### PR TITLE
OAK-10617: oak-search-elastic fix deadlock with includePathRestrictions=false and multiple filtered results

### DIFF
--- a/oak-doc/src/site/markdown/query/elastic.md
+++ b/oak-doc/src/site/markdown/query/elastic.md
@@ -33,9 +33,8 @@ however there are differences:
 * Indexes are NOT automatically built when needed: 
   They can be built by setting the `reindex` property to `true` or by using the `oak-run` tool.
   We recommend to build them using the `oak-run` tool.
-* `evaluatePathRestrictions` is only checked at query time (to keep the compatibility with Lucene). The parent paths are
-  always indexed. Changing this flag won't require a reindex then. It's strongly suggested to enable it. This control
-  might be removed in the future.
+* `evaluatePathRestrictions` cannot be disabled. The parent paths are always indexed. Queries with path restrictions are 
+  evaluated at index level when possible, otherwise they are evaluated at repository level.
 * `codec` is ignored.
 * `compatVersion` is ignored.
 * `useIfExists` is ignored.

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -103,6 +103,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.annotation.versioning</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -59,6 +59,9 @@ public class ElasticIndexDefinition extends IndexDefinition {
     public static final String QUERY_FETCH_SIZES = "queryFetchSizes";
     public static final Long[] QUERY_FETCH_SIZES_DEFAULT = new Long[]{10L, 100L, 1000L};
 
+    public static final String QUERY_TIMEOUT_MS = "queryTimeoutMs";
+    public static final long QUERY_TIMEOUT_MS_DEFAULT = 60000;
+
     public static final String TRACK_TOTAL_HITS = "trackTotalHits";
     public static final Integer TRACK_TOTAL_HITS_DEFAULT = 10000;
 
@@ -138,6 +141,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
     public final int numberOfShards;
     public final int numberOfReplicas;
     public final int[] queryFetchSizes;
+    public final long queryTimeoutMs;
     public final Integer trackTotalHits;
     public final String dynamicMapping;
     public final boolean failOnError;
@@ -162,6 +166,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
         this.similarityTagsBoost = getOptionalValue(defn, SIMILARITY_TAGS_BOOST, SIMILARITY_TAGS_BOOST_DEFAULT);
         this.queryFetchSizes = Arrays.stream(getOptionalValues(defn, QUERY_FETCH_SIZES, Type.LONGS, Long.class, QUERY_FETCH_SIZES_DEFAULT))
                 .mapToInt(Long::intValue).toArray();
+        this.queryTimeoutMs = getOptionalValue(defn, QUERY_TIMEOUT_MS, QUERY_TIMEOUT_MS_DEFAULT);
         this.trackTotalHits = getOptionalValue(defn, TRACK_TOTAL_HITS, TRACK_TOTAL_HITS_DEFAULT);
         this.dynamicMapping = getOptionalValue(defn, DYNAMIC_MAPPING, DYNAMIC_MAPPING_DEFAULT);
         this.failOnError = getOptionalValue(defn, FAIL_ON_ERROR,

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResponseListener.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResponseListener.java
@@ -20,17 +20,18 @@ import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.osgi.annotation.versioning.ProviderType;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * Generic listener of Elastic response
  */
+@ProviderType
 public interface ElasticResponseListener {
 
-    Set<String> DEFAULT_SOURCE_FIELDS = Collections.singleton(FieldNames.PATH);
+    Set<String> DEFAULT_SOURCE_FIELDS = Set.of(FieldNames.PATH);
 
     /**
      * Returns the source fields this listener is interested on

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResponseListener.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResponseListener.java
@@ -68,8 +68,9 @@ public interface ElasticResponseListener {
         /**
          * This method is called for each {@link Hit} retrieved
          * @param searchHit a search result
+         * @return true if the search hit was successfully processed, false otherwise
          */
-        void on(Hit<ObjectNode> searchHit);
+        boolean on(Hit<ObjectNode> searchHit);
     }
 
     /**

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -70,7 +70,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
     private static final FulltextResultRow POISON_PILL =
             new FulltextResultRow("___OAK_POISON_PILL___", 0d, Collections.emptyMap(), null, null);
 
-    private final BlockingQueue<FulltextResultRow> queue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<FulltextResultRow> queue;
 
     private final ElasticIndexNode indexNode;
     private final IndexPlan indexPlan;
@@ -97,6 +97,9 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
         this.rowInclusionPredicate = rowInclusionPredicate;
         this.metricHandler = metricHandler;
         this.elasticFacetProvider = elasticRequestHandler.getAsyncFacetProvider(indexNode.getConnection(), elasticResponseHandler);
+        // set the queue size to the limit of the query. This is to avoid to load too many results in memory in case the
+        // consumer is slow to process them
+        this.queue = new LinkedBlockingQueue<>((int) indexPlan.getFilter().getQueryLimits().getLimitReads());
         this.elasticQueryScanner = initScanner();
     }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -340,7 +340,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
                 LOG.trace("Emitting {} search hits, for a total of {} scanned results", searchHits.size(), scannedRows);
 
-                Set<SearchHitListener> listenersWithHits = new HashSet<>();
+                Set<SearchHitListener> listenersWithHits = new HashSet<>(searchHitListeners.size());
 
                 for (Hit<ObjectNode> hit : searchHits) {
                     for (SearchHitListener l : searchHitListeners) {
@@ -351,7 +351,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                 }
                 // if any listener has not processed any hit, it means we need to load more data since there could be
                 // listeners waiting for some results before triggering a new scan
-                boolean areAllListenersProcessed = listenersWithHits.containsAll(searchHitListeners);
+                boolean areAllListenersProcessed = listenersWithHits.size() == searchHitListeners.size();
 
                 if (!anyDataLeft.get()) {
                     LOG.trace("No data left: closing scanner, notifying listeners");

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -340,7 +340,8 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
                 LOG.trace("Emitting {} search hits, for a total of {} scanned results", searchHits.size(), scannedRows);
 
-                Set<SearchHitListener> listenersWithHits = new HashSet<>(searchHitListeners.size());
+                Set<SearchHitListener> listenersWithHits =
+                        new HashSet<>((int) Math.ceil(searchHitListeners.size() / 0.75 + 1), 0.75f);
 
                 for (Hit<ObjectNode> hit : searchHits) {
                     for (SearchHitListener l : searchHitListeners) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticSecureFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticSecureFacetAsyncProvider.java
@@ -71,7 +71,7 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider, ElasticRe
     }
 
     @Override
-    public void on(Hit<ObjectNode> searchHit) {
+    public boolean on(Hit<ObjectNode> searchHit) {
         final String path = elasticResponseHandler.getPath(searchHit);
         if (path != null && isAccessible.test(path)) {
             for (String field: facetFields) {
@@ -90,6 +90,7 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider, ElasticRe
                 }
             }
         }
+        return true;
     }
 
     @Override

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDescendantSpellcheckCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDescendantSpellcheckCommonTest.java
@@ -20,6 +20,8 @@ import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.plugins.index.IndexDescendantSpellcheckCommonTest;
 import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import javax.jcr.Repository;
 
@@ -38,4 +40,10 @@ public class ElasticIndexDescendantSpellcheckCommonTest extends IndexDescendantS
         return jcr.createRepository();
     }
 
+    @Override
+    @Test
+    @Ignore("OAK-10617: path restrictions are always applied. This test is not applicable for Elastic")
+    public void descendantSuggestionRequirePathRestrictionIndex() throws Exception {
+        super.descendantSuggestionRequirePathRestrictionIndex();
+    }
 }


### PR DESCRIPTION
This pull request addresses a potential deadlock issue in Elastic that may arise when an index definition has `includePathRestrictions=false` and a query with a large number of results is subjected to filtering.

The occurrence of this problem is attributed to the utilization of two threads during query execution. The first thread executes an asynchronous query in Elastic, waiting on a blocking queue for results, while the second thread reads the response and appends the results to the queue. This design facilitates the concurrent processing of results across multiple pages, allowing the initiation of subsequent result processing while the first thread handles the previous page.

However, when includePathRestrictions is set to false and a response exclusively contains filtered paths, the queue remains unpopulated, resulting in a process deadlock.

While path restrictions are always applicable in Elastic (ancestors are always persisted), certain scenarios (e.g., nodes requiring path transformations) may lead to result filtering. The proposed solution addresses this issue by continuously scanning results in situations where listeners are not able to process results within a page.