### PR TITLE
OAK-10800: (oak-search-elastic) add mapping for DictionaryCompoundWord

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
@@ -112,11 +112,8 @@ public class ElasticCustomAnalyzerMappings {
         LUCENE_ELASTIC_TRANSFORMERS = new LinkedHashMap<>();
 
         LUCENE_ELASTIC_TRANSFORMERS.put(WordDelimiterFilterFactory.class, luceneParams -> {
-            Consumer<String> transformFlag = flag -> {
-                if (luceneParams.containsKey(flag)) {
-                    luceneParams.put(flag, Integer.parseInt(luceneParams.get(flag).toString()) == 1);
-                }
-            };
+            Consumer<String> transformFlag = flag -> luceneParams.computeIfPresent(flag, (k, v) -> Integer.parseInt(v.toString()) == 1);
+
             transformFlag.accept("generateWordParts");
             transformFlag.accept("generateNumberParts");
             transformFlag.accept("catenateWords");

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ElasticCustomAnalyzerMappings {
@@ -111,33 +112,21 @@ public class ElasticCustomAnalyzerMappings {
         LUCENE_ELASTIC_TRANSFORMERS = new LinkedHashMap<>();
 
         LUCENE_ELASTIC_TRANSFORMERS.put(WordDelimiterFilterFactory.class, luceneParams -> {
-            if (luceneParams.containsKey("generateWordParts")) {
-                luceneParams.put("generateWordParts", Integer.parseInt(luceneParams.get("generateWordParts").toString()) == 1);
-            }
-            if (luceneParams.containsKey("generateNumberParts")) {
-                luceneParams.put("generateNumberParts", Integer.parseInt(luceneParams.get("generateNumberParts").toString()) == 1);
-            }
-            if (luceneParams.containsKey("catenateWords")) {
-                luceneParams.put("catenateWords", Integer.parseInt(luceneParams.get("catenateWords").toString()) == 1);
-            }
-            if (luceneParams.containsKey("catenateNumbers")) {
-                luceneParams.put("catenateNumbers", Integer.parseInt(luceneParams.get("catenateNumbers").toString()) == 1);
-            }
-            if (luceneParams.containsKey("catenateAll")) {
-                luceneParams.put("catenateAll", Integer.parseInt(luceneParams.get("catenateAll").toString()) == 1);
-            }
-            if (luceneParams.containsKey("splitOnCaseChange")) {
-                luceneParams.put("splitOnCaseChange", Integer.parseInt(luceneParams.get("splitOnCaseChange").toString()) == 1);
-            }
-            if (luceneParams.containsKey("preserveOriginal")) {
-                luceneParams.put("preserveOriginal", Integer.parseInt(luceneParams.get("preserveOriginal").toString()) == 1);
-            }
-            if (luceneParams.containsKey("splitOnNumerics")) {
-                luceneParams.put("splitOnNumerics", Integer.parseInt(luceneParams.get("splitOnNumerics").toString()) == 1);
-            }
-            if (luceneParams.containsKey("stemEnglishPossessive")) {
-                luceneParams.put("stemEnglishPossessive", Integer.parseInt(luceneParams.get("stemEnglishPossessive").toString()) == 1);
-            }
+            Consumer<String> transformFlag = flag -> {
+                if (luceneParams.containsKey(flag)) {
+                    luceneParams.put(flag, Integer.parseInt(luceneParams.get(flag).toString()) == 1);
+                }
+            };
+            transformFlag.accept("generateWordParts");
+            transformFlag.accept("generateNumberParts");
+            transformFlag.accept("catenateWords");
+            transformFlag.accept("catenateNumbers");
+            transformFlag.accept("catenateAll");
+            transformFlag.accept("splitOnCaseChange");
+            transformFlag.accept("preserveOriginal");
+            transformFlag.accept("splitOnNumerics");
+            transformFlag.accept("stemEnglishPossessive");
+
             return reKey.apply(luceneParams, Map.of(
                     "protectedTokens", "protected_words"
             ));

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
@@ -20,6 +20,7 @@ import org.apache.lucene.analysis.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.charfilter.MappingCharFilterFactory;
 import org.apache.lucene.analysis.cjk.CJKBigramFilterFactory;
 import org.apache.lucene.analysis.commongrams.CommonGramsFilterFactory;
+import org.apache.lucene.analysis.compound.DictionaryCompoundWordTokenFilterFactory;
 import org.apache.lucene.analysis.en.AbstractWordsFileFilterFactory;
 import org.apache.lucene.analysis.minhash.MinHashFilterFactory;
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
@@ -258,21 +259,30 @@ public class ElasticCustomAnalyzerMappings {
             luceneParams.remove("enablePositionIncrements");
             return reKey.apply(luceneParams, Map.of("words", "stopwords", "ignoreCase", "ignore_case"));
         });
+
+        LUCENE_ELASTIC_TRANSFORMERS.put(DictionaryCompoundWordTokenFilterFactory.class, luceneParams -> reKey.apply(luceneParams, Map.of(
+                "dictionary", "word_list",
+                "minWordSize", "min_word_size",
+                "maxSubwordSize", "max_subword_size",
+                "minSubwordSize", "min_subword_size",
+                "onlyLongestMatch", "only_longest_match"
+        )));
     }
 
     /*
      * Some filter names cannot be transformed from the original name. Here we map the exceptions
      */
-    protected static final Map<String, String> FILTERS = Map.of(
-            "porter_stem", "porter2",
-            "ascii_folding", "asciifolding",
-            "n_gram", "ngram",
-            "edge_n_gram", "edge_ngram",
-            "keep_word", "keep",
-            "k_stem", "kstem",
-            "limit_token_count", "limit",
-            "pattern_capture_group", "pattern_capture",
-            "reverse_string", "reverse",
-            "snowball_porter", "snowball"
+    protected static final Map<String, String> FILTERS = Map.ofEntries(
+            Map.entry("porter_stem", "porter2"),
+            Map.entry("ascii_folding", "asciifolding"),
+            Map.entry("n_gram", "ngram"),
+            Map.entry("edge_n_gram", "edge_ngram"),
+            Map.entry("keep_word", "keep"),
+            Map.entry("k_stem", "kstem"),
+            Map.entry("limit_token_count", "limit"),
+            Map.entry("pattern_capture_group", "pattern_capture"),
+            Map.entry("reverse_string", "reverse"),
+            Map.entry("snowball_porter", "snowball"),
+            Map.entry("dictionary_compound_word", "dictionary_decompounder")
     );
 }


### PR DESCRIPTION
* Lucene `DictionaryCompoundWord` is properly converted to Elastic `dictionary_decompounder `
* simplified lucene transformers: introduced a final step to transform the keys from camel case to snake case