### PR TITLE
OAK-10682 - [Indexing job] Improve Mongo regex filter to only use positive conditions (no negations)

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -194,7 +194,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             filters.add(Filters.not(Filters.regex(NodeDocument.ID, customRegexExcludePattern.get(0))));
         }
 
-
         if (filters.isEmpty()) {
             return null;
         } else if (filters.size() == 1) {
@@ -218,12 +217,16 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             }
             String regex = "^[0-9]{1,3}:" + Pattern.quote(path);
             if (negate) {
-//                https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex
                 regex = negateRegex(regex);
             }
             patterns.add(Pattern.compile(regex));
         }
         return patterns;
+    }
+
+    static String negateRegex(String regex) {
+        // https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex
+        return "^(?!.*" + regex + ").*$";
     }
 
     static List<Pattern> customExcludedPatterns(String customRegexPattern) {
@@ -234,10 +237,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             LOG.info("Excluding nodes with paths matching regex: {}", customRegexPattern);
             return List.of(Pattern.compile(customRegexPattern));
         }
-    }
-
-    static String negateRegex(String regex) {
-        return "^(?!.*" + regex + ").*$";
     }
 
     /**

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -226,7 +226,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
 
     static String negateRegex(String regex) {
         // https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex
-        return "^(?!.*" + regex + ").*$";
+        return "^(?!" + regex + ")";
     }
 
     static List<Pattern> customExcludedPatterns(String customRegexPattern) {

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -328,11 +328,10 @@ public class PipelinedMongoDownloadTaskTest {
                 null
         );
         // The generated filter should not include any condition to include the descendants of /
-        var expected =
-                Filters.nin(NodeDocument.ID,
-                        Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/excluded1/")),
-                        Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/"))
-                );
+        var expected = Filters.and(
+                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded1/")))),
+                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/")))
+                ));
         assertBsonEquals(expected, actual);
     }
 
@@ -357,7 +356,7 @@ public class PipelinedMongoDownloadTaskTest {
                 MongoFilterPaths.DOWNLOAD_ALL,
                 "^[0-9]{1,3}:/a/b.*$"
         );
-        Bson expectedFilter = Filters.nin(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:/a/b.*$"));
+        Bson expectedFilter = Filters.not(Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:/a/b.*$")));
         assertBsonEquals(expectedFilter, actual);
     }
 
@@ -372,7 +371,7 @@ public class PipelinedMongoDownloadTaskTest {
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")), LONG_PATH_ID_PATTERN),
-                        Filters.nin(NodeDocument.ID, excludesPattern)
+                        Filters.not(Filters.regex(NodeDocument.ID, excludesPattern))
                 );
         assertBsonEquals(expected, actual);
     }
@@ -391,7 +390,7 @@ public class PipelinedMongoDownloadTaskTest {
                                 Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")),
                                 LONG_PATH_ID_PATTERN
                         ),
-                        Filters.nin(NodeDocument.ID, excludePattern)
+                        Filters.not(Filters.regex(NodeDocument.ID, excludePattern))
                 );
         assertBsonEquals(expected, actual);
     }
@@ -404,8 +403,10 @@ public class PipelinedMongoDownloadTaskTest {
         );
 
         Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var expected =
-                Filters.nin(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/excluded/")), excludePattern);
+        var expected = Filters.and(
+                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/")))),
+                Filters.not(Filters.regex(NodeDocument.ID, excludePattern))
+        );
         assertBsonEquals(expected, actual);
     }
 
@@ -417,9 +418,9 @@ public class PipelinedMongoDownloadTaskTest {
         );
 
         Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var expected = Filters.nin(NodeDocument.ID,
-                Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/excluded/")),
-                excludePattern
+        var expected = Filters.and(
+                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/")))),
+                Filters.not(Filters.regex(NodeDocument.ID, excludePattern))
         );
         assertBsonEquals(expected, actual);
     }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -345,7 +345,7 @@ public class PipelinedMongoDownloadTaskTest {
                 null
         );
         var expected = Filters.in(NodeDocument.ID,
-                Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$"),
+                Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")),
                 LONG_PATH_ID_PATTERN
         );
         assertBsonEquals(expected, actual);
@@ -388,7 +388,7 @@ public class PipelinedMongoDownloadTaskTest {
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID,
-                                Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/") + ".*$"),
+                                Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")),
                                 LONG_PATH_ID_PATTERN
                         ),
                         Filters.nin(NodeDocument.ID, excludePattern)

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -299,14 +299,14 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void createCustomExcludeEntriesFilter() {
-        assertTrue(PipelinedMongoDownloadTask.customExcludedPatterns(null).isEmpty());
-        assertTrue(PipelinedMongoDownloadTask.customExcludedPatterns("").isEmpty());
+        assertTrue(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(null).isEmpty());
+        assertTrue(PipelinedMongoDownloadTask.compileCustomExcludedPatterns("").isEmpty());
 
-        Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var actualListOfPatterns = PipelinedMongoDownloadTask.customExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
-        assertEquals(1, actualListOfPatterns.size());
+        Pattern p = Pattern.compile("^(?!.*(^[0-9]{1,3}:/a/b.*$)$)");
+        var actualListOfPatterns = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertTrue(actualListOfPatterns.isPresent());
 
-        assertEquals(p.toString(), actualListOfPatterns.get(0).toString());
+        assertEquals(p.toString(), actualListOfPatterns.get().toString());
     }
 
     @Test
@@ -329,8 +329,8 @@ public class PipelinedMongoDownloadTaskTest {
         );
         // The generated filter should not include any condition to include the descendants of /
         var expected = Filters.and(
-                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded1/")))),
-                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/")))
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded1/"))),
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/"))
                 ));
         assertBsonEquals(expected, actual);
     }
@@ -356,7 +356,8 @@ public class PipelinedMongoDownloadTaskTest {
                 MongoFilterPaths.DOWNLOAD_ALL,
                 "^[0-9]{1,3}:/a/b.*$"
         );
-        Bson expectedFilter = Filters.not(Filters.regex(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:/a/b.*$")));
+        var customExcludedPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        Bson expectedFilter = Filters.regex(NodeDocument.ID, customExcludedPattern);
         assertBsonEquals(expectedFilter, actual);
     }
 
@@ -367,11 +368,11 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludesPattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludesPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")), LONG_PATH_ID_PATTERN),
-                        Filters.not(Filters.regex(NodeDocument.ID, excludesPattern))
+                        Filters.regex(NodeDocument.ID, excludesPattern)
                 );
         assertBsonEquals(expected, actual);
     }
@@ -383,14 +384,14 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID,
                                 Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")),
                                 LONG_PATH_ID_PATTERN
                         ),
-                        Filters.not(Filters.regex(NodeDocument.ID, excludePattern))
+                        Filters.regex(NodeDocument.ID, excludePattern)
                 );
         assertBsonEquals(expected, actual);
     }
@@ -402,10 +403,10 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
         var expected = Filters.and(
-                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/")))),
-                Filters.not(Filters.regex(NodeDocument.ID, excludePattern))
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
+                Filters.regex(NodeDocument.ID, excludePattern)
         );
         assertBsonEquals(expected, actual);
     }
@@ -417,10 +418,10 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
         var expected = Filters.and(
-                Filters.regex(NodeDocument.ID, Pattern.compile(PipelinedMongoDownloadTask.negateRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/")))),
-                Filters.not(Filters.regex(NodeDocument.ID, excludePattern))
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
+                Filters.regex(NodeDocument.ID, excludePattern)
         );
         assertBsonEquals(expected, actual);
     }


### PR DESCRIPTION
The current implementation of filtering excluded paths and custom regex is using a condition like
```
{ _id:  { $nin: [ /^[0-9]{1,3}:\/content\/dam\/.*$/ ] }
```
Although the condition uses only the `_id` field which is part of the index used by the query, Mongo cannot evaluate this condition without retrieving the full document, because a value of `null` would also match this condition and the index does not contain null values. Therefore, when the index contains excluded paths or custom filter regexes, the query will take longer to execute, because Mongo has to retrieve every single document to evaluate the condition.

As a workaround, we can transform the regex to an equivalent one that matches the complement of the original regex using [negative lookahead](https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex). This allows rewriting the filter condition using only positive conditions, which can be evaluated using only the index.