### PR TITLE
OAK-10814 - Tar file recovery still fails with SNFE in some cases.

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/AbstractFileStore.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/AbstractFileStore.java
@@ -234,6 +234,7 @@ public abstract class AbstractFileStore implements SegmentStore, Closeable {
         if (SegmentId.isDataSegmentId(lsb)) {
             SegmentId segmentId = tracker.newSegmentId(msb, lsb);
             Segment segment = new Segment(tracker, segmentReader, segmentId, buffer);
+            segmentCache.putSegment(segment);
             w.addSegment(segment);
             populateTarGraph(segment, w);
             populateTarBinaryReferences(segment, w);

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/LongIdMappingBlobStore.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/LongIdMappingBlobStore.java
@@ -25,7 +25,7 @@ public class LongIdMappingBlobStore extends IdMappingBlobStore {
 
     @Override
     protected String generateId() {
-        return Strings.repeat("0", Segment.BLOB_ID_SMALL_LIMIT) + next++;
+        return Strings.repeat("0", Segment.BLOB_ID_SMALL_LIMIT * 20) + next++;
     }
 
 }


### PR DESCRIPTION
Putting recovered segments in the SegmentCache makes them available during remaining recovery operations. In the case of the blobId map, this works as long as the blobId is stored in a data segment and not in a raw segment (raw segment's aren't cached). But the blobIds shouldn't become that large in practice.