### PR TITLE
OAK-10682 - [Indexing job] Improve Mongo regex filter to only use positive conditions (no negations)

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -159,7 +160,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex) {
         var filters = new ArrayList<Bson>();
 
-        List<Pattern> includedPatterns = toFilterPatterns(mongoFilterPaths.included);
+        List<Pattern> includedPatterns = compileIncludedDirectoriesRegex(mongoFilterPaths.included);
         if (!includedPatterns.isEmpty()) {
             // The conditions above on the _id field is not enough to match all JCR nodes in the given paths because nodes
             // with paths longer than a certain threshold, are represented by Mongo documents where the _id field is replaced
@@ -185,14 +186,11 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         // This is done because excluding also the top level path would add extra complexity to the filter and
         // would not have any measurable impact on performance because it only downloads a few extra documents, one
         // for each excluded subtree. The transform stage will anyway filter out these paths.
-        ArrayList<Pattern> excludedPatterns = new ArrayList<>();
-        excludedPatterns.addAll(toFilterPatterns(mongoFilterPaths.excluded));
-        // Custom regex filter to exclude paths
-        excludedPatterns.addAll(customExcludedPatterns(customExcludeEntriesRegex));
+        List<Pattern> filterPatterns = compileExcludedDirectoriesRegex(mongoFilterPaths.excluded);
+        filterPatterns.forEach(p -> filters.add(Filters.regex(NodeDocument.ID, p)));
 
-        if (!excludedPatterns.isEmpty()) {
-            filters.add(Filters.nin(NodeDocument.ID, excludedPatterns));
-        }
+        Optional<Pattern> customRegexExcludePattern = compileCustomExcludedPatterns(customExcludeEntriesRegex);
+        customRegexExcludePattern.ifPresent(p -> filters.add(Filters.regex(NodeDocument.ID, p)));
 
         if (filters.isEmpty()) {
             return null;
@@ -203,7 +201,15 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
     }
 
-    private static List<Pattern> toFilterPatterns(List<String> paths) {
+    private static List<Pattern> compileIncludedDirectoriesRegex(List<String> includedPaths) {
+        return compileDirectoryRegex(includedPaths, false);
+    }
+
+    private static List<Pattern> compileExcludedDirectoriesRegex(List<String> excludedPaths) {
+        return compileDirectoryRegex(excludedPaths, true);
+    }
+
+    private static List<Pattern> compileDirectoryRegex(List<String> paths, boolean negate) {
         if (paths.isEmpty()) {
             return List.of();
         }
@@ -215,19 +221,31 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             if (!path.endsWith("/")) {
                 path = path + "/";
             }
-            String quotedPath = Pattern.quote(path);
-            patterns.add(Pattern.compile("^[0-9]{1,3}:" + quotedPath));
+            String regex = "^[0-9]{1,3}:" + Pattern.quote(path);
+            Pattern pattern;
+            if (negate) {
+                pattern = compileExcludedDirectoryRegex(regex);
+            } else {
+                pattern = Pattern.compile(regex);
+            }
+            patterns.add(pattern);
         }
         return patterns;
     }
 
-    static List<Pattern> customExcludedPatterns(String customRegexPattern) {
+    static Pattern compileExcludedDirectoryRegex(String regex) {
+        // https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex
+        return Pattern.compile("^(?!" + regex + ")");
+    }
+
+    static Optional<Pattern> compileCustomExcludedPatterns(String customRegexPattern) {
         if (customRegexPattern == null || customRegexPattern.trim().isEmpty()) {
             LOG.info("Mongo custom regex is disabled");
-            return List.of();
+            return Optional.empty();
         } else {
             LOG.info("Excluding nodes with paths matching regex: {}", customRegexPattern);
-            return List.of(Pattern.compile(customRegexPattern));
+            var negatedRegex = "^(?!.*(" + customRegexPattern + ")$)";
+            return Optional.of(Pattern.compile(negatedRegex));
         }
     }
 
@@ -343,7 +361,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         this.reporter.addConfig(OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDED_PATHS, excludePathsString);
         if (excludePathsString.isEmpty()) {
             this.customExcludedPaths = List.of();
-        } else  if (!regexPathFiltering) {
+        } else if (!regexPathFiltering) {
             LOG.info("Ignoring custom excluded paths because regex path filtering is disabled");
             this.customExcludedPaths = List.of();
         } else {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -158,7 +158,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
      */
     static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex) {
         var filters = new ArrayList<Bson>();
-
         List<Pattern> includedPatterns = compileIncludedDirectoriesRegex(mongoFilterPaths.included);
         if (!includedPatterns.isEmpty()) {
             // The conditions above on the _id field is not enough to match all JCR nodes in the given paths because nodes

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -53,8 +53,8 @@ import java.util.stream.IntStream;
 
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -299,14 +299,14 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void createCustomExcludeEntriesFilter() {
-        assertTrue(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(null).isEmpty());
-        assertTrue(PipelinedMongoDownloadTask.compileCustomExcludedPatterns("").isEmpty());
+        assertNull(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(null));
+        assertNull(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(""));
 
         Pattern p = Pattern.compile("^(?!.*(^[0-9]{1,3}:/a/b.*$)$)");
         var actualListOfPatterns = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
-        assertTrue(actualListOfPatterns.isPresent());
+        assertNotNull(actualListOfPatterns);
 
-        assertEquals(p.toString(), actualListOfPatterns.get().toString());
+        assertEquals(p.toString(), actualListOfPatterns.toString());
     }
 
     @Test
@@ -356,7 +356,8 @@ public class PipelinedMongoDownloadTaskTest {
                 MongoFilterPaths.DOWNLOAD_ALL,
                 "^[0-9]{1,3}:/a/b.*$"
         );
-        var customExcludedPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        var customExcludedPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertNotNull(customExcludedPattern);
         Bson expectedFilter = Filters.regex(NodeDocument.ID, customExcludedPattern);
         assertBsonEquals(expectedFilter, actual);
     }
@@ -368,7 +369,8 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludesPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        Pattern excludesPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertNotNull(excludesPattern);
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")), LONG_PATH_ID_PATTERN),
@@ -384,7 +386,8 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertNotNull(excludePattern);
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID,
@@ -403,7 +406,8 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertNotNull(excludePattern);
         var expected = Filters.and(
                 Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
                 Filters.regex(NodeDocument.ID, excludePattern)
@@ -418,7 +422,8 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertNotNull(excludePattern);
         var expected = Filters.and(
                 Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
                 Filters.regex(NodeDocument.ID, excludePattern)

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -299,14 +299,14 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void createCustomExcludeEntriesFilter() {
-        assertTrue(PipelinedMongoDownloadTask.customExcludedPatterns(null).isEmpty());
-        assertTrue(PipelinedMongoDownloadTask.customExcludedPatterns("").isEmpty());
+        assertTrue(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(null).isEmpty());
+        assertTrue(PipelinedMongoDownloadTask.compileCustomExcludedPatterns("").isEmpty());
 
-        Pattern p = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var actualListOfPatterns = PipelinedMongoDownloadTask.customExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
-        assertEquals(1, actualListOfPatterns.size());
+        Pattern p = Pattern.compile("^(?!.*(^[0-9]{1,3}:/a/b.*$)$)");
+        var actualListOfPatterns = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        assertTrue(actualListOfPatterns.isPresent());
 
-        assertEquals(p.toString(), actualListOfPatterns.get(0).toString());
+        assertEquals(p.toString(), actualListOfPatterns.get().toString());
     }
 
     @Test
@@ -328,11 +328,10 @@ public class PipelinedMongoDownloadTaskTest {
                 null
         );
         // The generated filter should not include any condition to include the descendants of /
-        var expected =
-                Filters.nin(NodeDocument.ID,
-                        Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/excluded1/")),
-                        Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/"))
-                );
+        var expected = Filters.and(
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded1/"))),
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/"))
+                ));
         assertBsonEquals(expected, actual);
     }
 
@@ -357,7 +356,8 @@ public class PipelinedMongoDownloadTaskTest {
                 MongoFilterPaths.DOWNLOAD_ALL,
                 "^[0-9]{1,3}:/a/b.*$"
         );
-        Bson expectedFilter = Filters.nin(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:/a/b.*$"));
+        var customExcludedPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        Bson expectedFilter = Filters.regex(NodeDocument.ID, customExcludedPattern);
         assertBsonEquals(expectedFilter, actual);
     }
 
@@ -368,11 +368,11 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludesPattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludesPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")), LONG_PATH_ID_PATTERN),
-                        Filters.nin(NodeDocument.ID, excludesPattern)
+                        Filters.regex(NodeDocument.ID, excludesPattern)
                 );
         assertBsonEquals(expected, actual);
     }
@@ -384,14 +384,14 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
         var expected =
                 Filters.and(
                         Filters.in(NodeDocument.ID,
                                 Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/parent/")),
                                 LONG_PATH_ID_PATTERN
                         ),
-                        Filters.nin(NodeDocument.ID, excludePattern)
+                        Filters.regex(NodeDocument.ID, excludePattern)
                 );
         assertBsonEquals(expected, actual);
     }
@@ -403,9 +403,11 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var expected =
-                Filters.nin(NodeDocument.ID, Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/excluded/")), excludePattern);
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        var expected = Filters.and(
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
+                Filters.regex(NodeDocument.ID, excludePattern)
+        );
         assertBsonEquals(expected, actual);
     }
 
@@ -416,10 +418,10 @@ public class PipelinedMongoDownloadTaskTest {
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = Pattern.compile("^[0-9]{1,3}:/a/b.*$");
-        var expected = Filters.nin(NodeDocument.ID,
-                Pattern.compile("^[0-9]{1,3}:" + Pattern.quote("/excluded/")),
-                excludePattern
+        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$").get();
+        var expected = Filters.and(
+                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
+                Filters.regex(NodeDocument.ID, excludePattern)
         );
         assertBsonEquals(expected, actual);
     }


### PR DESCRIPTION
The current implementation of filtering excluded paths and custom regex is using a condition like

` _id:  { $nin: [ /^[0-9]{1,3}:\/content\/dam\/.*$/ ]`

Mongo cannot evaluate this condition without retrieving the full document, because a value of _null would also match this condition and the index does not contain null values. Therefore, when the index contains excluded paths, the download will be much slower because Mongo has to retrieve every single document to evaluate the condition.

As a workaround, we can transform the regex on an equivalent one that matches the complement of the original regex using [negative lookahead](https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex). This allows rewriting the filter condition using only positive conditions, which can be evaluated using only the index.


## Performance

As an example of the difference between the two approaches, the two following queries count the number of documents that match the regex filter. Using `$not` in the regex:
```
> db.nodes.find({ $and: [{ "_modified": { "$gte": 0 } }, { _id: { $not: { $regex: /^[0-9]{1,3}:\/content\/dam\/.*$/ } } }, { _id: { $not: { $regex: /^[0-9]{1,3}:\/oak:index\/.*$/ } } }] }).sort({ "_modified": 1 }).count()
15338210
```
4m18s

Using a negated regex to turn the Mongo filter into a positive filter:
```
> db.nodes.find( { $and: [ {"_modified": {"$gte": 0}}, { _id: { $regex: /^(?![0-9]{1,3}:\/content\/dam\/)/ } }, { _id: { $regex: /^(?![0-9]{1,3}:\/oak:index\/)/ } }]} ).sort({ "_modified":1 }).count()
15338210
```
39s


The plan for the query with `$not` fetches every document and then applies the regex filters:
```
  stage: 'FETCH',
  filter: {
    '$and': [
      {
        _id: {
          '$not': { '$regex': '^[0-9]{1,3}:\\/content\\/dam\\/.*$' }
        }
      },
      {
        _id: { '$not': { '$regex': '^[0-9]{1,3}:\\/oak:index\\/.*$' } }
      }
    ]
  },
  inputStage: {
    stage: 'IXSCAN',
    keyPattern: { _modified: 1, _id: 1 },
    indexName: '_modified_1__id_1',
    isMultiKey: false,
    multiKeyPaths: { _modified: [], _id: [] },
    isUnique: false,
    isSparse: false,
    isPartial: false,
    indexVersion: 2,
    direction: 'forward',
    indexBounds: { _modified: [ '[0, inf.0]' ], _id: [ '[MinKey, MaxKey]' ] }
  }
```

While the plan for the query with the negated regex applies the filter during the index scan, fetching only the documents that match:

```
  stage: 'FETCH',
  inputStage: {
    stage: 'IXSCAN',
    filter: {
      '$and': [
        {
          _id: { '$regex': '^(?![0-9]{1,3}:\\/content\\/dam\\/)' }
        },
        { _id: { '$regex': '^(?![0-9]{1,3}:\\/oak:index\\/)' } }
      ]
    },
    keyPattern: { _modified: 1, _id: 1 },
    indexName: '_modified_1__id_1',
    isMultiKey: false,
    multiKeyPaths: { _modified: [], _id: [] },
    isUnique: false,
    isSparse: false,
    isPartial: false,
    indexVersion: 2,
    direction: 'forward',
    indexBounds: { _modified: [ '[0, inf.0]' ], _id: [ '["", {})' ] }
  }
```