### PR TITLE
OAK-10759: JavaDoc of o.a.j.o.namepath.PathMapper is inaccurate

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/PathMapper.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/PathMapper.java
@@ -24,8 +24,8 @@ import org.osgi.annotation.versioning.ProviderType;
  * {@code PathMapper} instances provide methods for mapping paths from their JCR
  * string representation to their Oak representation and vice versa.
  *
- * The Oak representation of a path consists of a forward slash followed by the
- * names of the respective items in the {@link org.apache.jackrabbit.oak.api.Tree}
+ * The Oak representation of a path consists of an optional forward slash followed by
+ * the names of the respective items in the {@link org.apache.jackrabbit.oak.api.Tree}
  * separated by forward slashes.
  */
 @ProviderType


### PR DESCRIPTION
Fixed