### PR TITLE
OAK-10773 | Do not open index while getting ft index path for lucene …

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexLookupUtil.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexLookupUtil.java
@@ -22,6 +22,7 @@ package org.apache.jackrabbit.oak.plugins.index.lucene;
 import java.util.Collection;
 import java.util.function.Predicate;
 
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexFormatVersion;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexLookup;
 import org.apache.jackrabbit.oak.spi.query.Filter;
@@ -43,19 +44,11 @@ class LuceneIndexLookupUtil {
      */
     public static String getOldFullTextIndexPath(NodeState root, Filter filter, IndexTracker tracker) {
         Collection<String> indexPaths = getLuceneIndexLookup(root).collectIndexNodePaths(filter, false);
-        LuceneIndexNode indexNode = null;
         for (String path : indexPaths) {
-            try {
-                indexNode = tracker.acquireIndexNode(path);
-                if (indexNode != null
-                        && indexNode.getDefinition().isFullTextEnabled()
-                        && indexNode.getDefinition().getVersion() == IndexFormatVersion.V1) {
-                    return path;
-                }
-            } finally {
-                if (indexNode != null) {
-                    indexNode.release();
-                }
+            IndexDefinition indexDefinition = tracker.getIndexDefinition(path);
+            if (indexDefinition != null && indexDefinition.isFullTextEnabled()
+                    && indexDefinition.getVersion() == IndexFormatVersion.V1) {
+                return path;
             }
         }
         return null;


### PR DESCRIPTION
…version 1 indexes

When scanning for potentially available fulltext lucene version 1 indexes, we were opening the index nodes unnecessarily to check if the index definition supports fulltext and is version 1 or not.
This can be done simply using the IndexDefinition object and the IndexNode need not be opened (which can be a costly operation).