### PR TITLE
OAK-10771 - Add disk cache size stats and issue warning if evicted segment has zero length

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/ToolUtils.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/ToolUtils.java
@@ -48,6 +48,7 @@ import org.apache.jackrabbit.oak.segment.file.FileStore;
 import org.apache.jackrabbit.oak.segment.file.FileStoreBuilder;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
 import org.apache.jackrabbit.oak.segment.file.tar.TarPersistence;
+import org.apache.jackrabbit.oak.segment.remote.persistentcache.DiskCacheIOMonitor;
 import org.apache.jackrabbit.oak.segment.remote.persistentcache.PersistentDiskCache;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
@@ -63,6 +64,7 @@ import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.StorageCredentialsSharedAccessSignature;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobDirectory;
+import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,7 +132,7 @@ public class ToolUtils {
             SegmentNodeStorePersistence basePersistence = new AzurePersistence(cloudBlobDirectory);
 
             PersistentCache persistentCache = new PersistentDiskCache(new File(persistentCachePath),
-                        persistentCacheSize * 1024, new IOMonitorAdapter());
+                        persistentCacheSize * 1024, new DiskCacheIOMonitor(StatisticsProvider.NOOP));
             persistence = new CachingPersistence(persistentCache, basePersistence);
             break;
         default:

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/DiskCacheIOMonitor.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/DiskCacheIOMonitor.java
@@ -42,6 +42,10 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  *          a timer metrics for the time spent reading from segment disk cache</li>
  *     <li>{@link #OAK_SEGMENT_CACHE_DISk_SEGMENT_WRITE_TIME}:
  *          a timer metrics for the time spent writing to segment disk cache</li>
+ *     <li>{@link #OAK_SEGMENT_CACHE_DISK_CACHE_SIZE_CALCULATED}:
+ *          a histogram for the calculated segment disk cache size</li>
+ *     <li>{@link #OAK_SEGMENT_CACHE_DISK_CACHE_SIZE_CHANGE}:
+ *          a histogram for the segment disk cache size change</li>
  * </ul>
  */
 public class DiskCacheIOMonitor extends IOMonitorAdapter {
@@ -49,8 +53,8 @@ public class DiskCacheIOMonitor extends IOMonitorAdapter {
     public static final String OAK_SEGMENT_CACHE_DISK_SEGMENT_WRITE_BYTES = "oak.segment.cache.disk.segment-write-bytes";
     public static final String OAK_SEGMENT_CACHE_DISK_SEGMENT_READ_TIME = "oak.segment.cache.disk.segment-read-time";
     public static final String OAK_SEGMENT_CACHE_DISk_SEGMENT_WRITE_TIME = "oak.segment.cache.disk.segment-write-time";
-    public static final String OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_CALCULATED = "oak.segment.cache.disk.cache-size-calculated";
-    public static final String OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_ON_DISK = "oak.segment.cache.disk.cache-size-on-disk";
+    public static final String OAK_SEGMENT_CACHE_DISK_CACHE_SIZE_CALCULATED = "oak.segment.cache.disk.cache-size-calculated";
+    public static final String OAK_SEGMENT_CACHE_DISK_CACHE_SIZE_CHANGE = "oak.segment.cache.disk.cache-size-change";
 
     private final MeterStats segmentReadBytes;
     private final MeterStats segmentWriteBytes;
@@ -69,9 +73,9 @@ public class DiskCacheIOMonitor extends IOMonitorAdapter {
         segmentWriteTime = statisticsProvider.getTimer(
                 OAK_SEGMENT_CACHE_DISk_SEGMENT_WRITE_TIME, StatsOptions.METRICS_ONLY);
         cacheSizeCalculated = statisticsProvider.getHistogram(
-                OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_CALCULATED, StatsOptions.METRICS_ONLY);
+                OAK_SEGMENT_CACHE_DISK_CACHE_SIZE_CALCULATED, StatsOptions.METRICS_ONLY);
         cacheSizeOnDisk = statisticsProvider.getHistogram(
-                OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_ON_DISK, StatsOptions.METRICS_ONLY);
+                OAK_SEGMENT_CACHE_DISK_CACHE_SIZE_CHANGE, StatsOptions.METRICS_ONLY);
     }
 
     @Override
@@ -86,8 +90,8 @@ public class DiskCacheIOMonitor extends IOMonitorAdapter {
         segmentWriteTime.update(elapsed, NANOSECONDS);
     }
 
-    public void updateCacheSize(long calculated, long onDisk) {
+    public void updateCacheSize(long calculated, long change) {
         cacheSizeCalculated.update(calculated);
-        cacheSizeOnDisk.update(onDisk);
+        cacheSizeOnDisk.update(change);
     }
 }

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/DiskCacheIOMonitor.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/DiskCacheIOMonitor.java
@@ -19,6 +19,7 @@
 package org.apache.jackrabbit.oak.segment.remote.persistentcache;
 
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
+import org.apache.jackrabbit.oak.stats.HistogramStats;
 import org.apache.jackrabbit.oak.stats.MeterStats;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.apache.jackrabbit.oak.stats.StatsOptions;
@@ -48,11 +49,15 @@ public class DiskCacheIOMonitor extends IOMonitorAdapter {
     public static final String OAK_SEGMENT_CACHE_DISK_SEGMENT_WRITE_BYTES = "oak.segment.cache.disk.segment-write-bytes";
     public static final String OAK_SEGMENT_CACHE_DISK_SEGMENT_READ_TIME = "oak.segment.cache.disk.segment-read-time";
     public static final String OAK_SEGMENT_CACHE_DISk_SEGMENT_WRITE_TIME = "oak.segment.cache.disk.segment-write-time";
+    public static final String OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_CALCULATED = "oak.segment.cache.disk.cache-size-calculated";
+    public static final String OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_ON_DISK = "oak.segment.cache.disk.cache-size-on-disk";
 
     private final MeterStats segmentReadBytes;
     private final MeterStats segmentWriteBytes;
     private final TimerStats segmentReadTime;
     private final TimerStats segmentWriteTime;
+    private final HistogramStats cacheSizeCalculated;
+    private final HistogramStats cacheSizeOnDisk;
 
     public DiskCacheIOMonitor(@NotNull StatisticsProvider statisticsProvider) {
         segmentReadBytes = statisticsProvider.getMeter(
@@ -63,6 +68,10 @@ public class DiskCacheIOMonitor extends IOMonitorAdapter {
                 OAK_SEGMENT_CACHE_DISK_SEGMENT_READ_TIME, StatsOptions.METRICS_ONLY);
         segmentWriteTime = statisticsProvider.getTimer(
                 OAK_SEGMENT_CACHE_DISk_SEGMENT_WRITE_TIME, StatsOptions.METRICS_ONLY);
+        cacheSizeCalculated = statisticsProvider.getHistogram(
+                OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_CALCULATED, StatsOptions.METRICS_ONLY);
+        cacheSizeOnDisk = statisticsProvider.getHistogram(
+                OAK_SEGMENT_CACHE_DISk_CACHE_SIZE_ON_DISK, StatsOptions.METRICS_ONLY);
     }
 
     @Override
@@ -75,5 +84,10 @@ public class DiskCacheIOMonitor extends IOMonitorAdapter {
     public void afterSegmentWrite(File file, long msb, long lsb, int length, long elapsed) {
         segmentWriteBytes.mark(length);
         segmentWriteTime.update(elapsed, NANOSECONDS);
+    }
+
+    public void updateCacheSize(long calculated, long onDisk) {
+        cacheSizeCalculated.update(calculated);
+        cacheSizeOnDisk.update(onDisk);
     }
 }

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
@@ -204,7 +204,16 @@ public class PersistentDiskCache extends AbstractPersistentCache {
                     }
                     if (cacheSize.get() > maxCacheSizeBytes * 0.66) {
                         File segment = segmentCacheEntry.getPath().toFile();
-                        cacheSize.addAndGet(-segment.length());
+                        long length = segment.length();
+                        if (length == 0) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Avoiding removal of zero-sized file {}", segmentCacheEntry.getPath());
+                            } else {
+                                logger.warn("Avoiding removal of zero-sized file.");
+                            }
+                            return;
+                        }
+                        cacheSize.addAndGet(-length);
                         segment.delete();
                         evictionCount.incrementAndGet();
                     } else {

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
@@ -61,7 +61,7 @@ public class PersistentDiskCache extends AbstractPersistentCache {
 
     private final File directory;
     private final long maxCacheSizeBytes;
-    private final IOMonitor diskCacheIOMonitor;
+    private final DiskCacheIOMonitor diskCacheIOMonitor;
     /**
      * Wait time before attempting to clean up orphaned temp files
      */
@@ -71,11 +71,11 @@ public class PersistentDiskCache extends AbstractPersistentCache {
 
     final AtomicLong evictionCount = new AtomicLong();
 
-    public PersistentDiskCache(File directory, int cacheMaxSizeMB, IOMonitor diskCacheIOMonitor) {
+    public PersistentDiskCache(File directory, int cacheMaxSizeMB, DiskCacheIOMonitor diskCacheIOMonitor) {
         this(directory, cacheMaxSizeMB, diskCacheIOMonitor, DEFAULT_TEMP_FILES_CLEANUP_WAIT_TIME_MS);
     }
 
-    public PersistentDiskCache(File directory, int cacheMaxSizeMB, IOMonitor diskCacheIOMonitor, long tempFilesCleanupWaitTimeMs) {
+    public PersistentDiskCache(File directory, int cacheMaxSizeMB, DiskCacheIOMonitor diskCacheIOMonitor, long tempFilesCleanupWaitTimeMs) {
         this.directory = directory;
         this.maxCacheSizeBytes = cacheMaxSizeMB * 1024L * 1024L;
         this.diskCacheIOMonitor = diskCacheIOMonitor;
@@ -213,7 +213,8 @@ public class PersistentDiskCache extends AbstractPersistentCache {
                             }
                             return;
                         }
-                        cacheSize.addAndGet(-length);
+                        long cacheSizeAfter = cacheSize.addAndGet(-length);
+                        diskCacheIOMonitor.updateCacheSize(cacheSizeAfter, directory.length());
                         segment.delete();
                         evictionCount.incrementAndGet();
                     } else {

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
@@ -158,7 +158,8 @@ public class PersistentDiskCache extends AbstractPersistentCache {
                     } catch (AtomicMoveNotSupportedException e) {
                         Files.move(tempSegmentFile.toPath(), segmentFile.toPath());
                     }
-                    cacheSize.addAndGet(fileSize);
+                    long cacheSizeAfter = cacheSize.addAndGet(fileSize);
+                    diskCacheIOMonitor.updateCacheSize(cacheSizeAfter, fileSize);
                 } catch (Exception e) {
                     logger.error("Error writing segment {} to cache", segmentId, e);
                     try {
@@ -214,7 +215,7 @@ public class PersistentDiskCache extends AbstractPersistentCache {
                             return;
                         }
                         long cacheSizeAfter = cacheSize.addAndGet(-length);
-                        diskCacheIOMonitor.updateCacheSize(cacheSizeAfter, directory.length());
+                        diskCacheIOMonitor.updateCacheSize(cacheSizeAfter, -length);
                         segment.delete();
                         evictionCount.incrementAndGet();
                     } else {

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/package-info.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.0.0")
+@Version("2.0.0")
 package org.apache.jackrabbit.oak.segment.remote.persistentcache;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCacheTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCacheTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.segment.remote.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
+import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,13 +50,13 @@ public class PersistentDiskCacheTest extends AbstractPersistentCacheTest {
 
     @Before
     public void setUp() throws Exception {
-        persistentCache = new PersistentDiskCache(temporaryFolder.newFolder(), 10 * 1024, new IOMonitorAdapter());
+        persistentCache = new PersistentDiskCache(temporaryFolder.newFolder(), 10 * 1024, new DiskCacheIOMonitor(StatisticsProvider.NOOP));
     }
 
     @Test
     public void cleanupTest() throws Exception {
         persistentCache.close();
-        persistentCache = new PersistentDiskCache(temporaryFolder.newFolder(), 0, new IOMonitorAdapter(), 500);
+        persistentCache = new PersistentDiskCache(temporaryFolder.newFolder(), 0, new DiskCacheIOMonitor(StatisticsProvider.NOOP), 500);
         final List<TestSegment> testSegments = new ArrayList<>(SEGMENTS);
         final List<Map<String, Buffer>> segmentsRead = new ArrayList<>(THREADS);
 
@@ -127,7 +128,7 @@ public class PersistentDiskCacheTest extends AbstractPersistentCacheTest {
 
     @Test
     public void testIOMonitor() throws IOException {
-        IOMonitorAdapter ioMonitorAdapter = Mockito.mock(IOMonitorAdapter.class);
+        DiskCacheIOMonitor ioMonitorAdapter = Mockito.mock(DiskCacheIOMonitor.class);
 
         persistentCache.close();
         File cacheFolder = temporaryFolder.newFolder();


### PR DESCRIPTION
The persistent disk cache computes its size internally by adding/subtracting the size of added/purged segments. We would like to be able to see if that computation is correct, by having both the computed size and the effective size on disk in the metrics.

The background for this is that in a few rare instances, the disk cache evicted too many items (down to almost zero) instead of the expected 65% of its max size.

Also we want to make sure that no evictions happen on items that have a length of zero. We're not sure if that happens or not, so the change is to refuse eviction in that case and log a warning instead.
