### PR TITLE
OAK-10643: MongoDocumentStore: improve diagnostics for too large docs

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -1056,7 +1056,6 @@ public class MongoDocumentStore implements DocumentStore {
         }
         final Stopwatch watch = startWatch();
         boolean newEntry = false;
-        T oldDoc = null;
 
         try {
             // get modCount of cached document
@@ -1126,7 +1125,7 @@ public class MongoDocumentStore implements DocumentStore {
                 return null;
             }
 
-            oldDoc = convertFromDBObject(collection, oldNode);
+            T oldDoc = convertFromDBObject(collection, oldNode);
             if (oldDoc != null) {
                 if (collection == Collection.NODES) {
                     NodeDocument newDoc = (NodeDocument) applyChanges(collection, oldDoc, updateOp);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BasicDocumentStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BasicDocumentStoreTest.java
@@ -577,7 +577,7 @@ public class BasicDocumentStoreTest extends AbstractDocumentStoreTest {
 
         int i = 0;
         for (i = 0; i < 32 && exception == null; i++) {
-            String pval = generateString(1024 * 1024, true);
+            String pval = generateString(1024 * 1024 + i * 10, true);
             String pname = String.format("foo%02d", i);
             up.set(pname, pval);
             try {
@@ -596,6 +596,37 @@ public class BasicDocumentStoreTest extends AbstractDocumentStoreTest {
 
         super.ds.remove(Collection.NODES, id);
         LOG.info("max number of 1MB property additions for " + super.dsname + " was " + i + " (" + exception + ")");
+    }
+
+    @Test
+    public void testMaxAddPropertyUpdate() {
+
+        String id = this.getClass().getName() + ".testMaxAddPropertyUpdate";
+        UpdateOp up = new UpdateOp(id, true);
+        super.ds.create(Collection.NODES, Collections.singletonList(up));
+        String exception = null;
+
+        int i = 0;
+        for (i = 0; i < 32 && exception == null; i++) {
+            String pval = generateString(1024 * 1024 + i * 10, true);
+            String pname = "foo";
+            up.setMapEntry(pname, new Revision(System.currentTimeMillis(), i, 0), pval);
+            try {
+                NodeDocument doc = super.ds.findAndUpdate(Collection.NODES, up);
+                if (doc != null) {
+                    // check that we really can read it
+                    NodeDocument findme = super.ds.find(Collection.NODES, id, 0);
+                    assertNotNull("failed to retrieve previously stored document", findme);
+                    assertNotNull(findme.get(pname));
+                }
+            } catch (Throwable ex) {
+                LOG.error("trying to add " + i + "th 1MB property " + super.dsname + ": " + ex.getMessage(), ex);
+                exception = ex.getMessage();
+            }
+        }
+
+        super.ds.remove(Collection.NODES, id);
+        LOG.info("max number of 1MB property updates for " + super.dsname + " was " + i + " (" + exception + ")");
     }
 
     @Test


### PR DESCRIPTION
Sample output from new unit test:

~~~
18:14:46.339 ERROR [main] MongoDocumentStore.java:1151      Failed to update the document with Id=org.apache.jackrabbit.oak.plugins.document.BasicDocumentStoreTest.testMaxAddPropertyUpdate with MongoWriteException message = 'Resulting document after update is larger than 16777216'. Document statistics: _id: org.apache.jackrabbit.oak.plugins.document.BasicDocumentStoreTest.testMaxAddPropertyUpdate, _modCount: 16, memory: 31462382; Contents: foo: 31461660 bytes in 15 entries (2097444 avg), _id: 228 bytes, _modCount: 16 bytes.
~~~