### PR TITLE
OAK-10756: OrderableNodesTest.childOrderCleanupFeatureToggleTest fail…

### DIFF
--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/OrderableNodesTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/OrderableNodesTest.java
@@ -175,9 +175,11 @@ public class OrderableNodesTest extends AbstractRepositoryTest {
 
     @Test
     public void childOrderCleanupFeatureToggleTest() throws RepositoryException {
-        Tracker<FeatureToggle> track = fixture.getWhiteboard().track(FeatureToggle.class);
-        NodeStore nodeStore = createNodeStore(fixture);
+        //init repository
+        getAdminSession();
+        NodeStore nodeStore = getNodeStore();
         assertNotNull(nodeStore);
+        Tracker<FeatureToggle> track = fixture.getWhiteboard().track(FeatureToggle.class);
         if (nodeStore instanceof DocumentNodeStore) {
             DocumentNodeStore documentNodeStore = (DocumentNodeStore) nodeStore;
             assertTrue(documentNodeStore.isChildOrderCleanupEnabled());

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMemoryFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMemoryFixture.java
@@ -23,12 +23,15 @@ import org.apache.jackrabbit.oak.plugins.document.DocumentMK;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.spi.toggle.Feature;
+import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
 
 public class DocumentMemoryFixture extends NodeStoreFixture {
 
     @Override
     public NodeStore createNodeStore() {
         DocumentMK.Builder builder = new DocumentMK.Builder();
+        //do not reuse the whiteboard
+        setWhiteboard(new DefaultWhiteboard());
         builder.setNoChildOrderCleanupFeature(Feature.newFeature("FT_NOCOCLEANUP_OAK-10660", getWhiteboard()));
         return builder.getNodeStore();
     }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMongoFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMongoFixture.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.spi.toggle.Feature;
+import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
 import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,8 @@ public class DocumentMongoFixture extends NodeStoreFixture {
             }
             builder.setPersistentCache("target/persistentCache,time");
             builder.setMongoDB(createClient(), getDBName(suffix));
+            //do not reuse the whiteboard
+            setWhiteboard(new DefaultWhiteboard());
             builder.setNoChildOrderCleanupFeature(Feature.newFeature("FT_NOCOCLEANUP_OAK-10660", getWhiteboard()));
             DocumentNodeStore ns = builder.getNodeStore();
             suffixes.put(ns, suffix);

--- a/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/fixture/NodeStoreFixture.java
+++ b/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/fixture/NodeStoreFixture.java
@@ -28,7 +28,7 @@ import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
  */
 public abstract class NodeStoreFixture {
 
-    private final Whiteboard whiteboard = new DefaultWhiteboard();
+    private Whiteboard whiteboard = new DefaultWhiteboard();
 
     /**
      * Creates a new empty {@link NodeStore} instance. An implementation must
@@ -58,6 +58,10 @@ public abstract class NodeStoreFixture {
 
     public Whiteboard getWhiteboard() {
         return whiteboard;
+    }
+
+    public void setWhiteboard(Whiteboard whiteboard) {
+        this.whiteboard = whiteboard;
     }
 
 }


### PR DESCRIPTION
…s with -Dnsfixtures=DOCUMENT_NS

Fixed test classes to not reuse an existing whiteboard with a newly created NodeStore.