### PR TITLE
OAK-10544: oak-jcr: remapping a namespace prefix leaves namespace resolver in broken state

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionNamespaces.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionNamespaces.java
@@ -90,6 +90,8 @@ public class SessionNamespaces extends LocalNameMapper {
         local.put(prefix, uri);
 
         // make sure the previously mapped URI has a prefix
+        // (getNamespacePrefix has the side effect of generating
+        // a new prefix if none was found, and adding that to the local mapping)
         if (previouslyMappedUri != null) {
             getNamespacePrefix(previouslyMappedUri);
         }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionNamespaces.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionNamespaces.java
@@ -72,6 +72,8 @@ public class SessionNamespaces extends LocalNameMapper {
                     "Prefix is not a valid XML NCName: " + prefix);
         }
 
+        String previouslyMappedUri = getOakURIOrNull(prefix);
+
         // remove the possible existing mapping for the given prefix
         local.remove(prefix);
 
@@ -86,6 +88,11 @@ public class SessionNamespaces extends LocalNameMapper {
 
         // add the new mapping
         local.put(prefix, uri);
+
+        // make sure the previously mapped URI has a prefix
+        if (previouslyMappedUri != null) {
+            getNamespacePrefix(previouslyMappedUri);
+        }
     }
 
     /**

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/NamePathTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/NamePathTest.java
@@ -220,7 +220,6 @@ public class NamePathTest {
     }
 
     @Test
-    @Ignore("OAK-10544")
     public void testPrefixRemapping() throws NamespaceException, RepositoryException {
         Random r = new Random();
         int i1 = r.nextInt();


### PR DESCRIPTION
...based on @mreutegg 's suggestion to fix this on oak-jcr.

I don't believe we'd need a feature toggle for this.

Feedback appreciated.