### PR TITLE
OAK-10671- [Indexing Job] Improve Mongo regex query: remove condition on non-indexed _path field to speed-up traversal

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -147,13 +147,12 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
      * @param mongoFilterPaths          The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
      *                                  (see {@link MongoFilterPaths} for details)
      * @param customExcludeEntriesRegex Documents with paths matching this regex are excluded from download
-     * @param queryUsesIndexTraversal   Whether the query will use an index to traverse the documents.
      * @return The filter to be used in the Mongo query, or null if no filter is required
      */
-    static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex, boolean queryUsesIndexTraversal) {
+    static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex) {
         var filters = new ArrayList<Bson>();
 
-        Bson includedFilter = descendantsFilter(mongoFilterPaths.included, queryUsesIndexTraversal);
+        Bson includedFilter = descendantsIncludeFilter(mongoFilterPaths.included);
         if (includedFilter != null) {
             filters.add(includedFilter);
         }
@@ -164,15 +163,13 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // This is done because excluding also the top level path would add extra complexity to the filter and
         // would not have any measurable impact on performance because it only downloads a few extra documents, one
         // for each excluded subtree. The transform stage will anyway filter out these paths.
-        Bson excludedFilter = descendantsFilter(mongoFilterPaths.excluded, queryUsesIndexTraversal);
-        if (excludedFilter != null) {
-            filters.add(Filters.nor(excludedFilter));
-        }
-
+        ArrayList<Pattern> excludedPatterns = new ArrayList<>();
+        excludedPatterns.addAll(descendantsExcludeFilter(mongoFilterPaths.excluded));
         // Custom regex filter to exclude paths
-        Bson customExcludedPathsFilter = createCustomExcludedEntriesFilter(customExcludeEntriesRegex, queryUsesIndexTraversal);
-        if (customExcludedPathsFilter != null) {
-            filters.add(customExcludedPathsFilter);
+        excludedPatterns.addAll(createCustomExcludedEntriesFilter(customExcludeEntriesRegex));
+
+        if (!excludedPatterns.isEmpty()) {
+            filters.add(Filters.nin(NodeDocument.ID, excludedPatterns));
         }
 
         if (filters.isEmpty()) {
@@ -184,19 +181,18 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
     }
 
-    static Bson createCustomExcludedEntriesFilter(String customRegexPattern, boolean queryUsesIndexTraversal) {
+    static List<Pattern> createCustomExcludedEntriesFilter(String customRegexPattern) {
         if (customRegexPattern == null || customRegexPattern.trim().isEmpty()) {
             LOG.info("Mongo custom regex is disabled");
-            return null;
+            return List.of();
         } else {
             LOG.info("Excluding nodes with paths matching regex: {}", customRegexPattern);
             var pattern = Pattern.compile(customRegexPattern);
-            Bson pathFilter = createPathFilter(List.of(pattern), queryUsesIndexTraversal);
-            return Filters.nor(Filters.regex(NodeDocument.ID, pattern), pathFilter);
+            return List.of(pattern);
         }
     }
 
-    private static Bson descendantsFilter(List<String> paths, boolean queryUsesIndexTraversal) {
+    private static Bson descendantsIncludeFilter(List<String> paths) {
         if (paths.isEmpty()) {
             return null;
         }
@@ -204,14 +200,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             return null;
         }
 
-        // The filter for descendants of a list of paths is a series of or conditions. For each path, we have to build
-        // two conditions in two different fields of the documents:
-        // _ _id   - for non-long paths - In this case, the _id is of the form "2:/foo/bar"
-        // _ _path - for long paths - In this case, the _id is a hash and the document contains an additional _path
-        //      field with the path of the document.
+        // The filter for descendants of a list of paths is a series of or conditions, each a regex filter on the _id
+        // field.
         // We use the $in operator with a regular expression to match the paths.
         //  https://www.mongodb.com/docs/manual/reference/operator/query/in/#use-the--in-operator-with-a-regular-expression
-        ArrayList<Pattern> pathPatterns = new ArrayList<>();
         ArrayList<Pattern> idPatterns = new ArrayList<>();
 
         for (String path : paths) {
@@ -220,30 +212,41 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             }
             String quotedPath = Pattern.quote(path);
             idPatterns.add(Pattern.compile("^[0-9]{1,3}:" + quotedPath + ".*$"));
-            pathPatterns.add(Pattern.compile("^" + quotedPath + ".*$"));
         }
+        // The conditions above on the _id field is not enough to match all JCR nodes in the given paths because nodes
+        // with paths longer than a certain threshold, are represented by Mongo documents where the _id field is replaced
+        // by a hash and the full path is stored in an additional field _path. To retrieve these long path documents,
+        // we could add a condition on the _path field, but this would slow down substantially scanning the DB, because
+        // the _path field is not part of the index used by this query (it's an index on _modified, _id). Therefore,
+        // Mongo would have to retrieve every document from the column store to evaluate the filter condition. So instead
+        // we add below a condition to download all the long path documents. These documents can be identified by the
+        // format of the _id field (<n>:h<hash>), so it is possible to identify them using only the index.
+        // This might download documents for nodes that are not in the included paths, but those documents will anyway
+        // be filtered in the transform stage. And in most repositories, the number of long path documents is very small,
+        // often there are none, so the extra documents downloaded will not slow down by much the download. However, the
+        // performance gains of evaluating the filter of the query using only the index are very significant, especially
+        // when the index requieres only a small number of nodes.
+        idPatterns.add(LONG_PATH_ID_PATTERN);
 
-        Bson pathFilter = createPathFilter(pathPatterns, queryUsesIndexTraversal);
-        return Filters.or(Filters.in(NodeDocument.ID, idPatterns), pathFilter);
+        return Filters.in(NodeDocument.ID, idPatterns);
     }
 
-    private static Bson createPathFilter(List<Pattern> pattern, boolean queryUsesIndexTraversal) {
-        // If a document has a long path, the _id is replaced by a hash and the path is stored in an additional _path field.
-        // When doing an index scan, it may be more efficient to check that the _id is in the format of a long path id
-        // (that is, numeric prefix followed by ":h") first, before checking the _path field. The _id
-        // is available from the index while the _path field is only available on the document itself, so checking the
-        // _path will force an expensive retrieval of the full document. It is not guaranteed that Mongo will implement
-        // this optimization, but it is adding this additional check to allow MongoDB to apply this optimization.
-        // If the query does a column scan, then Mongo retrieves the full document from the column store, so we can
-        // check the _path directly, which simplifies a bit the query.
-        if (queryUsesIndexTraversal) {
-            return Filters.and(
-                    Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN),
-                    Filters.in(NodeDocument.PATH, pattern)
-            );
-        } else {
-            return Filters.in(NodeDocument.PATH, pattern);
+    private static List<Pattern> descendantsExcludeFilter(List<String> paths) {
+        if (paths.isEmpty()) {
+            return List.of();
         }
+        if (paths.size() == 1 && paths.get(0).equals("/")) {
+            return List.of();
+        }
+        ArrayList<Pattern> idPatterns = new ArrayList<>();
+        for (String path : paths) {
+            if (!path.endsWith("/")) {
+                path = path + "/";
+            }
+            String quotedPath = Pattern.quote(path);
+            idPatterns.add(Pattern.compile("^[0-9]{1,3}:" + quotedPath + ".*$"));
+        }
+        return idPatterns;
     }
 
     /**
@@ -421,7 +424,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // That is, download "/", "/content", "/content/dam" for a base path of "/content/dam". These nodes will not be
         // matched by the regex used in the Mongo query, which assumes a prefix of "???:/content/dam"
         MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
-        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex, true);
+        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
         if (mongoFilter == null) {
             LOG.info("Downloading full repository");
         } else {
@@ -516,7 +519,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // We are downloading potentially a large fraction of the repository, so using an index scan will be
         // inefficient. So we pass the natural hint to force MongoDB to use natural ordering, that is, column scan
         MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
-        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex, false);
+        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
         if (mongoFilter == null) {
             LOG.info("Downloading full repository from Mongo with natural order");
             FindIterable<NodeDocument> mongoIterable = dbCollection

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -299,11 +299,11 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void createCustomExcludeEntriesFilter() {
-        assertTrue(PipelinedMongoDownloadTask.createCustomExcludedEntriesFilter(null).isEmpty());
-        assertTrue(PipelinedMongoDownloadTask.createCustomExcludedEntriesFilter("").isEmpty());
+        assertTrue(PipelinedMongoDownloadTask.customExcludedPatterns(null).isEmpty());
+        assertTrue(PipelinedMongoDownloadTask.customExcludedPatterns("").isEmpty());
 
         Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var actualListOfPatterns = PipelinedMongoDownloadTask.createCustomExcludedEntriesFilter("^[0-9]{1,3}:/a/b.*$");
+        var actualListOfPatterns = PipelinedMongoDownloadTask.customExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertEquals(1, actualListOfPatterns.size());
 
         assertEquals(p.toString(), actualListOfPatterns.get(0).toString());


### PR DESCRIPTION
Regex path filtering currently is implemented with a condition like:

```
_id in [^[0-9]{1,3}:\Q/foo/bar/\E.*$] OR ('_id' in [^[0-9]{1,3}:h.*$}] AND _path in [^\Q/foo/bar/\E.*$]
```

The second condition is necessary to deal with long path documents, whose _id is an hash instead of the path of the document, and that have an additional `_path` property with the full path of the document. The `_id` field is part of the index used by the query, but `_path` is not indexed. So the performance of this query will be very sensitive to how many time the query condition can be resolved without having to lookup the value of `_path`, which requires retrieving the full document from the column store. If the condition can be evaluated only using the `_id` value, them if there is no match the document should not be retrieved from the column store.

Unfortunately, Mongo does not seem to properly optimize this query and is retrieving the document from the column storage even when `_id` does not match the path /foo/bar and the `_id` is not in the hash format. This leads to very poor performance as both the index and the column store have to be fully read by this query.

We can instead use the following condition:
```
_id in [^[0-9]{1,3}:\Q/foo/bar/\E.*$ , ^[0-9]{1,3}:h.*$}]
```
That is, download the document if the `_id` matches the path or if it is an hash. This has the disadvantage that it will download all long path documents from the repository, many of which might not be needed. However, this query condition only uses the `_id` field so it is guaranteed to be evaluated fully using only the data on the index. And the number of long paths documents is usually very small, some environments don't even have any long path documents, so downloading them should not take much time. And the indexing job will anyway reapply the filter on paths locally, to eliminate the long path documents which are not required by the indexing job.

The gains of scanning only the index can be substantial. For instance, in one experiment, reindexing an index that requires 400K documents out of 29M I got the following results to build the FFS:

- With filter on `_path`: 30 minutes
- No filter on `_path`: 1m30

On another instance, downloading 14M nodes out of 250M:

- With filter on `_path`: 1h30
- No filter on `_path`: 20 minutes.

The gains will be bigger the smaller the fraction of the OAK tree that has to be downloaded, but there should be benefits even when downloading a large fraction of the tree.

### Limitations
Using only the _id field on the filter condition improves the performance significantly when having only `includedPaths`, but it does not change the performance when there are excluded paths or there are custom regex exclude filters. The reason is that Mongo needs to retrieve the document when evaluating a condition like `not regex(_id, "/tmp/.*")`, because a value of `null` also matches this condition and the index does not contain null values. A future PR will address this limitation. 