### PR TITLE
OAK-10635 BundledTypeRegistry replace guava collection refs with facade

### DIFF
--- a/oak-commons/pom.xml
+++ b/oak-commons/pom.xml
@@ -49,6 +49,7 @@
               org.apache.jackrabbit.oak.commons,
               org.apache.jackrabbit.oak.commons.cache,
               org.apache.jackrabbit.oak.commons.concurrent,
+              org.apache.jackrabbit.oak.commons.guava,
               org.apache.jackrabbit.oak.commons.io,
               org.apache.jackrabbit.oak.commons.json,
               org.apache.jackrabbit.oak.commons.sort,
@@ -134,6 +135,6 @@
       <artifactId>lz4-java</artifactId>
       <version>1.8.0</version>
       <scope>test</scope>
-    </dependency>    
+    </dependency>
   </dependencies>
 </project>

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/guava/Collect.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/guava/Collect.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jackrabbit.oak.commons.guava;
+
+import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
+import org.apache.jackrabbit.guava.common.collect.Maps;
+import org.apache.jackrabbit.guava.common.collect.Sets;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * A limited set of facade factory methods over the {@code org.apache.jackrabbit.guava.common.collect} API.
+ */
+public final class Collect {
+    private Collect() {
+    }
+
+    /**
+     * Returns the result of {@code Maps.newHashMap()}.
+     *
+     * @param <K> key type
+     * @param <V> value type
+     * @return the result of {@code Maps.newHashMap()}.
+     * @see org.apache.jackrabbit.guava.common.collect.Maps#newHashMap()
+     */
+    public static <K, V> HashMap<K, V> newHashMap() {
+        return Maps.newHashMap();
+    }
+
+    /**
+     * Returns the result of {@code Sets.newHashSet()}.
+     *
+     * @param <E> element type
+     * @return the result of {@code Sets.newHashSet()}.
+     * @see org.apache.jackrabbit.guava.common.collect.Sets#newHashSet()
+     */
+    public static <E extends @Nullable Object> HashSet<E> newHashSet() {
+        return Sets.newHashSet();
+    }
+
+    /**
+     * Returns the result of {@code ImmutableMap.copyOf(map)}.
+     *
+     * @param map the mappings to be placed in the new map
+     * @param <K> key type
+     * @param <V> value type
+     * @return the result of {@code ImmutableMap.copyOf(map)}
+     * @see org.apache.jackrabbit.guava.common.collect.ImmutableMap#copyOf(java.util.Map)
+     */
+    public static <K, V> Map<K, V> immutableMapCopyOf(Map<? extends K, ? extends V> map) {
+        return ImmutableMap.copyOf(map);
+    }
+}

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/guava/package-info.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/guava/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Version("1.0.0")
+package org.apache.jackrabbit.oak.commons.guava;
+
+import org.osgi.annotation.versioning.Version;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/BundledTypesRegistry.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/BundledTypesRegistry.java
@@ -23,12 +23,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
-import org.apache.jackrabbit.guava.common.collect.Maps;
-import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.guava.Collect;
 import org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -44,11 +42,11 @@ public class BundledTypesRegistry {
     private final Map<String, DocumentBundlor> bundlors;
 
     public BundledTypesRegistry(Map<String, DocumentBundlor> bundlors) {
-        this.bundlors = ImmutableMap.copyOf(bundlors);
+        this.bundlors = Collect.immutableMapCopyOf(bundlors);
     }
 
     public static BundledTypesRegistry from(NodeState configParentState){
-        Map<String, DocumentBundlor> bundlors = Maps.newHashMap();
+        Map<String, DocumentBundlor> bundlors = Collect.newHashMap();
         for (ChildNodeEntry e : configParentState.getChildNodeEntries()){
             NodeState config = e.getNodeState();
             if (config.getBoolean(DocumentBundlor.PROP_DISABLED)){
@@ -141,7 +139,7 @@ public class BundledTypesRegistry {
         public static class TypeBuilder {
             private final BundledTypesRegistryBuilder parent;
             private final NodeBuilder typeBuilder;
-            private final Set<String> patterns = Sets.newHashSet();
+            private final Set<String> patterns = Collect.newHashSet();
 
             private TypeBuilder(BundledTypesRegistryBuilder parent, NodeBuilder typeBuilder) {
                 this.parent = parent;


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/OAK-10635

The oak-shaded-guava bundle exports shaded guava packages with a version that is defined by google to match the version of the upstream artifact. While it is a semantic versioning scheme, it follows the API contract of the entire artifact, and does not distinguish API changes in included packages like .base and .collect at a granular level, which can result in otherwise avoidable OSGi wiring errors when references to guava types leak outside of the greater Oak API boundary, such as when classes are embedded or when guava types are explicitly referenced in signatures outside of oak-shaded-guava.

oak-commons should endeavor to provide a stable facade API for the simpler parts of the guava library that are referenced at runtime by other oak bundles, such as newHashMap(), ImmutableList.copyOf(), Preconditions.check*, and perhaps Closer. 

One example I know of that could where I could benefit from this approach almost immediately is a project where I am embedding BundlingConfigInitializer and BundledTypesRegistry from oak-store-document in a customized repository configuration. When BundledTypesRegistry is embedded, it brings with it imports of ImmutableMap, Maps, and Sets from org.apache.jackrabbit.guava.common.collect. With the recent guava upgrade to 33.0.0 in [OAK-10605](https://issues.apache.org/jira/browse/OAK-10605) in 1.61-SNAPSHOT, the custom repository bundle fails to activate because the previous import-package bounds no longer match: `org.apache.jackrabbit.guava.common.collect;version=[32.1.3,33)`.