### PR TITLE
OAK-10672: move internal index version in oak-search

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -57,8 +57,13 @@ class ElasticIndexHelper {
      * WARN: Since this information might be needed from external tools that don't have a direct dependency on this module, the
      * actual version needs to be set in oak-search.
      */
-    protected static final String MAPPING_VERSION = FulltextIndexConstants.INDEX_VERSION_BY_TYPE.
-            getOrDefault(ElasticIndexDefinition.TYPE_ELASTICSEARCH, "1.0.0");
+    protected static final String MAPPING_VERSION;
+    static {
+        MAPPING_VERSION = FulltextIndexConstants.INDEX_VERSION_BY_TYPE.get(ElasticIndexDefinition.TYPE_ELASTICSEARCH);
+        if (MAPPING_VERSION == null) {
+            throw new IllegalStateException("Mapping version is not set");
+        }
+    }
 
     // Unset the refresh interval and disable replicas at index creation to optimize for initial loads
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -30,6 +30,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticPropertyDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,8 +53,12 @@ class ElasticIndexHelper {
      * Changes not breaking compatibility should increment the minor version (old queries still work, but they might not
      * use the new feature).
      * Changes that do not affect queries should increment the patch version (eg: bug fixes).
+     * <p>
+     * WARN: Since this information might be needed from external tools that don't have a direct dependency on this module, the
+     * actual version needs to be set in oak-search.
      */
-    protected static final String MAPPING_VERSION = "1.1.0";
+    protected static final String MAPPING_VERSION = FulltextIndexConstants.INDEX_VERSION_BY_TYPE.
+            getOrDefault(ElasticIndexDefinition.TYPE_ELASTICSEARCH, "1.0.0");
 
     // Unset the refresh interval and disable replicas at index creation to optimize for initial loads
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -78,7 +78,7 @@ public interface FulltextIndexConstants {
     /**
      * Type of the property being indexed defined as part of property definition
      * under the given index definition. Refer to {@link javax.jcr.PropertyType}
-     * contants for the possible values
+     * constants for the possible values
      */
     String PROP_TYPE = "type";
 
@@ -197,7 +197,7 @@ public interface FulltextIndexConstants {
 
     /**
      * Limit for maximum number of reaggregates allowed. For example if there is an aggregate of nt:folder
-     * and it also includes nt:folder then aggregation would traverse down untill this limit is hit
+     * and it also includes nt:folder then aggregation would traverse down until this limit is hit
      */
     String AGG_RECURSIVE_LIMIT = "reaggregateLimit";
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.plugins.index.search;
 
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Internal constants used in index definition, and index implementations.
@@ -436,4 +437,12 @@ public interface FulltextIndexConstants {
      * Boolean property indicating if in-built analyzer should preserve original term
      */
     String INDEX_ORIGINAL_TERM = "indexOriginalTerm";
+
+    /**
+     * Internal version of the index definition for specific index type. Index version is an information that might be
+     * needed from an outside process that does not have visibility to the specific index module.
+     */
+    Map<String, String> INDEX_VERSION_BY_TYPE = Map.of(
+            "elasticsearch", "1.1.0"
+    );
 }


### PR DESCRIPTION
Some indexes, like elasticsearch have a concept of an internal version (or mapping version) to handle breaking changes. This information is sometimes needed from external tools that do not have access to the specific index module. For this reason, the version information has been moved to oak-search.