### PR TITLE
OAK-10726 : fix and gctype-parameterize BranchCommitGCTest

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
@@ -155,7 +155,11 @@ public class VersionGarbageCollector {
         OLDER_THAN_24H_AND_BETWEEN_CHECKPOINTS_MODE
     }
 
-    final static RDGCType revisionDetailedGcType = RDGCType.NO_OLD_PROP_REV_GC;
+    private static RDGCType revisionDetailedGcType = RDGCType.NO_OLD_PROP_REV_GC;
+
+    static RDGCType getRevisionDetailedGcType() {
+        return revisionDetailedGcType;
+    }
 
     private final DocumentNodeStore nodeStore;
     private final DocumentStore ds;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DetailGCHelper.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DetailGCHelper.java
@@ -74,7 +74,7 @@ public class DetailGCHelper {
             final DocumentNodeStore store, final RevisionVector br,
             final String... exceptIds) {
         assertTrue(br.isBranch());
-        if (VersionGarbageCollector.revisionDetailedGcType == RDGCType.NO_OLD_PROP_REV_GC) {
+        if (VersionGarbageCollector.getRevisionDetailedGcType() == RDGCType.NO_OLD_PROP_REV_GC) {
             // then we must skip these asserts, as we cannot guarantee
             // that all revisions are cleaned up in this mode
             return;
@@ -96,7 +96,7 @@ public class DetailGCHelper {
             for (Entry<String, Object> e : target.data.entrySet()) {
                 String k = e.getKey();
                 final boolean internal = k.startsWith("_");
-                final boolean dgcSupportsInternalPropCleanup = (VersionGarbageCollector.revisionDetailedGcType != RDGCType.KEEP_ONE_CLEANUP_USER_PROPERTIES_ONLY_MODE);
+                final boolean dgcSupportsInternalPropCleanup = (VersionGarbageCollector.getRevisionDetailedGcType() != RDGCType.KEEP_ONE_CLEANUP_USER_PROPERTIES_ONLY_MODE);
                 if (internal && !dgcSupportsInternalPropCleanup) {
                     // skip
                     continue;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
@@ -134,7 +134,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class VersionGarbageCollectorIT {
 
-    private class GCCounts {
+    static class GCCounts {
         RDGCType mode;
         int deletedDocGCCount, deletedPropsCount, deletedInternalPropsCount,
                 deletedPropRevsCount, deletedInternalPropRevsCount,
@@ -1026,10 +1026,10 @@ public class VersionGarbageCollectorIT {
         assertFalse(jcrContent.hasProperty("prop0"));
     }
 
-    private void assertStatsCountsEqual(VersionGCStats stats, GCCounts... counts) {
+    static void assertStatsCountsEqual(VersionGCStats stats, GCCounts... counts) {
         GCCounts c = null;
         for (GCCounts a : counts) {
-            if (a.mode == VersionGarbageCollector.revisionDetailedGcType) {
+            if (a.mode == VersionGarbageCollector.getRevisionDetailedGcType()) {
                 c = a;
                 break;
             }
@@ -1058,15 +1058,15 @@ public class VersionGarbageCollectorIT {
         assertNotNull(stats);
         assertEquals(deletedDocGCCount, stats.deletedDocGCCount);
         assertEquals(deletedPropsCount, stats.deletedPropsCount);
-        if (VersionGarbageCollector.revisionDetailedGcType == RDGCType.KEEP_ONE_FULL_MODE) {
+        if (VersionGarbageCollector.getRevisionDetailedGcType() == RDGCType.KEEP_ONE_FULL_MODE) {
             assertEquals(deletedInternalPropsCount, stats.deletedInternalPropsCount);
         }
         assertEquals(deletedPropRevsCount, stats.deletedPropRevsCount);
-        if (VersionGarbageCollector.revisionDetailedGcType == RDGCType.KEEP_ONE_FULL_MODE) {
+        if (VersionGarbageCollector.getRevisionDetailedGcType() == RDGCType.KEEP_ONE_FULL_MODE) {
             assertEquals(deletedInternalPropRevsCount, stats.deletedInternalPropRevsCount);
         }
         assertEquals(deletedUnmergedBCCount, stats.deletedUnmergedBCCount);
-        if (VersionGarbageCollector.revisionDetailedGcType != RDGCType.KEEP_ONE_CLEANUP_USER_PROPERTIES_ONLY_MODE) {
+        if (VersionGarbageCollector.getRevisionDetailedGcType() != RDGCType.KEEP_ONE_CLEANUP_USER_PROPERTIES_ONLY_MODE) {
             // TODO: unfortunately, in cleanup-user-props-only mode the expected count below
             // is inaccurate. So either we extend this assert methods to get values per mode,
             // or we ignore this for now. not nice but should only be temporary
@@ -1631,7 +1631,7 @@ public class VersionGarbageCollectorIT {
                 betweenChkp(0, 2, 1, 2, 13, 3, 2));
     }
 
-    private GCCounts noOldPropGc(int deletedDocGCCount, int deletedPropsCount,
+    static GCCounts noOldPropGc(int deletedDocGCCount, int deletedPropsCount,
             int deletedInternalPropsCount, int deletedPropRevsCount,
             int deletedInternalPropRevsCount, int deletedUnmergedBCCount,
             int updatedDetailedGCDocsCount) {
@@ -1645,7 +1645,7 @@ public class VersionGarbageCollectorIT {
                 updatedDetailedGCDocsCount);
     }
 
-    private GCCounts keepOneFull(int deletedDocGCCount, int deletedPropsCount,
+    static GCCounts keepOneFull(int deletedDocGCCount, int deletedPropsCount,
             int deletedInternalPropsCount, int deletedPropRevsCount,
             int deletedInternalPropRevsCount, int deletedUnmergedBCCount,
             int updatedDetailedGCDocsCount) {
@@ -1655,7 +1655,7 @@ public class VersionGarbageCollectorIT {
                 updatedDetailedGCDocsCount);
     }
 
-    private GCCounts keepOneUser(int deletedDocGCCount, int deletedPropsCount,
+    static GCCounts keepOneUser(int deletedDocGCCount, int deletedPropsCount,
             int deletedInternalPropsCount, int deletedPropRevsCount,
             int deletedInternalPropRevsCount, int deletedUnmergedBCCount,
             int updatedDetailedGCDocsCount) {
@@ -1665,7 +1665,7 @@ public class VersionGarbageCollectorIT {
                 deletedUnmergedBCCount, updatedDetailedGCDocsCount);
     }
 
-    private GCCounts betweenChkp(int deletedDocGCCount, int deletedPropsCount,
+    static GCCounts betweenChkp(int deletedDocGCCount, int deletedPropsCount,
             int deletedInternalPropsCount, int deletedPropRevsCount,
             int deletedInternalPropRevsCount, int deletedUnmergedBCCount,
             int updatedDetailedGCDocsCount) {
@@ -1737,8 +1737,8 @@ public class VersionGarbageCollectorIT {
 
         NodeDocument doc = store1.getDocumentStore().find(NODES, "1:/x", -1);
         assertNotNull(doc);
-        if (VersionGarbageCollector.revisionDetailedGcType == RDGCType.OLDER_THAN_24H_AND_BETWEEN_CHECKPOINTS_MODE
-                || VersionGarbageCollector.revisionDetailedGcType == RDGCType.NO_OLD_PROP_REV_GC) {
+        if (VersionGarbageCollector.getRevisionDetailedGcType() == RDGCType.OLDER_THAN_24H_AND_BETWEEN_CHECKPOINTS_MODE
+                || VersionGarbageCollector.getRevisionDetailedGcType() == RDGCType.NO_OLD_PROP_REV_GC) {
             // this mode doesn't currently delete all revisions,
             // thus would fail below assert.
             return;


### PR DESCRIPTION
this is the follow-up https://github.com/apache/jackrabbit-oak/pull/1383 that fixes BranchCommitGCTest, while at the same time adds fixture/gcType parameters