### PR TITLE
OAK-10766 | Make lease time out configurable for individual lanes

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexerService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexerService.java
@@ -127,8 +127,6 @@ public class AsyncIndexerService {
         executor = new WhiteboardExecutor();
         executor.start(whiteboard);
 
-        //long leaseTimeOutMin = config.leaseTimeOutMinutes();
-
         TrackingCorruptIndexHandler corruptIndexHandler = createCorruptIndexHandler(config);
 
         for (AsyncConfig c : asyncIndexerConfig) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexerService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexerService.java
@@ -72,16 +72,16 @@ public class AsyncIndexerService {
         @AttributeDefinition(
                 cardinality = 1024,
                 name = "Async Indexer Configs",
-                description = "Async indexer configs in the form of <name>:<interval in secs> e.g. \"async:5\""
+                description = "Async indexer configs in the form of <name>:<interval in secs>:<lease time out in minutes> e.g. \"async:5:15\""
         )
-        String[] asyncConfigs() default {"async:5"};
+        String[] asyncConfigs() default {"async:5:15"};
 
         @AttributeDefinition(
                 name = "Lease time out",
                 description = "Lease timeout in minutes. AsyncIndexer would wait for this timeout period before breaking " +
                         "async indexer lease"
         )
-        int leaseTimeOutMinutes() default 15;
+        long leaseTimeOutMinutes() default 15L;
 
         @AttributeDefinition(
                 name = "Failing Index Timeout (s)",
@@ -127,12 +127,7 @@ public class AsyncIndexerService {
         executor = new WhiteboardExecutor();
         executor.start(whiteboard);
 
-        long leaseTimeOutMin = config.leaseTimeOutMinutes();
-
-        if (!(nodeStore instanceof Clusterable)){
-            leaseTimeOutMin = 0;
-            log.info("Detected non clusterable setup. Lease checking would be disabled for async indexing");
-        }
+        //long leaseTimeOutMin = config.leaseTimeOutMinutes();
 
         TrackingCorruptIndexHandler corruptIndexHandler = createCorruptIndexHandler(config);
 
@@ -141,14 +136,27 @@ public class AsyncIndexerService {
                     statisticsProvider, false);
             task.setCorruptIndexHandler(corruptIndexHandler);
             task.setValidatorProviders(Collections.singletonList(validatorProvider));
-            task.setLeaseTimeOut(TimeUnit.MINUTES.toMillis(leaseTimeOutMin));
 
+            long leaseTimeOutMin = config.leaseTimeOutMinutes();
+
+            // Set lease time out = 0 for a non clusterable setup.
+            if (!(nodeStore instanceof Clusterable)){
+                leaseTimeOutMin = 0;
+                log.info("Detected non clusterable setup. Lease checking would be disabled for async indexing");
+            } else if (c.leaseTimeOutInMin != null) {
+                // If lease time out is configured for a specific lane, use that.
+                leaseTimeOutMin = c.leaseTimeOutInMin;
+                log.info("Lease time out for {} configured as {} mins.", c.name, leaseTimeOutMin);
+            } else {
+                log.info("Lease time out for {} not configured explicitly. Using value {} mins configured via Lease Time out property.", c.name, leaseTimeOutMin);
+            }
+
+            task.setLeaseTimeOut(TimeUnit.MINUTES.toMillis(leaseTimeOutMin));
             indexRegistration.registerAsyncIndexer(task, c.timeIntervalInSecs);
             closer.register(task);
         }
         registerAsyncReindexSupport(whiteboard);
         log.info("Configured async indexers {} ", asyncIndexerConfig);
-        log.info("Lease time: {} mins and AsyncIndexUpdate configured with {}", leaseTimeOutMin, validatorProvider.getClass().getName());
     }
 
     private void registerAsyncReindexSupport(Whiteboard whiteboard) {
@@ -211,20 +219,25 @@ public class AsyncIndexerService {
             int idOfEq = config.indexOf(CONFIG_SEP);
             checkArgument(idOfEq > 0, "Invalid config provided [%s]", Arrays.toString(configs));
 
-            String name = config.substring(0, idOfEq).trim();
-            long interval = Long.parseLong(config.substring(idOfEq + 1));
-            result.add(new AsyncConfig(name, interval));
+            String[] configElements = config.split(String.valueOf(CONFIG_SEP));
+            String name = configElements[0].trim();
+            Long interval = configElements.length > 1 ? Long.parseLong(configElements[1].trim()) : null;
+            Long leaseTimeOut = configElements.length > 2 ? Long.parseLong(configElements[2].trim()) : null;
+
+            result.add(new AsyncConfig(name, interval, leaseTimeOut));
         }
         return result;
     }
 
     static class AsyncConfig {
         final String name;
-        final long timeIntervalInSecs;
+        final Long timeIntervalInSecs;
+        final Long leaseTimeOutInMin;
 
-        private AsyncConfig(String name, long timeIntervalInSecs) {
+        private AsyncConfig(String name, Long timeIntervalInSecs, Long leaseTimeOutInMin) {
             this.name = AsyncIndexUpdate.checkValidName(name);
             this.timeIntervalInSecs = timeIntervalInSecs;
+            this.leaseTimeOutInMin = leaseTimeOutInMin;
         }
 
         @Override
@@ -232,6 +245,7 @@ public class AsyncIndexerService {
             return "AsyncConfig{" +
                     "name='" + name + '\'' +
                     ", timeIntervalInSecs=" + timeIntervalInSecs +
+                    ", leaseTimeOutInMin=" + leaseTimeOutInMin +
                     '}';
         }
     }


### PR DESCRIPTION
Lease time out is required to prevent concurrent updates in case of 2 oak instances simultaneously trying to upgrade the async indexes. 
This can be a big problem in case of lucene indexes however not so much in case of elastic indexes. Projects implementing oak can have different types of indexes configured on different async lanes, so it can be useful to provide them with an option to configure different lease time outs for different lanes. 

Also, in case of lucene indexes, nrt part of the index usually provides support in case of the lease time out duration, however elastic indexes don't have nrt support, so might make sense to be able to configure a lane with only elastic indexes with a lesser lease time out.

The PR maintains backward compatibility. keeping the general least time out config in place. Only if the new per lane lease time out is configured - it would be given priority, otherwise the general lease time out property will be picked up.