### PR TITLE
OAK-10837: Add documentation for UT/IT NodeStore fixtures

### DIFF
--- a/oak-doc/src/site/markdown/dev_getting_started.md
+++ b/oak-doc/src/site/markdown/dev_getting_started.md
@@ -40,7 +40,7 @@ Before committing changes or submitting a patch, please make sure that the above
 build passes without errors. If you like, you can enable integration tests by default by setting the
 `OAK_INTEGRATION_TESTING` environment variable.
 
-Please also refer to the documentation [Developing with Git](./developing-with-git.html)
+Please also refer to the documentation [Developing with Git](./developing-with-git.html) and [Testing using different nodestore fixtures](./testing.html).
 
 MongoDB integration
 -------------------

--- a/oak-doc/src/site/markdown/testing.md
+++ b/oak-doc/src/site/markdown/testing.md
@@ -1,0 +1,44 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+Testing using different NodeStore fixtures
+---------------
+
+In Jackrabbit Oak unit and integration tests are run using different fixtures which represent configurations of the NodeStore underlying storage for the content repository.
+This ensures that there is a fixed environment in which tests are run and the results are consistent and repeatable across different runs.
+
+The default fixture used when running `mvn clean install` is `SEGMENT_TAR` which uses the SegmentNodeStore with the local storage with TAR files. 
+
+To run the tests using a different fixture, you can use the following command: `mvn clean install -Dfixture=<FIXTURE>`. 
+You can also update the `pom.xml` file to use a different fixture by updating the `fixture` property in the `oak-parent/pom.xml` file. If you want to run using multiple fixtures, provide a space separated list of fixtures.
+
+These are the possible fixtures that can be used:
+- `SEGMENT_TAR` - Uses the SegmentNodeStore with the local storage with TAR files.
+- `SEGMENT_AWS` - Uses the SegmentNodeStore with the AWS backend.
+- `SEGMENT_AZURE` - Uses the SegmentNodeStore with the Azure backend.
+- `DOCUMENT_NS` - Uses the DocumentNodeStore with MongoDB as the underlying storage engine. This requires a running instance of MongoDB. 
+- `DOCUMENT_RDB` - Uses the DocumentNodeStore with the relational databases such as PostgreSQL, MySQL as underlying storage engine.
+- `DOCUMENT_MEM` - Uses the DocumentNodeStore with the in-memory backend. This can be used for running tests that do not require persistence.
+- `MEMORY_NS` - Uses the MemoryNodeStore with the in-memory backend which is more lightweight than DocumentNodeStore but is not as feature-rich.
+- `COMPOSITE_SEGMENT` - Uses the CompositeNodeStore which allows combining multiple underlying segment stores into a single logical repository. It is useful in scenarios where different parts of the content tree have different storage requirements. For example, frequently accessed content can be stored in a high-performance segment store, while less frequently accessed content can be stored in a more cost-effective storage backend.
+- `COMPOSITE_MEM` - Uses the CompositeNodeStore setup which is combining multiple in-memory node stores. 
+- `COW_DOCUMENT` - Uses the COWNodeStore setup in which all the changes are stored in a volatile storage. 
+
+Note that the [Jenkins job](https://github.com/apache/jackrabbit-oak/blob/trunk/Jenkinsfile) that is run as part of the CI flow use both `SEGMENT_TAR` and `DOCUMENT_NS` fixtures to run the tests.
+
+
+

--- a/oak-doc/src/site/site.xml
+++ b/oak-doc/src/site/site.xml
@@ -154,6 +154,7 @@ under the License.
     <menu name="Developing Oak">
       <item href="dev_getting_started.html" name="Getting Started" />
       <item href="participating.html" name="Participating" />
+      <item href="testing.html" name="Testing" />
       <item href="oakathons.html" name="Oakathons" />
       <item href="developing-with-git.html" name="Developing with Git" />
       <item href="diagnostic-builds.html" name="Cutting diagnostic builds" />


### PR DESCRIPTION
Added a new page in the public documentation about different nsfixtures that are available when running unit and integration tests. 
<img width="1606" alt="image" src="https://github.com/apache/jackrabbit-oak/assets/169812327/199df69f-4fb5-499a-a7f8-0ef2c9a19d5b">

Proposal - add this under Getting Started page as a subtree:
<img width="245" alt="image" src="https://github.com/apache/jackrabbit-oak/assets/169812327/46530034-3093-45c4-89bd-90c55f360fe8">

Nice to have: provide more instructions about how to use each fixture. For example, for DOCUMENT_NS make sure a local mongoDB instance is running and provide `mongo.db` parameter. For `SEGMENT_AWS` there needs to be some config files in a specific location. But I need to dig more into the past tickets and codebase to find that out. 
@Joscorbe  @reschke @stefan-egli what do you think? 