### PR TITLE
OAK-10841: log error cause when ES cannot process a query

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.query.async;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.SortOptions;
@@ -377,8 +378,13 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                 LOG.warn("Error reference for async iterator was previously set to {}. It has now been reset to new error {}", error.getMessage(), t.getMessage());
             }
 
-            LOG.error("Error retrieving data for jcr query [{}] :: Corresponding ES query {} : closing scanner, notifying listeners",
-                indexPlan.getFilter(), query, t);
+            if (t instanceof ElasticsearchException) {
+                LOG.error("Elastic could not process the request for jcr query [{}] :: Corresponding ES query {} :: ES Response {} : closing scanner, notifying listeners",
+                        indexPlan.getFilter(), query, ((ElasticsearchException) t).error(), t);
+            } else {
+                LOG.error("Error retrieving data for jcr query [{}] :: Corresponding ES query {} : closing scanner, notifying listeners",
+                        indexPlan.getFilter(), query, t);
+            }
             // closing scanner immediately after a failure avoiding them to hang (potentially) forever
             close();
         }


### PR DESCRIPTION
When ES cannot process a query, the generic message `all shards failed` is printed in the logs. Adding the error cause in case of `ElasticsearchException`s.