### PR TITLE
OAK-10786: exclude automaton package from RAT check

### DIFF
--- a/oak-lucene/pom.xml
+++ b/oak-lucene/pom.xml
@@ -142,6 +142,8 @@
             <exclude>**/test.txt</exclude>
             <exclude>**/fvs.csv</exclude>
             <exclude>src/test/resources/**/*.txt</exclude>
+            <!-- see OAK-10786 -->
+            <exclude>src/main/java/org/apache/lucene/util/automaton/*</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
This excludes the 12 files in the Lucene automaton package from the RAT check. Note that the licenses have not changes in current Lucene; see https://github.com/apache/lucene/commit/4b3f7662ce880204632ff5dabf55d5326e064703