### PR TITLE
OAK-10637 - Indexing job/regex path filtering - when / is the only included path, do not add an explicit filter

### DIFF
--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -238,6 +238,25 @@ public class PipelinedIT {
     }
 
     @Test
+    public void createFFS_mongoFiltering_include_excludes_retryOnConnectionErrors() throws Exception {
+        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "true");
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");
+
+        Predicate<String> pathPredicate = s -> true;
+
+        List<PathFilter> pathFilters = List.of(new PathFilter(List.of("/"), List.of("/content/dam", "/etc", "/home", "/jcr:system")));
+
+        testSuccessfulDownload(pathPredicate, pathFilters, List.of(
+                "/|{}",
+                "/content|{}",
+                "/content/dam|{}",
+                "/etc|{}",
+                "/home|{}",
+                "/jcr:system|{}"
+        ));
+    }
+
+    @Test
     public void createFFS_mongoFiltering_include_excludes4() throws Exception {
         System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "false");
         System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");


### PR DESCRIPTION
If downloading the root directory, do not add a filter to the Mongo query.

This PR changes the documents that are downloaded from Mongo but without affecting the final FFS. The filter on `<depth>:/<path>` is going to exclude some documents, for instance, partial documents which have an id of the form `<depth>:p/<path>`. So if we remove this filter, these documents will also be downloaded. We are already downloading these documents when regex path filtering is disabled or when the included paths are / and there are no excluded paths. The transform phase will ignore the partial documents which are not necessary and will download missing partial documents, so the correctness is not affected.

The performance may be affected, but in the repositories that I checked, the number of partial documents is very small, a few tens of thousands out of hundreds of millions. Therefore, I think it is worth to add this check to remove the filter on `<depth>:/<path>` for the case when `includedPaths=/` and `excludedPaths` is non empty, as we are doing something similar when `includedPaths=/` and `excludedPaths` is empty.