### PR TITLE
OAK-10639 : NodeImpl calculate mixinTypes lazy

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/nodetype/EffectiveNodeTypeProvider.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/nodetype/EffectiveNodeTypeProvider.java
@@ -87,7 +87,7 @@ public interface EffectiveNodeTypeProvider {
      * @deprecated use {@link #isNodeType(String, Supplier, String)} instead
      */
     default boolean isNodeType(@NotNull String primaryTypeName, @NotNull Iterable<String> mixinTypes, @NotNull String nodeTypeName) throws NoSuchNodeTypeException, RepositoryException {
-        return isNodeType(primaryTypeName,() -> mixinTypes, nodeTypeName);
+        return isNodeType(primaryTypeName, () -> mixinTypes, nodeTypeName);
     }
 
     /**

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/nodetype/EffectiveNodeTypeProvider.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/nodetype/EffectiveNodeTypeProvider.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.spi.nodetype;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -83,8 +84,26 @@ public interface EffectiveNodeTypeProvider {
      * refer to an existing node type.
      * @throws RepositoryException If the given node type name is invalid or if
      * some other error occurs.
+     * @deprecated use {@link #isNodeType(String, Supplier, String)} instead
      */
-    boolean isNodeType(@NotNull String primaryTypeName, @NotNull Iterable<String> mixinTypes, @NotNull String nodeTypeName) throws NoSuchNodeTypeException, RepositoryException;
+    default boolean isNodeType(@NotNull String primaryTypeName, @NotNull Iterable<String> mixinTypes, @NotNull String nodeTypeName) throws NoSuchNodeTypeException, RepositoryException {
+        return isNodeType(primaryTypeName,() -> mixinTypes, nodeTypeName);
+    }
+
+    /**
+     * Returns {@code true} if {@code typeName} is of the specified primary node
+     * type or mixin type, or a subtype thereof. Returns {@code false} otherwise.
+     *
+     * @param primaryTypeName  the internal oak name of the node to test
+     * @param mixinTypes the internal oak names of the node to test.
+     * @param nodeTypeName The internal oak name of the node type to be tested.
+     * @return {@code true} if the specified node type is of the given node type.
+     * @throws NoSuchNodeTypeException If the specified node type name doesn't
+     * refer to an existing node type.
+     * @throws RepositoryException If the given node type name is invalid or if
+     * some other error occurs.
+     */
+    boolean isNodeType(@NotNull String primaryTypeName, @NotNull Supplier<Iterable<String>> mixinTypes, @NotNull String nodeTypeName) throws NoSuchNodeTypeException, RepositoryException;
 
     /**
      * Returns {@code true} if {@code typeName} is of the specified primary node

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/nodetype/package-info.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/nodetype/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.1.0")
+@Version("1.2.0")
 package org.apache.jackrabbit.oak.spi.nodetype;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/ReadOnlyNodeTypeManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/ReadOnlyNodeTypeManager.java
@@ -26,6 +26,7 @@ import static org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants.NODE_TYPE
 import static org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants.REP_SUPERTYPES;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -283,8 +284,7 @@ public abstract class ReadOnlyNodeTypeManager implements NodeTypeManager, Effect
         return false;
     }
 
-    @Override
-    public boolean isNodeType(@Nullable String primaryTypeName, @NotNull Iterable<String> mixinTypes, @NotNull String nodeTypeName) {
+    public boolean isNodeType(@Nullable String primaryTypeName, @NotNull Supplier<Iterable<String>> mixinTypes, @NotNull String nodeTypeName) {
         // shortcut
         if (JcrConstants.NT_BASE.equals(nodeTypeName)) {
             return true;
@@ -293,7 +293,7 @@ public abstract class ReadOnlyNodeTypeManager implements NodeTypeManager, Effect
         if (primaryTypeName != null && isa(types, primaryTypeName, nodeTypeName)) {
             return true;
         }
-        for (String mixin : mixinTypes) {
+        for (String mixin : mixinTypes.get()) {
             if (isa(types, mixin, nodeTypeName)) {
                 return true;
             }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/ReadOnlyNodeTypeManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/ReadOnlyNodeTypeManager.java
@@ -284,6 +284,7 @@ public abstract class ReadOnlyNodeTypeManager implements NodeTypeManager, Effect
         return false;
     }
 
+    @Override
     public boolean isNodeType(@Nullable String primaryTypeName, @NotNull Supplier<Iterable<String>> mixinTypes, @NotNull String nodeTypeName) {
         // shortcut
         if (JcrConstants.NT_BASE.equals(nodeTypeName)) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionEditor.java
@@ -114,7 +114,7 @@ class VersionEditor implements Editor {
                 && !this.before.exists()) {
             Tree tree = new TreeProviderService().createReadOnlyTree(this.node.getNodeState());
             if (vMgr.getNodeTypeManager().isNodeType(
-                    TreeUtil.getPrimaryTypeName(tree), TreeUtil.getMixinTypeNames(tree), MIX_VERSIONABLE)) {
+                    TreeUtil.getPrimaryTypeName(tree), () -> TreeUtil.getMixinTypeNames(tree), MIX_VERSIONABLE)) {
                 // OAK-10462: the node has mix:versionable, but not the mandatory property jcr:isCheckedOut,
                 // so it has to be sentinel node for a restore operation.
                 // Unfortunately, there is no API available to detect that.

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
@@ -977,8 +977,7 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
             @Override
             public Boolean perform() throws RepositoryException {
                 Tree tree = node.getTree();
-                Supplier<Iterable<String>> mixinTypes = () -> getMixinTypeNames(tree);
-                return getNodeTypeManager().isNodeType(getPrimaryTypeName(tree), mixinTypes , oakName);
+                return getNodeTypeManager().isNodeType(getPrimaryTypeName(tree), () -> getMixinTypeNames(tree) , oakName);
             }
         });
     }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
@@ -977,7 +977,7 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
             @Override
             public Boolean perform() throws RepositoryException {
                 Tree tree = node.getTree();
-                return getNodeTypeManager().isNodeType(getPrimaryTypeName(tree), () -> getMixinTypeNames(tree) , oakName);
+                return getNodeTypeManager().isNodeType(getPrimaryTypeName(tree), () -> getMixinTypeNames(tree), oakName);
             }
         });
     }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
@@ -36,8 +36,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
-
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Binary;
 import javax.jcr.InvalidItemStateException;

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Binary;
@@ -976,7 +977,8 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
             @Override
             public Boolean perform() throws RepositoryException {
                 Tree tree = node.getTree();
-                return getNodeTypeManager().isNodeType(getPrimaryTypeName(tree), getMixinTypeNames(tree), oakName);
+                Supplier<Iterable<String>> mixinTypes = () -> getMixinTypeNames(tree);
+                return getNodeTypeManager().isNodeType(getPrimaryTypeName(tree), mixinTypes , oakName);
             }
         });
     }


### PR DESCRIPTION
Change the EffectiveNodeTypeProvider.isNodeType() to use a Supplier for the mixins, as they are not always required, and adapt all consumers of it (most notably the NodeImpl).

Updated package version of org.apache.jackrabbit.oak.spi.nodetype.