### PR TITLE
OAK-10872 - Replace use of StringBuilder by string concatenation in PathUtils.concat(String,String)

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
@@ -317,13 +317,8 @@ public final class PathUtils {
         } else if (isAbsolutePath(subPath)) {
             throw new IllegalArgumentException("Cannot append absolute path " + subPath);
         }
-        StringBuilder buff = new StringBuilder(parentPath.length() + subPath.length() + 1);
-        buff.append(parentPath);
-        if (!denotesRootPath(parentPath)) {
-            buff.append('/');
-        }
-        buff.append(subPath);
-        return buff.toString();
+        String separator = denotesRootPath(parentPath) ? "" : "/";
+        return parentPath + separator + subPath;
     }
 
     /**


### PR DESCRIPTION
Using String concatenation in this case is much faster, because the JVM will use invokedynamic to concatenate the Strings. The method `PathUtils.concat(String, String)` is heavily used by Oak, so it is worth to optimize.

With the following test code, using String concatenation provides a 2x speedup:
```
    public static void main(String[] args) {
        var p1 = "parent";
        var start = Stopwatch.createStarted();
        long totalSize = 0;
        for (int i = 0; i < 500_000_000; i++) {
            totalSize += PathUtils.concat(p1, "child"+i).length();
        }
        System.out.println("totalSize: " + totalSize + " start.elapsed() = " + start.elapsed(TimeUnit.MILLISECONDS) + " ms" );
    }
```

Baseline, with StringBuilder:
```
TotalSize: 10388888890
Duration: 21056 ms
```
Optimized with String concatenation:
```
TotalSize: 10388888890
Duration: 11215 ms
```