### PR TITLE
OAK-10851 -  Log START/END/FAIL messages of indexing job phases inside the same package

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
@@ -64,7 +64,7 @@ public final class IndexUtils {
 
     // Logger used for START/END/FAIL messages of indexing phases. Logged in a separate logger to make them easier to
     // identify and parse by log analysis tools.
-    public static final Logger INDEXING_PHASE_LOGGER = LoggerFactory.getLogger("indexing-phase");
+    public static final Logger INDEXING_PHASE_LOGGER = LoggerFactory.getLogger("indexing-task");
 
     public static NodeBuilder getOrCreateOakIndex(NodeBuilder root) {
         NodeBuilder index;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
@@ -51,6 +51,8 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * TODO document
@@ -59,6 +61,10 @@ public final class IndexUtils {
 
     private IndexUtils() {
     }
+
+    // Logger used for START/END/FAIL messages of indexing phases. Logged in a separate logger to make them easier to
+    // identify and parse by log analysis tools.
+    public static final Logger INDEXING_PHASE_LOGGER = LoggerFactory.getLogger("indexing-phase");
 
     public static NodeBuilder getOrCreateOakIndex(NodeBuilder root) {
         NodeBuilder index;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexImporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexImporter.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_COUNT;
+import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
 import static org.apache.jackrabbit.oak.plugins.index.importer.IndexDefinitionUpdater.INDEX_DEFINITIONS_JSON;
 import static org.apache.jackrabbit.oak.plugins.index.importer.NodeStoreUtils.mergeWithConcurrentCheck;
 
@@ -486,14 +487,14 @@ public class IndexImporter {
         String indexImportPhaseName = indexImportState == null ? "null" : indexImportState.toString();
         int count = 1;
         Stopwatch start = Stopwatch.createStarted();
-        LOG.info("[TASK:{}:START]", indexImportPhaseName);
+        INDEXING_PHASE_LOGGER.info("[TASK:{}:START]", indexImportPhaseName);
         try {
             while (count <= maxRetries) {
                 LOG.info("IndexImporterStepExecutor:{}, count:{}", indexImportPhaseName, count);
                 try {
                     step.execute();
                     long durationSeconds = start.elapsed(TimeUnit.SECONDS);
-                    LOG.info("[TASK:{}:END] Metrics: {}",
+                    INDEXING_PHASE_LOGGER.info("[TASK:{}:END] Metrics: {}",
                             indexImportPhaseName,
                             MetricsFormatter.createMetricsWithDurationOnly(durationSeconds)
                     );
@@ -515,7 +516,7 @@ public class IndexImporter {
                 }
             }
         } catch (Throwable t) {
-            LOG.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
+            INDEXING_PHASE_LOGGER.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
                     indexImportPhaseName,
                     MetricsFormatter.createMetricsWithDurationOnly(start),
                     t.toString());

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMergeSortTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMergeSortTask.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy.SENTINEL_SORTED_FILES_QUEUE;
 import static org.apache.jackrabbit.oak.index.indexer.document.indexstore.IndexStoreUtils.getSortedStoreFileName;
+import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
 
 /**
  * Accumulates the intermediate sorted files and, when all files are generated, merges them into a single sorted file,
@@ -210,7 +211,7 @@ public class PipelinedMergeSortTask implements Callable<PipelinedMergeSortTask.R
         String originalName = Thread.currentThread().getName();
         Thread.currentThread().setName(THREAD_NAME);
         int intermediateFilesCount = 0;
-        LOG.info("[TASK:{}:START] Starting merge sort task", THREAD_NAME.toUpperCase(Locale.ROOT));
+        INDEXING_PHASE_LOGGER.info("[TASK:{}:START] Starting merge sort task", THREAD_NAME.toUpperCase(Locale.ROOT));
         Stopwatch finalMergeWatch = Stopwatch.createUnstarted();
         try {
             while (true) {
@@ -236,7 +237,7 @@ public class PipelinedMergeSortTask implements Callable<PipelinedMergeSortTask.R
                             .add("ffsSize", IOUtils.humanReadableByteCountBin(ffsSizeBytes))
                             .build();
 
-                    LOG.info("[TASK:{}:END] Metrics: {}", THREAD_NAME.toUpperCase(Locale.ROOT), metrics);
+                    INDEXING_PHASE_LOGGER.info("[TASK:{}:END] Metrics: {}", THREAD_NAME.toUpperCase(Locale.ROOT), metrics);
                     reporter.addTiming("Merge sort", FormattingUtils.formatToSeconds(finalMergeWatch));
                     MetricsUtils.addMetric(statisticsProvider, reporter, PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_FINAL_MERGE_DURATION_SECONDS, durationSeconds);
                     MetricsUtils.addMetric(statisticsProvider, reporter, PipelinedMetrics.OAK_INDEXER_PIPELINED_MERGE_SORT_INTERMEDIATE_FILES_TOTAL, intermediateFilesCount);
@@ -261,7 +262,7 @@ public class PipelinedMergeSortTask implements Callable<PipelinedMergeSortTask.R
                 }
             }
         } catch (Throwable t) {
-            LOG.info("[TASK:{}:FAIL] Metrics: {}, Error: {}", THREAD_NAME.toUpperCase(Locale.ROOT),
+            INDEXING_PHASE_LOGGER.info("[TASK:{}:FAIL] Metrics: {}, Error: {}", THREAD_NAME.toUpperCase(Locale.ROOT),
                     MetricsFormatter.createMetricsWithDurationOnly(finalMergeWatch),
                     t.toString());
             LOG.warn("Thread terminating with exception", t);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -74,6 +74,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
+
 public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownloadTask.Result> {
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class);
 
@@ -325,7 +327,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                         .withCodecRegistry(nodeDocumentCodecRegistry)
                         .getCollection(Collection.NODES.toString(), NodeDocument.class);
 
-                LOG.info("[TASK:{}:START] Starting to download from MongoDB", Thread.currentThread().getName().toUpperCase(Locale.ROOT));
+                INDEXING_PHASE_LOGGER.info("[TASK:{}:START] Starting to download from MongoDB", Thread.currentThread().getName().toUpperCase(Locale.ROOT));
                 try {
                     downloadStartWatch.start();
                     if (retryOnConnectionErrors) {
@@ -337,11 +339,11 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                     long durationMillis = downloadStartWatch.elapsed(TimeUnit.MILLISECONDS);
                     downloadStageStatistics.publishStatistics(statisticsProvider, reporter, durationMillis);
                     String metrics = downloadStageStatistics.formatStats(durationMillis);
-                    LOG.info("[TASK:{}:END] Metrics: {}", Thread.currentThread().getName().toUpperCase(Locale.ROOT), metrics);
+                    INDEXING_PHASE_LOGGER.info("[TASK:{}:END] Metrics: {}", Thread.currentThread().getName().toUpperCase(Locale.ROOT), metrics);
                     reporter.addTiming("Mongo dump", FormattingUtils.formatToSeconds(downloadStartWatch));
                     return new PipelinedMongoDownloadTask.Result(downloadStageStatistics.getDocumentsDownloadedTotal());
                 } catch (Throwable t) {
-                    LOG.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
+                    INDEXING_PHASE_LOGGER.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
                             Thread.currentThread().getName().toUpperCase(Locale.ROOT),
                             MetricsFormatter.createMetricsWithDurationOnly(downloadStartWatch),
                             t.toString());

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedSortBatchTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedSortBatchTask.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Callable;
 import static org.apache.jackrabbit.oak.commons.IOUtils.humanReadableByteCountBin;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy.SENTINEL_NSE_BUFFER;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedUtils.formatAsPercentage;
+import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
 
 /**
  * Receives batches of node state entries, sorts then in memory, and finally writes them to a file.
@@ -103,7 +104,7 @@ class PipelinedSortBatchTask implements Callable<PipelinedSortBatchTask.Result> 
         Stopwatch taskStartTime = Stopwatch.createStarted();
         String originalName = Thread.currentThread().getName();
         Thread.currentThread().setName(THREAD_NAME);
-        LOG.info("[TASK:{}:START] Starting sort-and-save task", THREAD_NAME.toUpperCase(Locale.ROOT));
+        INDEXING_PHASE_LOGGER.info("[TASK:{}:START] Starting sort-and-save task", THREAD_NAME.toUpperCase(Locale.ROOT));
         try {
             while (true) {
                 LOG.info("Waiting for next batch");
@@ -126,7 +127,7 @@ class PipelinedSortBatchTask implements Callable<PipelinedSortBatchTask.Result> 
                             .add("timeWritingPercentage", timeWritingPercentage)
                             .add("totalTimeSeconds", totalTimeMillis / 1000)
                             .build();
-                    LOG.info("[TASK:{}:END] Metrics: {}", THREAD_NAME.toUpperCase(Locale.ROOT), metrics);
+                    INDEXING_PHASE_LOGGER.info("[TASK:{}:END] Metrics: {}", THREAD_NAME.toUpperCase(Locale.ROOT), metrics);
                     MetricsUtils.addMetric(statisticsProvider, reporter,
                             PipelinedMetrics.OAK_INDEXER_PIPELINED_SORT_BATCH_PHASE_CREATE_SORT_ARRAY_PERCENTAGE,
                             PipelinedUtils.toPercentage(timeCreatingSortArrayMillis, totalTimeMillis));
@@ -143,7 +144,7 @@ class PipelinedSortBatchTask implements Callable<PipelinedSortBatchTask.Result> 
                 emptyBuffersQueue.put(nseBuffer);
             }
         } catch (Throwable t) {
-            LOG.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
+            INDEXING_PHASE_LOGGER.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
                     THREAD_NAME.toUpperCase(Locale.ROOT),
                     MetricsFormatter.createMetricsWithDurationOnly(taskStartTime),
                     t.toString());

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import static org.apache.jackrabbit.oak.commons.IOUtils.humanReadableByteCountBin;
+import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
 
 /**
  * Downloads the contents of the MongoDB repository dividing the tasks in a pipeline with the following stages:
@@ -375,7 +376,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
                 emptyBatchesQueue.add(NodeStateEntryBatch.createNodeStateEntryBatch(nseBuffersSizeBytes, Integer.MAX_VALUE));
             }
 
-            LOG.info("[TASK:PIPELINED-DUMP:START] Starting to build FFS");
+            INDEXING_PHASE_LOGGER.info("[TASK:PIPELINED-DUMP:START] Starting to build FFS");
             Stopwatch start = Stopwatch.createStarted();
 
             Future<PipelinedMongoDownloadTask.Result> downloadFuture = ecs.submit(new PipelinedMongoDownloadTask(
@@ -507,7 +508,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
                     }
                 }
                 long elapsedSeconds = start.elapsed(TimeUnit.SECONDS);
-                LOG.info("[TASK:PIPELINED-DUMP:END] Metrics: {}", MetricsFormatter.newBuilder()
+                INDEXING_PHASE_LOGGER.info("[TASK:PIPELINED-DUMP:END] Metrics: {}", MetricsFormatter.newBuilder()
                         .add("duration", FormattingUtils.formatToSeconds(elapsedSeconds))
                         .add("durationSeconds", elapsedSeconds)
                         .add("nodeStateEntriesExtracted", nodeStateEntriesExtracted)
@@ -516,7 +517,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
 
                 LOG.info("[INDEXING_REPORT:BUILD_FFS]\n{}", indexingReporter.generateReport());
             } catch (Throwable e) {
-                LOG.info("[TASK:PIPELINED-DUMP:FAIL] Metrics: {}, Error: {}",
+                INDEXING_PHASE_LOGGER.info("[TASK:PIPELINED-DUMP:FAIL] Metrics: {}, Error: {}",
                         MetricsFormatter.createMetricsWithDurationOnly(start), e.toString()
                 );
                 LOG.warn("Error dumping from MongoDB. Cancelling all tasks. Error: {}", e.toString());

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTransformTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTransformTask.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy.SENTINEL_MONGO_DOCUMENT;
+import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
 
 /**
  * Receives batches of Mongo documents, converts them to node state entries, batches them in a {@link NodeStateEntryBatch}
@@ -117,7 +118,7 @@ class PipelinedTransformTask implements Callable<PipelinedTransformTask.Result> 
         Thread.currentThread().setName(threadName);
         Stopwatch taskStartWatch = Stopwatch.createStarted();
         try {
-            LOG.info("[TASK:{}:START] Starting transform task", threadName.toUpperCase(Locale.ROOT));
+            INDEXING_PHASE_LOGGER.info("[TASK:{}:START] Starting transform task", threadName.toUpperCase(Locale.ROOT));
             NodeDocumentCache nodeCache = MongoDocumentStoreHelper.getNodeDocumentCache(mongoStore);
             long totalDocumentQueueWaitTimeMillis = 0;
             long totalEntryCount = 0;
@@ -148,7 +149,7 @@ class PipelinedTransformTask implements Callable<PipelinedTransformTask.Result> 
                             .add("totalEmptyBatchQueueWaitTimeMillis", totalEmptyBatchQueueWaitTimeMillis)
                             .add("totalEmptyBatchQueueWaitPercentage", totalEmptyBatchQueueWaitPercentage)
                             .build();
-                    LOG.info("[TASK:{}:END] Metrics: {}", threadName.toUpperCase(Locale.ROOT), metrics);
+                    INDEXING_PHASE_LOGGER.info("[TASK:{}:END] Metrics: {}", threadName.toUpperCase(Locale.ROOT), metrics);
                     //Save the last batch
                     nseBatch.getBuffer().flip();
                     tryEnqueue(nseBatch);
@@ -216,7 +217,7 @@ class PipelinedTransformTask implements Callable<PipelinedTransformTask.Result> 
                 }
             }
         } catch (Throwable t) {
-            LOG.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
+            INDEXING_PHASE_LOGGER.info("[TASK:{}:FAIL] Metrics: {}, Error: {}",
                     threadName.toUpperCase(Locale.ROOT), MetricsFormatter.createMetricsWithDurationOnly(taskStartWatch), t.toString());
             LOG.warn("Thread terminating with exception", t);
             throw t;


### PR DESCRIPTION
To facilitate parsing by log management systems, we should the messages like [TASK:<phase>:START/END/FAIL] logged inside the same package (different from the rest of the logs).