### PR TITLE
OAK-10662 improve Reproducible Builds

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -34,6 +34,9 @@
   <packaging>pom</packaging>
 
   <properties>
+    <!-- build time stamp: should be updated prior to a release -->
+    <!-- see https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+    <project.build.outputTimestamp>1708183173</project.build.outputTimestamp>
     <minimalMavenBuildVersion>3.3.9</minimalMavenBuildVersion><!-- evaluated by ASF parent -->
     <test.opts.memory>-Xmx512m</test.opts.memory>
     <test.opts>${test.opts.coverage} ${test.opts.memory} -XX:+HeapDumpOnOutOfMemoryError -Dupdate.limit=100 -Djava.awt.headless=true</test.opts>
@@ -136,7 +139,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.8</version>
+          <version>5.1.9</version>
           <extensions>true</extensions>
           <inherited>true</inherited>
           <dependencies>
@@ -333,6 +336,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.14.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.5.2</version>
         </plugin>
         
         <!-- This plugin's configuration is used to store Eclipse m2e      -->
@@ -1341,6 +1349,6 @@
   </profiles>
 
   <scm>
-    <tag>jackrabbit-oak-1.54.0</tag>
+    <tag>trunk</tag>
   </scm>
 </project>

--- a/oak-store-composite/pom.xml
+++ b/oak-store-composite/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.apache.servicemix.tooling</groupId>
         <artifactId>depends-maven-plugin</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <executions>
           <!-- Generate dependency file used by Pax Exam -->
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <connection>scm:git:https://gitbox.apache.org/repos/asf/jackrabbit-oak.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/jackrabbit-oak.git</developerConnection>
     <url>https://github.com/apache/jackrabbit-oak/tree/${project.scm.tag}</url>
-    <tag>jackrabbit-oak-1.54.0</tag>
+    <tag>trunk</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/OAK-10662

if someone know how `OSGI-INF/l10n/*.properties` are generated, this is one common case for most of remaining issues = Properties save with timestamp: I don't know where this happens and I'd prefer avoiding post-processing