### PR TITLE
OAK-10775: LeaseUpdateSocketTimeoutIT still wants a mongo:4.2 image

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/LeaseUpdateSocketTimeoutIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/LeaseUpdateSocketTimeoutIT.java
@@ -55,8 +55,6 @@ public class LeaseUpdateSocketTimeoutIT {
 
     private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.6.0");
 
-    private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:4.2");
-
     private static final int MONGODB_DEFAULT_PORT = 27017;
 
     private static final int LEASE_SO_TIMEOUT = 50;
@@ -65,7 +63,7 @@ public class LeaseUpdateSocketTimeoutIT {
     public Network network = Network.newNetwork();
 
     @Rule
-    public MongoDBContainer mongoDBContainer = new MongoDBContainer(MONGODB_IMAGE)
+    public MongoDBContainer mongoDBContainer = new MongoDBContainer(MongoDockerRule.getDockerImageName())
             .withNetwork(network)
             .withNetworkAliases("mongo")
             .withExposedPorts(MONGODB_DEFAULT_PORT);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDockerRule.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDockerRule.java
@@ -132,4 +132,6 @@ public class MongoDockerRule extends ExternalResource {
     public static boolean isDockerAvailable() {
         return DOCKER_AVAILABLE;
     }
+
+    public static DockerImageName getDockerImageName() { return DOCKER_IMAGE_NAME; }
 }


### PR DESCRIPTION
Now uses the image name from MongoDockerRule.