### PR TITLE
OAK-10879 - Indexing job: in the index report, list phase timings in chronological order and not alphabetic order

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporter.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ConsoleIndexingReporter implements IndexingReporter {
     // Print configuration in alphabetical order
@@ -87,11 +88,11 @@ public class ConsoleIndexingReporter implements IndexingReporter {
         return "Indexes: " + String.join(", ", indexes) + "\n" +
                 "Date: " + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()) + "\n" +
                 "OAK Version: " + OakVersion.getVersion() + "\n" +
-                "Configuration:\n" + mapToString(config) + "\n" +
+                "Configuration:\n" + mapToString(config, true) + "\n" +
                 "Environment Variables:\n" + genEnvVariables() + "\n" +
                 "Information:\n" + listToString(informationStrings) + "\n" +
-                "Timings:\n" + mapToString(timings) + "\n" +
-                "Metrics:\n" + mapToString(metrics);
+                "Timings:\n" + mapToString(timings, false) + "\n" +
+                "Metrics:\n" + mapToString(metrics, true);
     }
 
     private String genEnvVariables() {
@@ -101,10 +102,12 @@ public class ConsoleIndexingReporter implements IndexingReporter {
                 .collect(Collectors.joining("\n"));
     }
 
-    private String mapToString(Map<String, String> map) {
-        return map.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .map(entry -> "  " + entry.getKey() + ": " + entry.getValue())
+    private String mapToString(Map<String, String> map, boolean sortKeys) {
+        Stream<Map.Entry<String, String>> stream = map.entrySet().stream();
+        if (sortKeys) {
+            stream = stream.sorted(Map.Entry.comparingByKey());
+        }
+        return stream.map(entry -> "  " + entry.getKey() + ": " + entry.getValue())
                 .collect(Collectors.joining("\n"));
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporterTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/ConsoleIndexingReporterTest.java
@@ -65,7 +65,12 @@ public class ConsoleIndexingReporterTest {
                 "  A message\n" +
                 "  Foo Bar\n" +
                 "Timings:\n" +
-                "  stage1: 10:23\n" +
+                "  Mongo dump: 00:02:44\n" +
+                "  Merge sort: 00:00:06\n" +
+                "  Build FFS (Dump+Merge): 00:02:59\n" +
+                "  Build Lucene Index: 00:01:14\n" +
+                "  Merge node store: 00:00:00\n" +
+                "  Total time: 00:04:15\n" +
                 "Metrics:\n" +
                 "  metric1: 1\n" +
                 "  metric2: 123\n" +
@@ -77,18 +82,26 @@ public class ConsoleIndexingReporterTest {
 
         consoleIndexingReporter.setIndexNames(List.of("index1", "index2"));
 
+        // Should be printed in alphabetic order
         consoleIndexingReporter.addMetric("metric1", 1);
         consoleIndexingReporter.addMetricByteSize("metric2", 123);
         consoleIndexingReporter.addMetricByteSize("metric3", 123456);
         consoleIndexingReporter.addMetricByteSize("metric4", 123456789);
         consoleIndexingReporter.addMetricByteSize("metric5", 1234567890123456L);
 
+        // Should be printed in alphabetic order
         consoleIndexingReporter.addConfig("config1", "value1");
         consoleIndexingReporter.addConfig("config2", 12);
         consoleIndexingReporter.addInformation("Foo Bar");
         consoleIndexingReporter.addInformation("A message");
 
-        consoleIndexingReporter.addTiming("stage1", "10:23");
+        // These should be printed by the order they were added
+        consoleIndexingReporter.addTiming("Mongo dump", "00:02:44");
+        consoleIndexingReporter.addTiming("Merge sort", "00:00:06");
+        consoleIndexingReporter.addTiming("Build FFS (Dump+Merge)", "00:02:59");
+        consoleIndexingReporter.addTiming("Build Lucene Index", "00:01:14");
+        consoleIndexingReporter.addTiming("Merge node store", "00:00:00");
+        consoleIndexingReporter.addTiming("Total time", "00:04:15");
 
         String report = consoleIndexingReporter.generateReport();
 


### PR DESCRIPTION
Instead of:
```
Timings:
  Build FFS (Dump+Merge): 00:00:30
  Build Lucene Index: 00:00:00
  Merge node store: 00:00:00
  Merge sort: 00:00:00
  Mongo dump: 00:00:30
  Total time: 00:00:32
```

It should be:
```
Timings
  Mongo dump: 00:00:30
  Merge sort: 00:00:00
  Build FFS (Dump+Merge): 00:00:30
  Build Lucene Index: 00:00:00
  Merge node store: 00:00:00
  Total time: 00:00:32
```