### PR TITLE
OAK-10798: Introduce functions to clean nodes based on regular expression

### DIFF
--- a/oak-run/src/main/js/oak-mongo.js
+++ b/oak-run/src/main/js/oak-mongo.js
@@ -348,10 +348,10 @@ var oak = (function(global){
      * Use regexFind to find the nodes that match the pattern prior deletion.
      *
      * @memberof oak
-     * @method removeDescendantsMatching
+     * @method removeDescendantsAndSelfMatching
      * @param {string} pattern the pattern to match the nodes to be removed.
      */
-    api.removeDescendantsMatching = function(pattern) {
+    api.removeDescendantsAndSelfMatching = function(pattern) {
         var count = 0;
         db.nodes.find({_id: {$regex: pattern}}).forEach(function(doc) {
             print("Removing " + doc._id + " and its children");
@@ -369,7 +369,7 @@ var oak = (function(global){
      * @method removeRootTempNodes
      */
     api.removeRootTempNodes = function() {
-        this.removeDescendantsMatching("^1:/tmp.+");
+        this.removeDescendantsAndSelfMatching("^1:/tmp.+");
     }
 
     /**

--- a/oak-run/src/main/js/oak-mongo.js
+++ b/oak-run/src/main/js/oak-mongo.js
@@ -330,6 +330,59 @@ var oak = (function(global){
     };
 
     /**
+     * Helper method to find nodes based on Regular Expression.
+     *
+     * @memberof oak
+     * @method regexFind
+     * @param {string} pattern the pattern to match the nodes.
+     */
+	api.regexFind = function(pattern) {
+		print(db.nodes.find({_id: {$regex: pattern}}));
+		db.nodes.find({_id: {$regex: pattern}}).forEach(function(doc) {
+			print(doc._id);
+        });
+	}
+
+    /**
+     * Remove the complete subtree of all the nodes matching a regex pattern.
+     * Use regexFind to find the nodes that match the pattern prior deletion.
+     *
+     * @memberof oak
+     * @method removeDescendantsMatching
+     * @param {string} pattern the pattern to match the nodes to be removed.
+     */
+    api.removeDescendantsMatching = function(pattern) {
+        var count = 0;
+        db.nodes.find({_id: {$regex: pattern}}).forEach(function(doc) {
+			print("Removing " + doc._id + " and its children");
+            var result = api.removeDescendantsAndSelf(api.pathFromId(doc._id));
+            count += result.nRemoved;
+			print("nRemoved : " + result.nRemoved);
+        });
+        print("Total removed : " + count);
+    }
+
+	/**
+	 * Wrapper function to clean all the /tmpXXXXXX nodes from the repository.
+	 *
+	 * @memberof oak
+	 * @method removeRootTempNodes
+	 */
+	api.removeRootTempNodes = function() {
+		this.removeDescendantsMatching("^1:/tmp(?!$).*");
+	}
+
+    /**
+     * List all the nodes under /tmpXXXXXX.
+     *
+     * @memberof oak
+     * @method listRootTempNodes
+     */
+	api.listRootTempNodes = function() {
+		this.regexFind("^1:/tmp(?!$).*");
+	}
+
+    /**
      * List all checkpoints.
      *
      * @memberof oak

--- a/oak-run/src/main/js/oak-mongo.js
+++ b/oak-run/src/main/js/oak-mongo.js
@@ -336,12 +336,12 @@ var oak = (function(global){
      * @method regexFind
      * @param {string} pattern the pattern to match the nodes.
      */
-	api.regexFind = function(pattern) {
-		print(db.nodes.find({_id: {$regex: pattern}}));
-		db.nodes.find({_id: {$regex: pattern}}).forEach(function(doc) {
-			print(doc._id);
+    api.regexFind = function(pattern) {
+        print(db.nodes.find({_id: {$regex: pattern}}));
+        db.nodes.find({_id: {$regex: pattern}}).forEach(function(doc) {
+            print(doc._id);
         });
-	}
+    }
 
     /**
      * Remove the complete subtree of all the nodes matching a regex pattern.
@@ -354,23 +354,23 @@ var oak = (function(global){
     api.removeDescendantsMatching = function(pattern) {
         var count = 0;
         db.nodes.find({_id: {$regex: pattern}}).forEach(function(doc) {
-			print("Removing " + doc._id + " and its children");
+            print("Removing " + doc._id + " and its children");
             var result = api.removeDescendantsAndSelf(api.pathFromId(doc._id));
             count += result.nRemoved;
-			print("nRemoved : " + result.nRemoved);
+            print("nRemoved : " + result.nRemoved);
         });
         print("Total removed : " + count);
     }
 
-	/**
-	 * Wrapper function to clean all the /tmpXXXXXX nodes from the repository.
-	 *
-	 * @memberof oak
-	 * @method removeRootTempNodes
-	 */
-	api.removeRootTempNodes = function() {
-		this.removeDescendantsMatching("^1:/tmp(?!$).*");
-	}
+    /**
+     * Wrapper function to clean all the /tmpXXXXXX nodes from the repository.
+     *
+     * @memberof oak
+     * @method removeRootTempNodes
+     */
+    api.removeRootTempNodes = function() {
+        this.removeDescendantsMatching("^1:/tmp.+");
+    }
 
     /**
      * List all the nodes under /tmpXXXXXX.
@@ -378,9 +378,9 @@ var oak = (function(global){
      * @memberof oak
      * @method listRootTempNodes
      */
-	api.listRootTempNodes = function() {
-		this.regexFind("^1:/tmp(?!$).*");
-	}
+    api.listRootTempNodes = function() {
+        this.regexFind("^1:/tmp.+");
+    }
 
     /**
      * List all checkpoints.


### PR DESCRIPTION
This adds a few functions to the [oak-mongo.js](https://github.com/apache/jackrabbit-oak/blob/ad7e429b02f724a05679ca0e96ab2c45d0e2a6e7/oak-run/src/main/js/oak-mongo.js) in [oak-run](https://github.com/apache/jackrabbit-oak/tree/trunk/oak-run) to perform some low-level operations.