### PR TITLE
OAK-10656: MongoDocumentStore: keep metrics about document size related exceptions

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -1,4 +1,4 @@
-/*
+/*c
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 
 import org.apache.jackrabbit.guava.common.base.Optional;
@@ -214,6 +215,8 @@ public class MongoDocumentStore implements DocumentStore {
     private Clock clock = Clock.SIMPLE;
 
     private final long maxReplicationLagMillis;
+
+    private final AtomicLong mongoWriteExceptions = new AtomicLong();
 
     /**
      * Duration in seconds under which queries would use index on _modified field
@@ -2317,8 +2320,17 @@ public class MongoDocumentStore implements DocumentStore {
                 invalidateCache(collection, id);
             }
         }
+
+        if (ex instanceof MongoWriteException) {
+            mongoWriteExceptions.incrementAndGet();
+        }
+
         return asDocumentStoreException(ex.getMessage(), ex,
                 getDocumentStoreExceptionTypeFor(ex), ids);
+    }
+
+    public long getAmountOfMongoWriteExceptions() {
+        return mongoWriteExceptions.get();
     }
 
     private <T extends Document> DocumentStoreException handleException(Throwable ex,

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -1,4 +1,4 @@
-/*c
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStoreMetricsTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStoreMetricsTest.java
@@ -62,6 +62,7 @@ public class MongoDocumentStoreMetricsTest extends AbstractMongoConnectionTest {
             MongoDocumentStoreMetrics metrics = new MongoDocumentStoreMetrics(store, statsProvider);
             assertEquals(0, getCount("MongoDB.fsUsedSize"));
             assertEquals(0, getCount("MongoDB.fsTotalSize"));
+            assertEquals(0, getCount("MongoDB.DocumentStore.mongoWriteExceptions"));
 
             metrics.run();
             assertThat(getCount("MongoDB.fsUsedSize"), greaterThan(0L));


### PR DESCRIPTION
...we can later expand this to cover different exceptions.