### PR TITLE
OAK-10778 - Support downloading from Mongo in parallel. 

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexingReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexingReporter.java
@@ -20,6 +20,9 @@ package org.apache.jackrabbit.oak.plugins.index;
 
 import java.util.List;
 
+/**
+ * Stores diagnostic and performance information about indexing operations for reporting at the end of the indexing job.
+ */
 public interface IndexingReporter {
     IndexingReporter NOOP = new IndexingReporter() {
         @Override

--- a/oak-run-commons/pom.xml
+++ b/oak-run-commons/pom.xml
@@ -204,16 +204,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>toxiproxy</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- see https://issues.apache.org/jira/browse/OAK-7787 -->
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -20,6 +20,7 @@
 package org.apache.jackrabbit.oak.index.indexer.document;
 
 import com.codahale.metrics.MetricRegistry;
+import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.io.Closer;
@@ -183,6 +184,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
                         .withRootRevision(rootDocumentState.getRootRevision())
                         .withNodeStore(nodeStore)
                         .withMongoDocumentStore(getMongoDocumentStore())
+                        .withMongoClientURI(getMongoClientURI())
                         .withMongoDatabase(getMongoDatabase())
                         .withNodeStateEntryTraverserFactory(new MongoNodeStateEntryTraverserFactory(rootDocumentState.getRootRevision(),
                                 nodeStore, getMongoDocumentStore(), traversalLog))
@@ -393,6 +395,10 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
 
     private MongoDocumentStore getMongoDocumentStore() {
         return checkNotNull(indexHelper.getService(MongoDocumentStore.class));
+    }
+
+    private MongoClientURI getMongoClientURI() {
+        return checkNotNull(indexHelper.getService(MongoClientURI.class));
     }
 
     private MongoDatabase getMongoDatabase() {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -19,6 +19,7 @@
 
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
+import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -104,6 +105,7 @@ public class FlatFileNodeStoreBuilder {
     private String checkpoint;
     private StatisticsProvider statisticsProvider = StatisticsProvider.NOOP;
     private IndexingReporter indexingReporter = IndexingReporter.NOOP;
+    private MongoClientURI mongoClientURI;
 
     public enum SortStrategyType {
         /**
@@ -174,6 +176,11 @@ public class FlatFileNodeStoreBuilder {
 
     public FlatFileNodeStoreBuilder withCheckpoint(String checkpoint) {
         this.checkpoint = checkpoint;
+        return this;
+    }
+
+    public FlatFileNodeStoreBuilder withMongoClientURI(MongoClientURI mongoClientURI) {
+        this.mongoClientURI = mongoClientURI;
         return this;
     }
 
@@ -322,7 +329,7 @@ public class FlatFileNodeStoreBuilder {
                 List<PathFilter> pathFilters = indexDefinitions.stream().map(IndexDefinition::getPathFilter).collect(Collectors.toList());
                 List<String> indexNames = indexDefinitions.stream().map(IndexDefinition::getIndexName).collect(Collectors.toList());
                 indexingReporter.setIndexNames(indexNames);
-                return new PipelinedStrategy(mongoDocumentStore, mongoDatabase, nodeStore, rootRevision,
+                return new PipelinedStrategy(mongoClientURI, mongoDocumentStore, nodeStore, rootRevision,
                         preferredPathElements, blobStore, dir, algorithm, pathPredicate, pathFilters, checkpoint,
                         statisticsProvider, indexingReporter);
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadRange.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadRange.java
@@ -57,16 +57,8 @@ public final class DownloadRange {
         if (lastModifiedFrom == lastModifiedToInclusive) {
             filters.add(Filters.eq(NodeDocument.MODIFIED_IN_SECS, lastModifiedFrom));
         } else {
-            if (lastModifiedFrom == 0 && lastModifiedToInclusive == Long.MAX_VALUE) {
-                filters.add(Filters.exists(NodeDocument.MODIFIED_IN_SECS));
-            } else {
-                if (lastModifiedFrom != 0) {
-                    filters.add(Filters.gte(NodeDocument.MODIFIED_IN_SECS, lastModifiedFrom));
-                }
-                if (lastModifiedToInclusive != Long.MAX_VALUE) {
-                    filters.add(Filters.lte(NodeDocument.MODIFIED_IN_SECS, lastModifiedToInclusive));
-                }
-            }
+            filters.add(Filters.gte(NodeDocument.MODIFIED_IN_SECS, lastModifiedFrom));
+            filters.add(Filters.lte(NodeDocument.MODIFIED_IN_SECS, lastModifiedToInclusive));
         }
         if (startAfterDocumentID != null) {
             if (traversingInAscendingOrder) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadRange.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadRange.java
@@ -18,20 +18,25 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
+import com.mongodb.client.model.Filters;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
-import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
 
-final class DownloadRange {
+import java.util.ArrayList;
+
+public final class DownloadRange {
     private final long lastModifiedFrom;
-    private final long lastModifiedTo;
+    private final long lastModifiedToInclusive;
     private final String startAfterDocumentID;
+    private final boolean traversingInAscendingOrder;
 
-    public DownloadRange(long lastModifiedFrom, long lastModifiedTo, String startAfterDocumentID) {
-        if (lastModifiedTo < lastModifiedFrom) {
-            throw new IllegalArgumentException("Invalid range (" + lastModifiedFrom + ", " + lastModifiedTo + ")");
+    public DownloadRange(long lastModifiedFrom, long lastModifiedToInclusive, String startAfterDocumentID, boolean traversingInAscendingOrder) {
+        this.traversingInAscendingOrder = traversingInAscendingOrder;
+        if (!(lastModifiedFrom <= lastModifiedToInclusive)) {
+            throw new IllegalArgumentException("Invalid range (" + lastModifiedFrom + ", " + lastModifiedToInclusive + ")");
         }
         this.lastModifiedFrom = lastModifiedFrom;
-        this.lastModifiedTo = lastModifiedTo;
+        this.lastModifiedToInclusive = lastModifiedToInclusive;
         this.startAfterDocumentID = startAfterDocumentID;
     }
 
@@ -43,31 +48,42 @@ final class DownloadRange {
         return lastModifiedFrom;
     }
 
-    public long getLastModifiedTo() {
-        return lastModifiedTo;
+    public long getLastModifiedToInclusive() {
+        return lastModifiedToInclusive;
     }
 
-    public BsonDocument getFindQuery() {
-        String lastModifiedRangeQueryPart = "{$gte:" + lastModifiedFrom;
-        if (lastModifiedTo == Long.MAX_VALUE) {
-            lastModifiedRangeQueryPart += "}";
+    public Bson getFindQuery() {
+        ArrayList<Bson> filters = new ArrayList<>(3);
+        if (lastModifiedFrom == lastModifiedToInclusive) {
+            filters.add(Filters.eq(NodeDocument.MODIFIED_IN_SECS, lastModifiedFrom));
         } else {
-            lastModifiedRangeQueryPart += ", $lt:" + lastModifiedTo + "}";
+            if (lastModifiedFrom == 0 && lastModifiedToInclusive == Long.MAX_VALUE) {
+                filters.add(Filters.exists(NodeDocument.MODIFIED_IN_SECS));
+            } else {
+                if (lastModifiedFrom != 0) {
+                    filters.add(Filters.gte(NodeDocument.MODIFIED_IN_SECS, lastModifiedFrom));
+                }
+                if (lastModifiedToInclusive != Long.MAX_VALUE) {
+                    filters.add(Filters.lte(NodeDocument.MODIFIED_IN_SECS, lastModifiedToInclusive));
+                }
+            }
         }
-        String idRangeQueryPart = "";
         if (startAfterDocumentID != null) {
-            String condition = "{$gt:\"" + startAfterDocumentID + "\"}";
-            idRangeQueryPart = ", " + NodeDocument.ID + ":" + condition;
+            if (traversingInAscendingOrder) {
+                filters.add(Filters.gt(NodeDocument.ID, startAfterDocumentID));
+            } else {
+                filters.add(Filters.lt(NodeDocument.ID, startAfterDocumentID));
+            }
         }
-        return BsonDocument.parse("{" + NodeDocument.MODIFIED_IN_SECS + ":" + lastModifiedRangeQueryPart
-                + idRangeQueryPart + "}");
+        // If there is only one filter, do not wrap it in an $and
+        return filters.size() == 1 ? filters.get(0) : Filters.and(filters);
     }
 
     @Override
     public String toString() {
         return "DownloadRange{" +
                 "lastModifiedFrom=" + lastModifiedFrom +
-                ", lastModifiedTo=" + lastModifiedTo +
+                ", lastModifiedToInclusive=" + lastModifiedToInclusive +
                 ", startAfterDocumentID='" + startAfterDocumentID + '\'' +
                 '}';
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadStageStatistics.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadStageStatistics.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
- * Used to aggregate statistics when downloading from Mongo with two threads
+ * Aggregates statistics when downloading from Mongo with two threads
  */
 public class DownloadStageStatistics {
     public static final Logger LOG = LoggerFactory.getLogger(DownloadStageStatistics.class);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadStageStatistics.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/DownloadStageStatistics.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import org.apache.jackrabbit.oak.commons.IOUtils;
+import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
+import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;
+import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;
+import org.apache.jackrabbit.oak.plugins.index.MetricsUtils;
+import org.apache.jackrabbit.oak.stats.StatisticsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Used to aggregate statistics when downloading from Mongo with two threads
+ */
+public class DownloadStageStatistics {
+    public static final Logger LOG = LoggerFactory.getLogger(DownloadStageStatistics.class);
+
+    private final LongAdder totalEnqueueWaitTimeMillis = new LongAdder();
+    private final LongAdder documentsDownloadedTotal = new LongAdder();
+    private final LongAdder documentsDownloadedTotalBytes = new LongAdder();
+
+
+    public long getTotalEnqueueWaitTimeMillis() {
+        return totalEnqueueWaitTimeMillis.sum();
+    }
+
+    public long getDocumentsDownloadedTotal() {
+        return documentsDownloadedTotal.sum();
+    }
+
+    public long getDocumentsDownloadedTotalBytes() {
+        return documentsDownloadedTotalBytes.sum();
+    }
+
+    public void incrementTotalEnqueueWaitTimeMillis(long millis) {
+        this.totalEnqueueWaitTimeMillis.add(millis);
+    }
+
+    public void incrementDocumentsDownloadedTotal() {
+        this.documentsDownloadedTotal.increment();
+    }
+
+    public void incrementDocumentsDownloadedTotalBytes(long bytes) {
+        this.documentsDownloadedTotalBytes.add(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return MetricsFormatter.newBuilder()
+                .add("totalEnqueueWaitTimeMillis", getTotalEnqueueWaitTimeMillis())
+                .add("documentsDownloadedTotal", getDocumentsDownloadedTotal())
+                .add("documentsDownloadedTotalBytes", getDocumentsDownloadedTotalBytes())
+                .build();
+    }
+
+    public void publishStatistics(StatisticsProvider statisticsProvider, IndexingReporter reporter, long durationMillis) {
+        LOG.info("Publishing download stage statistics");
+        MetricsUtils.addMetric(statisticsProvider, reporter,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_DURATION_SECONDS, durationMillis / 1000);
+        MetricsUtils.addMetric(statisticsProvider, reporter,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL, getDocumentsDownloadedTotal());
+        MetricsUtils.addMetric(statisticsProvider, reporter,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_ENQUEUE_DELAY_PERCENTAGE,
+                PipelinedUtils.toPercentage(getTotalEnqueueWaitTimeMillis(), durationMillis)
+        );
+        MetricsUtils.addMetricByteSize(statisticsProvider, reporter,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL_BYTES,
+                getDocumentsDownloadedTotalBytes());
+    }
+
+    public String formatStats(long durationMillis) {
+        String enqueueingDelayPercentage = PipelinedUtils.formatAsPercentage(getTotalEnqueueWaitTimeMillis(), durationMillis);
+        long durationSeconds = durationMillis / 1000;
+        return MetricsFormatter.newBuilder()
+                .add("duration", FormattingUtils.formatToSeconds(durationSeconds))
+                .add("durationSeconds", durationSeconds)
+                .add("documentsDownloaded", getDocumentsDownloadedTotal())
+                .add("documentsDownloadedTotalBytes", getDocumentsDownloadedTotalBytes())
+                .add("dataDownloaded", IOUtils.humanReadableByteCountBin(getDocumentsDownloadedTotalBytes()))
+                .add("enqueueingDelayMillis", getTotalEnqueueWaitTimeMillis())
+                .add("enqueueingDelayPercentage", enqueueingDelayPercentage)
+                .build();
+    }
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
@@ -150,13 +150,11 @@ class MongoDownloaderRegexUtils {
         TreeSet<String> ancestors = new TreeSet<>();
         for (String child : paths) {
             String parent = child;
-            while (true) {
+            while (!PathUtils.denotesRoot(parent)) {
                 ancestors.add(parent);
-                if (PathUtils.denotesRoot(parent)) {
-                    break;
-                }
                 parent = PathUtils.getParentPath(parent);
             }
+            ancestors.add(parent); // add the root path as well
         }
         return new ArrayList<>(ancestors);
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
@@ -1,0 +1,152 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import com.mongodb.client.model.Filters;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.plugins.document.util.Utils;
+import org.bson.conversions.Bson;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+class MongoDownloaderRegexUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class);
+
+    final static Pattern LONG_PATH_ID_PATTERN = Pattern.compile("^[0-9]{1,3}:h");
+
+    /**
+     * Creates the filter to be used in the Mongo query
+     *
+     * @param mongoFilterPaths          The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
+     *                                  (see {@link MongoRegexPathFilterFactory.MongoFilterPaths} for details)
+     * @param customExcludeEntriesRegex Documents with paths matching this regex are excluded from download
+     * @return The filter to be used in the Mongo query, or null if no filter is required
+     */
+    static Bson computeMongoQueryFilter(@NotNull MongoRegexPathFilterFactory.MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex) {
+        var filters = new ArrayList<Bson>();
+
+        List<Pattern> includedPatterns = compileIncludedDirectoriesRegex(mongoFilterPaths.included);
+        if (!includedPatterns.isEmpty()) {
+            // The conditions above on the _id field is not enough to match all JCR nodes in the given paths because nodes
+            // with paths longer than a certain threshold, are represented by Mongo documents where the _id field is replaced
+            // by a hash and the full path is stored in an additional field _path. To retrieve these long path documents,
+            // we could add a condition on the _path field, but this would slow down substantially scanning the DB, because
+            // the _path field is not part of the index used by this query (it's an index on _modified, _id). Therefore,
+            // Mongo would have to retrieve every document from the column store to evaluate the filter condition. So instead
+            // we add below a condition to download all the long path documents. These documents can be identified by the
+            // format of the _id field (<n>:h<hash>), so it is possible to identify them using only the index.
+            // This might download documents for nodes that are not in the included paths, but those documents will anyway
+            // be filtered in the transform stage. And in most repositories, the number of long path documents is very small,
+            // often there are none, so the extra documents downloaded will not slow down by much the download. However, the
+            // performance gains of evaluating the filter of the query using only the index are very significant, especially
+            // when the index requires only a small number of nodes.
+            var patternsWithLongPathInclude = new ArrayList<>(includedPatterns);
+            patternsWithLongPathInclude.add(LONG_PATH_ID_PATTERN);
+            filters.add(Filters.in(NodeDocument.ID, patternsWithLongPathInclude));
+        }
+
+        // The Mongo filter returned here will download the top level path of each excluded subtree, which in theory
+        // should be excluded. That is, if the tree /a/b/c is excluded, the filter will download /a/b/c but none of
+        // its descendants.
+        // This is done because excluding also the top level path would add extra complexity to the filter and
+        // would not have any measurable impact on performance because it only downloads a few extra documents, one
+        // for each excluded subtree. The transform stage will anyway filter out these paths.
+        List<Pattern> filterPatterns = compileExcludedDirectoriesRegex(mongoFilterPaths.excluded);
+        filterPatterns.forEach(p -> filters.add(Filters.regex(NodeDocument.ID, p)));
+
+        Pattern customRegexExcludePattern = compileCustomExcludedPatterns(customExcludeEntriesRegex);
+        if (customRegexExcludePattern != null) {
+            filters.add(Filters.regex(NodeDocument.ID, customRegexExcludePattern));
+        }
+
+        if (filters.isEmpty()) {
+            return null;
+        } else if (filters.size() == 1) {
+            return filters.get(0);
+        } else {
+            return Filters.and(filters);
+        }
+    }
+
+    private static List<Pattern> compileIncludedDirectoriesRegex(List<String> includedPaths) {
+        return compileDirectoryRegex(includedPaths, false);
+    }
+
+    private static List<Pattern> compileExcludedDirectoriesRegex(List<String> excludedPaths) {
+        return compileDirectoryRegex(excludedPaths, true);
+    }
+
+    private static List<Pattern> compileDirectoryRegex(List<String> paths, boolean negate) {
+        if (paths.isEmpty()) {
+            return List.of();
+        }
+        if (paths.size() == 1 && paths.get(0).equals("/")) {
+            return List.of();
+        }
+        ArrayList<Pattern> patterns = new ArrayList<>();
+        for (String path : paths) {
+            if (!path.endsWith("/")) {
+                path = path + "/";
+            }
+            String regex = "^[0-9]{1,3}:" + Pattern.quote(path);
+            Pattern pattern;
+            if (negate) {
+                pattern = compileExcludedDirectoryRegex(regex);
+            } else {
+                pattern = Pattern.compile(regex);
+            }
+            patterns.add(pattern);
+        }
+        return patterns;
+    }
+
+    static Pattern compileExcludedDirectoryRegex(String regex) {
+        // https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex
+        return Pattern.compile("^(?!" + regex + ")");
+    }
+
+    static Pattern compileCustomExcludedPatterns(String customRegexPattern) {
+        if (customRegexPattern == null || customRegexPattern.trim().isEmpty()) {
+            LOG.info("Mongo custom regex is disabled");
+            return null;
+        } else {
+            LOG.info("Excluding nodes with paths matching regex: {}", customRegexPattern);
+            var negatedRegex = "^(?!.*(" + customRegexPattern + ")$)";
+            return Pattern.compile(negatedRegex);
+        }
+    }
+
+    /**
+     * Returns all the ancestors paths of the given list of paths. That is, if the list is ["/a/b/c", "/a/b/d"],
+     * this method will return ["/", "/a", "/a/b", "/a/b/c", "/a/b/d"]. Note that the paths on the input list are also
+     * returned, even though they are not strictly ancestors of themselves.
+     */
+    static List<String> getAncestors(List<String> paths) {
+        TreeSet<String> ancestors = new TreeSet<>();
+        for (String child : paths) {
+            String parent = child;
+            while (true) {
+                ancestors.add(parent);
+                if (PathUtils.denotesRoot(parent)) {
+                    break;
+                }
+                parent = PathUtils.getParentPath(parent);
+            }
+        }
+        return new ArrayList<>(ancestors);
+    }
+
+
+    static Bson ancestorsFilter(List<String> paths) {
+        List<String> parentFilters = getAncestors(paths).stream()
+                .map(Utils::getIdFromPath)
+                .collect(Collectors.toList());
+        return Filters.in(NodeDocument.ID, parentFilters);
+    }
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
@@ -146,6 +146,7 @@ class MongoDownloaderRegexUtils {
      * returned, even though they are not strictly ancestors of themselves.
      */
     static List<String> getAncestors(List<String> paths) {
+        // Use a TreeSet to remove duplicates and sort them
         TreeSet<String> ancestors = new TreeSet<>();
         for (String child : paths) {
             String parent = child;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoDownloaderRegexUtils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import com.mongodb.client.model.Filters;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Coordinates the two parallel download streams used to download from Mongo when parallelDump is enabled. One stream
  * downloads in ascending order the other in descending order. This class keeps track of the top limit of the ascending
- * stream and of the bottom limit of the descending stream, and determines if the streams have crossed. This indidcates
+ * stream and of the bottom limit of the descending stream, and determines if the streams have crossed. This indicates
  * that the download completed and the two threads should stop.
  */
 class MongoParallelDownloadCoordinator {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
@@ -1,0 +1,112 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Coordinates the two parallel download streams used to download from Mongo when parallelDump is enabled. One stream
+ * downloads in ascending order the other in descending order. This class keeps track of the top limit of the ascending
+ * stream and of the bottom limit of the descending stream, and determines if the streams have crossed. This indidcates
+ * that the download completed and the two threads should stop.
+ */
+class MongoParallelDownloadCoordinator {
+
+    static class DownloadPosition implements Comparable<DownloadPosition> {
+        final long lastModified;
+        final String lastId;
+
+        public DownloadPosition(long lastModified, String lastId) {
+            this.lastModified = lastModified;
+            this.lastId = lastId;
+        }
+
+        @Override
+        public int compareTo(@NotNull DownloadPosition o) {
+            int lastModifiedComparison = Long.compare(lastModified, o.lastModified);
+            if (lastModifiedComparison != 0) {
+                return lastModifiedComparison;
+            } else {
+                return lastId.compareTo(o.lastId);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "DownloadPosition{" +
+                    "lastModified=" + lastModified +
+                    ", lastId='" + lastId + '\'' +
+                    '}';
+        }
+    }
+
+    private DownloadPosition lowerRangeTop = new DownloadPosition(0, null);
+    private DownloadPosition upperRangeBottom = new DownloadPosition(Long.MAX_VALUE, null);
+
+    public DownloadPosition getUpperRangeBottom() {
+        return upperRangeBottom;
+    }
+
+    public DownloadPosition getLowerRangeTop() {
+        return lowerRangeTop;
+    }
+
+    /**
+     * Extends the lower range of downloaded documents with the documents in the given batch and returns the index of
+     * the first/lowest document in this batch that was already downloaded by the descending download thread.
+     * <p>
+     * That is, if this method returns i, then the documents in the range batch[0:i) were not yet downloaded by the
+     * descending downloader, but batch[i] and above were already downloaded. The following are degenerate cases:
+     * <p>
+     * If i==0 then all documents of this batch were already downloaded. That is, b[0] >= upperRangeBottom.
+     * If i==sizeOfBatch then none of the documents were downloaded. That is, b[sizeOfBatch-i] < upperRangeBottom.
+     * <p>
+     * <p>
+     * The batch must be in ascending order of (_modified, _id).
+     * <p>
+     * Updates the lower range top to b[i].
+     */
+    public synchronized int extendLowerRange(NodeDocument[] batch, int sizeOfBatch) {
+        // batch must be in ascending order
+        int i = sizeOfBatch - 1;
+        // Start by the highest value in the range and compare it with the bottom of the upper range.
+        while (i >= 0) {
+            var bi = new DownloadPosition(batch[i].getModified(), batch[i].getId());
+            if (bi.compareTo(upperRangeBottom) < 0) {
+                // batch[i] < upperRangeLowerLimit. Can add this element
+                this.lowerRangeTop = bi;
+                return i + 1;
+            }
+            // batch[i] >= lowerRangeTop, so it was already downloaded. Keep going down on this batch, trying to find
+            // an element that was not yet downloaded
+            i--;
+        }
+
+        // The whole batch block was already downloaded as part of the upper range
+        return 0;
+    }
+
+    public synchronized int extendUpperRange(NodeDocument[] batch, int sizeOfBatch) {
+        // batch must be in descending order
+        int i = sizeOfBatch - 1;
+        // Find the highest value in the batch that is not yet on the upper range of values downloaded
+        while (i >= 0) {
+            var bi = new DownloadPosition(batch[i].getModified(), batch[i].getId());
+            if (bi.compareTo(lowerRangeTop) > 0) {
+                // batch[i] > upperRangeLowerLimit. Can add this element
+                upperRangeBottom = bi;
+                return i + 1;
+            }
+            i--;
+        }
+        // The whole batch block was already downloaded as part of the upper range
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return "MongoParallelDownloadCoordinator{" +
+                "lowerRangeTop=" + lowerRangeTop +
+                ", upperRangeBottom=" + upperRangeBottom +
+                '}';
+    }
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinator.java
@@ -82,6 +82,8 @@ class MongoParallelDownloadCoordinator {
      * The batch must be in ascending order of (_modified, _id).
      * <p>
      * Updates the lower range top to b[i].
+     *
+     * @param batch The batch of documents to be added to the lower range, must be in ascending order
      */
     public synchronized int extendLowerRange(NodeDocument[] batch, int sizeOfBatch) {
         // batch must be in ascending order
@@ -103,6 +105,12 @@ class MongoParallelDownloadCoordinator {
         return 0;
     }
 
+    /**
+     * Extends the upper range of downloaded documents with the documents in the given batch and returns the index of
+     * the first/highest document in this batch that was already downloaded by the ascending download thread.
+     *
+     * @param batch The batch of documents to be added to the upper range, must be in descending order
+     */
     public synchronized int extendUpperRange(NodeDocument[] batch, int sizeOfBatch) {
         // batch must be in descending order
         int i = sizeOfBatch - 1;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoRegexPathFilterFactory.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoRegexPathFilterFactory.java
@@ -170,9 +170,9 @@ public class MongoRegexPathFilterFactory {
             return indexExcludedPaths;
         }
 
-        var excludedUnion = new HashSet<>(indexExcludedPaths);
+        HashSet<String> excludedUnion = new HashSet<>(indexExcludedPaths);
         excludedUnion.addAll(customExcludedPaths);
-        var mergedExcludes = new ArrayList<String>();
+        ArrayList<String> mergedExcludes = new ArrayList<>();
         for (String testPath : excludedUnion) {
             // Add a path only if it is not a subpath of any other path in the list
             if (excludedUnion.stream().noneMatch(p -> PathUtils.isAncestor(p, testPath))) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -18,59 +18,63 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoClientURI;
 import com.mongodb.MongoException;
 import com.mongodb.MongoIncompatibleDriverException;
 import com.mongodb.MongoInterruptedException;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
 import org.apache.jackrabbit.guava.common.base.Preconditions;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
+import org.apache.jackrabbit.guava.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.MongoRegexPathFilterFactory.MongoFilterPaths;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.util.Utils;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStoreHelper;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
-import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;
 import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;
-import org.apache.jackrabbit.oak.plugins.index.MetricsUtils;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.mongodb.client.model.Sorts.ascending;
-
 public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownloadTask.Result> {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class);
+
+    private static final Logger TRAVERSAL_LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class.getName() + ".traversal");
 
     public static class Result {
         private final long documentsDownloaded;
@@ -84,7 +88,20 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
     }
 
-    private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class);
+    private static class RetryException extends RuntimeException {
+
+        private final int retrialDurationSeconds;
+
+        public RetryException(int retrialDurationSeconds, String message, Throwable cause) {
+            super(message, cause);
+            this.retrialDurationSeconds = retrialDurationSeconds;
+        }
+
+        @Override
+        public String toString() {
+            return "Tried for " + retrialDurationSeconds + " seconds: \n" + super.toString();
+        }
+    }
 
     /**
      * Whether to retry on connection errors to MongoDB.
@@ -134,192 +151,67 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     public static final String OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDED_PATHS = "oak.indexer.pipelined.mongoCustomExcludedPaths";
     public static final String DEFAULT_OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDED_PATHS = "";
 
+    /**
+     * Whether to download in parallel from Mongo with two streams, one per each secondary.
+     * This applies only if Mongo is a cluster with two secondaries.
+     * One thread downloads in ascending order of (_modified, _id) and the other in descending order, until they cross.
+     * This feature requires that the retryOnConnectionErrors property is set to true, because it relies on downloading
+     * in a given order (if retryOnConnectionErrors is false, the download is done in natural order, that is, it is
+     * undefined).
+     */
+    public static final String OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP = "oak.indexer.pipelined.mongoParallelDump";
+    public static final boolean DEFAULT_OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP = false;
+
     // Use a short initial retry interval. In most cases if the connection to a replica fails, there will be other
     // replicas available so a reconnection attempt will succeed immediately.
-    private final static long retryInitialIntervalMillis = 100;
-    private final static long retryMaxIntervalMillis = 10_000;
+    private static final long retryInitialIntervalMillis = 100;
+    private static final long retryMaxIntervalMillis = 10_000;
 
     // TODO: Revise this timeout. It is used to prevent the indexer from blocking forever if the queue is full.
     private static final Duration MONGO_QUEUE_OFFER_TIMEOUT = Duration.ofMinutes(30);
     private static final int MIN_INTERVAL_BETWEEN_DELAYED_ENQUEUING_MESSAGES = 10;
-    private final static BsonDocument NATURAL_HINT = BsonDocument.parse("{ $natural: 1 }");
-    private final static BsonDocument ID_INDEX_HINT = BsonDocument.parse("{ _id: 1 }");
-    final static Pattern LONG_PATH_ID_PATTERN = Pattern.compile("^[0-9]{1,3}:h");
+    private static final BsonDocument NATURAL_HINT = BsonDocument.parse("{ $natural: 1 }");
+    private static final BsonDocument ID_INDEX_HINT = BsonDocument.parse("{ _id: 1 }");
 
-    private static final String THREAD_NAME = "mongo-dump";
-
-    /**
-     * Creates the filter to be used in the Mongo query
-     *
-     * @param mongoFilterPaths          The paths to be included/excluded in the filter. These define subtrees to be included or excluded.
-     *                                  (see {@link MongoFilterPaths} for details)
-     * @param customExcludeEntriesRegex Documents with paths matching this regex are excluded from download
-     * @return The filter to be used in the Mongo query, or null if no filter is required
-     */
-    static Bson computeMongoQueryFilter(@NotNull MongoFilterPaths mongoFilterPaths, String customExcludeEntriesRegex) {
-        var filters = new ArrayList<Bson>();
-
-        List<Pattern> includedPatterns = compileIncludedDirectoriesRegex(mongoFilterPaths.included);
-        if (!includedPatterns.isEmpty()) {
-            // The conditions above on the _id field is not enough to match all JCR nodes in the given paths because nodes
-            // with paths longer than a certain threshold, are represented by Mongo documents where the _id field is replaced
-            // by a hash and the full path is stored in an additional field _path. To retrieve these long path documents,
-            // we could add a condition on the _path field, but this would slow down substantially scanning the DB, because
-            // the _path field is not part of the index used by this query (it's an index on _modified, _id). Therefore,
-            // Mongo would have to retrieve every document from the column store to evaluate the filter condition. So instead
-            // we add below a condition to download all the long path documents. These documents can be identified by the
-            // format of the _id field (<n>:h<hash>), so it is possible to identify them using only the index.
-            // This might download documents for nodes that are not in the included paths, but those documents will anyway
-            // be filtered in the transform stage. And in most repositories, the number of long path documents is very small,
-            // often there are none, so the extra documents downloaded will not slow down by much the download. However, the
-            // performance gains of evaluating the filter of the query using only the index are very significant, especially
-            // when the index requires only a small number of nodes.
-            var patternsWithLongPathInclude = new ArrayList<>(includedPatterns);
-            patternsWithLongPathInclude.add(LONG_PATH_ID_PATTERN);
-            filters.add(Filters.in(NodeDocument.ID, patternsWithLongPathInclude));
-        }
-
-        // The Mongo filter returned here will download the top level path of each excluded subtree, which in theory
-        // should be excluded. That is, if the tree /a/b/c is excluded, the filter will download /a/b/c but none of
-        // its descendants.
-        // This is done because excluding also the top level path would add extra complexity to the filter and
-        // would not have any measurable impact on performance because it only downloads a few extra documents, one
-        // for each excluded subtree. The transform stage will anyway filter out these paths.
-        List<Pattern> filterPatterns = compileExcludedDirectoriesRegex(mongoFilterPaths.excluded);
-        filterPatterns.forEach(p -> filters.add(Filters.regex(NodeDocument.ID, p)));
-
-        Pattern customRegexExcludePattern = compileCustomExcludedPatterns(customExcludeEntriesRegex);
-        if (customRegexExcludePattern != null) {
-            filters.add(Filters.regex(NodeDocument.ID, customRegexExcludePattern));
-        }
-
-        if (filters.isEmpty()) {
-            return null;
-        } else if (filters.size() == 1) {
-            return filters.get(0);
-        } else {
-            return Filters.and(filters);
-        }
-    }
-
-    private static List<Pattern> compileIncludedDirectoriesRegex(List<String> includedPaths) {
-        return compileDirectoryRegex(includedPaths, false);
-    }
-
-    private static List<Pattern> compileExcludedDirectoriesRegex(List<String> excludedPaths) {
-        return compileDirectoryRegex(excludedPaths, true);
-    }
-
-    private static List<Pattern> compileDirectoryRegex(List<String> paths, boolean negate) {
-        if (paths.isEmpty()) {
-            return List.of();
-        }
-        if (paths.size() == 1 && paths.get(0).equals("/")) {
-            return List.of();
-        }
-        ArrayList<Pattern> patterns = new ArrayList<>();
-        for (String path : paths) {
-            if (!path.endsWith("/")) {
-                path = path + "/";
-            }
-            String regex = "^[0-9]{1,3}:" + Pattern.quote(path);
-            Pattern pattern;
-            if (negate) {
-                pattern = compileExcludedDirectoryRegex(regex);
-            } else {
-                pattern = Pattern.compile(regex);
-            }
-            patterns.add(pattern);
-        }
-        return patterns;
-    }
-
-    static Pattern compileExcludedDirectoryRegex(String regex) {
-        // https://stackoverflow.com/questions/1240275/how-to-negate-specific-word-in-regex
-        return Pattern.compile("^(?!" + regex + ")");
-    }
-
-    static Pattern compileCustomExcludedPatterns(String customRegexPattern) {
-        if (customRegexPattern == null || customRegexPattern.trim().isEmpty()) {
-            LOG.info("Mongo custom regex is disabled");
-            return null;
-        } else {
-            LOG.info("Excluding nodes with paths matching regex: {}", customRegexPattern);
-            var negatedRegex = "^(?!.*(" + customRegexPattern + ")$)";
-            return Pattern.compile(negatedRegex);
-        }
-    }
-
-    /**
-     * Returns all the ancestors paths of the given list of paths. That is, if the list is ["/a/b/c", "/a/b/d"],
-     * this method will return ["/", "/a", "/a/b", "/a/b/c", "/a/b/d"]. Note that the paths on the input list are also
-     * returned, even though they are not strictly ancestors of themselves.
-     */
-    static List<String> getAncestors(List<String> paths) {
-        TreeSet<String> ancestors = new TreeSet<>();
-        for (String child : paths) {
-            String parent = child;
-            while (true) {
-                ancestors.add(parent);
-                if (PathUtils.denotesRoot(parent)) {
-                    break;
-                }
-                parent = PathUtils.getParentPath(parent);
-            }
-        }
-        return new ArrayList<>(ancestors);
-    }
+    static final String THREAD_NAME_PREFIX = "mongo-dump";
 
 
-    private static Bson ancestorsFilter(List<String> paths) {
-        List<String> parentFilters = getAncestors(paths).stream()
-                .map(Utils::getIdFromPath)
-                .collect(Collectors.toList());
-        return Filters.in(NodeDocument.ID, parentFilters);
-    }
-
+    private final MongoClientURI mongoClientURI;
+    private final MongoDocumentStore docStore;
+    private final int maxBatchSizeBytes;
     private final int maxBatchNumberOfDocuments;
     private final BlockingQueue<NodeDocument[]> mongoDocQueue;
     private final List<PathFilter> pathFilters;
+    private final StatisticsProvider statisticsProvider;
+    private final IndexingReporter reporter;
+
     private final int retryDuringSeconds;
     private final boolean retryOnConnectionErrors;
     private final boolean regexPathFiltering;
-    private final Logger traversalLog = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class.getName() + ".traversal");
-    private final MongoCollection<NodeDocument> dbCollection;
-    private final ReadPreference readPreference;
-    private final Stopwatch downloadStartWatch = Stopwatch.createUnstarted();
-    private final int maxBatchSizeBytes;
-    private final StatisticsProvider statisticsProvider;
-    private final IndexingReporter reporter;
-    private final MongoRegexPathFilterFactory regexPathFilterFactory;
     private final String customExcludeEntriesRegex;
     private final List<String> customExcludedPaths;
+    private final boolean parallelDump;
+    private final MongoRegexPathFilterFactory regexPathFilterFactory;
 
-    private long totalEnqueueWaitTimeMillis = 0;
+    private MongoCollection<NodeDocument> dbCollection;
+    private PipelinedMongoServerSelector mongoServerSelector;
+    private final Stopwatch downloadStartWatch = Stopwatch.createUnstarted();
+    private final DownloadStageStatistics downloadStageStatistics = new DownloadStageStatistics();
     private Instant lastDelayedEnqueueWarningMessageLoggedTimestamp = Instant.now();
-    private long documentsDownloadedTotal = 0;
-    private long documentsDownloadedTotalBytes = 0;
-    private long nextLastModified = 0;
-    private String lastIdDownloaded = null;
+    private MongoParallelDownloadCoordinator mongoParallelDownloadCoordinator;
 
-    public PipelinedMongoDownloadTask(MongoDatabase mongoDatabase,
-                                      MongoDocumentStore mongoDocStore,
+    public PipelinedMongoDownloadTask(MongoClientURI mongoClientURI,
+                                      MongoDocumentStore docStore,
                                       int maxBatchSizeBytes,
                                       int maxBatchNumberOfDocuments,
                                       BlockingQueue<NodeDocument[]> queue,
                                       List<PathFilter> pathFilters,
                                       StatisticsProvider statisticsProvider,
                                       IndexingReporter reporter) {
+        this.mongoClientURI = mongoClientURI;
+        this.docStore = docStore;
         this.statisticsProvider = statisticsProvider;
         this.reporter = reporter;
-        NodeDocumentCodecProvider nodeDocumentCodecProvider = new NodeDocumentCodecProvider(mongoDocStore, Collection.NODES);
-        CodecRegistry nodeDocumentCodecRegistry = CodecRegistries.fromRegistries(
-                CodecRegistries.fromProviders(nodeDocumentCodecProvider),
-                MongoClientSettings.getDefaultCodecRegistry()
-        );
-        this.dbCollection = mongoDatabase
-                .withCodecRegistry(nodeDocumentCodecRegistry)
-                .getCollection(Collection.NODES.toString(), NodeDocument.class);
         this.maxBatchSizeBytes = maxBatchSizeBytes;
         this.maxBatchNumberOfDocuments = maxBatchNumberOfDocuments;
         this.mongoDocQueue = queue;
@@ -349,6 +241,15 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         this.reporter.addConfig(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING_MAX_PATHS, String.valueOf(regexPathFilteringMaxNumberOfPaths));
         this.regexPathFilterFactory = new MongoRegexPathFilterFactory(regexPathFilteringMaxNumberOfPaths);
 
+        var parallelDumpConfig = ConfigHelper.getSystemPropertyAsBoolean(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP, DEFAULT_OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP);
+        if (parallelDumpConfig && !retryOnConnectionErrors) {
+            LOG.warn("Parallel dump requires " + OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS + " to be set to true, but it is false. Disabling parallel dump.");
+            this.parallelDump = false;
+        } else {
+            this.parallelDump = parallelDumpConfig;
+        }
+        this.reporter.addConfig(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP, String.valueOf(parallelDump));
+
         this.customExcludeEntriesRegex = ConfigHelper.getSystemPropertyAsString(
                 OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDE_ENTRIES_REGEX,
                 DEFAULT_OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDE_ENTRIES_REGEX
@@ -377,79 +278,114 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             throw new IllegalArgumentException("Invalid paths in " + OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDED_PATHS + " " +
                     " system property: " + invalidPaths + ". Paths must be valid, must be absolute and must not be the root.");
         }
-
-        //TODO This may lead to reads being routed to secondary depending on MongoURI
-        //So caller must ensure that its safe to read from secondary
-//        this.readPreference = MongoDocumentStoreHelper.getConfiguredReadPreference(mongoStore, collection);
-        this.readPreference = ReadPreference.secondaryPreferred();
-        LOG.info("maxBatchSizeBytes: {}, maxBatchNumberOfDocuments: {}, readPreference: {}",
-                maxBatchSizeBytes, maxBatchNumberOfDocuments, readPreference.getName());
     }
 
     @Override
     public Result call() throws Exception {
         String originalName = Thread.currentThread().getName();
-        Thread.currentThread().setName(THREAD_NAME);
-        LOG.info("[TASK:{}:START] Starting to download from MongoDB", THREAD_NAME.toUpperCase(Locale.ROOT));
+        Thread.currentThread().setName(THREAD_NAME_PREFIX);
         try {
-            this.nextLastModified = 0;
-            this.lastIdDownloaded = null;
+            // When downloading in parallel, we must create the connection to Mongo using a custom instance of ServerSelector
+            // instead of using the default policy defined by readPreference configuration setting.
+            // Here we create the configuration that is common to the two cases (parallelDump true or false).
+            NodeDocumentCodecProvider nodeDocumentCodecProvider = new NodeDocumentCodecProvider(docStore, Collection.NODES);
+            CodecRegistry nodeDocumentCodecRegistry = CodecRegistries.fromRegistries(
+                    CodecRegistries.fromProviders(nodeDocumentCodecProvider),
+                    MongoClientSettings.getDefaultCodecRegistry()
+            );
 
-            downloadStartWatch.start();
-            if (retryOnConnectionErrors) {
-                downloadWithRetryOnConnectionErrors();
+            MongoClientSettings.Builder settingsBuilder = MongoClientSettings.builder()
+                    .applyConnectionString(new ConnectionString(mongoClientURI.getURI()))
+                    .readPreference(ReadPreference.secondaryPreferred());
+            if (parallelDump) {
+                // Set a custom server selector that is able to distribute the two connections between the two secondaries.
+                // Overrides the readPreference setting. We also need to listen for changes in the cluster to detect
+                // when a node is promoted to primary, so we can stop downloading from that node
+                this.mongoServerSelector = new PipelinedMongoServerSelector();
+                settingsBuilder.applyToClusterSettings(builder -> builder
+                        .serverSelector(mongoServerSelector)
+                        .addClusterListener(mongoServerSelector)
+                );
+                // Shared object between the two download threads to store the last document download by either of them
+                // and determine when the two downloads have crossed
+                this.mongoParallelDownloadCoordinator = new MongoParallelDownloadCoordinator();
             } else {
-                downloadWithNaturalOrdering();
+                this.mongoParallelDownloadCoordinator = null;
+                this.mongoServerSelector = null;
             }
 
-            long durationMillis = downloadStartWatch.elapsed(TimeUnit.MILLISECONDS);
-            String enqueueingDelayPercentage = PipelinedUtils.formatAsPercentage(totalEnqueueWaitTimeMillis, durationMillis);
-            String metrics = MetricsFormatter.newBuilder()
-                    .add("duration", FormattingUtils.formatToSeconds(downloadStartWatch))
-                    .add("durationSeconds", durationMillis / 1000)
-                    .add("documentsDownloaded", documentsDownloadedTotal)
-                    .add("documentsDownloadedTotalBytes", documentsDownloadedTotalBytes)
-                    .add("dataDownloaded", IOUtils.humanReadableByteCountBin(documentsDownloadedTotalBytes))
-                    .add("enqueueingDelayMillis", totalEnqueueWaitTimeMillis)
-                    .add("enqueueingDelayPercentage", enqueueingDelayPercentage)
-                    .build();
-            MetricsUtils.addMetric(statisticsProvider, reporter, PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_DURATION_SECONDS, durationMillis / 1000);
-            MetricsUtils.addMetric(statisticsProvider, reporter, PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL, documentsDownloadedTotal);
-            MetricsUtils.addMetric(statisticsProvider, reporter, PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_ENQUEUE_DELAY_PERCENTAGE,
-                    PipelinedUtils.toPercentage(totalEnqueueWaitTimeMillis, durationMillis)
-            );
-            MetricsUtils.addMetricByteSize(statisticsProvider, reporter, PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL_BYTES,
-                    documentsDownloadedTotalBytes);
-            LOG.info("[TASK:{}:END] Metrics: {}", THREAD_NAME.toUpperCase(Locale.ROOT), metrics);
-            reporter.addTiming("Mongo dump", FormattingUtils.formatToSeconds(downloadStartWatch));
-            return new Result(documentsDownloadedTotal);
-        } catch (InterruptedException t) {
-            LOG.warn("Thread interrupted", t);
-            throw t;
-        } catch (Throwable t) {
-            LOG.warn("Thread terminating with exception.", t);
-            throw t;
+            String mongoDatabaseName = MongoDocumentStoreHelper.getMongoDatabaseName(docStore);
+            try (MongoClient client = MongoClients.create(settingsBuilder.build())) {
+                MongoDatabase mongoDatabase = client.getDatabase(mongoDatabaseName);
+                this.dbCollection = mongoDatabase
+                        .withCodecRegistry(nodeDocumentCodecRegistry)
+                        .getCollection(Collection.NODES.toString(), NodeDocument.class);
+
+                LOG.info("[TASK:{}:START] Starting to download from MongoDB", Thread.currentThread().getName().toUpperCase(Locale.ROOT));
+                try {
+                    downloadStartWatch.start();
+                    if (retryOnConnectionErrors) {
+                        downloadWithRetryOnConnectionErrors();
+                    } else {
+                        downloadWithNaturalOrdering();
+                    }
+                    downloadStartWatch.stop();
+                    long durationMillis = downloadStartWatch.elapsed(TimeUnit.MILLISECONDS);
+                    downloadStageStatistics.publishStatistics(statisticsProvider, reporter, durationMillis);
+                    String metrics = downloadStageStatistics.formatStats(durationMillis);
+                    LOG.info("[TASK:{}:END] Metrics: {}", Thread.currentThread().getName().toUpperCase(Locale.ROOT), metrics);
+                    reporter.addTiming("Mongo dump", FormattingUtils.formatToSeconds(downloadStartWatch));
+                    return new PipelinedMongoDownloadTask.Result(downloadStageStatistics.getDocumentsDownloadedTotal());
+                } catch (InterruptedException t) {
+                    LOG.warn("Thread interrupted", t);
+                    throw t;
+                } catch (Throwable t) {
+                    LOG.warn("Thread terminating with exception.", t);
+                    throw t;
+                }
+            }
         } finally {
             Thread.currentThread().setName(originalName);
         }
     }
 
-    private void reportProgress(String id) {
-        if (this.documentsDownloadedTotal % 10000 == 0) {
-            double rate = ((double) this.documentsDownloadedTotal) / downloadStartWatch.elapsed(TimeUnit.SECONDS);
-            String formattedRate = String.format(Locale.ROOT, "%1.2f nodes/s, %1.2f nodes/hr", rate, rate * 3600);
-            LOG.info("Dumping from NSET Traversed #{} {} [{}] (Elapsed {})",
-                    this.documentsDownloadedTotal, id, formattedRate, FormattingUtils.formatToSeconds(downloadStartWatch));
+    private void downloadWithNaturalOrdering() throws InterruptedException, TimeoutException {
+        LOG.info("Downloading with natural order");
+        // We are downloading potentially a large fraction of the repository, so using an index scan will be
+        // inefficient. So we pass the natural hint to force MongoDB to use natural ordering, that is, column scan
+        MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
+        Bson mongoFilter = MongoDownloaderRegexUtils.computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
+
+        if (mongoFilter == null) {
+            LOG.info("Downloading full repository from Mongo with natural order");
+            FindIterable<NodeDocument> mongoIterable = dbCollection
+                    .find()
+                    .hint(NATURAL_HINT);
+            DownloadTask downloadTask = new DownloadTask(DownloadOrder.UNDEFINED, downloadStageStatistics);
+            downloadTask.download(mongoIterable);
+            downloadTask.reportFinalResults();
+
+        } else {
+            DownloadTask ancestorsDownloadTask = new DownloadTask(DownloadOrder.UNDEFINED, downloadStageStatistics);
+            ancestorsDownloadTask.downloadAncestors(mongoFilterPaths.included);
+
+            DownloadTask downloadTask = new DownloadTask(DownloadOrder.UNDEFINED, downloadStageStatistics);
+            LOG.info("Downloading from Mongo with natural order using filter: {}", mongoFilter);
+            FindIterable<NodeDocument> findIterable = dbCollection
+                    .find(mongoFilter)
+                    .hint(NATURAL_HINT);
+            downloadTask.download(findIterable);
+            downloadTask.reportFinalResults();
         }
-        traversalLog.trace(id);
     }
 
     private void downloadWithRetryOnConnectionErrors() throws InterruptedException, TimeoutException {
+        LOG.info("Downloading with retry on connection errors, index scan");
         // If regex filtering is enabled, start by downloading the ancestors of the path used for filtering.
         // That is, download "/", "/content", "/content/dam" for a base path of "/content/dam". These nodes will not be
         // matched by the regex used in the Mongo query, which assumes a prefix of "???:/content/dam"
         MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
-        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
+        Bson mongoFilter = MongoDownloaderRegexUtils.computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
         if (mongoFilter == null) {
             LOG.info("Downloading full repository");
         } else {
@@ -457,111 +393,66 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             // Regex path filtering is enabled
             // Download the ancestors in a separate query. No retrials done on this query, as it will take only a few
             // seconds and is done at the start of the job, so if it fails, the job can be retried without losing much work
-            downloadAncestors(mongoFilterPaths.included);
+            DownloadTask ancestorsDownloadTask = new DownloadTask(DownloadOrder.UNDEFINED, downloadStageStatistics);
+            ancestorsDownloadTask.downloadAncestors(mongoFilterPaths.included);
         }
+        if (parallelDump) {
+            DownloadTask ascendingDownloadTask = new DownloadTask(DownloadOrder.ASCENDING, downloadStageStatistics);
+            DownloadTask descendingDownloadTask = new DownloadTask(DownloadOrder.DESCENDING, downloadStageStatistics);
+            LOG.info("Downloading in parallel with two connections, one in ascending the other in descending order");
 
-        Instant failuresStartTimestamp = null; // When the last series of failures started
-        long retryIntervalMs = retryInitialIntervalMillis;
-        int numberOfFailures = 0;
-        boolean downloadCompleted = false;
-        Map<String, Integer> exceptions = new HashMap<>();
-        this.nextLastModified = 0;
-        this.lastIdDownloaded = null;
-        while (!downloadCompleted) {
+            // Launch a thread to monitor the total download rate, that is, the sum of the metrics of each download thread
+            ScheduledExecutorService monitorThreadPool = Executors.newSingleThreadScheduledExecutor(
+                    new ThreadFactoryBuilder().setNameFormat(THREAD_NAME_PREFIX).setDaemon(true).build()
+            );
+            ScheduledFuture<?> monitorTask = monitorThreadPool.scheduleWithFixedDelay(() -> {
+                long secondsElapsed = downloadStartWatch.elapsed(TimeUnit.SECONDS);
+                String formattedRate;
+                if (secondsElapsed == 0) {
+                    formattedRate = "N/A nodes/s, N/A nodes/hr, N/A /s";
+                } else {
+                    double docRate = ((double) downloadStageStatistics.getDocumentsDownloadedTotal()) / secondsElapsed;
+                    double bytesRate = ((double) downloadStageStatistics.getDocumentsDownloadedTotalBytes()) / secondsElapsed;
+                    formattedRate = String.format(Locale.ROOT, "%1.2f nodes/s, %1.2f nodes/hr, %s/s",
+                            docRate, docRate * 3600, IOUtils.humanReadableByteCountBin((long) bytesRate));
+                }
+                LOG.info("Dumping from NSET Traversed #{} - [{}] (Elapsed {})",
+                        downloadStageStatistics.getDocumentsDownloadedTotal(), formattedRate, FormattingUtils.formatToSeconds(secondsElapsed));
+            }, 10, 10, TimeUnit.SECONDS);
+
+            // The current thread will download in ascending order. We launch a separate thread to download in
+            // descending order.
+            var originalName = Thread.currentThread().getName();
+            Thread.currentThread().setName(THREAD_NAME_PREFIX + "-ascending");
             try {
-                if (lastIdDownloaded != null) {
-                    LOG.info("Recovering from broken connection, finishing downloading documents with _modified={}", nextLastModified);
-                    downloadRange(new DownloadRange(nextLastModified, nextLastModified + 1, lastIdDownloaded), mongoFilter);
-                    // We have managed to reconnect, reset the failure timestamp
-                    failuresStartTimestamp = null;
-                    numberOfFailures = 0;
-                    // Continue downloading everything starting from the next _lastmodified value
-                    downloadRange(new DownloadRange(nextLastModified + 1, Long.MAX_VALUE, null), mongoFilter);
-                } else {
-                    downloadRange(new DownloadRange(nextLastModified, Long.MAX_VALUE, null), mongoFilter);
-                }
-                downloadCompleted = true;
-            } catch (MongoException e) {
-                if (e instanceof MongoInterruptedException || e instanceof MongoIncompatibleDriverException) {
-                    // Non-recoverable exceptions
-                    throw e;
-                }
-                if (failuresStartTimestamp == null) {
-                    failuresStartTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-                }
-                LOG.warn("Connection error downloading from MongoDB.", e);
-                long secondsSinceStartOfFailures = Duration.between(failuresStartTimestamp, Instant.now()).toSeconds();
-                if (secondsSinceStartOfFailures > retryDuringSeconds) {
-                    // Give up. Get a string of all exceptions that were thrown
-                    StringBuilder summary = new StringBuilder();
-                    for (Map.Entry<String, Integer> entry : exceptions.entrySet()) {
-                        summary.append("\n\t").append(entry.getValue()).append("x: ").append(entry.getKey());
+                var descendingDownloadThread = new Thread(() -> {
+                    try {
+                        descendingDownloadTask.download(mongoFilter);
+                        descendingDownloadTask.reportFinalResults();
+                    } catch (InterruptedException | TimeoutException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        mongoServerSelector.threadFinished();
                     }
-                    throw new RetryException(retryDuringSeconds, summary.toString(), e);
-                } else {
-                    numberOfFailures++;
-                    LOG.warn("Retrying download in {} ms; number of times failed: {}; current series of failures started at: {} ({} seconds ago)",
-                            retryIntervalMs, numberOfFailures, failuresStartTimestamp, secondsSinceStartOfFailures);
-                    exceptions.compute(e.getClass().getSimpleName() + " - " + e.getMessage(),
-                            (key, val) -> val == null ? 1 : val + 1
-                    );
-                    Thread.sleep(retryIntervalMs);
-                    // simple exponential backoff mechanism
-                    retryIntervalMs = Math.min(retryMaxIntervalMillis, retryIntervalMs * 2);
-                }
+                }, THREAD_NAME_PREFIX + "-descending");
+                descendingDownloadThread.start();
+
+                // Download in ascending order in the current thread.
+                ascendingDownloadTask.download(mongoFilter);
+                ascendingDownloadTask.reportFinalResults();
+                LOG.info("Ascending download finished. Waiting for descending download to finish.");
+                descendingDownloadThread.join();
+            } finally {
+                mongoServerSelector.threadFinished();
+                Thread.currentThread().setName(originalName);
+                monitorTask.cancel(false);
+                monitorThreadPool.shutdown();
             }
-        }
-    }
-
-    private void downloadRange(DownloadRange range, Bson filter) throws InterruptedException, TimeoutException {
-        Bson findQuery = range.getFindQuery();
-        if (filter != null) {
-            findQuery = Filters.and(findQuery, filter);
-        }
-        LOG.info("Traversing: {}. Query: {}", range, findQuery);
-        FindIterable<NodeDocument> mongoIterable = dbCollection
-                .withReadPreference(readPreference)
-                .find(findQuery)
-                .sort(ascending(NodeDocument.MODIFIED_IN_SECS, NodeDocument.ID));
-        download(mongoIterable);
-    }
-
-    private void downloadAncestors(List<String> basePath) throws InterruptedException, TimeoutException {
-        if (basePath.size() == 1 && basePath.get(0).equals("/")) {
-            return; // No need to download ancestors of root, the root will be downloaded as part of the normal traversal
-        }
-        Bson ancestorQuery = ancestorsFilter(basePath);
-        LOG.info("Downloading ancestors of: {}, Query: {}.", basePath, ancestorQuery);
-        FindIterable<NodeDocument> ancestorsIterable = dbCollection
-                .withReadPreference(readPreference)
-                .find(ancestorQuery)
-                // Use the index on _id: this query returns very few documents and the filter condition is on _id.
-                .hint(ID_INDEX_HINT);
-        download(ancestorsIterable);
-    }
-
-    private void downloadWithNaturalOrdering() throws InterruptedException, TimeoutException {
-        // We are downloading potentially a large fraction of the repository, so using an index scan will be
-        // inefficient. So we pass the natural hint to force MongoDB to use natural ordering, that is, column scan
-        MongoFilterPaths mongoFilterPaths = getPathsForRegexFiltering();
-        Bson mongoFilter = computeMongoQueryFilter(mongoFilterPaths, customExcludeEntriesRegex);
-        if (mongoFilter == null) {
-            LOG.info("Downloading full repository from Mongo with natural order");
-            FindIterable<NodeDocument> mongoIterable = dbCollection
-                    .withReadPreference(readPreference)
-                    .find()
-                    .hint(NATURAL_HINT);
-            download(mongoIterable);
-
+            LOG.info("Download complete.");
         } else {
-            downloadAncestors(mongoFilterPaths.included);
-
-            LOG.info("Downloading from Mongo with natural order using filter: {}", mongoFilter);
-            FindIterable<NodeDocument> findIterable = dbCollection
-                    .withReadPreference(readPreference)
-                    .find(mongoFilter)
-                    .hint(NATURAL_HINT);
-            download(findIterable);
+            // Single threaded dump
+            DownloadTask downloadTask = new DownloadTask(DownloadOrder.UNDEFINED, downloadStageStatistics);
+            downloadTask.download(mongoFilter);
         }
     }
 
@@ -581,74 +472,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
     }
 
-    private void download(FindIterable<NodeDocument> mongoIterable) throws InterruptedException, TimeoutException {
-        try (MongoCursor<NodeDocument> cursor = mongoIterable.iterator()) {
-            NodeDocument[] batch = new NodeDocument[maxBatchNumberOfDocuments];
-            int nextIndex = 0;
-            int batchSize = 0;
-            try {
-                while (cursor.hasNext()) {
-                    NodeDocument next = cursor.next();
-                    String id = next.getId();
-                    // If we are retrying on connection errors, we need to keep track of the last _modified value
-                    if (retryOnConnectionErrors) {
-                        this.nextLastModified = next.getModified();
-                    }
-                    this.lastIdDownloaded = id;
-                    this.documentsDownloadedTotal++;
-                    reportProgress(id);
-
-                    batch[nextIndex] = next;
-                    nextIndex++;
-                    int docSize = (int) next.remove(NodeDocumentCodec.SIZE_FIELD);
-                    batchSize += docSize;
-                    documentsDownloadedTotalBytes += docSize;
-                    if (batchSize >= maxBatchSizeBytes || nextIndex == batch.length) {
-                        LOG.trace("Enqueuing block with {} elements, estimated size: {} bytes", nextIndex, batchSize);
-                        tryEnqueueCopy(batch, nextIndex);
-                        nextIndex = 0;
-                        batchSize = 0;
-                    }
-                }
-                if (nextIndex > 0) {
-                    LOG.info("Enqueueing last block with {} elements, estimated size: {}",
-                            nextIndex, IOUtils.humanReadableByteCountBin(batchSize));
-                    tryEnqueueCopy(batch, nextIndex);
-                }
-            } catch (MongoException e) {
-                if (e instanceof MongoInterruptedException || e instanceof MongoIncompatibleDriverException) {
-                    // Non-recoverable exceptions
-                    throw e;
-                }
-                // There may be some documents in the current batch, enqueue them and rethrow the exception
-                if (nextIndex > 0) {
-                    LOG.info("Connection interrupted with recoverable failure. Enqueueing partial block with {} elements, estimated size: {}",
-                            nextIndex, IOUtils.humanReadableByteCountBin(batchSize));
-                    tryEnqueueCopy(batch, nextIndex);
-                }
-                throw e;
-            }
-        }
-    }
-
-    private void tryEnqueueCopy(NodeDocument[] batch, int nextIndex) throws TimeoutException, InterruptedException {
-        NodeDocument[] copyOfBatch = Arrays.copyOfRange(batch, 0, nextIndex);
-        Stopwatch enqueueDelayStopwatch = Stopwatch.createStarted();
-        if (!mongoDocQueue.offer(copyOfBatch, MONGO_QUEUE_OFFER_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
-            throw new TimeoutException("Timeout trying to enqueue batch of MongoDB documents. Waited " + MONGO_QUEUE_OFFER_TIMEOUT);
-        }
-        long enqueueDelay = enqueueDelayStopwatch.elapsed(TimeUnit.MILLISECONDS);
-        totalEnqueueWaitTimeMillis += enqueueDelay;
-        if (enqueueDelay > 1) {
-            logWithRateLimit(() ->
-                    LOG.info("Enqueuing of Mongo document batch was delayed, took {} ms. mongoDocQueue size {}. " +
-                                    "Consider increasing the number of Transform threads. " +
-                                    "(This message is logged at most once every {} seconds)",
-                            enqueueDelay, mongoDocQueue.size(), MIN_INTERVAL_BETWEEN_DELAYED_ENQUEUING_MESSAGES)
-            );
-        }
-    }
-
     private void logWithRateLimit(Runnable f) {
         Instant now = Instant.now();
         if (Duration.between(lastDelayedEnqueueWarningMessageLoggedTimestamp, now).toSeconds() > MIN_INTERVAL_BETWEEN_DELAYED_ENQUEUING_MESSAGES) {
@@ -657,18 +480,263 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
     }
 
-    private static class RetryException extends RuntimeException {
+    enum DownloadOrder {
+        ASCENDING,
+        DESCENDING,
+        UNDEFINED;
 
-        private final int retrialDurationSeconds;
+        public boolean downloadInAscendingOrder() {
+            return this == ASCENDING || this == UNDEFINED;
+        }
+    }
 
-        public RetryException(int retrialDurationSeconds, String message, Throwable cause) {
-            super(message, cause);
-            this.retrialDurationSeconds = retrialDurationSeconds;
+    private class DownloadTask {
+        private final DownloadOrder downloadOrder;
+        private final DownloadStageStatistics downloadStatics;
+        private long documentsDownloadedTotalBytes;
+        private long documentsDownloadedTotal;
+        private long totalEnqueueWaitTimeMillis;
+        private long nextLastModified;
+        private String lastIdDownloaded;
+
+        DownloadTask(DownloadOrder downloadOrder, DownloadStageStatistics downloadStatics) {
+            this.downloadOrder = downloadOrder;
+            this.downloadStatics = downloadStatics;
+            this.documentsDownloadedTotalBytes = 0;
+            this.documentsDownloadedTotal = 0;
+            this.totalEnqueueWaitTimeMillis = 0;
+            this.nextLastModified = downloadOrder.downloadInAscendingOrder() ? 0 : Long.MAX_VALUE;
+            this.lastIdDownloaded = null;
         }
 
-        @Override
-        public String toString() {
-            return "Tried for " + retrialDurationSeconds + " seconds: \n" + super.toString();
+        private Instant failuresStartTimestamp = null; // When the last series of failures started
+        private int numberOfFailures = 0;
+
+        private void download(Bson mongoQueryFilter) throws InterruptedException, TimeoutException {
+            failuresStartTimestamp = null; // When the last series of failures started
+            numberOfFailures = 0;
+            long retryIntervalMs = retryInitialIntervalMillis;
+            boolean downloadCompleted = false;
+            Map<String, Integer> exceptions = new HashMap<>();
+            while (!downloadCompleted) {
+                try {
+                    if (lastIdDownloaded == null) {
+                        // lastIdDownloaded is null only when starting the download or if there is a connection error
+                        // before anything is downloaded
+                        var firstRange = new DownloadRange(0, Long.MAX_VALUE, null, downloadOrder.downloadInAscendingOrder());
+                        downloadRange(firstRange, mongoQueryFilter, downloadOrder);
+                    } else {
+                        LOG.info("Recovering from broken connection, finishing downloading documents with _modified={}", nextLastModified);
+                        var partialLastModifiedRange = new DownloadRange(nextLastModified, nextLastModified, lastIdDownloaded, downloadOrder.downloadInAscendingOrder());
+                        downloadRange(partialLastModifiedRange, mongoQueryFilter, downloadOrder);
+                        // Downloaded everything from _nextLastModified. Continue with the next timestamp for _modified
+                        var nextRange = downloadOrder.downloadInAscendingOrder() ?
+                                new DownloadRange(nextLastModified + 1, Long.MAX_VALUE, null, true) :
+                                new DownloadRange(0, nextLastModified - 1, null, false);
+                        downloadRange(nextRange, mongoQueryFilter, downloadOrder);
+                    }
+                    downloadCompleted = true;
+                } catch (MongoException e) {
+                    if (e instanceof MongoInterruptedException || e instanceof MongoIncompatibleDriverException) {
+                        // Non-recoverable exceptions
+                        throw e;
+                    }
+                    if (failuresStartTimestamp == null) {
+                        failuresStartTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+                    }
+                    LOG.warn("Connection error downloading from MongoDB.", e);
+                    long secondsSinceStartOfFailures = Duration.between(failuresStartTimestamp, Instant.now()).toSeconds();
+                    if (parallelDump && mongoServerSelector.atLeastOneConnectionActive()) {
+                        // Special case, the cluster is up because one of the connections is active. This happens when
+                        // there is a single secondary, maybe because of a scale-up/down. In this case, do not abort the
+                        // download, keep retrying to connect forever
+                        int retryTime = 1000;
+                        LOG.info("At least one connection is active. Retrying download in {} ms", retryTime);
+                        Thread.sleep(retryTime);
+                    } else if (secondsSinceStartOfFailures > retryDuringSeconds) {
+                        // Give up. Get a string of all exceptions that were thrown
+                        StringBuilder summary = new StringBuilder();
+                        for (Map.Entry<String, Integer> entry : exceptions.entrySet()) {
+                            summary.append("\n\t").append(entry.getValue()).append("x: ").append(entry.getKey());
+                        }
+                        throw new RetryException(retryDuringSeconds, summary.toString(), e);
+                    } else {
+                        numberOfFailures++;
+                        LOG.warn("Retrying download in {} ms; number of times failed: {}; current series of failures started at: {} ({} seconds ago)",
+                                retryIntervalMs, numberOfFailures, failuresStartTimestamp, secondsSinceStartOfFailures);
+                        exceptions.compute(e.getClass().getSimpleName() + " - " + e.getMessage(),
+                                (key, val) -> val == null ? 1 : val + 1
+                        );
+                        Thread.sleep(retryIntervalMs);
+                        // simple exponential backoff mechanism
+                        retryIntervalMs = Math.min(retryMaxIntervalMillis, retryIntervalMs * 2);
+                    }
+                }
+            }
+        }
+
+        private void downloadRange(DownloadRange range, Bson filter, DownloadOrder downloadOrder) throws InterruptedException, TimeoutException {
+            Bson findQuery = range.getFindQuery();
+            if (filter != null) {
+                findQuery = Filters.and(findQuery, filter);
+            }
+            Bson sortOrder = downloadOrder.downloadInAscendingOrder() ?
+                    Sorts.ascending(NodeDocument.MODIFIED_IN_SECS, NodeDocument.ID) :
+                    Sorts.descending(NodeDocument.MODIFIED_IN_SECS, NodeDocument.ID);
+
+            FindIterable<NodeDocument> mongoIterable = dbCollection
+                    .find(findQuery)
+                    .sort(sortOrder);
+
+            LOG.info("Traversing: {}. Query: {}, Traverse order: {}", range, findQuery, sortOrder);
+            download(mongoIterable);
+        }
+
+        void download(FindIterable<NodeDocument> mongoIterable) throws InterruptedException, TimeoutException {
+            try (MongoCursor<NodeDocument> cursor = mongoIterable.iterator()) {
+                NodeDocument[] batch = new NodeDocument[maxBatchNumberOfDocuments];
+                int nextIndex = 0;
+                int batchSize = 0;
+                if (cursor.hasNext()) {
+                    // We have managed to reconnect, reset the failure timestamp
+                    failuresStartTimestamp = null;
+                    numberOfFailures = 0;
+                }
+                try {
+                    while (cursor.hasNext()) {
+                        NodeDocument next = cursor.next();
+                        String id = next.getId();
+                        this.nextLastModified = next.getModified();
+                        this.lastIdDownloaded = id;
+                        this.documentsDownloadedTotal++;
+                        downloadStatics.incrementDocumentsDownloadedTotal();
+                        reportProgress(id);
+
+                        batch[nextIndex] = next;
+                        nextIndex++;
+                        int docSize = (int) next.remove(NodeDocumentCodec.SIZE_FIELD);
+                        batchSize += docSize;
+                        documentsDownloadedTotalBytes += docSize;
+                        downloadStageStatistics.incrementDocumentsDownloadedTotalBytes(docSize);
+                        if (batchSize >= maxBatchSizeBytes || nextIndex == batch.length) {
+                            LOG.trace("Enqueuing block with {} elements, estimated size: {} bytes", nextIndex, batchSize);
+                            var downloadCompleted = tryEnqueueCopy(batch, nextIndex);
+                            if (downloadCompleted) {
+                                LOG.info("Download of range with download order {} completed, intersected with other download.", downloadOrder);
+                                return;
+                            }
+                            nextIndex = 0;
+                            batchSize = 0;
+                            if (parallelDump && mongoServerSelector.isConnectedToPrimary()) {
+                                LOG.info("Connected to primary. Will disconnect from MongoDB to force a new connection to a secondary.");
+                                throw new MongoException("Disconnecting from MongoDB primary to force a new connection");
+
+                            }
+                        }
+                    }
+                    if (nextIndex > 0) {
+                        LOG.info("Enqueueing last block with {} elements, estimated size: {}",
+                                nextIndex, IOUtils.humanReadableByteCountBin(batchSize));
+                        tryEnqueueCopy(batch, nextIndex);
+                    }
+                } catch (MongoException e) {
+                    if (e instanceof MongoInterruptedException || e instanceof MongoIncompatibleDriverException) {
+                        // Non-recoverable exceptions
+                        throw e;
+                    }
+                    // There may be some documents in the current batch, enqueue them and rethrow the exception
+                    if (nextIndex > 0) {
+                        LOG.info("Connection interrupted with recoverable failure. Enqueueing partial block with {} elements, estimated size: {}",
+                                nextIndex, IOUtils.humanReadableByteCountBin(batchSize));
+                        tryEnqueueCopy(batch, nextIndex);
+                    }
+                    throw e;
+                }
+            }
+        }
+
+        private void downloadAncestors(List<String> basePath) throws InterruptedException, TimeoutException {
+            if (basePath.size() == 1 && basePath.get(0).equals("/")) {
+                return; // No need to download ancestors of root, the root will be downloaded as part of the normal traversal
+            }
+            Bson ancestorQuery = MongoDownloaderRegexUtils.ancestorsFilter(basePath);
+            LOG.info("Downloading ancestors of: {}, Query: {}.", basePath, ancestorQuery);
+            FindIterable<NodeDocument> ancestorsIterable = dbCollection
+                    .find(ancestorQuery)
+                    // Use the index on _id: this query returns very few documents and the filter condition is on _id.
+                    .hint(ID_INDEX_HINT);
+            download(ancestorsIterable);
+        }
+
+        private boolean tryEnqueueCopy(NodeDocument[] batch, int sizeOfBatch) throws TimeoutException, InterruptedException {
+            // Find the first element that was not yet added
+            boolean completedDownload = false;
+            int effectiveSize = sizeOfBatch;
+            if (downloadOrder != DownloadOrder.UNDEFINED) {
+                var sizeOfRangeNotAdded = downloadOrder == DownloadOrder.ASCENDING ?
+                        mongoParallelDownloadCoordinator.extendLowerRange(batch, sizeOfBatch) :
+                        mongoParallelDownloadCoordinator.extendUpperRange(batch, sizeOfBatch);
+                if (sizeOfRangeNotAdded != sizeOfBatch) {
+                    completedDownload = true;
+                    effectiveSize = sizeOfRangeNotAdded;
+                    var firstAlreadySeen = batch[sizeOfRangeNotAdded];
+                    LOG.info("Download complete, reached already seen document: {}: {}", firstAlreadySeen.getModified(), firstAlreadySeen.getId());
+                }
+            }
+            if (effectiveSize == 0) {
+                LOG.info("Batch is empty, not enqueuing.");
+            } else {
+                NodeDocument[] copyOfBatch = Arrays.copyOfRange(batch, 0, effectiveSize);
+                Stopwatch enqueueDelayStopwatch = Stopwatch.createStarted();
+                if (!mongoDocQueue.offer(copyOfBatch, MONGO_QUEUE_OFFER_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+                    throw new TimeoutException("Timeout trying to enqueue batch of MongoDB documents. Waited " + MONGO_QUEUE_OFFER_TIMEOUT);
+                }
+                long enqueueDelay = enqueueDelayStopwatch.elapsed(TimeUnit.MILLISECONDS);
+                this.totalEnqueueWaitTimeMillis += enqueueDelay;
+                downloadStageStatistics.incrementTotalEnqueueWaitTimeMillis(enqueueDelay);
+                if (enqueueDelay > 1) {
+                    logWithRateLimit(() ->
+                            LOG.info("Enqueuing of Mongo document batch was delayed, took {} ms. mongoDocQueue size {}. " +
+                                            "Consider increasing the number of Transform threads. " +
+                                            "(This message is logged at most once every {} seconds)",
+                                    enqueueDelay, mongoDocQueue.size(), MIN_INTERVAL_BETWEEN_DELAYED_ENQUEUING_MESSAGES)
+                    );
+                }
+            }
+            return completedDownload;
+        }
+
+        void reportFinalResults() {
+            long secondsElapsed = downloadStartWatch.elapsed(TimeUnit.SECONDS);
+            String formattedRate;
+            if (secondsElapsed == 0) {
+                formattedRate = "N/A nodes/s, N/A nodes/hr, N/A /s";
+            } else {
+                double docRate = ((double) this.documentsDownloadedTotal) / secondsElapsed;
+                double bytesRate = ((double) this.documentsDownloadedTotalBytes) / secondsElapsed;
+                formattedRate = String.format(Locale.ROOT, "%1.2f nodes/s, %1.2f nodes/hr, %s/s",
+                        docRate, docRate * 3600, IOUtils.humanReadableByteCountBin((long) bytesRate));
+            }
+            LOG.info("Finished download task. Dumped {} documents. Rate: {}. Elapsed {}.",
+                    this.documentsDownloadedTotal, formattedRate, FormattingUtils.formatToSeconds(downloadStartWatch));
+        }
+
+        private void reportProgress(String id) {
+            if (this.documentsDownloadedTotal % 10000 == 0) {
+                long secondsElapsed = downloadStartWatch.elapsed(TimeUnit.SECONDS);
+                String formattedRate;
+                if (secondsElapsed == 0) {
+                    formattedRate = "N/A nodes/s, N/A nodes/hr, N/A /s";
+                } else {
+                    double docRate = ((double) this.documentsDownloadedTotal) / secondsElapsed;
+                    double bytesRate = ((double) this.documentsDownloadedTotalBytes) / secondsElapsed;
+                    formattedRate = String.format(Locale.ROOT, "%1.2f nodes/s, %1.2f nodes/hr, %s/s",
+                            docRate, docRate * 3600, IOUtils.humanReadableByteCountBin((long) bytesRate));
+                }
+                LOG.info("Dumping from NSET Traversed #{} {} [{}] (Elapsed {})",
+                        this.documentsDownloadedTotal, id, formattedRate, FormattingUtils.formatToSeconds(secondsElapsed));
+            }
+            TRAVERSAL_LOG.trace(id);
         }
     }
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -625,7 +625,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                         this.lastIdDownloaded = id;
                         this.documentsDownloadedTotal++;
                         downloadStatics.incrementDocumentsDownloadedTotal();
-                        if (this.documentsDownloadedTotal % 10000 == 0) {
+                        if (this.documentsDownloadedTotal % 20000 == 0) {
                             reportProgress(id);
                         }
                         TRAVERSAL_LOG.trace(id);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import com.mongodb.ServerAddress;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
@@ -1,0 +1,152 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.event.ClusterClosedEvent;
+import com.mongodb.event.ClusterDescriptionChangedEvent;
+import com.mongodb.event.ClusterListener;
+import com.mongodb.event.ClusterOpeningEvent;
+import com.mongodb.selector.ServerSelector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Selects a Mongo server that is available for a new connection. This policy is used by PipelinedMongoDownloadTask,
+ * the goal being to spread the two connections between the secondaries and avoid downloading from the primary.
+ * The policy tries to ensure the following:
+ *
+ * <p>
+ * - Establish new connections only to secondaries.
+ * - Do not establish more than one connection to a secondary.
+ * - If there is a connection to a secondary and that secondary is promoted to primary, the thread should disconnect
+ * from the primary and reconnect to a secondary.
+ * <p>
+ * This class uses the thread id of the caller to distribute the connections, that is, it assumes that there are
+ * two threads downloading from Mongo and each thread should be sent to a different secondary. If a thread calls several
+ * times the selection logic, it will receive always the same server. The thread id is used to identify the calling
+ * thread.
+ */
+public class PipelinedMongoServerSelector implements ServerSelector, ClusterListener {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoServerSelector.class);
+
+    // Thread ID -> ServerAddress
+    private final HashMap<Long, ServerAddress> serverAddressHashMap = new HashMap<>();
+    // IDs of threads connected to primary
+    private final HashSet<Long> connectedToPrimaryThreads = new HashSet<>();
+
+    private ClusterDescription lastSeenClusterDescription;
+
+    @Override
+    synchronized public List<ServerDescription> select(ClusterDescription clusterDescription) {
+        return select(clusterDescription.getType(), clusterDescription.getServerDescriptions());
+    }
+
+    // Exposed for testing
+    List<ServerDescription> select(ClusterType clusterType, List<ServerDescription> serverDescriptions) {
+        if (clusterType != ClusterType.REPLICA_SET) {
+            LOG.info("Cluster is not a replica set, returning all servers");
+            return serverDescriptions;
+        }
+        String threadName = Thread.currentThread().getName();
+        if (!threadName.startsWith(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-")) {
+            LOG.info("Thread name does not start with {}, returning all servers", PipelinedMongoDownloadTask.THREAD_NAME_PREFIX);
+            return serverDescriptions;
+        }
+
+        Long threadId = Thread.currentThread().getId();
+        LOG.debug("Selecting server from cluster: {}", serverDescriptions.stream()
+                .map(sd -> sd.getAddress() + ", " + sd.getType() + ", " + sd.getState())
+                .collect(Collectors.joining("\n", "\n", "")));
+        var secondaries = serverDescriptions.stream()
+                .filter(ServerDescription::isSecondary)
+                .collect(Collectors.toSet());
+        if (secondaries.isEmpty()) {
+            LOG.info("No secondaries found, not selecting the primary. Returning empty list.");
+            return List.of();
+        }
+        // Secondaries available
+        serverAddressHashMap.remove(threadId);
+        // No server assigned to this thread yet. Find an unused server
+        for (var replica : secondaries) {
+            var address = replica.getAddress();
+            if (!serverAddressHashMap.containsValue(address)) {
+                // This server is not assigned to any thread yet. Assign it to this thread
+                serverAddressHashMap.put(threadId, address);
+                LOG.info("Selected server: {}", address);
+                return List.of(replica);
+            }
+        }
+        // All secondaries are already assigned to some thread
+        LOG.debug("All available Mongo secondaries are assigned. Returning empty list.");
+        return List.of();
+    }
+
+    @Override
+    public void clusterOpening(ClusterOpeningEvent event) {
+        // Ignore
+    }
+
+    @Override
+    public synchronized void clusterClosed(ClusterClosedEvent event) {
+        // Ignore
+    }
+
+    @Override
+    public synchronized void clusterDescriptionChanged(ClusterDescriptionChangedEvent event) {
+        // Secondaries can be promoted to primary at any time. If that happens, any downloader thread connected to this
+        // replica should disconnect. We use the cluster description event to detect if any of the threads is connected
+        // to the replica that is now the primary. The downloader threads are then responsible for periodically calling
+        // #isConnectedToPrimary to check if they are connected to the primary and in that case close the connection
+        // and open a new connection, which will trigger the Mongo driver to call again the selection logic in this class
+        this.lastSeenClusterDescription = event.getNewDescription();
+        if (lastSeenClusterDescription.getType() != ClusterType.REPLICA_SET) {
+            return;
+        }
+
+        // Check if any thread is connected to primary
+        connectedToPrimaryThreads.clear();
+        lastSeenClusterDescription.getServerDescriptions().stream()
+                .filter(ServerDescription::isPrimary)
+                .map(ServerDescription::getAddress)
+                .forEach(primaryAddress -> {
+                    for (var entry : serverAddressHashMap.entrySet()) {
+                        if (entry.getValue().equals(primaryAddress)) {
+                            connectedToPrimaryThreads.add(entry.getKey());
+                        }
+                    }
+                });
+    }
+
+    /**
+     * Returns true if the current thread is connected to the primary.
+     */
+    public synchronized boolean isConnectedToPrimary() {
+        return connectedToPrimaryThreads.contains(Thread.currentThread().getId());
+    }
+
+    /**
+     * Returns true if there is at least one connection active.
+     */
+    public synchronized boolean atLeastOneConnectionActive() {
+        return !serverAddressHashMap.isEmpty();
+    }
+
+    /**
+     * Called by the downloader thread when it finishes downloading. This method removes the thread from the list of
+     * active threads.
+     */
+    public synchronized void threadFinished() {
+        LOG.info("Thread finished downloading. Unregistering.");
+        var previous = serverAddressHashMap.remove(Thread.currentThread().getId());
+        if (lastSeenClusterDescription.getType() == ClusterType.REPLICA_SET && previous == null) {
+            LOG.warn("Thread was not registered with Mongo server selector.");
+        }
+    }
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
@@ -58,8 +58,17 @@ public class PipelinedMongoServerSelector implements ServerSelector, ClusterList
     private final HashMap<Long, ServerAddress> serverAddressHashMap = new HashMap<>();
     // IDs of threads connected to primary
     private final HashSet<Long> connectedToPrimaryThreads = new HashSet<>();
+    private final String threadNamePrefix;
 
     private ClusterDescription lastSeenClusterDescription;
+
+    /**
+     * @param threadNamePrefix Threads that start with this prefix will be assigned only to secondary server. Other
+     *                         threads will be assigned all servers available.
+     */
+    public PipelinedMongoServerSelector(String threadNamePrefix) {
+        this.threadNamePrefix = threadNamePrefix;
+    }
 
     @Override
     synchronized public List<ServerDescription> select(ClusterDescription clusterDescription) {
@@ -73,8 +82,8 @@ public class PipelinedMongoServerSelector implements ServerSelector, ClusterList
             return serverDescriptions;
         }
         String threadName = Thread.currentThread().getName();
-        if (!threadName.startsWith(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-")) {
-            LOG.info("Thread name does not start with {}, returning all servers", PipelinedMongoDownloadTask.THREAD_NAME_PREFIX);
+        if (!threadName.startsWith(threadNamePrefix)) {
+            LOG.info("Thread name does not start with {}, returning all servers", threadNamePrefix);
             return serverDescriptions;
         }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -228,7 +228,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
     /**
      * @param mongoClientURI     URI of the Mongo cluster.
      * @param pathPredicate      Used by the transform stage to test if a node should be kept or discarded.
-     * @param pathFilters        If non-empty, the download stage will use these filters to try to create a query that downloads
+     * @param pathFilters        If non-empty, the download stage will use these filters to create a query that downloads
      *                           only the matching MongoDB documents.
      * @param statisticsProvider Used to collect statistics about the indexing process.
      * @param indexingReporter   Used to collect diagnostics, metrics and statistics and report them at the end of the indexing process.

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -18,7 +18,7 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
-import com.mongodb.client.MongoDatabase;
+import com.mongodb.MongoClientURI;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.guava.common.base.Preconditions;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
@@ -208,7 +208,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
     }
 
     private final MongoDocumentStore docStore;
-    private final MongoDatabase mongoDatabase;
+    private final MongoClientURI mongoClientURI;
     private final DocumentNodeStore documentNodeStore;
     private final RevisionVector rootRevision;
     private final BlobStore blobStore;
@@ -226,14 +226,15 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
     private long nodeStateEntriesExtracted;
 
     /**
-     * @param pathPredicate    Used by the transform stage to test if a node should be kept or discarded.
-     * @param pathFilters      If non-empty, the download stage will use these filters to try to create a query that downloads
-     *                         only the matching MongoDB documents.
+     * @param mongoClientURI     URI of the Mongo cluster.
+     * @param pathPredicate      Used by the transform stage to test if a node should be kept or discarded.
+     * @param pathFilters        If non-empty, the download stage will use these filters to try to create a query that downloads
+     *                           only the matching MongoDB documents.
      * @param statisticsProvider Used to collect statistics about the indexing process.
-     * @param indexingReporter
+     * @param indexingReporter   Used to collect diagnostics, metrics and statistics and report them at the end of the indexing process.
      */
-    public PipelinedStrategy(MongoDocumentStore documentStore,
-                             MongoDatabase mongoDatabase,
+    public PipelinedStrategy(MongoClientURI mongoClientURI,
+                             MongoDocumentStore documentStore,
                              DocumentNodeStore documentNodeStore,
                              RevisionVector rootRevision,
                              Set<String> preferredPathElements,
@@ -246,8 +247,8 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
                              StatisticsProvider statisticsProvider,
                              IndexingReporter indexingReporter) {
         super(storeDir, algorithm, pathPredicate, preferredPathElements, checkpoint);
+        this.mongoClientURI = mongoClientURI;
         this.docStore = documentStore;
-        this.mongoDatabase = mongoDatabase;
         this.documentNodeStore = documentNodeStore;
         this.rootRevision = rootRevision;
         this.blobStore = blobStore;
@@ -375,7 +376,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
     public File createSortedStoreFile() throws IOException {
         int numberOfThreads = 1 + numberOfTransformThreads + 1 + 1; // dump, transform, sort threads, sorted files merge
         ExecutorService threadPool = Executors.newFixedThreadPool(numberOfThreads,
-                new ThreadFactoryBuilder().setNameFormat("mongo-dump").setDaemon(true).build()
+                new ThreadFactoryBuilder().setDaemon(true).build()
         );
         // This executor can wait for several tasks at the same time. We use this below to wait at the same time for
         // all the tasks, so that if one of them fails, we can abort the whole pipeline. Otherwise, if we wait on
@@ -412,8 +413,9 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
 
             LOG.info("[TASK:PIPELINED-DUMP:START] Starting to build FFS");
             Stopwatch start = Stopwatch.createStarted();
+
             ecs.submit(new PipelinedMongoDownloadTask(
-                    mongoDatabase,
+                    mongoClientURI,
                     docStore,
                     (int) (mongoDocBatchMaxSizeMB * FileUtils.ONE_MB),
                     mongoDocBatchMaxNumberOfDocuments,
@@ -470,7 +472,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
                         Object result = completedTask.get();
                         if (result instanceof PipelinedMongoDownloadTask.Result) {
                             PipelinedMongoDownloadTask.Result downloadResult = (PipelinedMongoDownloadTask.Result) result;
-                            LOG.info("Download task finished. Documents downloaded: {}", downloadResult.getDocumentsDownloaded());
+                            LOG.info("Download finished. Documents downloaded: {}", downloadResult.getDocumentsDownloaded());
                             // Signal the end of documents to the transform threads.
                             for (int i = 0; i < numberOfTransformThreads; i++) {
                                 mongoDocQueue.put(SENTINEL_MONGO_DOCUMENT);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -536,7 +536,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
                         throw new RuntimeException(ex);
                     }
                 }
-                var elapsedSeconds = start.elapsed(TimeUnit.SECONDS);
+                long elapsedSeconds = start.elapsed(TimeUnit.SECONDS);
                 LOG.info("[TASK:PIPELINED-DUMP:END] Metrics: {}", MetricsFormatter.newBuilder()
                         .add("duration", FormattingUtils.formatToSeconds(elapsedSeconds))
                         .add("durationSeconds", elapsedSeconds)

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStoreHelper.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStoreHelper.java
@@ -117,4 +117,8 @@ public class MongoDocumentStoreHelper {
     public static ReadPreference getConfiguredReadPreference(MongoDocumentStore mongoStore, Collection<? extends Document> collection) {
         return mongoStore.getConfiguredReadPreference(collection);
     }
+
+    public static String getMongoDatabaseName(MongoDocumentStore store) {
+        return store.getDatabase().getName();
+    }
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/DocumentFixtureProvider.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/DocumentFixtureProvider.java
@@ -109,6 +109,7 @@ class DocumentFixtureProvider {
                 System.exit(1);
             }
             MongoConnection mongo = new MongoConnection(uri.getURI());
+            wb.register(MongoClientURI.class, uri, emptyMap());
             wb.register(MongoConnection.class, mongo, emptyMap());
             wb.register(MongoDatabase.class, mongo.getDatabase(), emptyMap());
             closer.register(mongo::close);

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinatorTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinatorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinatorTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoParallelDownloadCoordinatorTest.java
@@ -1,0 +1,151 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class MongoParallelDownloadCoordinatorTest {
+    static class NodeDocumentArrayBuilder {
+        private final ArrayList<NodeDocument> list = new ArrayList<>();
+        private final MemoryDocumentStore docStore = new MemoryDocumentStore();
+
+        public static NodeDocumentArrayBuilder create() {
+            return new NodeDocumentArrayBuilder();
+        }
+
+        public NodeDocumentArrayBuilder add(long modified, String id) {
+            var d = new NodeDocument(docStore, 0);
+            d.put(NodeDocument.ID, id);
+            d.put(NodeDocument.MODIFIED_IN_SECS, modified);
+            list.add(d);
+            return this;
+        }
+
+        public NodeDocument[] build() {
+            return list.toArray(new NodeDocument[0]);
+        }
+    }
+
+
+    @Test
+    public void noIntersection() {
+        var m = new MongoParallelDownloadCoordinator();
+
+        NodeDocument[] ascendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(1L, "a")
+                .add(2L, "b")
+                .add(3L, "c")
+                .build();
+
+        NodeDocument[] descendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(10L, "z")
+                .add(9L, "y")
+                .add(8L, "x")
+                .add(7L, "w")
+                .build();
+
+        assertEquals(3, m.extendLowerRange(ascendingOrderBatch, ascendingOrderBatch.length));
+        assertEquals(4, m.extendUpperRange(descendingOrderBatch, descendingOrderBatch.length));
+
+        assertDownloadPositionEquals(3L, "c", m.getLowerRangeTop());
+        assertDownloadPositionEquals(7L, "w", m.getUpperRangeBottom());
+    }
+
+    @Test
+    public void noIntersectionModifiedEqualsIdHigher() {
+        var m = new MongoParallelDownloadCoordinator();
+
+        NodeDocument[] ascendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(1L, "a")
+                .add(2L, "b")
+                .add(3L, "c")
+                .build();
+
+        NodeDocument[] descendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(4L, "e")
+                .add(3L, "d")
+                .build();
+
+        assertEquals(3, m.extendLowerRange(ascendingOrderBatch, ascendingOrderBatch.length));
+        assertEquals(2, m.extendUpperRange(descendingOrderBatch, descendingOrderBatch.length));
+
+        assertDownloadPositionEquals(3L, "c", m.getLowerRangeTop());
+        assertDownloadPositionEquals(3L, "d", m.getUpperRangeBottom());
+    }
+
+    @Test
+    public void descendingBatchLastElementEqualsBottomRangeTop() {
+        var m = new MongoParallelDownloadCoordinator();
+        NodeDocument[] ascendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(1L, "a")
+                .add(2L, "b")
+                .add(3L, "c")
+                .build();
+        NodeDocument[] descendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(4L, "d")
+                .add(3L, "c")
+                .build();
+
+        assertEquals(3, m.extendLowerRange(ascendingOrderBatch, ascendingOrderBatch.length));
+        assertEquals(1, m.extendUpperRange(descendingOrderBatch, descendingOrderBatch.length));
+
+        assertDownloadPositionEquals(3L, "c", m.getLowerRangeTop());
+        assertDownloadPositionEquals(4L, "d", m.getUpperRangeBottom());
+    }
+
+    @Test
+    public void intersectionPartial() {
+        var m = new MongoParallelDownloadCoordinator();
+        NodeDocument[] ascendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(1L, "a")
+                .add(2L, "b")
+                .add(3L, "c")
+                .build();
+
+        NodeDocument[] descendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(4L, "z")
+                .add(3L, "y")
+                .add(2L, "x")
+                .build();
+
+        // Should add all elements
+        assertEquals(3, m.extendLowerRange(ascendingOrderBatch, ascendingOrderBatch.length));
+        // Only add the first two elements because descendingOrderBatch[2] is already in the range
+        assertEquals(2, m.extendUpperRange(descendingOrderBatch, descendingOrderBatch.length));
+
+        assertDownloadPositionEquals(3L, "c", m.getLowerRangeTop());
+        assertDownloadPositionEquals(3L, "y", m.getUpperRangeBottom());
+    }
+
+    @Test
+    public void intersectionFull() {
+        var m = new MongoParallelDownloadCoordinator();
+        NodeDocument[] ascendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(1L, "a")
+                .add(2L, "b")
+                .add(3L, "c")
+                .build();
+
+        NodeDocument[] descendingOrderBatch = NodeDocumentArrayBuilder.create()
+                .add(2L, "z")
+                .add(1L, "x")
+                .build();
+
+        // Should add all elements
+        assertEquals(3, m.extendLowerRange(ascendingOrderBatch, ascendingOrderBatch.length));
+        // Do not add any element.
+        assertEquals(0, m.extendUpperRange(descendingOrderBatch, descendingOrderBatch.length));
+
+        assertDownloadPositionEquals(3L, "c", m.getLowerRangeTop());
+        assertDownloadPositionEquals(Long.MAX_VALUE, null, m.getUpperRangeBottom());
+    }
+
+    private void assertDownloadPositionEquals(long expectedModified, String expectedId, MongoParallelDownloadCoordinator.DownloadPosition actualPosition) {
+        assertEquals(expectedId, actualPosition.lastId);
+        assertEquals(expectedModified, actualPosition.lastModified);
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoTestBackend.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoTestBackend.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoTestBackend.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoTestBackend.java
@@ -1,0 +1,40 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+
+import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoDatabase;
+import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+class MongoTestBackend implements Closeable {
+    final MongoClientURI mongoClientURI;
+    final MongoDocumentStore mongoDocumentStore;
+    final DocumentNodeStore documentNodeStore;
+    final MongoDatabase mongoDatabase;
+
+    public MongoTestBackend(MongoClientURI mongoClientURI, MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoDatabase mongoDatabase) {
+        this.mongoClientURI = mongoClientURI;
+        this.mongoDocumentStore = mongoDocumentStore;
+        this.documentNodeStore = documentNodeStore;
+        this.mongoDatabase = mongoDatabase;
+    }
+
+    @Override
+    public void close() throws IOException {
+        documentNodeStore.dispose();
+        mongoDocumentStore.dispose();
+    }
+
+    @Override
+    public String toString() {
+        return "Backend{" +
+                "mongoClientURI=" + mongoClientURI +
+                ", mongoDocumentStore=" + mongoDocumentStore +
+                ", documentNodeStore=" + documentNodeStore +
+                ", mongoDatabase=" + mongoDatabase +
+                '}';
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoTestBackend.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoTestBackend.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
-
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
@@ -1,0 +1,198 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import com.mongodb.MongoClientURI;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.commons.Compression;
+import org.apache.jackrabbit.oak.plugins.document.DocumentMK;
+import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
+import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
+import org.apache.jackrabbit.oak.plugins.document.MongoConnectionFactory;
+import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
+import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;
+import org.apache.jackrabbit.oak.plugins.metric.MetricStatisticsProvider;
+import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.stats.StatisticsProvider;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class PipelineITUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineITUtil.class);
+
+    private static final int LONG_PATH_TEST_LEVELS = 30;
+    private static final String LONG_PATH_LEVEL_STRING = "Z12345678901234567890-Level_";
+
+    static final List<String> EXPECTED_FFS = new ArrayList<>(List.of(
+            "/|{}",
+            "/content|{}",
+            "/content/dam|{}",
+            "/content/dam/1000|{}",
+            "/content/dam/1000/12|{\"p1\":\"v100012\"}",
+            "/content/dam/2022|{}",
+            "/content/dam/2022/01|{\"p1\":\"v202201\"}",
+            "/content/dam/2022/01/01|{\"p1\":\"v20220101\"}",
+            "/content/dam/2022/02|{\"p1\":\"v202202\"}",
+            "/content/dam/2022/02/01|{\"p1\":\"v20220201\"}",
+            "/content/dam/2022/02/02|{\"p1\":\"v20220202\"}",
+            "/content/dam/2022/02/03|{\"p1\":\"v20220203\"}",
+            "/content/dam/2022/02/04|{\"p1\":\"v20220204\"}",
+            "/content/dam/2022/03|{\"p1\":\"v202203\"}",
+            "/content/dam/2022/04|{\"p1\":\"v202204\"}",
+            "/content/dam/2023|{\"p2\":\"v2023\"}",
+            "/content/dam/2023/01|{\"p1\":\"v202301\"}",
+            "/content/dam/2023/02|{}",
+            "/content/dam/2023/02/28|{\"p1\":\"v20230228\"}"
+    ));
+
+    static final PathFilter contentDamPathFilter = new PathFilter(List.of("/content/dam"), List.of());
+
+    static {
+        // Generate dynamically the entries expected for the long path tests
+        StringBuilder path = new StringBuilder("/content/dam");
+        for (int i = 0; i < LONG_PATH_TEST_LEVELS; i++) {
+            path.append("/").append(LONG_PATH_LEVEL_STRING).append(i);
+            EXPECTED_FFS.add(path + "|{}");
+        }
+    }
+
+    static void createContent(NodeStore rwNodeStore) throws CommitFailedException {
+        @NotNull NodeBuilder rootBuilder = rwNodeStore.getRoot().builder();
+        @NotNull NodeBuilder contentDamBuilder = rootBuilder.child("content").child("dam");
+        contentDamBuilder.child("1000").child("12").setProperty("p1", "v100012");
+        contentDamBuilder.child("2022").child("01").setProperty("p1", "v202201");
+        contentDamBuilder.child("2022").child("01").child("01").setProperty("p1", "v20220101");
+        contentDamBuilder.child("2022").child("02").setProperty("p1", "v202202");
+        contentDamBuilder.child("2022").child("02").child("01").setProperty("p1", "v20220201");
+        contentDamBuilder.child("2022").child("02").child("02").setProperty("p1", "v20220202");
+        contentDamBuilder.child("2022").child("02").child("03").setProperty("p1", "v20220203");
+        contentDamBuilder.child("2022").child("02").child("04").setProperty("p1", "v20220204");
+        contentDamBuilder.child("2022").child("03").setProperty("p1", "v202203");
+        contentDamBuilder.child("2022").child("04").setProperty("p1", "v202204");
+        contentDamBuilder.child("2023").setProperty("p2", "v2023");
+        contentDamBuilder.child("2023").child("01").setProperty("p1", "v202301");
+        contentDamBuilder.child("2023").child("01").setProperty("p1", "v202301");
+        contentDamBuilder.child("2023").child("02").child("28").setProperty("p1", "v20230228");
+
+        // Node with very long name
+        @NotNull NodeBuilder node = contentDamBuilder;
+        for (int i = 0; i < LONG_PATH_TEST_LEVELS; i++) {
+            node = node.child(LONG_PATH_LEVEL_STRING + i);
+        }
+
+        // Other subtrees, to exercise filtering
+        rootBuilder.child("jcr:system").child("jcr:versionStorage")
+                .child("42").child("41").child("1.0").child("jcr:frozenNode").child("nodes").child("node0");
+        rootBuilder.child("home").child("users").child("system").child("cq:services").child("internal")
+                .child("dam").child("foobar").child("rep:principalPolicy").child("entry2")
+                .child("rep:restrictions");
+        rootBuilder.child("etc").child("scaffolding").child("jcr:content").child("cq:dialog")
+                .child("content").child("items").child("tabs").child("items").child("basic")
+                .child("items");
+
+        rwNodeStore.merge(rootBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+    }
+
+    static void assertMetrics(MetricStatisticsProvider statsProvider) {
+        // Check the statistics
+        Set<String> metricsNames = statsProvider.getRegistry().getCounters().keySet();
+
+        assertEquals(Set.of(
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_DURATION_SECONDS,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_ENQUEUE_DELAY_PERCENTAGE,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL_BYTES,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_TRAVERSED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_REJECTED_SPLIT_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_ACCEPTED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_REJECTED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_ACCEPTED_PERCENTAGE,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_REJECTED_EMPTY_NODE_STATE_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_TRAVERSED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_ACCEPTED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_REJECTED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_ACCEPTED_PERCENTAGE,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_REJECTED_HIDDEN_PATHS_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_REJECTED_PATH_FILTERED_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_EXTRACTED_ENTRIES_TOTAL_BYTES,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_CREATE_SORT_ARRAY_PERCENTAGE,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_SORT_ARRAY_PERCENTAGE,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_WRITE_TO_DISK_PERCENTAGE,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_INTERMEDIATE_FILES_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_EAGER_MERGES_RUNS_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FINAL_MERGE_FILES_COUNT_TOTAL,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FLAT_FILE_STORE_SIZE_BYTES,
+                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FINAL_MERGE_DURATION_SECONDS
+        ), metricsNames);
+
+        String pipelinedMetrics = statsProvider.getRegistry()
+                .getCounters()
+                .entrySet().stream()
+                .map(e -> e.getKey() + " " + e.getValue().getCount())
+                .collect(Collectors.joining("\n"));
+        LOG.info("Metrics\n{}", pipelinedMetrics);
+    }
+
+    static MongoTestBackend createNodeStore(boolean readOnly, MongoConnectionFactory connectionFactory, DocumentMKBuilderProvider builderProvider) {
+        MongoConnection c = connectionFactory.getConnection();
+        DocumentMK.Builder builder = builderProvider.newBuilder();
+        builder.setMongoDB(c.getMongoClient(), c.getDBName());
+        if (readOnly) {
+            builder.setReadOnlyMode();
+        }
+        builder.setAsyncDelay(1);
+        DocumentNodeStore documentNodeStore = builder.getNodeStore();
+        return new MongoTestBackend(c.getMongoURI(), (MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase());
+    }
+
+    static MongoTestBackend createNodeStore(boolean readOnly, String mongoUri, DocumentMKBuilderProvider builderProvider) {
+        MongoClientURI mongoClientUri = new MongoClientURI(mongoUri);
+        DocumentMK.Builder builder = builderProvider.newBuilder();
+        builder.setMongoDB(mongoUri, "oak", 0);
+        if (readOnly) {
+            builder.setReadOnlyMode();
+        }
+        builder.setAsyncDelay(1);
+        DocumentNodeStore documentNodeStore = builder.getNodeStore();
+        MongoDocumentStore mongoDocumentStore = (MongoDocumentStore) builder.getDocumentStore();
+        // TODO: Resource not released
+        MongoConnection c = new MongoConnection(mongoUri);
+        return new MongoTestBackend(mongoClientUri, mongoDocumentStore, documentNodeStore, c.getDatabase());
+    }
+
+
+    static PipelinedStrategy createStrategy(MongoTestBackend backend, Predicate<String> pathPredicate, List<PathFilter> pathFilters, File storeDir) {
+        Set<String> preferredPathElements = Set.of();
+        RevisionVector rootRevision = backend.documentNodeStore.getRoot().getRootRevision();
+        return new PipelinedStrategy(
+                backend.mongoClientURI,
+                backend.mongoDocumentStore,
+                backend.documentNodeStore,
+                rootRevision,
+                preferredPathElements,
+                new MemoryBlobStore(),
+                storeDir,
+                Compression.NONE,
+                pathPredicate,
+                pathFilters,
+                null,
+                StatisticsProvider.NOOP,
+                IndexingReporter.NOOP);
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import com.mongodb.MongoClientURI;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
-
 public class PipelineITUtil {
     private static final Logger LOG = LoggerFactory.getLogger(PipelineITUtil.class);
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -382,7 +382,7 @@ public class PipelinedIT {
         settings.forEach(System::setProperty);
 
         try (MongoTestBackend rwStore = createNodeStore(false)) {
-            var rwNodeStore = rwStore.documentNodeStore;
+            DocumentNodeStore rwNodeStore = rwStore.documentNodeStore;
             contentBuilder.accept(rwNodeStore);
             MongoTestBackend roStore = createNodeStore(true);
 
@@ -416,7 +416,7 @@ public class PipelinedIT {
                 // documents, even if they do not match the includedPaths.
                 result = result.stream()
                         .filter(s -> {
-                            var name = s.split("\\|")[0];
+                            String name = s.split("\\|")[0];
                             return name.length() < Utils.PATH_LONG;
                         })
                         .collect(Collectors.toList());

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedIT.java
@@ -18,19 +18,16 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
-import com.mongodb.client.MongoDatabase;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.commons.Compression;
 import org.apache.jackrabbit.oak.commons.PathUtils;
-import org.apache.jackrabbit.oak.plugins.document.DocumentMK;
 import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.MongoConnectionFactory;
 import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.plugins.index.ConsoleIndexingReporter;
@@ -40,7 +37,6 @@ import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
-import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -52,8 +48,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,6 +65,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelineITUtil.assertMetrics;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelineITUtil.contentDamPathFilter;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDED_PATHS;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDE_ENTRIES_REGEX;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING;
@@ -81,11 +77,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class PipelinedIT {
-    private static final Logger LOG = LoggerFactory.getLogger(PipelinedIT.class);
-    private static final PathFilter contentDamPathFilter = new PathFilter(List.of("/content/dam"), List.of());
-    private static final int LONG_PATH_TEST_LEVELS = 30;
-    private static final String LONG_PATH_LEVEL_STRING = "Z12345678901234567890-Level_";
-
     private static ScheduledExecutorService executorService;
     @Rule
     public final MongoConnectionFactory connectionFactory = new MongoConnectionFactory();
@@ -103,12 +94,6 @@ public class PipelinedIT {
     @BeforeClass
     public static void setup() throws IOException {
         Assume.assumeTrue(MongoUtils.isAvailable());
-        // Generate dynamically the entries expected for the long path tests
-        StringBuilder path = new StringBuilder("/content/dam");
-        for (int i = 0; i < LONG_PATH_TEST_LEVELS; i++) {
-            path.append("/").append(LONG_PATH_LEVEL_STRING).append(i);
-            EXPECTED_FFS.add(path + "|{}");
-        }
         executorService = Executors.newSingleThreadScheduledExecutor();
     }
 
@@ -138,39 +123,6 @@ public class PipelinedIT {
         statsProvider.close();
         statsProvider = null;
         indexingReporter = null;
-    }
-
-    @Test
-    public void createFFS_retryOnMongoFailures_noMongoFiltering() throws Exception {
-        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "true");
-        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "false");
-
-        Predicate<String> pathPredicate = s -> contentDamPathFilter.filter(s) != PathFilter.Result.EXCLUDE;
-        List<PathFilter> pathFilters = null;
-
-        testSuccessfulDownload(pathPredicate, pathFilters);
-    }
-
-    @Test
-    public void createFFS_retryOnMongoFailures_mongoFiltering() throws Exception {
-        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "true");
-        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");
-
-        Predicate<String> pathPredicate = s -> true;
-        List<PathFilter> pathFilters = List.of(contentDamPathFilter);
-
-        testSuccessfulDownload(pathPredicate, pathFilters);
-    }
-
-    @Test
-    public void createFFS_noRetryOnMongoFailures_mongoFiltering() throws Exception {
-        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "false");
-        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");
-
-        Predicate<String> pathPredicate = s -> true;
-        List<PathFilter> pathFilters = List.of(contentDamPathFilter);
-
-        testSuccessfulDownload(pathPredicate, pathFilters);
     }
 
     @Test
@@ -310,23 +262,12 @@ public class PipelinedIT {
     }
 
     @Test
-    public void createFFS_noRetryOnMongoFailures_noMongoFiltering() throws Exception {
-        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "false");
-        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "false");
-
-        Predicate<String> pathPredicate = s -> contentDamPathFilter.filter(s) != PathFilter.Result.EXCLUDE;
-        List<PathFilter> pathFilters = List.of(new PathFilter(List.of("/content/dam"), List.of()));
-
-        testSuccessfulDownload(pathPredicate, pathFilters);
-    }
-
-    @Test
     public void createFFS_filter_long_paths() throws Exception {
         System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, "false");
         System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, "true");
 
         // Create a filter on the node with the longest path
-        String longestLine = EXPECTED_FFS.stream().max(Comparator.comparingInt(String::length)).get();
+        String longestLine = PipelineITUtil.EXPECTED_FFS.stream().max(Comparator.comparingInt(String::length)).get();
         String longestPath = longestLine.substring(0, longestLine.lastIndexOf("|"));
         String parent = PathUtils.getParentPath(longestPath);
         Predicate<String> pathPredicate = s -> true;
@@ -440,134 +381,99 @@ public class PipelinedIT {
                                        List<String> expected) throws IOException {
         settings.forEach(System::setProperty);
 
-        Backend rwStore = createNodeStore(false);
-        var rwNodeStore = rwStore.documentNodeStore;
-        contentBuilder.accept(rwNodeStore);
-        Backend roStore = createNodeStore(true);
+        try (MongoTestBackend rwStore = createNodeStore(false)) {
+            var rwNodeStore = rwStore.documentNodeStore;
+            contentBuilder.accept(rwNodeStore);
+            MongoTestBackend roStore = createNodeStore(true);
 
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
-        File file = pipelinedStrategy.createSortedStoreFile();
+            PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
+            File file = pipelinedStrategy.createSortedStoreFile();
 
-        assertTrue(file.exists());
-        assertEquals(expected, Files.readAllLines(file.toPath()));
-        assertMetrics();
+            assertTrue(file.exists());
+            assertEquals(expected, Files.readAllLines(file.toPath()));
+            assertMetrics(statsProvider);
+        }
     }
 
     private void testSuccessfulDownload(Predicate<String> pathPredicate, List<PathFilter> pathFilters)
             throws CommitFailedException, IOException {
-        testSuccessfulDownload(pathPredicate, pathFilters, EXPECTED_FFS, false);
+        testSuccessfulDownload(pathPredicate, pathFilters, PipelineITUtil.EXPECTED_FFS, false);
     }
 
     private void testSuccessfulDownload(Predicate<String> pathPredicate, List<PathFilter> pathFilters, List<String> expected, boolean ignoreLongPaths)
             throws CommitFailedException, IOException {
-        Backend rwStore = createNodeStore(false);
-        createContent(rwStore.documentNodeStore);
-
-        Backend roStore = createNodeStore(true);
-
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
-
-        File file = pipelinedStrategy.createSortedStoreFile();
-        assertTrue(file.exists());
-        List<String> result = Files.readAllLines(file.toPath());
-        if (ignoreLongPaths) {
-            // Remove the long paths from the result. The filter on Mongo is best-effort, it will download long path
-            // documents, even if they do not match the includedPaths.
-            result = result.stream()
-                    .filter(s -> {
-                        var name = s.split("\\|")[0];
-                        return name.length() < Utils.PATH_LONG;
-                    })
-                    .collect(Collectors.toList());
-
+        try (MongoTestBackend rwStore = createNodeStore(false)) {
+            PipelineITUtil.createContent(rwStore.documentNodeStore);
         }
-        assertEquals(expected, result);
-        assertMetrics();
-    }
 
-    private void assertMetrics() {
-        // Check the statistics
-        Set<String> metricsNames = statsProvider.getRegistry().getCounters().keySet();
+        try (MongoTestBackend roStore = createNodeStore(true)) {
+            PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
+            File file = pipelinedStrategy.createSortedStoreFile();
+            assertTrue(file.exists());
+            List<String> result = Files.readAllLines(file.toPath());
+            if (ignoreLongPaths) {
+                // Remove the long paths from the result. The filter on Mongo is best-effort, it will download long path
+                // documents, even if they do not match the includedPaths.
+                result = result.stream()
+                        .filter(s -> {
+                            var name = s.split("\\|")[0];
+                            return name.length() < Utils.PATH_LONG;
+                        })
+                        .collect(Collectors.toList());
 
-        assertEquals(Set.of(
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_DURATION_SECONDS,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_ENQUEUE_DELAY_PERCENTAGE,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL_BYTES,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_TRAVERSED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_REJECTED_SPLIT_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_ACCEPTED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_REJECTED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_ACCEPTED_PERCENTAGE,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_REJECTED_EMPTY_NODE_STATE_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_TRAVERSED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_ACCEPTED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_REJECTED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_ACCEPTED_PERCENTAGE,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_REJECTED_HIDDEN_PATHS_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_REJECTED_PATH_FILTERED_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_EXTRACTED_ENTRIES_TOTAL_BYTES,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_CREATE_SORT_ARRAY_PERCENTAGE,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_SORT_ARRAY_PERCENTAGE,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_WRITE_TO_DISK_PERCENTAGE,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_INTERMEDIATE_FILES_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_EAGER_MERGES_RUNS_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FINAL_MERGE_FILES_COUNT_TOTAL,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FLAT_FILE_STORE_SIZE_BYTES,
-                PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FINAL_MERGE_DURATION_SECONDS
-        ), metricsNames);
-
-        String pipelinedMetrics = statsProvider.getRegistry()
-                .getCounters()
-                .entrySet().stream()
-                .map(e -> e.getKey() + " " + e.getValue().getCount())
-                .collect(Collectors.joining("\n"));
-        LOG.info("Metrics\n{}", pipelinedMetrics);
+            }
+            assertEquals(expected, result);
+            assertMetrics(statsProvider);
+        }
     }
 
     @Test
     public void createFFS_pathPredicateDoesNotMatch() throws Exception {
-        Backend rwStore = createNodeStore(false);
-        createContent(rwStore.documentNodeStore);
+        try (MongoTestBackend rwStore = createNodeStore(false)) {
+            PipelineITUtil.createContent(rwStore.documentNodeStore);
+        }
 
-        Backend roStore = createNodeStore(true);
-        Predicate<String> pathPredicate = s -> s.startsWith("/content/dam/does-not-exist");
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, null);
+        try (MongoTestBackend roStore = createNodeStore(true)) {
+            Predicate<String> pathPredicate = s -> s.startsWith("/content/dam/does-not-exist");
+            PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, null);
 
-        File file = pipelinedStrategy.createSortedStoreFile();
+            File file = pipelinedStrategy.createSortedStoreFile();
 
-        assertTrue(file.exists());
-        assertEquals("", Files.readString(file.toPath()));
+            assertTrue(file.exists());
+            assertEquals("", Files.readString(file.toPath()));
+        }
     }
 
     @Test
-    public void createFFS_badNumberOfTransformThreads() throws CommitFailedException {
+    public void createFFS_badNumberOfTransformThreads() throws CommitFailedException, IOException {
         System.setProperty(PipelinedStrategy.OAK_INDEXER_PIPELINED_TRANSFORM_THREADS, "0");
 
-        Backend rwStore = createNodeStore(false);
-        createContent(rwStore.documentNodeStore);
+        try (MongoTestBackend rwStore = createNodeStore(false)) {
+            PipelineITUtil.createContent(rwStore.documentNodeStore);
+        }
 
-        Backend roStore = createNodeStore(true);
-
-        assertThrows("Invalid value for property " + PipelinedStrategy.OAK_INDEXER_PIPELINED_TRANSFORM_THREADS + ": 0. Must be > 0",
-                IllegalArgumentException.class,
-                () -> createStrategy(roStore)
-        );
+        try (MongoTestBackend roStore = createNodeStore(true)) {
+            assertThrows("Invalid value for property " + PipelinedStrategy.OAK_INDEXER_PIPELINED_TRANSFORM_THREADS + ": 0. Must be > 0",
+                    IllegalArgumentException.class,
+                    () -> createStrategy(roStore)
+            );
+        }
     }
 
     @Test
-    public void createFFS_badWorkingMemorySetting() throws CommitFailedException {
+    public void createFFS_badWorkingMemorySetting() throws CommitFailedException, IOException {
         System.setProperty(PipelinedStrategy.OAK_INDEXER_PIPELINED_WORKING_MEMORY_MB, "-1");
 
-        Backend rwStore = createNodeStore(false);
-        createContent(rwStore.documentNodeStore);
+        try (MongoTestBackend rwStore = createNodeStore(false)) {
+            PipelineITUtil.createContent(rwStore.documentNodeStore);
+        }
 
-        Backend roStore = createNodeStore(true);
-
-        assertThrows("Invalid value for property " + PipelinedStrategy.OAK_INDEXER_PIPELINED_WORKING_MEMORY_MB + ": -1. Must be >= 0",
-                IllegalArgumentException.class,
-                () -> createStrategy(roStore)
-        );
+        try (MongoTestBackend roStore = createNodeStore(true)) {
+            assertThrows("Invalid value for property " + PipelinedStrategy.OAK_INDEXER_PIPELINED_WORKING_MEMORY_MB + ": -1. Must be >= 0",
+                    IllegalArgumentException.class,
+                    () -> createStrategy(roStore)
+            );
+        }
     }
 
     @Test
@@ -588,7 +494,7 @@ public class PipelinedIT {
         Predicate<String> pathPredicate = s -> contentDamPathFilter.filter(s) != PathFilter.Result.EXCLUDE;
         List<PathFilter> pathFilters = null;
 
-        Backend rwStore = createNodeStore(false);
+        MongoTestBackend rwStore = createNodeStore(false);
         @NotNull NodeBuilder rootBuilder = rwStore.documentNodeStore.getRoot().builder();
         // This property does not fit in the reserved memory, but must still be processed without errors
         String longString = RandomStringUtils.random((int) (10 * FileUtils.ONE_MB), true, true);
@@ -610,13 +516,13 @@ public class PipelinedIT {
                 "/content/dam/2023/01|{\"p1\":\"v202301\"}"
         );
 
-        Backend roStore = createNodeStore(true);
+        MongoTestBackend roStore = createNodeStore(true);
         PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
 
         File file = pipelinedStrategy.createSortedStoreFile();
         assertTrue(file.exists());
         assertArrayEquals(expected.toArray(new String[0]), Files.readAllLines(file.toPath()).toArray(new String[0]));
-        assertMetrics();
+        assertMetrics(statsProvider);
     }
 
 
@@ -697,27 +603,32 @@ public class PipelinedIT {
         System.setProperty(PipelinedStrategy.OAK_INDEXER_PIPELINED_TRANSFORM_THREADS, "1");
         System.setProperty(PipelinedStrategy.OAK_INDEXER_PIPELINED_WORKING_MEMORY_MB, "8000");
 
-        Backend rwStore = createNodeStore(false);
-        createContent(rwStore.documentNodeStore);
+        try (MongoTestBackend rwStore = createNodeStore(false)) {
+            PipelineITUtil.createContent(rwStore.documentNodeStore);
+        }
 
-        Backend roStore = createNodeStore(true);
-        Predicate<String> pathPredicate = s -> s.startsWith("/content/dam");
-        PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, null);
-
-        pipelinedStrategy.createSortedStoreFile();
+        try (MongoTestBackend roStore = createNodeStore(true)) {
+            Predicate<String> pathPredicate = s -> s.startsWith("/content/dam");
+            PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, null);
+            pipelinedStrategy.createSortedStoreFile();
+        }
     }
 
-    private PipelinedStrategy createStrategy(Backend roStore) {
+    private MongoTestBackend createNodeStore(boolean b) {
+        return PipelineITUtil.createNodeStore(b, connectionFactory, builderProvider);
+    }
+
+    private PipelinedStrategy createStrategy(MongoTestBackend roStore) {
         return createStrategy(roStore, s -> true, null);
     }
 
-    private PipelinedStrategy createStrategy(Backend backend, Predicate<String> pathPredicate, List<PathFilter> pathFilters) {
+    private PipelinedStrategy createStrategy(MongoTestBackend backend, Predicate<String> pathPredicate, List<PathFilter> pathFilters) {
         Set<String> preferredPathElements = Set.of();
         RevisionVector rootRevision = backend.documentNodeStore.getRoot().getRootRevision();
         indexingReporter.setIndexNames(List.of("testIndex"));
         return new PipelinedStrategy(
+                backend.mongoClientURI,
                 backend.mongoDocumentStore,
-                backend.mongoDatabase,
                 backend.documentNodeStore,
                 rootRevision,
                 preferredPathElements,
@@ -729,88 +640,5 @@ public class PipelinedIT {
                 null,
                 statsProvider,
                 indexingReporter);
-    }
-
-    private void createContent(NodeStore rwNodeStore) throws CommitFailedException {
-        @NotNull NodeBuilder rootBuilder = rwNodeStore.getRoot().builder();
-        @NotNull NodeBuilder contentDamBuilder = rootBuilder.child("content").child("dam");
-        contentDamBuilder.child("1000").child("12").setProperty("p1", "v100012");
-        contentDamBuilder.child("2022").child("01").setProperty("p1", "v202201");
-        contentDamBuilder.child("2022").child("01").child("01").setProperty("p1", "v20220101");
-        contentDamBuilder.child("2022").child("02").setProperty("p1", "v202202");
-        contentDamBuilder.child("2022").child("02").child("01").setProperty("p1", "v20220201");
-        contentDamBuilder.child("2022").child("02").child("02").setProperty("p1", "v20220202");
-        contentDamBuilder.child("2022").child("02").child("03").setProperty("p1", "v20220203");
-        contentDamBuilder.child("2022").child("02").child("04").setProperty("p1", "v20220204");
-        contentDamBuilder.child("2022").child("03").setProperty("p1", "v202203");
-        contentDamBuilder.child("2022").child("04").setProperty("p1", "v202204");
-        contentDamBuilder.child("2023").setProperty("p2", "v2023");
-        contentDamBuilder.child("2023").child("01").setProperty("p1", "v202301");
-        contentDamBuilder.child("2023").child("01").setProperty("p1", "v202301");
-        contentDamBuilder.child("2023").child("02").child("28").setProperty("p1", "v20230228");
-
-        // Node with very long name
-        @NotNull NodeBuilder node = contentDamBuilder;
-        for (int i = 0; i < LONG_PATH_TEST_LEVELS; i++) {
-            node = node.child(LONG_PATH_LEVEL_STRING + i);
-        }
-
-        // Other subtrees, to exercise filtering
-        rootBuilder.child("jcr:system").child("jcr:versionStorage")
-                .child("42").child("41").child("1.0").child("jcr:frozenNode").child("nodes").child("node0");
-        rootBuilder.child("home").child("users").child("system").child("cq:services").child("internal")
-                .child("dam").child("foobar").child("rep:principalPolicy").child("entry2")
-                .child("rep:restrictions");
-        rootBuilder.child("etc").child("scaffolding").child("jcr:content").child("cq:dialog")
-                .child("content").child("items").child("tabs").child("items").child("basic")
-                .child("items");
-
-        rwNodeStore.merge(rootBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-    }
-
-    private static final List<String> EXPECTED_FFS = new ArrayList<>(List.of(
-            "/|{}",
-            "/content|{}",
-            "/content/dam|{}",
-            "/content/dam/1000|{}",
-            "/content/dam/1000/12|{\"p1\":\"v100012\"}",
-            "/content/dam/2022|{}",
-            "/content/dam/2022/01|{\"p1\":\"v202201\"}",
-            "/content/dam/2022/01/01|{\"p1\":\"v20220101\"}",
-            "/content/dam/2022/02|{\"p1\":\"v202202\"}",
-            "/content/dam/2022/02/01|{\"p1\":\"v20220201\"}",
-            "/content/dam/2022/02/02|{\"p1\":\"v20220202\"}",
-            "/content/dam/2022/02/03|{\"p1\":\"v20220203\"}",
-            "/content/dam/2022/02/04|{\"p1\":\"v20220204\"}",
-            "/content/dam/2022/03|{\"p1\":\"v202203\"}",
-            "/content/dam/2022/04|{\"p1\":\"v202204\"}",
-            "/content/dam/2023|{\"p2\":\"v2023\"}",
-            "/content/dam/2023/01|{\"p1\":\"v202301\"}",
-            "/content/dam/2023/02|{}",
-            "/content/dam/2023/02/28|{\"p1\":\"v20230228\"}"
-    ));
-
-    private Backend createNodeStore(boolean readOnly) {
-        MongoConnection c = connectionFactory.getConnection();
-        DocumentMK.Builder builder = builderProvider.newBuilder();
-        builder.setMongoDB(c.getMongoClient(), c.getDBName());
-        if (readOnly) {
-            builder.setReadOnlyMode();
-        }
-        builder.setAsyncDelay(1);
-        DocumentNodeStore documentNodeStore = builder.getNodeStore();
-        return new Backend((MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase());
-    }
-
-    static class Backend {
-        final MongoDocumentStore mongoDocumentStore;
-        final DocumentNodeStore documentNodeStore;
-        final MongoDatabase mongoDatabase;
-
-        public Backend(MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoDatabase mongoDatabase) {
-            this.mongoDocumentStore = mongoDocumentStore;
-            this.documentNodeStore = documentNodeStore;
-            this.mongoDatabase = mongoDatabase;
-        }
     }
 }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import eu.rekawek.toxiproxy.model.toxic.LimitData;
+import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
+import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP;
+
+public class PipelinedMongoConnectionFailureIT {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoConnectionFailureIT.class);
+
+    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.6.0");
+    // We cannot use the MongoDockerRule/MongoConnectionFactory because they don't allow customizing the docker network
+    // used to launch the Mongo container.
+    private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:5.0");
+    private static final int MONGODB_DEFAULT_PORT = 27017;
+
+    @Rule
+    public final Network network = Network.newNetwork();
+    @Rule
+    public final TemporaryFolder sortFolder = new TemporaryFolder();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+    @Rule
+    public final MongoDBContainer mongoDBContainer = new MongoDBContainer(MONGODB_IMAGE)
+            .withNetwork(network)
+            .withNetworkAliases("mongo")
+            .withExposedPorts(MONGODB_DEFAULT_PORT);
+    @Rule
+    public final ToxiproxyContainer toxiproxy = new ToxiproxyContainer(TOXIPROXY_IMAGE).withNetwork(network);
+    @Rule
+    public final DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
+
+    private Proxy proxy;
+    private String mongoUri;
+
+    @Before
+    public void before() throws Exception {
+        ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+        this.proxy = toxiproxyClient.createProxy("mongo", "0.0.0.0:8666", "mongo:" + MONGODB_DEFAULT_PORT);
+        this.mongoUri = "mongodb://" + toxiproxy.getHost() + ":" + toxiproxy.getMappedPort(8666) + "/" + MongoUtils.DB;
+    }
+
+    @Test
+    public void mongoDisconnectTest() throws Exception {
+        // Testcontainers' MongoDBContainer starts a Mongo replica set of one node. If parallel dump is enabled, the
+        // Mongo server selector will refuse to connect to the primary node, which is the only node, so it will forever
+        // fail to connect to Mongo. For the time being, we test reconnections without parallel dump
+
+        // TODO: Update the server selector policy to also connect to the primary in case there are no secondaries after some
+        // grace period to allow for the discovery of replicas to complete.
+
+        // Add a test case with more data to test the reconnection logic
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP, "false");
+
+        try (MongoTestBackend rwBackend = PipelineITUtil.createNodeStore(false, mongoUri, builderProvider)) {
+            PipelineITUtil.createContent(rwBackend.documentNodeStore);
+            rwBackend.documentNodeStore.dispose();
+            rwBackend.mongoDocumentStore.dispose();
+        }
+
+        Path resultWithoutInterruption;
+        LOG.info("Creating a FFS: reference run without failures.");
+        try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUri, builderProvider)) {
+            var strategy = createStrategy(roBackend);
+            resultWithoutInterruption = strategy.createSortedStoreFile().toPath();
+        }
+
+        Path resultWithInterruption;
+        LOG.info("Creating a FFS: test run with disconnection to Mongo.");
+        try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUri, builderProvider)) {
+            LimitData cutConnectionUpstream = proxy.toxics()
+                    .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.DOWNSTREAM, 30000L);
+            var scheduleExecutor = Executors.newSingleThreadScheduledExecutor();
+            try {
+                scheduleExecutor.schedule(() -> {
+                    try {
+                        LOG.info("Removing connection block");
+                        cutConnectionUpstream.remove();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }, 5, TimeUnit.SECONDS);
+
+                PipelinedStrategy strategy = createStrategy(roBackend);
+                resultWithInterruption = strategy.createSortedStoreFile().toPath();
+            } finally {
+                scheduleExecutor.shutdown();
+            }
+        }
+
+        LOG.info("Comparing resulting FFS with and without Mongo disconnections: {} {}", resultWithoutInterruption, resultWithInterruption);
+        Assert.assertEquals(Files.readAllLines(resultWithoutInterruption), Files.readAllLines(resultWithInterruption));
+    }
+
+    private PipelinedStrategy createStrategy(MongoTestBackend roStore) throws IOException {
+        return PipelineITUtil.createStrategy(roStore, s -> true, null, sortFolder.newFolder());
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
@@ -24,6 +24,7 @@ import eu.rekawek.toxiproxy.model.ToxicDirection;
 import eu.rekawek.toxiproxy.model.toxic.LimitData;
 import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
 import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDockerRule;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,22 +50,14 @@ import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipeline
 public class PipelinedMongoConnectionFailureIT {
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoConnectionFailureIT.class);
 
-    private static final String MONGO_VERSION = System.getProperty("mongo.version", "5.0");
-    private static final String MONGO_IMAGE = "mongo:" + MONGO_VERSION;
     private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.6.0");
     // We cannot use the MongoDockerRule/MongoConnectionFactory because they don't allow customizing the docker network
     // used to launch the Mongo container.
-    private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse(MONGO_IMAGE);
     private static final int MONGODB_DEFAULT_PORT = 27017;
-
     @Rule
     public final Network network = Network.newNetwork();
     @Rule
-    public final TemporaryFolder sortFolder = new TemporaryFolder();
-    @Rule
-    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
-    @Rule
-    public final MongoDBContainer mongoDBContainer = new MongoDBContainer(MONGODB_IMAGE)
+    public final MongoDBContainer mongoDBContainer = new MongoDBContainer(MongoDockerRule.getDockerImageName())
             .withNetwork(network)
             .withNetworkAliases("mongo")
             .withExposedPorts(MONGODB_DEFAULT_PORT);
@@ -72,6 +65,10 @@ public class PipelinedMongoConnectionFailureIT {
     public final ToxiproxyContainer toxiproxy = new ToxiproxyContainer(TOXIPROXY_IMAGE).withNetwork(network);
     @Rule
     public final DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
+    @Rule
+    public final TemporaryFolder sortFolder = new TemporaryFolder();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     private Proxy proxy;
     private String mongoUri;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP;
@@ -103,7 +104,7 @@ public class PipelinedMongoConnectionFailureIT {
         Path resultWithoutInterruption;
         LOG.info("Creating a FFS: reference run without failures.");
         try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUri, builderProvider)) {
-            var strategy = createStrategy(roBackend);
+            PipelinedStrategy strategy = createStrategy(roBackend);
             resultWithoutInterruption = strategy.createSortedStoreFile().toPath();
         }
 
@@ -112,7 +113,7 @@ public class PipelinedMongoConnectionFailureIT {
         try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUri, builderProvider)) {
             LimitData cutConnectionUpstream = proxy.toxics()
                     .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.DOWNSTREAM, 30000L);
-            var scheduleExecutor = Executors.newSingleThreadScheduledExecutor();
+            ScheduledExecutorService scheduleExecutor = Executors.newSingleThreadScheduledExecutor();
             try {
                 scheduleExecutor.schedule(() -> {
                     try {

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
@@ -48,10 +48,12 @@ import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipeline
 public class PipelinedMongoConnectionFailureIT {
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoConnectionFailureIT.class);
 
+    private static final String MONGO_VERSION = System.getProperty("mongo.version", "5.0");
+    private static final String MONGO_IMAGE = "mongo:" + MONGO_VERSION;
     private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.6.0");
     // We cannot use the MongoDockerRule/MongoConnectionFactory because they don't allow customizing the docker network
     // used to launch the Mongo container.
-    private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:5.0");
+    private static final DockerImageName MONGODB_IMAGE = DockerImageName.parse(MONGO_IMAGE);
     private static final int MONGODB_DEFAULT_PORT = 27017;
 
     @Rule

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -19,49 +19,34 @@
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import com.mongodb.MongoClient;
-import com.mongodb.MongoSocketException;
-import com.mongodb.ServerAddress;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
-import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.MongoRegexPathFilterFactory.MongoFilterPaths;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.index.ConsoleIndexingReporter;
-import org.apache.jackrabbit.oak.plugins.metric.MetricStatisticsProvider;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.LONG_PATH_ID_PATTERN;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.MongoDownloaderRegexUtils.LONG_PATH_ID_PATTERN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class PipelinedMongoDownloadTaskTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     private MongoRegexPathFilterFactory regexFilterBuilder;
 
@@ -78,94 +63,17 @@ public class PipelinedMongoDownloadTaskTest {
         this.regexFilterBuilder = new MongoRegexPathFilterFactory(PipelinedMongoDownloadTask.DEFAULT_OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING_MAX_PATHS);
     }
 
-    @Test
-    public void connectionToMongoFailure() throws Exception {
-        @SuppressWarnings("unchecked")
-        MongoCollection<NodeDocument> dbCollection = mock(MongoCollection.class);
-
-        MongoDatabase mongoDatabase = mock(MongoDatabase.class);
-        when(mongoDatabase.withCodecRegistry(any())).thenReturn(mongoDatabase);
-        when(mongoDatabase.getCollection(eq(Collection.NODES.toString()), eq(NodeDocument.class))).thenReturn(dbCollection);
-
-        DocumentStore docStore = mock(DocumentStore.class);
-        List<NodeDocument> documents = List.of(
-                newBasicDBObject("1", 123_000, docStore),
-                newBasicDBObject("2", 123_000, docStore),
-                newBasicDBObject("3", 123_001, docStore),
-                newBasicDBObject("4", 123_002, docStore));
-
-        @SuppressWarnings("unchecked")
-        MongoCursor<NodeDocument> cursor = mock(MongoCursor.class);
-        when(cursor.hasNext())
-                .thenReturn(true)
-                .thenThrow(new MongoSocketException("test", new ServerAddress()))
-                .thenReturn(true, false) // response to the query that will finish downloading the documents with _modified = 123_000
-                .thenReturn(true, true, false); // response to the query that downloads everything again starting from _modified >= 123_001
-        when(cursor.next()).thenReturn(
-                documents.get(0),
-                documents.subList(1, documents.size()).toArray(new NodeDocument[0])
-        );
-
-        @SuppressWarnings("unchecked")
-        FindIterable<NodeDocument> findIterable = mock(FindIterable.class);
-        when(findIterable.sort(any())).thenReturn(findIterable);
-        when(findIterable.iterator()).thenReturn(cursor);
-
-        when(dbCollection.withReadPreference(any())).thenReturn(dbCollection);
-        when(dbCollection.find()).thenReturn(findIterable);
-        when(dbCollection.find(any(Bson.class))).thenReturn(findIterable);
-
-        int batchMaxMemorySize = 512;
-        int batchMaxElements = 10;
-        BlockingQueue<NodeDocument[]> queue = new ArrayBlockingQueue<>(100);
-        MongoDocumentStore mongoDocumentStore = mock(MongoDocumentStore.class);
-
-        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-        try {
-            try (MetricStatisticsProvider metricStatisticsProvider = new MetricStatisticsProvider(null, executor)) {
-                ConsoleIndexingReporter reporter = new ConsoleIndexingReporter();
-                PipelinedMongoDownloadTask task = new PipelinedMongoDownloadTask(mongoDatabase, mongoDocumentStore,
-                        batchMaxMemorySize, batchMaxElements, queue, null,
-                        metricStatisticsProvider, reporter);
-
-                // Execute
-                PipelinedMongoDownloadTask.Result result = task.call();
-
-                // Verify results
-                assertEquals(documents.size(), result.getDocumentsDownloaded());
-                ArrayList<NodeDocument[]> c = new ArrayList<>();
-                queue.drainTo(c);
-                List<NodeDocument> actualDocuments = c.stream().flatMap(Arrays::stream).collect(Collectors.toList());
-                assertEquals(documents, actualDocuments);
-
-                Set<String> metricNames = metricStatisticsProvider.getRegistry().getCounters().keySet();
-                assertEquals(metricNames, Set.of(
-                        PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_ENQUEUE_DELAY_PERCENTAGE,
-                        PipelinedMetrics.OAK_INDEXER_PIPELINED_MONGO_DOWNLOAD_DURATION_SECONDS,
-                        PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL,
-                        PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL_BYTES
-                ));
-            }
-        } finally {
-            executor.shutdown();
-        }
-
-        verify(dbCollection).find(BsonDocument.parse("{\"_modified\": {\"$gte\": 0}}"));
-        verify(dbCollection).find(BsonDocument.parse("{\"_modified\": {\"$gte\": 123000, \"$lt\": 123001}, \"_id\": {\"$gt\": \"3:/content/dam/asset1\"}}"));
-        verify(dbCollection).find(BsonDocument.parse("{\"_modified\": {\"$gte\": 123001}}"));
-    }
-
     private List<PathFilter> createIncludedPathFilters(String... paths) {
         return Arrays.stream(paths).map(path -> new PathFilter(List.of(path), List.of())).collect(Collectors.toList());
     }
 
     @Test
     public void ancestorsFilters() {
-        assertEquals(List.of(), PipelinedMongoDownloadTask.getAncestors(List.of()));
-        assertEquals(List.of("/"), PipelinedMongoDownloadTask.getAncestors(List.of("/")));
-        assertEquals(List.of("/", "/a"), PipelinedMongoDownloadTask.getAncestors(List.of("/a")));
+        assertEquals(List.of(), MongoDownloaderRegexUtils.getAncestors(List.of()));
+        assertEquals(List.of("/"), MongoDownloaderRegexUtils.getAncestors(List.of("/")));
+        assertEquals(List.of("/", "/a"), MongoDownloaderRegexUtils.getAncestors(List.of("/a")));
         assertEquals(List.of("/", "/a", "/b", "/c", "/c/c1", "/c/c1/c2", "/c/c1/c2/c3", "/c/c1/c2/c4"),
-                PipelinedMongoDownloadTask.getAncestors(List.of("/a", "/b", "/c/c1/c2/c3", "/c/c1/c2/c4"))
+                MongoDownloaderRegexUtils.getAncestors(List.of("/a", "/b", "/c/c1/c2/c3", "/c/c1/c2/c4"))
         );
     }
 
@@ -299,11 +207,11 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void createCustomExcludeEntriesFilter() {
-        assertNull(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(null));
-        assertNull(PipelinedMongoDownloadTask.compileCustomExcludedPatterns(""));
+        assertNull(MongoDownloaderRegexUtils.compileCustomExcludedPatterns(null));
+        assertNull(MongoDownloaderRegexUtils.compileCustomExcludedPatterns(""));
 
         Pattern p = Pattern.compile("^(?!.*(^[0-9]{1,3}:/a/b.*$)$)");
-        var actualListOfPatterns = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        var actualListOfPatterns = MongoDownloaderRegexUtils.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertNotNull(actualListOfPatterns);
 
         assertEquals(p.toString(), actualListOfPatterns.toString());
@@ -313,7 +221,7 @@ public class PipelinedMongoDownloadTaskTest {
     public void computeMongoQueryFilterNoPathFilterNoExcludeFilter() {
         // No path filter and no exclude filter
         assertNull(
-                PipelinedMongoDownloadTask.computeMongoQueryFilter(
+                MongoDownloaderRegexUtils.computeMongoQueryFilter(
                         MongoFilterPaths.DOWNLOAD_ALL,
                         null
                 )
@@ -323,14 +231,14 @@ public class PipelinedMongoDownloadTaskTest {
     @Test
     public void computeMongoQueryFilterOptimizeWhenIncludedPathIsRoot() {
         // Path filter but no exclude filter
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 new MongoFilterPaths(List.of("/"), List.of("/excluded1", "/content/excluded2")),
                 null
         );
         // The generated filter should not include any condition to include the descendants of /
         var expected = Filters.and(
-                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded1/"))),
-                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/"))
+                Filters.regex(NodeDocument.ID, MongoDownloaderRegexUtils.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded1/"))),
+                Filters.regex(NodeDocument.ID, MongoDownloaderRegexUtils.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/content/excluded2/"))
                 ));
         assertBsonEquals(expected, actual);
     }
@@ -339,7 +247,7 @@ public class PipelinedMongoDownloadTaskTest {
     @Test
     public void computeMongoQueryFilterWithPathFilterNoExcludeFilter() {
         // Path filter but no exclude filter
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 new MongoFilterPaths(List.of("/parent"), List.of()),
                 null
         );
@@ -352,11 +260,11 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void computeMongoQueryFilterNoPathFilterWithExcludeFilter() {
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 MongoFilterPaths.DOWNLOAD_ALL,
                 "^[0-9]{1,3}:/a/b.*$"
         );
-        var customExcludedPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        var customExcludedPattern = MongoDownloaderRegexUtils.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertNotNull(customExcludedPattern);
         Bson expectedFilter = Filters.regex(NodeDocument.ID, customExcludedPattern);
         assertBsonEquals(expectedFilter, actual);
@@ -364,12 +272,12 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void computeMongoQueryFilterWithPathFilterWithExcludeFilter() {
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 new MongoFilterPaths(List.of("/parent"), List.of()),
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludesPattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludesPattern = MongoDownloaderRegexUtils.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertNotNull(excludesPattern);
         var expected =
                 Filters.and(
@@ -381,12 +289,12 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void computeMongoQueryFilterWithPathFilterWithExcludeFilterAndNaturalOrderTraversal() {
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 new MongoFilterPaths(List.of("/parent"), List.of()),
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = MongoDownloaderRegexUtils.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertNotNull(excludePattern);
         var expected =
                 Filters.and(
@@ -401,15 +309,15 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void computeMongoQueryFilterWithPathFilterWithExcludeFilterAndNaturalColumnTraversal() {
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 new MongoFilterPaths(List.of("/"), List.of("/excluded")),
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = MongoDownloaderRegexUtils.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertNotNull(excludePattern);
         var expected = Filters.and(
-                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
+                Filters.regex(NodeDocument.ID, MongoDownloaderRegexUtils.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
                 Filters.regex(NodeDocument.ID, excludePattern)
         );
         assertBsonEquals(expected, actual);
@@ -417,15 +325,15 @@ public class PipelinedMongoDownloadTaskTest {
 
     @Test
     public void computeMongoQueryFilterWithPathFilterWithExcludeFilterAndNaturalIndexTraversal() {
-        var actual = PipelinedMongoDownloadTask.computeMongoQueryFilter(
+        var actual = MongoDownloaderRegexUtils.computeMongoQueryFilter(
                 new MongoFilterPaths(List.of("/"), List.of("/excluded")),
                 "^[0-9]{1,3}:/a/b.*$"
         );
 
-        Pattern excludePattern = PipelinedMongoDownloadTask.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
+        Pattern excludePattern = MongoDownloaderRegexUtils.compileCustomExcludedPatterns("^[0-9]{1,3}:/a/b.*$");
         assertNotNull(excludePattern);
         var expected = Filters.and(
-                Filters.regex(NodeDocument.ID, PipelinedMongoDownloadTask.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
+                Filters.regex(NodeDocument.ID, MongoDownloaderRegexUtils.compileExcludedDirectoryRegex("^[0-9]{1,3}:" + Pattern.quote("/excluded/"))),
                 Filters.regex(NodeDocument.ID, excludePattern)
         );
         assertBsonEquals(expected, actual);

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelectorTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelectorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import com.mongodb.ServerAddress;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelectorTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelectorTest.java
@@ -1,0 +1,297 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterConnectionMode;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterId;
+import com.mongodb.connection.ClusterType;
+import com.mongodb.connection.ServerConnectionState;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.ServerType;
+import com.mongodb.event.ClusterDescriptionChangedEvent;
+import org.apache.jackrabbit.guava.common.util.concurrent.ThreadFactoryBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PipelinedMongoServerSelectorTest {
+
+    public static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoServerSelector.class);
+    private final static ClusterId TEST_CLUSTER_ID = new ClusterId("test-mongo-cluster");
+
+    private final AtomicInteger serverId = new AtomicInteger(0);
+
+    private final List<ServerDescription> allReplicas = List.of(
+            createServerDescription(ServerType.REPLICA_SET_PRIMARY, ServerConnectionState.CONNECTED),
+            createServerDescription(ServerType.REPLICA_SET_SECONDARY, ServerConnectionState.CONNECTED),
+            createServerDescription(ServerType.REPLICA_SET_SECONDARY, ServerConnectionState.CONNECTED)
+    );
+
+    private final List<ServerDescription> oneSecondaryUp = List.of(
+            createServerDescription(ServerType.REPLICA_SET_PRIMARY, ServerConnectionState.CONNECTED),
+            createServerDescription(ServerType.REPLICA_SET_SECONDARY, ServerConnectionState.CONNECTED)
+    );
+
+    private final List<ServerDescription> noSecondaryUp = List.of(
+            createServerDescription(ServerType.REPLICA_SET_PRIMARY, ServerConnectionState.CONNECTED)
+    );
+
+    private ExecutorService threadAscending;
+    private ExecutorService threadDescending;
+    private ExecutorService threadOther;
+
+    @Before
+    public void setUp() {
+        threadAscending = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-ascending").setDaemon(true).build());
+        threadDescending = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-descending").setDaemon(true).build());
+        threadOther = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("mongo-server-selector-test-thread").setDaemon(true).build());
+    }
+
+    @After
+    public void tearDown() {
+        threadAscending.shutdown();
+        threadDescending.shutdown();
+        threadOther.shutdown();
+    }
+
+    @Test
+    public void calledFromANonDownloaderThread() throws ExecutionException, InterruptedException {
+        // If the Mongo server selector is called from a thread that is not a downloader thread, it should return all 
+        // servers, that is, it is neutral.
+        var t = new PipelinedMongoServerSelector();
+        threadOther.submit(() -> {
+            assertEquals(3, t.select(ClusterType.REPLICA_SET, allReplicas).size());
+            assertEquals(2, t.select(ClusterType.REPLICA_SET, oneSecondaryUp).size());
+            assertEquals(1, t.select(ClusterType.REPLICA_SET, noSecondaryUp).size());
+        }).get();
+    }
+
+    @Test
+    public void allMongoReplicasUp() throws ExecutionException, InterruptedException {
+        var mongoServerSelector = new PipelinedMongoServerSelector();
+
+        var firstThreadSelection = new AtomicReference<ServerDescription>();
+
+        // All nodes available, a downloader thread asks for a connection. It should get one of the secondaries
+        threadAscending.submit(() -> {
+            var firstSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, allReplicas);
+            assertEquals(1, firstSelection.size());
+            var firstSecondarySelected = firstSelection.get(0);
+            assertEquals(ServerType.REPLICA_SET_SECONDARY, firstSecondarySelected.getType());
+            assertTrue(allReplicas.contains(firstSecondarySelected));
+
+            firstThreadSelection.set(firstSecondarySelected);
+
+            // One secondary is taken, the other is available.
+            // If the thread asks again for a connection, it receives the same replica.
+            var secondSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, allReplicas);
+            assertEquals(1, secondSelection.size());
+            assertEquals(firstSecondarySelected, secondSelection.get(0));
+        }).get();
+
+        // Another thread tries to select a replica. It should receive the secondary that is still available.
+        threadDescending.submit(() -> {
+            var serverSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, allReplicas);
+            assertEquals(1, serverSelection.size());
+            var firstSecondarySelected = serverSelection.get(0);
+            assertEquals(ServerType.REPLICA_SET_SECONDARY, firstSecondarySelected.getType());
+            assertTrue(allReplicas.contains(firstSecondarySelected));
+            assertNotEquals(firstThreadSelection.get(), firstSecondarySelected);
+        }).get();
+    }
+
+    @Test
+    public void primaryAndOneSecondaryUp() throws ExecutionException, InterruptedException {
+        var mongoServerSelector = new PipelinedMongoServerSelector();
+        mongoServerSelector.clusterDescriptionChanged(new ClusterDescriptionChangedEvent(
+                        TEST_CLUSTER_ID,
+                        new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, oneSecondaryUp),
+                        new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, oneSecondaryUp)
+                )
+        );
+
+        var firstThreadSelection = new AtomicReference<ServerDescription>();
+
+        threadAscending.submit(() -> {
+            // Should select one of the secondaries
+            var firstSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, oneSecondaryUp);
+            assertEquals(1, firstSelection.size());
+            var firstSecondarySelected = firstSelection.get(0);
+            assertEquals(ServerType.REPLICA_SET_SECONDARY, firstSecondarySelected.getType());
+            assertTrue(oneSecondaryUp.contains(firstSecondarySelected));
+            firstThreadSelection.set(firstSecondarySelected);
+        }).get();
+
+        // Another thread tries to select a replica. But the only secondary available is taken, so the selection algorithm
+        // returns an empty list.
+        threadDescending.submit(() -> {
+            var serverSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, oneSecondaryUp);
+            assertTrue(serverSelection.isEmpty());
+        }).get();
+
+        // The first thread finishes, so the secondary is available again.
+        threadAscending.submit(mongoServerSelector::threadFinished).get();
+
+        threadDescending.submit(() -> {
+            var serverSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, oneSecondaryUp);
+            assertEquals(1, serverSelection.size());
+            assertEquals(firstThreadSelection.get(), serverSelection.get(0));
+        }).get();
+    }
+
+    @Test
+    public void onlyPrimaryUp() throws ExecutionException, InterruptedException {
+        var mongoServerSelector = new PipelinedMongoServerSelector();
+        threadAscending.submit(() -> {
+            // If there is only the primary, do not select it.
+            var firstSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, noSecondaryUp);
+            assertTrue(firstSelection.isEmpty());
+        }).get();
+    }
+
+    @Test
+    public void mongoScaling() throws ExecutionException, InterruptedException {
+        ArrayList<ServerDescription> clusterState = new ArrayList<>();
+        clusterState.add(createServerDescription(ServerType.REPLICA_SET_PRIMARY, ServerConnectionState.CONNECTED));
+        clusterState.add(createServerDescription(ServerType.REPLICA_SET_SECONDARY, ServerConnectionState.CONNECTED));
+        clusterState.add(createServerDescription(ServerType.REPLICA_SET_SECONDARY, ServerConnectionState.CONNECTED));
+
+        /* A scaling of Mongo happens in the following way
+         * 1. Initial state, three replicas available, one primary and two secondaries.
+         *    Downloader threads are connected each to a secondary.
+         * 2. One secondary is taken down. That thread fails, unregisters and tries to get another secondary.
+         *    But fails because there is no other secondary available
+         * 3. After some time, a new replica comes up as a new secondary. The thread that was not able to connect to any
+         *    replica, can now connect to this new secondary
+         * 4. The second secondary of the original replicas is taken down. The thread that was connected to it fails.
+         * 5. After some time, a new secondary comes up and the thread that was disconnected can connect to it.
+         * 6. One of the secondaries (both are new replicas) is promoted to primary and the previous primary (which is
+         *    still an old replica) is demoted to secondary and taken down to be replaced. The thread that is connected
+         *    to the secondary that is promoted to primary should disconnect from it and try to get a new secondary.
+         * 7. After a while, a new replica comes up with the role of secondary and the thread that was idle should
+         *    connect to it.
+         * 8. Scaling is complete.
+         */
+        var allUpClusterDescription = new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, List.copyOf(clusterState));
+        var mongoServerSelector = new PipelinedMongoServerSelector();
+        mongoServerSelector.clusterDescriptionChanged(
+                new ClusterDescriptionChangedEvent(TEST_CLUSTER_ID, allUpClusterDescription, allUpClusterDescription)
+        );
+
+        var ascendingThreadReplica = new AtomicReference<ServerDescription>();
+        var descendingThreadReplica = new AtomicReference<ServerDescription>();
+        threadAscending.submit(() -> {
+            var selection = mongoServerSelector.select(ClusterType.REPLICA_SET, clusterState);
+            assertEquals(1, selection.size());
+            ascendingThreadReplica.set(selection.get(0));
+        }).get();
+        threadDescending.submit(() -> {
+            var selection = mongoServerSelector.select(ClusterType.REPLICA_SET, clusterState);
+            assertEquals(1, selection.size());
+            descendingThreadReplica.set(selection.get(0));
+        }).get();
+
+        ServerDescription firstSecondaryDown = ascendingThreadReplica.get();
+        ServerDescription secondSecondaryDown = descendingThreadReplica.get();
+        ServerDescription originalPrimary = clusterState.stream().filter(ServerDescription::isPrimary).findFirst().get();
+
+        // ****************************
+        // One secondary goes down
+        // ****************************
+        // All threads have a secondary assigned. Take down the replica of the ascending thread.
+        clusterState.remove(firstSecondaryDown);
+        var oneSecondaryDownClusterDescription = new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, List.copyOf(clusterState));
+        mongoServerSelector.clusterDescriptionChanged(
+                new ClusterDescriptionChangedEvent(TEST_CLUSTER_ID, allUpClusterDescription, oneSecondaryDownClusterDescription)
+        );
+
+        // The ascending thread should not be able to connect to any secondary
+        threadAscending.submit(() -> {
+            var selection = mongoServerSelector.select(ClusterType.REPLICA_SET, clusterState);
+            assertTrue(selection.isEmpty());
+            ascendingThreadReplica.set(null);
+        }).get();
+
+        // The descending thread should still have a secondary assigned
+        threadDescending.submit(() -> {
+            var selection = mongoServerSelector.select(ClusterType.REPLICA_SET, clusterState);
+            assertEquals(1, selection.size());
+            assertEquals(descendingThreadReplica.get(), selection.get(0));
+        }).get();
+
+        // ************************************************
+        // The first secondary is replaced by a new replica
+        // ************************************************
+        clusterState.add(firstSecondaryDown);
+        // The ascending thread should now be able to connect to the new secondary
+        threadAscending.submit(() -> {
+            var selection = mongoServerSelector.select(ClusterType.REPLICA_SET, List.copyOf(clusterState));
+            assertEquals(1, selection.size());
+            ascendingThreadReplica.set(selection.get(0));
+            assertNotEquals(descendingThreadReplica.get(), selection.get(0));
+            assertEquals(firstSecondaryDown, selection.get(0));
+        }).get();
+
+        // Taking down the second secondary is similar to the first one, so skipping testing that.
+        // Test the replacement of the primary.
+        // Demote the current primary to secondary and promote the new replica to primary.
+        var demotedPrimary = updateServerType(originalPrimary, ServerType.REPLICA_SET_SECONDARY);
+        var promotedSecondary = updateServerType(firstSecondaryDown, ServerType.REPLICA_SET_PRIMARY);
+        clusterState.set(clusterState.indexOf(originalPrimary), demotedPrimary);
+        clusterState.set(clusterState.indexOf(firstSecondaryDown), promotedSecondary);
+
+        // Update the cluster description
+        var descAfterPrimaryDemoted = new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, List.copyOf(clusterState));
+        mongoServerSelector.clusterDescriptionChanged(
+                new ClusterDescriptionChangedEvent(TEST_CLUSTER_ID, descAfterPrimaryDemoted, oneSecondaryDownClusterDescription)
+        );
+
+        // The ascending thread was connected to the secondary that is now promoted to primary.
+        threadAscending.submit(() -> {
+            // The thread should detect that it is connected to a primary and disconnect from it.
+            assertTrue("Failed to detect that it is connected to primary", mongoServerSelector.isConnectedToPrimary());
+            mongoServerSelector.threadFinished();
+
+            // When it tries to connect again, it should receive a secondary
+            var selection = mongoServerSelector.select(ClusterType.REPLICA_SET, clusterState);
+            assertEquals(1, selection.size());
+            ascendingThreadReplica.set(selection.get(0));
+            assertEquals(demotedPrimary.getSetName(), selection.get(0).getSetName());
+        }).get();
+    }
+
+    public ServerDescription createServerDescription(ServerType type, ServerConnectionState state) {
+        var id = serverId.incrementAndGet();
+        return ServerDescription
+                .builder()
+                .ok(true)
+                .setName("mongo-server-" + id)
+                .address(new ServerAddress("localhost", 20000 + id))
+                .state(state)
+                .type(type)
+                .build();
+    }
+
+    private ServerDescription updateServerType(ServerDescription serverDescription, ServerType newType) {
+        return ServerDescription.builder()
+                .ok(serverDescription.isOk())
+                .setName(serverDescription.getSetName())
+                .address(serverDescription.getAddress())
+                .state(serverDescription.getState())
+                .type(newType)
+                .build();
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelectorTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelectorTest.java
@@ -89,7 +89,7 @@ public class PipelinedMongoServerSelectorTest {
     public void calledFromANonDownloaderThread() throws ExecutionException, InterruptedException {
         // If the Mongo server selector is called from a thread that is not a downloader thread, it should return all 
         // servers, that is, it is neutral.
-        var t = new PipelinedMongoServerSelector();
+        var t = new PipelinedMongoServerSelector(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-");
         threadOther.submit(() -> {
             assertEquals(3, t.select(ClusterType.REPLICA_SET, allReplicas).size());
             assertEquals(2, t.select(ClusterType.REPLICA_SET, oneSecondaryUp).size());
@@ -99,7 +99,7 @@ public class PipelinedMongoServerSelectorTest {
 
     @Test
     public void allMongoReplicasUp() throws ExecutionException, InterruptedException {
-        var mongoServerSelector = new PipelinedMongoServerSelector();
+        var mongoServerSelector = new PipelinedMongoServerSelector(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-");
 
         var firstThreadSelection = new AtomicReference<ServerDescription>();
 
@@ -133,7 +133,7 @@ public class PipelinedMongoServerSelectorTest {
 
     @Test
     public void primaryAndOneSecondaryUp() throws ExecutionException, InterruptedException {
-        var mongoServerSelector = new PipelinedMongoServerSelector();
+        var mongoServerSelector = new PipelinedMongoServerSelector(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-");
         mongoServerSelector.clusterDescriptionChanged(new ClusterDescriptionChangedEvent(
                         TEST_CLUSTER_ID,
                         new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, oneSecondaryUp),
@@ -172,7 +172,7 @@ public class PipelinedMongoServerSelectorTest {
 
     @Test
     public void onlyPrimaryUp() throws ExecutionException, InterruptedException {
-        var mongoServerSelector = new PipelinedMongoServerSelector();
+        var mongoServerSelector = new PipelinedMongoServerSelector(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-");
         threadAscending.submit(() -> {
             // If there is only the primary, do not select it.
             var firstSelection = mongoServerSelector.select(ClusterType.REPLICA_SET, noSecondaryUp);
@@ -204,7 +204,7 @@ public class PipelinedMongoServerSelectorTest {
          * 8. Scaling is complete.
          */
         var allUpClusterDescription = new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.REPLICA_SET, List.copyOf(clusterState));
-        var mongoServerSelector = new PipelinedMongoServerSelector();
+        var mongoServerSelector = new PipelinedMongoServerSelector(PipelinedMongoDownloadTask.THREAD_NAME_PREFIX + "-");
         mongoServerSelector.clusterDescriptionChanged(
                 new ClusterDescriptionChangedEvent(TEST_CLUSTER_ID, allUpClusterDescription, allUpClusterDescription)
         );

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedParametrizedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedParametrizedIT.java
@@ -18,6 +18,7 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
+import com.codahale.metrics.Counter;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import joptsimple.internal.Strings;
@@ -56,6 +57,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
@@ -232,7 +234,7 @@ public class PipelinedParametrizedIT {
             File file = pipelinedStrategy.createSortedStoreFile();
 
 
-            var counters = statsProvider.getRegistry().getCounters();
+            SortedMap<String, Counter> counters = statsProvider.getRegistry().getCounters();
 
             long nDocumentsMatchingFilter = regexPathFiltering ?
                     numberOfFilteredDocuments(roStore.mongoDatabase, "/content/dam") :

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedParametrizedIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedParametrizedIT.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import joptsimple.internal.Strings;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.commons.Compression;
+import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
+import org.apache.jackrabbit.oak.plugins.document.MongoConnectionFactory;
+import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.plugins.document.Path;
+import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
+import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
+import org.apache.jackrabbit.oak.plugins.document.util.Utils;
+import org.apache.jackrabbit.oak.plugins.index.ConsoleIndexingReporter;
+import org.apache.jackrabbit.oak.plugins.metric.MetricStatisticsProvider;
+import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
+import org.apache.jackrabbit.oak.spi.filter.PathFilter;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.MongoDownloaderRegexUtils.LONG_PATH_ID_PATTERN;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelineITUtil.assertMetrics;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelineITUtil.contentDamPathFilter;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelineITUtil.createNodeStore;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(Parameterized.class)
+public class PipelinedParametrizedIT {
+    private static final Logger LOG = LoggerFactory.getLogger(PipelinedParametrizedIT.class);
+    private static final int LONG_PATH_TEST_LEVELS = 30;
+    private static final String LONG_PATH_LEVEL_STRING = "Z12345678901234567890-Level_";
+    private static ScheduledExecutorService executorService;
+    private static final List<String> EXPECTED_FFS = new ArrayList<>(List.of(
+            "/|{}",
+            "/content|{}",
+            "/content/dam|{}",
+            "/content/dam/1000|{}",
+            "/content/dam/1000/12|{\"p1\":\"v100012\"}",
+            "/content/dam/2022|{}",
+            "/content/dam/2022/01|{\"p1\":\"v202201\"}",
+            "/content/dam/2022/01/01|{\"p1\":\"v20220101\"}",
+            "/content/dam/2022/02|{\"p1\":\"v202202\"}",
+            "/content/dam/2022/02/01|{\"p1\":\"v20220201\"}",
+            "/content/dam/2022/02/02|{\"p1\":\"v20220202\"}",
+            "/content/dam/2022/02/03|{\"p1\":\"v20220203\"}",
+            "/content/dam/2022/02/04|{\"p1\":\"v20220204\"}",
+            "/content/dam/2022/03|{\"p1\":\"v202203\"}",
+            "/content/dam/2022/04|{\"p1\":\"v202204\"}",
+            "/content/dam/2023|{\"p2\":\"v2023\"}",
+            "/content/dam/2023/01|{\"p1\":\"v202301\"}",
+            "/content/dam/2023/02|{}",
+            "/content/dam/2023/02/28|{\"p1\":\"v20230228\"}"
+    ));
+
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        Assume.assumeTrue(MongoUtils.isAvailable());
+        // Generate dynamically the entries expected for the long path tests
+        StringBuilder path = new StringBuilder("/content/dam");
+        for (int i = 0; i < LONG_PATH_TEST_LEVELS; i++) {
+            path.append("/").append(LONG_PATH_LEVEL_STRING).append(i);
+            EXPECTED_FFS.add(path + "|{}");
+        }
+        executorService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @AfterClass
+    public static void teardown() {
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+    }
+
+    @Rule
+    public final MongoConnectionFactory connectionFactory = new MongoConnectionFactory();
+    @Rule
+    public final DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+    @Rule
+    public final TemporaryFolder sortFolder = new TemporaryFolder();
+
+
+    private MetricStatisticsProvider statsProvider;
+    private ConsoleIndexingReporter indexingReporter;
+
+    private final boolean retryOnConnectionErrors;
+    private final boolean regexPathFiltering;
+    private final boolean parallelDump;
+
+    @Parameterized.Parameters(name = "retryOnConnectionErrors={0},regexPathFiltering={1},parallelDump={2}")
+    public static Collection<Object[]> parameters() {
+        return List.of(
+                new Object[]{true, true, true},
+                new Object[]{true, true, false},
+                new Object[]{true, false, true},
+                new Object[]{true, false, false},
+                new Object[]{false, true, true},
+                new Object[]{false, true, false},
+                new Object[]{false, false, true},
+                new Object[]{false, false, false}
+        );
+    }
+
+    public PipelinedParametrizedIT(boolean retryOnConnectionErrors, boolean regexPathFiltering, boolean parallelDump) {
+        this.retryOnConnectionErrors = retryOnConnectionErrors;
+        this.regexPathFiltering = regexPathFiltering;
+        this.parallelDump = parallelDump;
+    }
+
+    @Before
+    public void before() {
+        LOG.info("retryOnConnectionErrors={},regexPathFiltering={},parallelDump={}",
+                retryOnConnectionErrors, regexPathFiltering, parallelDump);
+
+        MongoConnection c = connectionFactory.getConnection();
+        if (c != null) {
+            c.getDatabase().drop();
+        }
+        statsProvider = new MetricStatisticsProvider(getPlatformMBeanServer(), executorService);
+        indexingReporter = new ConsoleIndexingReporter();
+    }
+
+    @After
+    public void tear() {
+        LOG.info("tear");
+        MongoConnection c = connectionFactory.getConnection();
+        if (c != null) {
+            c.getDatabase().drop();
+        }
+        statsProvider.close();
+        statsProvider = null;
+        indexingReporter = null;
+    }
+
+
+    @Test
+    public void testCreateFFS() throws IOException, CommitFailedException {
+        LOG.info("testCreateFFS");
+        System.setProperty(OAK_INDEXER_PIPELINED_RETRY_ON_CONNECTION_ERRORS, Boolean.toString(retryOnConnectionErrors));
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING, Boolean.toString(regexPathFiltering));
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP, Boolean.toString(parallelDump));
+
+        Predicate<String> pathPredicate = s -> contentDamPathFilter.filter(s) != PathFilter.Result.EXCLUDE;
+        List<PathFilter> pathFilters = List.of(contentDamPathFilter);
+
+        testSuccessfulDownload(pathPredicate, pathFilters);
+    }
+
+    private void testSuccessfulDownload(Predicate<String> pathPredicate, List<PathFilter> pathFilters)
+            throws CommitFailedException, IOException {
+        testSuccessfulDownload(pathPredicate, pathFilters, EXPECTED_FFS, false);
+    }
+
+    private long numberOfDocumentsOnMongo(MongoDatabase mongoDatabase) {
+        return mongoDatabase.getCollection(org.apache.jackrabbit.oak.plugins.document.Collection.NODES.toString()).countDocuments();
+    }
+
+    private long numberOfFilteredDocuments(MongoDatabase mongoDatabase, String path) {
+        String idRegex = "^[0-9]{1,3}:" + Pattern.quote(path);
+        int parentNodes = Path.fromString(path).getDepth();
+        long childNodes = mongoDatabase.getCollection(org.apache.jackrabbit.oak.plugins.document.Collection.NODES.toString())
+                .countDocuments(Filters.or(
+                        Filters.regex(NodeDocument.ID, idRegex),
+                        Filters.regex(NodeDocument.ID, LONG_PATH_ID_PATTERN))
+                );
+        return parentNodes + childNodes;
+    }
+
+
+    private void testSuccessfulDownload(Predicate<String> pathPredicate, List<PathFilter> pathFilters, List<String> expected, boolean ignoreLongPaths)
+            throws CommitFailedException, IOException {
+        try (MongoTestBackend rwStore = createNodeStore(false, connectionFactory, builderProvider)) {
+            PipelineITUtil.createContent(rwStore.documentNodeStore);
+        }
+
+        try (MongoTestBackend roStore = createNodeStore(true, connectionFactory, builderProvider)) {
+
+            PipelinedStrategy pipelinedStrategy = createStrategy(roStore, pathPredicate, pathFilters);
+
+            File file = pipelinedStrategy.createSortedStoreFile();
+
+
+            var counters = statsProvider.getRegistry().getCounters();
+
+            long nDocumentsMatchingFilter = regexPathFiltering ?
+                    numberOfFilteredDocuments(roStore.mongoDatabase, "/content/dam") :
+                    numberOfDocumentsOnMongo(roStore.mongoDatabase);
+            long actualDocumentsDownloaded = counters.get(PipelinedMetrics.OAK_INDEXER_PIPELINED_DOCUMENTS_DOWNLOADED_TOTAL).getCount();
+            if (parallelDump) {
+                // With parallel download, we may download more documents than the ones matching the filter
+                assertTrue("Docs downloaded: " + actualDocumentsDownloaded + " must be between " + nDocumentsMatchingFilter + " and " + nDocumentsMatchingFilter * 2,
+                        nDocumentsMatchingFilter <= actualDocumentsDownloaded && actualDocumentsDownloaded <= nDocumentsMatchingFilter * 2);
+            } else {
+                assertEquals(nDocumentsMatchingFilter, actualDocumentsDownloaded);
+            }
+            assertEquals(expected.size(), counters.get(PipelinedMetrics.OAK_INDEXER_PIPELINED_ENTRIES_ACCEPTED_TOTAL).getCount());
+
+            assertTrue(file.exists());
+            List<String> result = Files.readAllLines(file.toPath());
+            if (ignoreLongPaths) {
+                // Remove the long paths from the result. The filter on Mongo is best-effort, it will download long path
+                // documents, even if they do not match the includedPaths.
+                result = result.stream()
+                        .filter(s -> {
+                            var name = s.split("\\|")[0];
+                            return name.length() < Utils.PATH_LONG;
+                        })
+                        .collect(Collectors.toList());
+            }
+            assertEquals("Expected:\n" + Strings.join(expected, "\n") + "\nActual: " + Strings.join(result, "\n"), expected, result);
+            assertMetrics(statsProvider);
+        }
+    }
+
+    private PipelinedStrategy createStrategy(MongoTestBackend backend, Predicate<String> pathPredicate, List<PathFilter> pathFilters) {
+        Set<String> preferredPathElements = Set.of();
+        RevisionVector rootRevision = backend.documentNodeStore.getRoot().getRootRevision();
+        indexingReporter.setIndexNames(List.of("testIndex"));
+        return new PipelinedStrategy(
+                backend.mongoClientURI,
+                backend.mongoDocumentStore,
+                backend.documentNodeStore,
+                rootRevision,
+                preferredPathElements,
+                new MemoryBlobStore(),
+                sortFolder.getRoot(),
+                Compression.NONE,
+                pathPredicate,
+                pathFilters,
+                null,
+                statsProvider,
+                indexingReporter);
+    }
+}

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/DocumentStoreIndexerIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/DocumentStoreIndexerIT.java
@@ -20,6 +20,7 @@
 package org.apache.jackrabbit.oak.index;
 
 import com.codahale.metrics.Counter;
+import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.oak.InitialContent;
@@ -318,6 +319,7 @@ public class DocumentStoreIndexerIT extends LuceneAbstractIndexCommandTest {
         Whiteboard wb = new DefaultWhiteboard();
         MongoDocumentStore ds = (MongoDocumentStore) docBuilder.getDocumentStore();
         Registration r1 = wb.register(MongoDocumentStore.class, ds, emptyMap());
+        wb.register(MongoClientURI.class, c1.getMongoURI(), emptyMap());
         wb.register(StatisticsProvider.class, StatisticsProvider.NOOP, emptyMap());
         wb.register(IndexingReporter.class, IndexingReporter.NOOP, emptyMap());
         Registration c1Registration = wb.register(MongoDatabase.class, c1.getDatabase(), emptyMap());
@@ -406,6 +408,7 @@ public class DocumentStoreIndexerIT extends LuceneAbstractIndexCommandTest {
             wb.register(StatisticsProvider.class, metricsStatisticsProvider, emptyMap());
             wb.register(IndexingReporter.class, new ConsoleIndexingReporter(), emptyMap());
             Registration c1Registration = wb.register(MongoDatabase.class, mongoConnection.getDatabase(), emptyMap());
+            wb.register(MongoClientURI.class, mongoConnection.getMongoURI(), emptyMap());
 
             configureIndex(store);
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/IncrementalStoreTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/IncrementalStoreTest.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.index;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
 import org.apache.commons.collections4.set.ListOrderedSet;
 import org.apache.commons.io.IOUtils;
@@ -358,8 +359,8 @@ public class IncrementalStoreTest {
     private PipelinedStrategy createPipelinedStrategy(Backend backend, Predicate<String> pathPredicate, Set<String> preferredPathElements, List<PathFilter> pathFilters, String checkpoint) {
         RevisionVector rootRevision = backend.documentNodeStore.getRoot().getRootRevision();
         return new PipelinedStrategy(
+                backend.mongoURI,
                 backend.mongoDocumentStore,
-                backend.mongoDatabase,
                 backend.documentNodeStore,
                 rootRevision,
                 preferredPathElements,
@@ -641,17 +642,19 @@ public class IncrementalStoreTest {
         builder.setAsyncDelay(1);
         DocumentNodeStore documentNodeStore = builder.getNodeStore();
         BlobStore blobStore = new MemoryBlobStore();
-        return new Backend((MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase(), blobStore);
+        return new Backend(c.getMongoURI(), (MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase(), blobStore);
     }
 
 
     static class Backend {
+        private final MongoClientURI mongoURI;
         final MongoDocumentStore mongoDocumentStore;
         final DocumentNodeStore documentNodeStore;
         final MongoDatabase mongoDatabase;
         final BlobStore blobStore;
 
-        public Backend(MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoDatabase mongoDatabase, BlobStore blobStore) {
+        public Backend(MongoClientURI mongoURI, MongoDocumentStore mongoDocumentStore, DocumentNodeStore documentNodeStore, MongoDatabase mongoDatabase, BlobStore blobStore) {
+            this.mongoURI = mongoURI;
             this.mongoDocumentStore = mongoDocumentStore;
             this.documentNodeStore = documentNodeStore;
             this.mongoDatabase = mongoDatabase;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/MongoConnection.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/MongoConnection.java
@@ -96,6 +96,14 @@ public class MongoConnection {
     }
 
     /**
+     *
+     * @return the {@link MongoClientURI} for this connection
+     */
+    public MongoClientURI getMongoURI() {
+        return mongoURI;
+    }
+
+    /**
      * @return the {@link MongoClient} for this connection.
      */
     public MongoClient getMongoClient() {


### PR DESCRIPTION
A Mongo cluster (`REPLICA_SET`) usually consists of one primary and two secondaries. This PR adds support to download in parallel from the two secondaries.

Adds new boolean system property: `oak.indexer.pipelined.mongoParallelDump` defaults to false.

Parallel download can be enabled only when `oak.indexer.pipelined.retryOnConnectionErrors` is true. (Parallel download requires ordered traversals on Mongo which are enabled by retry on connection errors.) 


## Goals of this PR ##
- Do not download from the primary because this is more likely to slow down the operation of the Mongo and affect the other workloads (read/writes by Oak). 
-  Use one and only one connection at a time to each secondary to avoid overloading any given replica. More on this in the notes below.
- Gracefully handle scale up/down operations and failures in general, pausing the second download when there is only one secondary available and reconnecting when all secondaries are up.   

## Implementation
One of the difficulties of parallel downloading is to partition the range of documents among the download threads. We do not know in advance the distribution of the documents over the range of keys `(_modified, _id)` which are used to download, so it is challenging to distribute them evenly among the download threads. This PR sidesteps this problem by having one thread download in ascending and the other in descending order. This has the limitation that we can only have 2 parallel threads, but this fits nicely the typical configuration of a Mongo cluster with two secondaries. Adding more parallel downloads would provide a smaller increase in overall download speed and would risk overloading the replicas.

The two download threads coordinate to check when the ranges they have downloaded have crossed, to stop the download at this point.

To distribute the threads among replicas this PR creates a custom implementation of [ServerSelector](https://mongodb.github.io/mongo-java-driver/3.12/javadoc/com/mongodb/selector/ServerSelector.html). The Mongo Java driver calls the registered ServerSelectors whenever it needs to open a connection to a Mongo cluster to get a list of eligible servers. The default implementations are taken from the `readPreference` settings, but it is possible to create and register a custom implementation. This PR uses an implementation that allows connections only to secondaries and keeps track of which thread last received a given secondary, so that this secondary is not given to any other thread. 

There is also a mechanism to disconnect from a replica who was promoted from secondary to primary. This happens whenever there is a scale up/down. Mongo will first take one secondary down and replace it by a new one, then the other secondary, and before taking down the primary, it promotes one of the new secondaries to primary. Therefore, we may have connected to a secondary which in the meantime was promoted to primary. Since is very likely to happen during a scale up/down, it was important to detect promotions of secondaries to primary and disconnect. This is done by listening to [ClusterListener](https://mongodb.github.io/mongo-java-driver/3.12/javadoc/com/mongodb/event/ClusterListener.html) events and having each download thread periodically query to check if the replica it is using is now the Primary. If it is, the replica disconnects and tries to establish a new connection, which will be redirected to a secondary.

## Performance results

### System 1
Sequential download:
```
Timings:
  Mongo dump: 12:09:11
  Merge sort: 00:05:28
  Build FFS (Dump+Merge): 12:14:40
```

Parallel download
```
Timings:
  Mongo dump: 06:14:16
  Merge sort: 00:05:26
  Build FFS (Dump+Merge): 06:19:46
```

### System 2

Sequential download:
```
Timings:
  Mongo dump: 00:14:10
  Merge sort: 00:02:19
  Build FFS (Dump+Merge): 00:16:29
```

Parallel download
```
Timings:
  Mongo dump: 00:06:41
  Merge sort: 00:02:13
  Build FFS (Dump+Merge): 00:08:54
```


## Note on risk of slowing down the Mongo cluster
When parallel download is enabled, both secondaries will be under load. There may be a concern if this will slow down writes, which need an ack from the primary and a secondary. I do not think this would be a problem in the common cases. A single download connection should not be enough to saturate a node. Mongo seems to allocate only one thread to handle a connection, so as long as the Mongo node has at least 2 cores, the download query will not take up all the CPU. The pressure on IOPS, disk throughput and network bandwidth created by the downloader may in some situations get close to the limit, but even there this pressure is not kept all the time. The protocol used by the Mongo Java driver is synchronous request/response, and the client only sends the request for the next batch of results after the current one is parsed and iterated over, so during this time the Mongo server is idle. I have observed that the IOPS and disk throughput usually stay below 80% on Mongo, which gives some spare headroom to process other queries. 

# Additional changes
- Improve the test of recovery from disconnections from Mongo. The previous test was relying on mockito to simulate a connection failure. This was very complex and tedious to write. This PR replaces that test by one that uses a real Mongo server inside a Docker container and toxiproxy to simulate a connection failure. 
- Create a parametrized version of PipelinedIT tests which test all combinations of: regex path filtering, parallel download and retry on connection errors. 


This PR has a large change set in part because it refactors the PipelinedMongoDownloadTask in order to make it more concise and cohesive:
- It moves out the logic to handle regex filtering to a separate class
- It creates a new DownloadTask class that includes the logic to do the actual download from Mongo, trying to separate it from the logic to setup and launch download threads.