### PR TITLE
OAK-10611: o.a.j.o.namepath.JcrPathParser does not handle invalid characters correctly

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/JcrPathParser.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/JcrPathParser.java
@@ -200,18 +200,6 @@ public final class JcrPathParser {
                     }
                     break;
 
-                case '[':
-                    if (state == STATE_PREFIX || state == STATE_NAME) {
-                        if (wasSlash) {
-                            pathAwareListener.error("Trailing slashes not allowed in prefixes and names.");
-                            return false;
-                        }
-                        state = STATE_INDEX;
-                        name = jcrPath.substring(lastPos, pos - 1);
-                        lastPos = pos;
-                    }
-                    break;
-
                 case ']':
                     if (state == STATE_INDEX) {
                         try {
@@ -253,6 +241,19 @@ public final class JcrPathParser {
                         state = STATE_URI_END;
                     }
                     break;
+
+                case '[':
+                    if (state == STATE_PREFIX || state == STATE_NAME) {
+                        if (wasSlash) {
+                            pathAwareListener.error("Trailing slashes not allowed in prefixes and names.");
+                            return false;
+                        }
+                        state = STATE_INDEX;
+                        name = jcrPath.substring(lastPos, pos - 1);
+                        lastPos = pos;
+                        break;
+                    }
+                    // intentionally no break, so we get the default treatment for all other states
 
                 default:
                     if (state == STATE_PREFIX_START || state == STATE_DOT || state == STATE_DOTDOT) {

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/namepath/PathParserTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/namepath/PathParserTest.java
@@ -252,7 +252,6 @@ public class PathParserTest {
     //TODO add more tests to cover all edge cases
 
     @Test
-    @Ignore  //OAK-10611
     public void testUnexpectedOpeningSquareBracket() throws RepositoryException {
         String path = "[";
         TestListener listener = new TestListener(
@@ -301,20 +300,21 @@ public class PathParserTest {
 
         path = "a[[";
         listener = new TestListener(
+                CALLBACKRESULT_ERROR_ANY
                 //the parser actually produces an error, but we should change the error message to something like this
-                CALLBACKRESULT_ERROR(errorClosingQuareBracketExpected(path))
+                //CALLBACKRESULT_ERROR(errorClosingQuareBracketExpected(path))
         );
         verifyResult(path, listener, false);
     }
 
     @Test
-    @Ignore  //OAK-10611
     public void testMissingClosingSquareBracket() throws RepositoryException {
         String path = "/a[";
         TestListener listener = new TestListener(
                 CALLBACKRESULT_ROOT,
+                CALLBACKRESULT_ERROR_ANY
                 //the parser actually produces an error, but we should change the error message to something like this
-                CALLBACKRESULT_ERROR(errorClosingQuareBracketExpected(path))
+                //CALLBACKRESULT_ERROR(errorClosingQuareBracketExpected(path))
         );
         verifyResult(path, listener, false);
     }

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/namepath/PathParserTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/namepath/PathParserTest.java
@@ -249,8 +249,6 @@ public class PathParserTest {
         verifyResult(path, listener, true);
     }
 
-    //TODO add more tests to cover all edge cases
-
     @Test
     public void testUnexpectedOpeningSquareBracket() throws RepositoryException {
         String path = "[";
@@ -300,9 +298,10 @@ public class PathParserTest {
 
         path = "a[[";
         listener = new TestListener(
+                //TODO OAK-10616
+                //the parser actually produces an error, but we should change the error message to something like
+                //CALLBACKRESULT_ERROR(errorClosingSquareBracketExpected(path))
                 CALLBACKRESULT_ERROR_ANY
-                //the parser actually produces an error, but we should change the error message to something like this
-                //CALLBACKRESULT_ERROR(errorClosingQuareBracketExpected(path))
         );
         verifyResult(path, listener, false);
     }
@@ -312,9 +311,10 @@ public class PathParserTest {
         String path = "/a[";
         TestListener listener = new TestListener(
                 CALLBACKRESULT_ROOT,
+                //TODO OAK-10616
+                //the parser actually produces an error, but we should change the error message to something like
+                //CALLBACKRESULT_ERROR(errorClosingSquareBracketExpected(path))
                 CALLBACKRESULT_ERROR_ANY
-                //the parser actually produces an error, but we should change the error message to something like this
-                //CALLBACKRESULT_ERROR(errorClosingQuareBracketExpected(path))
         );
         verifyResult(path, listener, false);
     }
@@ -336,14 +336,12 @@ public class PathParserTest {
 
         path = ".]";
         listener = new TestListener(
-                //TODO improve error message?
                 CALLBACKRESULT_ERROR(errorCharacterNotAllowedInName(path, ']'))
         );
         verifyResult(path, listener, false);
 
         path = "..]";
         listener = new TestListener(
-                //TODO improve error message?
                 CALLBACKRESULT_ERROR(errorCharacterNotAllowedInName(path, ']'))
         );
         verifyResult(path, listener, false);
@@ -481,10 +479,11 @@ public class PathParserTest {
         );
         verifyResult(path, listener, true);
 
-        // TODO fix error message (OAK-10625)
         path = "/a:";
         listener = new TestListener(
                 CALLBACKRESULT_ROOT,
+                //TODO OAK-10616
+                //the parser actually produces an error, but the error message contains an EOF.
                 CALLBACKRESULT_ERROR_ANY
         );
         verifyResult(path, listener, false);
@@ -503,12 +502,12 @@ public class PathParserTest {
         );
         verifyResult(path, listener, false);
 
-        //TODO fix error message
         path = "/a:[1]";
         listener = new TestListener(
                 CALLBACKRESULT_ROOT,
-               CALLBACKRESULT_ERROR_ANY
-               //CALLBACKRESULT_ERROR("'/a:[1]' is not a valid path. Local name after ':' expected")
+                //TODO OAK-10616
+                //the parser actually produces an error, but the error message is misleading
+               CALLBACKRESULT_ERROR("'/a:[1]' is not a valid path. ']' not allowed in name.")
         );
         verifyResult(path, listener, false);
     }


### PR DESCRIPTION
…racters correctly

Fixed treatment of square brackets in some edge cases.