### PR TITLE
OAK-10789 - Log paths used for inclusing/exclusion for Mongo regex filters in job summary

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporter.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,13 +41,14 @@ public class ConsoleIndexingReporter implements IndexingReporter {
     private final Map<String, String> metrics = new TreeMap<>();
     private final List<String> envVariablesToLog;
     private List<String> indexes = List.of();
+    private final List<String> informationStrings = new ArrayList<>();
 
     public ConsoleIndexingReporter() {
         this(List.of());
     }
 
     /**
-     * @param envVariablesToLog  These environment variables and their values will be included in the final report.
+     * @param envVariablesToLog These environment variables and their values will be included in the final report.
      */
     public ConsoleIndexingReporter(@NotNull List<String> envVariablesToLog) {
         this.envVariablesToLog = List.copyOf(envVariablesToLog);
@@ -68,6 +70,11 @@ public class ConsoleIndexingReporter implements IndexingReporter {
         metrics.put(name, String.valueOf(value));
     }
 
+    @Override
+    public void addInformation(String value) {
+        informationStrings.add(value);
+    }
+
     public void addMetricByteSize(String name, long value) {
         String v = String.valueOf(value);
         if (value >= FileUtils.ONE_KB) {
@@ -82,6 +89,7 @@ public class ConsoleIndexingReporter implements IndexingReporter {
                 "OAK Version: " + OakVersion.getVersion() + "\n" +
                 "Configuration:\n" + mapToString(config) + "\n" +
                 "Environment Variables:\n" + genEnvVariables() + "\n" +
+                "Information:\n" + listToString(informationStrings) + "\n" +
                 "Timings:\n" + mapToString(timings) + "\n" +
                 "Metrics:\n" + mapToString(metrics);
     }
@@ -95,7 +103,15 @@ public class ConsoleIndexingReporter implements IndexingReporter {
 
     private String mapToString(Map<String, String> map) {
         return map.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
                 .map(entry -> "  " + entry.getKey() + ": " + entry.getValue())
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String listToString(List<String> map) {
+        return map.stream()
+                .sorted()
+                .map(entry -> "  " + entry)
                 .collect(Collectors.joining("\n"));
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexingReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexingReporter.java
@@ -42,6 +42,10 @@ public interface IndexingReporter {
         }
 
         @Override
+        public void addInformation(String value) {
+        }
+
+        @Override
         public void addMetricByteSize(String name, long value) {
         }
 
@@ -58,6 +62,8 @@ public interface IndexingReporter {
     void addTiming(String stage, String time);
 
     void addMetric(String name, long value);
+
+    void addInformation(String value);
 
     /**
      * Similar to {@link #addMetric(String, long)} but size should be logged in a human-friendly format, that is,

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporterTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporterTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ConsoleIndexingReporterTest {
 
-    private static char DELIM = new DecimalFormatSymbols().getDecimalSeparator();
+    private static final char DELIM = new DecimalFormatSymbols().getDecimalSeparator();
 
     @Test
     public void emptyReport() {
@@ -37,6 +37,8 @@ public class ConsoleIndexingReporterTest {
                 "Configuration:\n" +
                 "\n" +
                 "Environment Variables:\n" +
+                "\n" +
+                "Information:\n" +
                 "\n" +
                 "Timings:\n" +
                 "\n" +
@@ -59,6 +61,9 @@ public class ConsoleIndexingReporterTest {
                 "Environment Variables:\n" +
                 "  ENV_VAR1: <value>\n" +
                 "  ENV_VAR2: <value>\n" +
+                "Information:\n" +
+                "  A message\n" +
+                "  Foo Bar\n" +
                 "Timings:\n" +
                 "  stage1: 10:23\n" +
                 "Metrics:\n" +
@@ -80,6 +85,8 @@ public class ConsoleIndexingReporterTest {
 
         consoleIndexingReporter.addConfig("config1", "value1");
         consoleIndexingReporter.addConfig("config2", 12);
+        consoleIndexingReporter.addInformation("Foo Bar");
+        consoleIndexingReporter.addInformation("A message");
 
         consoleIndexingReporter.addTiming("stage1", "10:23");
 
@@ -97,7 +104,7 @@ public class ConsoleIndexingReporterTest {
     }
 
     private String replaceVariable(String report, String varName) {
-        return report.replaceAll("  " + varName + ": .*", "  " + varName + ": <value>");
+        return report.replaceAll(" {2}" + varName + ": .*", "  " + varName + ": <value>");
     }
 
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoRegexPathFilterFactory.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/MongoRegexPathFilterFactory.java
@@ -55,6 +55,10 @@ public class MongoRegexPathFilterFactory {
                     '}';
         }
 
+        public String prettyPrint() {
+            return "{included=" + included + ", excluded=" + excluded + "}";
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -136,7 +140,7 @@ public class MongoRegexPathFilterFactory {
         }
 
         if (customExcludedPaths.stream().anyMatch(PathUtils::denotesRoot)) {
-            LOG.warn("Ignoring custom excluded paths setting, root cannot be excluded: {}",  customExcludedPaths);
+            LOG.warn("Ignoring custom excluded paths setting, root cannot be excluded: {}", customExcludedPaths);
         } else if (!isRootPath(finalIncludedPathsRoots)) {
             LOG.info("Ignoring custom excluded paths because included paths did not resolve to root. Mongo filters: {}", finalIncludedPathsRoots);
         } else {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -484,6 +484,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     private MongoFilterPaths getPathsForRegexFiltering() {
         if (!regexPathFiltering) {
             LOG.info("Regex path filtering disabled.");
+            reporter.addInformation("Mongo regex filter paths: " + MongoFilterPaths.DOWNLOAD_ALL.prettyPrint());
             return MongoFilterPaths.DOWNLOAD_ALL;
         } else {
             LOG.info("Computing included/excluded paths for Mongo regex path filtering. PathFilters: {}",
@@ -493,6 +494,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             );
             MongoFilterPaths mongoFilterPaths = this.regexPathFilterFactory.buildMongoFilter(pathFilters, customExcludedPaths);
             LOG.info("Paths used for regex filtering on Mongo: {}", mongoFilterPaths);
+            reporter.addInformation("Mongo regex filter paths: " + mongoFilterPaths.prettyPrint());
             return mongoFilterPaths;
         }
     }


### PR DESCRIPTION
This PR adds the `Information` section below.
```
...
  oak.indexer.pipelined.sortBufferMemoryPercentage: 25
  oak.indexer.pipelined.transformThreads: 2
  oak.indexer.pipelined.workingMemoryMB: 0
Information:
  Mongo regex filter paths: {included=[/content/dam/1000, /content/dam/2022], excluded=[/content/dam/2022/01]}
Environment Variables:

Timings:
  Build FFS (Dump+Merge): 00:00:00
  Merge sort: 00:00:00
  Mongo dump: 00:00:00
...
```