### PR TITLE
OAK-10866 - Avoid creating an intermediate String when appending a string value to a JsopBuilder.

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
@@ -28,7 +28,7 @@ public class JsopBuilder implements JsopWriter {
 
     private static final boolean JSON_NEWLINES = false;
 
-    private final StringBuilder buff = new StringBuilder();
+    private StringBuilder buff = new StringBuilder();
     private boolean needComma;
     private int lineLength, previous;
 
@@ -286,7 +286,7 @@ public class JsopBuilder implements JsopWriter {
      * @param buff the target buffer
      * @return the target buffer with the encoded string appended
      */
-    public static StringBuilder encode(String s, StringBuilder buff) {
+    private static StringBuilder encode(String s, StringBuilder buff) {
         if (s == null) {
             return buff.append("null");
         }

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
@@ -197,6 +197,7 @@ public class JsopBuilder implements JsopWriter {
      * @param value the value
      * @return this
      */
+    @Override
     public JsopBuilder value(String value) {
         optionalCommaAndNewline(strLength(value));
         encode(value, buff);
@@ -267,7 +268,7 @@ public class JsopBuilder implements JsopWriter {
         }
         for (int i = 0; i < length; i++) {
             char c = s.charAt(i);
-            if (c == '\"' || c == '\\' || c < ' ' || (c >= 0xd800 && c <= 0xdbff)) {
+            if (shouldEscape(c)) {
                 StringBuilder buff = new StringBuilder(length + 2 + length / 8);
                 buff.append('\"');
                 escape(s, length, buff);
@@ -296,7 +297,7 @@ public class JsopBuilder implements JsopWriter {
         }
         for (int i = 0; i < length; i++) {
             char c = s.charAt(i);
-            if (c == '\"' || c == '\\' || c < ' ' || (c >= 0xd800 && c <= 0xdbff)) {
+            if (shouldEscape(c)) {
                 buff.append('\"');
                 escape(s, length, buff);
                 return buff.append('\"');
@@ -313,6 +314,10 @@ public class JsopBuilder implements JsopWriter {
      */
     public static void escape(String s, StringBuilder buff) {
         escape(s, s.length(), buff);
+    }
+
+    private static boolean shouldEscape(char c) {
+        return c == '\"' || c == '\\' || c < ' ' || (c >= 0xd800 && c <= 0xdbff);
     }
 
     /**

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/json/JsopBuilder.java
@@ -222,7 +222,7 @@ public class JsopBuilder implements JsopWriter {
         if (value != null) {
             return value.length();
         } else {
-            return 4; //"null".length();
+            return "null".length();
         }
     }
 


### PR DESCRIPTION
Provides a ~10% improvement when generating Json.

Microbenchmark adapted from JsopStreamTest:
```
public static void main(String... args) {
    for (int k = 0; k < 5; k++) {
        String s = "Hello \"World\" Hello \"World\" Hello \"World\" Hello \"World\" Hello \"World\" Hello \"World\" ";
        StopWatch timer = new StopWatch();
        JsopBuilder w = new JsopBuilder() ;
        for (int i = 0; i < 50000000; i++) {
            w.value(s);
            if (i % 100 == 0) {
                w.resetWriter();
            }
        }
        System.out.println(w.getClass() + ": " + timer.seconds());
    }
}
```

Base line:
```
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 9.27 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 9.19 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 9.21 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 9.23 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 9.20 seconds
```

Optimized `JsopBuilder.value(String)`
```
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 8.09 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 8.04 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 8.12 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 8.22 seconds
class org.apache.jackrabbit.oak.commons.json.JsopBuilder: 8.16 seconds