### PR TITLE
OAK-10854: Allow oak.findOne to find long path documents.

### DIFF
--- a/oak-run/src/main/js/oak-mongo.js
+++ b/oak-run/src/main/js/oak-mongo.js
@@ -656,13 +656,20 @@ var oak = (function(global){
      * @memberof oak
      * @method findOne
      * @param {string} path the path of the document.
+     * @param {boolean} [longPaths=false] if true, it will extend the search
+     *        to look for long paths.
      * @returns {object} the document or null if it doesn't exist.
      */
-    api.findOne = function(path) {
+    api.findOne = function(path, longPaths) {
         if (path === undefined) {
             return null;
         }
-        return db.nodes.findOne({_id: pathDepth(path) + ":" + path});
+        if (longPaths === undefined || longPaths === false) {
+            return db.nodes.findOne({_id: pathDepth(path) + ":" + path});
+        } else {
+            var depth = pathDepth(path);
+            return db.nodes.findOne(longPathFilter(depth, path));
+        }
     };
 
     /**


### PR DESCRIPTION
This adds a new optional argument to `oak.findOne` method to oak-mongo.js. This new parameter allows to control if the find should be extended to long paths.

If the second parameter is not specified, the `oak.findOne` method will work as always.