### PR TITLE
OAK-10657: shrink in-DB documents after updates fail due to 16MB limit

### DIFF
--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/AbstractRepositoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/AbstractRepositoryTest.java
@@ -39,6 +39,8 @@ import org.apache.jackrabbit.oak.query.QueryEngineSettings;
 import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -180,7 +182,7 @@ public abstract class AbstractRepositoryTest {
         QueryEngineSettings qs = new QueryEngineSettings();
         qs.setFullTextComparisonWithoutIndex(true);
         jcr.with(BundlingConfigInitializer.INSTANCE);
-        return jcr.withAsyncIndexing().with(qs);
+        return jcr.withAsyncIndexing().with(qs).with(fixture.getWhiteboard());
     }
 
     protected NodeStore getNodeStore() {
@@ -196,6 +198,10 @@ public abstract class AbstractRepositoryTest {
             return ((ComponentHolder) fixture).get(nodeStore, name);
         }
         return null;
+    }
+
+    protected Whiteboard getWhiteboard() {
+        return fixture.getWhiteboard();
     }
 
     protected Session getAnonymousSession() throws RepositoryException {

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ManyChildrenIT.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ManyChildrenIT.java
@@ -82,7 +82,7 @@ public class ManyChildrenIT extends AbstractRepositoryTest {
     }
 
     @Test
-    @Ignore //OAK-10646
+    // @Ignore //OAK-10646
     public void orderableAddManyChildrenWithSave() throws Exception {
         int childCount = 1000;
         StringBuilder prefix = new StringBuilder("");
@@ -98,7 +98,7 @@ public class ManyChildrenIT extends AbstractRepositoryTest {
     }
 
     @Test
-    @Ignore //OAK-10646
+    // @Ignore //OAK-10646
     public void moveOrderableWithManyChildren() throws Exception {
         int childCount = 1000;
         int moveCount = 1;
@@ -121,7 +121,7 @@ public class ManyChildrenIT extends AbstractRepositoryTest {
     }
 
     @Test
-    @Ignore //OAK-10646
+    // @Ignore //OAK-10646
     public void copyOrderableWithManyChildren() throws Exception {
         int childCount = 1000;
         int copyCount = 1;

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ManyChildrenIT.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ManyChildrenIT.java
@@ -21,13 +21,15 @@ import static org.junit.Assert.assertTrue;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
+import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
+import org.apache.jackrabbit.oak.spi.whiteboard.Tracker;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.UUID;
 
 /**
  * Test nodes with many child nodes.
@@ -36,6 +38,18 @@ public class ManyChildrenIT extends AbstractRepositoryTest {
 
     public ManyChildrenIT(NodeStoreFixture fixture) {
         super(fixture);
+    }
+
+    @Before
+    public void before() throws RepositoryException {
+        //make sure that the repository is initialized
+        getRepository();
+        Tracker<FeatureToggle> toggleTracker = getWhiteboard().track(FeatureToggle.class);
+        for (FeatureToggle ft : toggleTracker.getServices()) {
+            if ("FT_COCLEANUP_OAK-10657".equals(ft.getName())) {
+                ft.setEnabled(true);
+            }
+        }
     }
 
     @Test
@@ -101,7 +115,6 @@ public class ManyChildrenIT extends AbstractRepositoryTest {
     // @Ignore //OAK-10646
     public void moveOrderableWithManyChildren() throws Exception {
         int childCount = 1000;
-        int moveCount = 1;
         StringBuilder prefix = new StringBuilder("");
         for (int k = 0; k < 90; k++) {
             prefix.append("0123456789");
@@ -124,7 +137,6 @@ public class ManyChildrenIT extends AbstractRepositoryTest {
     // @Ignore //OAK-10646
     public void copyOrderableWithManyChildren() throws Exception {
         int childCount = 1000;
-        int copyCount = 1;
         StringBuilder prefix = new StringBuilder("");
         for (int k = 0; k < 90; k++) {
             prefix.append("0123456789");

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -127,6 +127,7 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
     private boolean isReadOnlyMode = false;
     private Feature prefetchFeature;
     private Feature docStoreThrottlingFeature;
+    private Feature docStoreCommitCleanupFeature;
     private Feature cancelInvalidationFeature;
     private Weigher<CacheValue, CacheValue> weigher = new EmpiricalWeigher();
     private long memoryCacheSize = DEFAULT_MEMORY_CACHE_SIZE;
@@ -316,6 +317,16 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
     @Nullable
     public Feature getDocStoreThrottlingFeature() {
         return docStoreThrottlingFeature;
+    }
+
+    public T setDocStoreCommitCleanupFeature(@Nullable Feature docStoreCommitCleanup) {
+        this.docStoreCommitCleanupFeature = docStoreCommitCleanup;
+        return thisBuilder();
+    }
+
+    @Nullable
+    public Feature getDocStoreCommitCleanupFeature() {
+        return docStoreCommitCleanupFeature;
     }
 
     public T setCancelInvalidationFeature(@Nullable Feature cancelInvalidation) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -181,6 +181,8 @@ public class DocumentNodeStoreService {
      */
     private static final String FT_NAME_DOC_STORE_THROTTLING = "FT_THROTTLING_OAK-9909";
 
+    private static final String FT_NAME_DOC_STORE_COCLEANUP = "FT_COCLEANUP_OAK-10657";
+
     /**
      * Feature toggle name to enable invalidation on cancel (due to a merge collision)
      */
@@ -221,6 +223,7 @@ public class DocumentNodeStoreService {
     private JournalPropertyHandlerFactory journalPropertyHandlerFactory = new JournalPropertyHandlerFactory();
     private Feature prefetchFeature;
     private Feature docStoreThrottlingFeature;
+    private Feature docStoreCommitCleanupFeature;
     private Feature cancelInvalidationFeature;
     private ComponentContext context;
     private Whiteboard whiteboard;
@@ -256,6 +259,7 @@ public class DocumentNodeStoreService {
         documentStoreType = DocumentStoreType.fromString(this.config.documentStoreType());
         prefetchFeature = Feature.newFeature(FT_NAME_PREFETCH, whiteboard);
         docStoreThrottlingFeature = Feature.newFeature(FT_NAME_DOC_STORE_THROTTLING, whiteboard);
+        docStoreCommitCleanupFeature = Feature.newFeature(FT_NAME_DOC_STORE_COCLEANUP, whiteboard);
         cancelInvalidationFeature = Feature.newFeature(FT_NAME_CANCEL_INVALIDATION, whiteboard);
 
         registerNodeStoreIfPossible();
@@ -474,6 +478,7 @@ public class DocumentNodeStoreService {
                 setLeaseCheckMode(ClusterNodeInfo.DEFAULT_LEASE_CHECK_DISABLED ? LeaseCheckMode.DISABLED : LeaseCheckMode.valueOf(config.leaseCheckMode())).
                 setPrefetchFeature(prefetchFeature).
                 setDocStoreThrottlingFeature(docStoreThrottlingFeature).
+                setDocStoreCommitCleanupFeature(docStoreCommitCleanupFeature).
                 setCancelInvalidationFeature(cancelInvalidationFeature).
                 setThrottlingEnabled(config.throttlingEnabled()).
                 setSuspendTimeoutMillis(config.suspendTimeoutMillis()).

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UpdateOp.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UpdateOp.java
@@ -156,7 +156,7 @@ public final class UpdateOp {
      * @param revision the revision
      * @param value the value
      */
-    void setMapEntry(@NotNull String property, @NotNull Revision revision, String value) {
+    public void setMapEntry(@NotNull String property, @NotNull Revision revision, String value) {
         Operation op = new Operation(Operation.Type.SET_MAP_ENTRY, value);
         changes.put(new Key(property, checkNotNull(revision)), op);
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UpdateOp.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UpdateOp.java
@@ -156,7 +156,7 @@ public final class UpdateOp {
      * @param revision the revision
      * @param value the value
      */
-    public void setMapEntry(@NotNull String property, @NotNull Revision revision, String value) {
+    void setMapEntry(@NotNull String property, @NotNull Revision revision, String value) {
         Operation op = new Operation(Operation.Type.SET_MAP_ENTRY, value);
         changes.put(new Key(property, checkNotNull(revision)), op);
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
@@ -348,7 +348,7 @@ public class MemoryDocumentStore implements DocumentStore {
             try {
                 checkSize(doc);
             } catch (DocumentStoreException ex) {
-                UpdateOp shrink = Utils.getShrinkOp(doc, ":childOrder", "(x)");
+                UpdateOp shrink = Utils.getShrinkOp(doc, ":childOrder");
                 // try cleanup and then retry once
                 long before = doc.getMemory();
                 UpdateUtils.applyChanges(doc, shrink);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
@@ -51,6 +51,8 @@ import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
@@ -100,6 +102,8 @@ public class MemoryDocumentStore implements DocumentStore {
     private static final Key KEY_MODIFIED = new Key(MODIFIED_IN_SECS, null);
 
     private static final long SIZE_LIMIT = SystemPropertySupplier.create("memoryds.size.limit", -1).get();
+
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryDocumentStore.class); 
 
     public MemoryDocumentStore() {
         this(false);
@@ -341,7 +345,18 @@ public class MemoryDocumentStore implements DocumentStore {
             // update the document
             UpdateUtils.applyChanges(doc, update);
             maintainModCount(doc);
-            checkSize(doc);
+            try {
+                checkSize(doc);
+            } catch (DocumentStoreException ex) {
+                UpdateOp shrink = Utils.getShrinkOp(doc, ":childOrder", "(x)");
+                // try cleanup and then retry once
+                long before = doc.getMemory();
+                UpdateUtils.applyChanges(doc, shrink);
+                long after = doc.getMemory();
+                LOG.warn("Doc size was exceeded for {}:  {} bytes. Applied shrink ops: {}. New size: {}. Doing one retry.",
+                        doc.getId(), before, shrink, after);
+                checkSize(doc);
+            }
             doc.seal();
             map.put(update.getId(), doc);
             return oldDoc;
@@ -474,7 +489,10 @@ public class MemoryDocumentStore implements DocumentStore {
         return 0;
     }
 
-    private void checkSize(Document doc) {
+    /**
+     * aborts the operation if a size limit is configured and exceeded
+     */
+    private void checkSize(Document doc) throws DocumentStoreException {
         if (SIZE_LIMIT >= 0) {
             int size = doc.getMemory();
             if (size >= SIZE_LIMIT) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
@@ -352,12 +352,14 @@ public class MemoryDocumentStore implements DocumentStore {
                 if (update.hasChanges()) {
                     final int clusterid = Utils.extractClusterId(update);
                     UpdateOp shrink = Utils.getShrinkOp(doc, ":childOrder", r -> r.getClusterId() == clusterid);
-                    // try cleanup and then retry once
-                    long before = doc.getMemory();
-                    UpdateUtils.applyChanges(doc, shrink);
-                    long after = doc.getMemory();
-                    LOG.info("Doc size was exceeded for {}:  {} bytes. Applied shrink ops: {}. New size: {}. Doing one retry.",
-                            doc.getId(), before, shrink, after);
+                    if (shrink != null) {
+                        // try cleanup and then retry once
+                        long before = doc.getMemory();
+                        UpdateUtils.applyChanges(doc, shrink);
+                        long after = doc.getMemory();
+                        LOG.info("Doc size was exceeded for {}:  {} bytes. Applied shrink ops: {}. New size: {}. Doing one retry.",
+                                doc.getId(), before, shrink, after);
+                    }
                 }
                 checkSize(doc);
             }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/memory/MemoryDocumentStore.java
@@ -350,23 +350,14 @@ public class MemoryDocumentStore implements DocumentStore {
             } catch (DocumentStoreException ex) {
                 // slightly hacky approach to find "our" cluster id
                 if (update.hasChanges()) {
-                    int t_clusterid = -1;
-                    for (Key key : update.getChanges().keySet()) {
-                        if (t_clusterid == -1 && key.getRevision() != null) {
-                            t_clusterid = key.getRevision().getClusterId();
-                            break;
-                        }
-                    }
-                    if (t_clusterid != -1) {
-                        final int clusterid = t_clusterid;
-                        UpdateOp shrink = Utils.getShrinkOp(doc, ":childOrder", r -> r.getClusterId() == clusterid);
-                        // try cleanup and then retry once
-                        long before = doc.getMemory();
-                        UpdateUtils.applyChanges(doc, shrink);
-                        long after = doc.getMemory();
-                        LOG.info("Doc size was exceeded for {}:  {} bytes. Applied shrink ops: {}. New size: {}. Doing one retry.",
-                                doc.getId(), before, shrink, after);
-                    }
+                    final int clusterid = Utils.extractClusterId(update);
+                    UpdateOp shrink = Utils.getShrinkOp(doc, ":childOrder", r -> r.getClusterId() == clusterid);
+                    // try cleanup and then retry once
+                    long before = doc.getMemory();
+                    UpdateUtils.applyChanges(doc, shrink);
+                    long after = doc.getMemory();
+                    LOG.info("Doc size was exceeded for {}:  {} bytes. Applied shrink ops: {}. New size: {}. Doing one retry.",
+                            doc.getId(), before, shrink, after);
                 }
                 checkSize(doc);
             }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -279,8 +279,13 @@ public class Utils {
 
     /**
      * Produce an {@link UpdateOp} suitable for shrinking branch revision entries for given property in {@link Document}, {@code null} otherwise.
+     * 
+     * @param doc document to inspect for repeated branch commits
+     * @param propertName property to check for
+     * @param revisionChecker filter for revisions (for instance, to check for cluster id)
+     * @return {@link UpdateOp} suitable for shrinking document, {@code null} otherwise
      */
-    public static @Nullable UpdateOp getShrinkOp(Document doc, String propertyName) {
+    public static @Nullable UpdateOp getShrinkOp(Document doc, String propertyName, Predicate<Revision> revisionChecker) {
         Object t_bc = doc.get("_bc");
         Object t_property = doc.get(propertyName);
         if (t_bc instanceof Map && t_property instanceof Map) {
@@ -291,9 +296,11 @@ public class Utils {
             List<Revision> revs = new ArrayList<>();
             for (Map.Entry<Revision, String> en : pMap.entrySet()) {
                 Revision r = en.getKey();
-                String bcv = _bc.get(r);
-                if ("true".equals(bcv)) {
-                    revs.add(r);
+                if (revisionChecker.apply(r)) {
+                    String bcv = _bc.get(r);
+                    if ("true".equals(bcv)) {
+                        revs.add(r);
+                    }
                 }
             }
             // sort by age

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -280,7 +280,7 @@ public class Utils {
     /**
      * Produce an {@link UpdateOp} suitable for shrinking branch revision entries for given property in {@link Document}, {@code null} otherwise.
      */
-    public static @Nullable UpdateOp getShrinkOp(Document doc, String propertyName, String replacementValue) {
+    public static @Nullable UpdateOp getShrinkOp(Document doc, String propertyName) {
         Object t_bc = doc.get("_bc");
         Object t_property = doc.get(propertyName);
         if (t_bc instanceof Map && t_property instanceof Map) {
@@ -314,7 +314,7 @@ public class Utils {
             for (Revision r : revs) {
                 if (last != null) {
                     if (last.getClusterId() == r.getClusterId()) {
-                        clean.setMapEntry(propertyName, last, replacementValue);
+                        clean.removeMapEntry(propertyName, last);
                     }
                 }
                 last = r;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -26,6 +26,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Iterator;
@@ -46,6 +47,7 @@ import org.apache.jackrabbit.oak.commons.StringUtils;
 import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo;
 import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfoDocument;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
+import org.apache.jackrabbit.oak.plugins.document.Document;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreBuilder;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStoreException;
@@ -54,6 +56,7 @@ import org.apache.jackrabbit.oak.plugins.document.Path;
 import org.apache.jackrabbit.oak.plugins.document.Revision;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
 import org.apache.jackrabbit.oak.plugins.document.StableRevisionComparator;
+import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.apache.jackrabbit.oak.stats.Clock;
 import org.jetbrains.annotations.NotNull;
@@ -271,6 +274,54 @@ public class Utils {
             return redactMemberName(name) + ": "+ stat.size + " bytes";
         } else {
             return redactMemberName(name) + ": "+ stat.size + " bytes in " + stat.count + " entries (" + stat.size / stat.count + " avg)";
+        }
+    }
+
+    /**
+     * Produce an {@link UpdateOp} suitable for shrinking branch revision entries for given property in {@link Document}, {@code null} otherwise.
+     */
+    public static @Nullable UpdateOp getShrinkOp(Document doc, String propertyName, String replacementValue) {
+        Object t_bc = doc.get("_bc");
+        Object t_property = doc.get(propertyName);
+        if (t_bc instanceof Map && t_property instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<Revision, String> _bc = (Map<Revision, String>)t_bc;
+            @SuppressWarnings("unchecked")
+            Map<Revision, String> pMap = (Map<Revision, String>)t_property;
+            List<Revision> revs = new ArrayList<>();
+            for (Map.Entry<Revision, String> en : pMap.entrySet()) {
+                Revision r = en.getKey();
+                String bcv = _bc.get(r);
+                if ("true".equals(bcv)) {
+                    revs.add(r);
+                }
+            }
+            // sort by age
+            Collections.sort(revs, new Comparator<Revision>() {
+                @Override
+                public int compare(Revision r1, Revision r2) {
+                    if (r1.getClusterId() != r2.getClusterId()) {
+                        return r1.getClusterId() - r2.getClusterId();
+                    } else if (r1.getTimestamp() != r2.getTimestamp()) {
+                        return r1.getTimestamp() > r2.getTimestamp() ? 1 : -1;
+                    } else {
+                        return r1.getCounter() - r2.getCounter();
+                    }
+                }});
+
+            UpdateOp clean = new UpdateOp(doc.getId(), false);
+            Revision last = null;
+            for (Revision r : revs) {
+                if (last != null) {
+                    if (last.getClusterId() == r.getClusterId()) {
+                        clean.setMapEntry(propertyName, last, replacementValue);
+                    }
+                }
+                last = r;
+            }
+            return clean.hasChanges() ? clean : null;
+        } else {
+            return null;
         }
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -57,6 +57,7 @@ import org.apache.jackrabbit.oak.plugins.document.Revision;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
 import org.apache.jackrabbit.oak.plugins.document.StableRevisionComparator;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
+import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Key;
 import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.apache.jackrabbit.oak.stats.Clock;
 import org.jetbrains.annotations.NotNull;
@@ -275,6 +276,18 @@ public class Utils {
         } else {
             return redactMemberName(name) + ": "+ stat.size + " bytes in " + stat.count + " entries (" + stat.size / stat.count + " avg)";
         }
+    }
+
+    /**
+     * @return cluster if from first revision found in op, {@code -1} otherwise
+     */
+    public static int extractClusterId(UpdateOp op) {
+        for (Key key : op.getChanges().keySet()) {
+            if (key.getRevision() != null) {
+                return key.getRevision().getClusterId();
+            }
+        }
+        return -1;
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -294,7 +294,7 @@ public class Utils {
      * Produce an {@link UpdateOp} suitable for shrinking branch revision entries for given property in {@link Document}, {@code null} otherwise.
      * 
      * @param doc document to inspect for repeated branch commits
-     * @param propertName property to check for
+     * @param propertyName property to check for
      * @param revisionChecker filter for revisions (for instance, to check for cluster id)
      * @return {@link UpdateOp} suitable for shrinking document, {@code null} otherwise
      */

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMongoFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMongoFixture.java
@@ -28,6 +28,8 @@ import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.spi.toggle.Feature;
+import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
 import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +71,7 @@ public class DocumentMongoFixture extends NodeStoreFixture {
             }
             builder.setPersistentCache("target/persistentCache,time");
             builder.setMongoDB(createClient(), getDBName(suffix));
+            builder.setDocStoreCommitCleanupFeature(Feature.newFeature("FT_COCLEANUP_OAK-10657", getWhiteboard()));
             DocumentNodeStore ns = builder.getNodeStore();
             suffixes.put(ns, suffix);
             return ns;

--- a/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/fixture/NodeStoreFixture.java
+++ b/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/fixture/NodeStoreFixture.java
@@ -20,11 +20,15 @@
 package org.apache.jackrabbit.oak.fixture;
 
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
 
 /**
  * NodeStore fixture for parametrized tests.
  */
 public abstract class NodeStoreFixture {
+
+    private final Whiteboard whiteboard = new DefaultWhiteboard();
 
     /**
      * Creates a new empty {@link NodeStore} instance. An implementation must
@@ -50,6 +54,10 @@ public abstract class NodeStoreFixture {
 
     public boolean isAvailable() {
         return true;
+    }
+
+    public Whiteboard getWhiteboard() {
+        return whiteboard;
     }
 
 }


### PR DESCRIPTION
Just a proof-of-concept.