### PR TITLE
Oak-10874 | Add jmx function for bringing forward a delayed async lane to a latest checkpoint.

### DIFF
--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
@@ -128,8 +128,8 @@ public interface IndexStatsMBean {
      */
     String getReferenceCheckpoint();
 
-    @Description("Force update the indexing lane to a latest checkpoint. This will abort and pause the running lane, release it's lease and set the reference checkpoint to a latest one." +
-            "Any content changes b/w the old reference checkpoint and the new one will be not be indexed and a reindexing would be required." +
+    @Description("Force update the indexing lane to a checkpoint created during execution of this function. This will abort and pause the running lane, release it's lease and set the reference checkpoint to a latest one." +
+            "Any content changes between the old reference checkpoint and the new one will be not be indexed and a reindexing would be required." +
             "Only use this operation if you are sure that the lane is stuck and not updated since many days and cannot catchup on it's own." +
             "Once this operation is completed, reindexing for all indexes on the lane is required.")
     String forceIndexLaneCatchup(

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
@@ -128,9 +128,9 @@ public interface IndexStatsMBean {
      */
     String getReferenceCheckpoint();
 
-    @Description("Force update the indexing lane to a latest checkpoint. This will abort and pause the running lane, release it's lease and set the reference checkpoint to a latest one." +
+    @Description("Force update the indexing lane to a latest checkpoint. This will abort and pause the running lane, release its lease and set the reference checkpoint to a latest one." +
             "Any content changes b/w the old reference checkpoint and the new one will be not be indexed and a reindexing would be required." +
-            "Only use this operation if you are sure that the lane is stuck and not updated since many days and cannot catchup on it's own." +
+            "Only use this operation if you are sure that the lane is stuck and not updated for many days and cannot catch up on its own." +
             "Once this operation is completed, reindexing for all indexes on the lane is required.")
     String forceIndexLaneCatchup(
             @Name("Confirmation Message")

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.api.jmx;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
+import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
@@ -126,6 +127,18 @@ public interface IndexStatsMBean {
      * @return the reference checkpoint
      */
     String getReferenceCheckpoint();
+
+    /**
+     * Used to set the reference checkpoint for the async indexer to the provided checkpoint value.
+     */
+    @Description("Force update the indexing lane to a latest checkpoint. This will abort and pause the running lane, release it's lease and set the reference checkpoint to a latest one." +
+            "Any content changes b/w the old reference checkpoint and the new one will be not be indexed and a reindexing would be required." +
+            "Only use this operation if you are sure that the lane is stuck and not updated since many days and cannot catchup on it's own." +
+            "Once this operation is completed, reindexing for all indexes on the lane is required.")
+    void pretendIndexLaneCatchup(
+            @Name("Confirmation Message")
+            @Description("Enter 'CONFIRM' to confirm the operation")
+            String confirmationMessage) throws CommitFailedException;
 
     /**
      * Returns the processed checkpoint used by the async indexer. If this index

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/IndexStatsMBean.java
@@ -128,14 +128,11 @@ public interface IndexStatsMBean {
      */
     String getReferenceCheckpoint();
 
-    /**
-     * Used to set the reference checkpoint for the async indexer to the provided checkpoint value.
-     */
     @Description("Force update the indexing lane to a latest checkpoint. This will abort and pause the running lane, release it's lease and set the reference checkpoint to a latest one." +
             "Any content changes b/w the old reference checkpoint and the new one will be not be indexed and a reindexing would be required." +
             "Only use this operation if you are sure that the lane is stuck and not updated since many days and cannot catchup on it's own." +
             "Once this operation is completed, reindexing for all indexes on the lane is required.")
-    void pretendIndexLaneCatchup(
+    String forceIndexLaneCatchup(
             @Name("Confirmation Message")
             @Description("Enter 'CONFIRM' to confirm the operation")
             String confirmationMessage) throws CommitFailedException;

--- a/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/package-info.java
+++ b/oak-api/src/main/java/org/apache/jackrabbit/oak/api/jmx/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-@Version("4.12.0")
+@Version("4.13.0")
 package org.apache.jackrabbit.oak.api.jmx;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -1252,12 +1252,12 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
             }
 
             if (!this.isFailing()) {
-                String msg = "The lane is not failing. This operation should only be performed if the lane is failing, it should first be allowed to catchup on it's own.";
+                String msg = "The lane is not failing. This operation should only be performed if the lane is failing, it should first be allowed to catchup on its own.";
                 log.warn(msg);
                 return msg;
             }
 
-            log.info("Running a forced catchup for indexing lane [{}]. ", name);
+            log.info("Running a forced catchup for indexing lane [{}]", name);
             // First we need to abort and pause the running indexing task
             this.abortAndPause();
             log.info("Aborted and paused async indexing for lane [{}]", name);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -1291,9 +1291,10 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
             } catch (Exception e) {
                 log.error("Exception while trying to force update the indexing lane [{}]", name, e);
                 if (this.isPaused()) {
+                    this.resume();
                     log.info("Resuming the lane [{}] as it was paused during the operation", name);
                 }
-                return "Unable to complete the force update due to" + e.getMessage() + "Please check logs for more details";
+                return "Unable to complete the force update due to " + e.getMessage() + ".Please check logs for more details";
             }
         }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -1282,7 +1282,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
             } else {
                 log.warn("Unable to remove old reference checkpoint {}. This can result in orphaned checkpoints and would need to be removed manually.", existingReferenceCheckpoint);
             }
-            mergeWithConcurrencyCheck(store, validatorProviders, builder, null, null, name);
+            mergeWithConcurrencyCheck(store, validatorProviders, builder, existingReferenceCheckpoint, null, name);
 
             // Resume the paused lane;
             this.resume();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -117,7 +117,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
      */
     static final String ASYNC = ":async";
 
-    private static final long DEFAULT_LIFETIME = TimeUnit.DAYS.toMillis(1000);
+    private static final long DEFAULT_LIFETIME = TimeUnit.DAYS.toMillis(100);
 
     private static final CommitFailedException INTERRUPTED = new CommitFailedException(
             "Async", 1, "Indexing stopped forcefully");

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -1246,33 +1246,33 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
         public String forceIndexLaneCatchup(String confirmMessage) throws CommitFailedException {
 
             if (!"CONFIRM".equals(confirmMessage)) {
-                String msg = "Please confirm that you want to force the lane catchup by passing 'CONFIRM' as argument";
+                String msg = "Please confirm that you want to force the lane catch-up by passing 'CONFIRM' as argument";
                 log.warn(msg);
                 return msg;
             }
 
             if (!this.isFailing()) {
-                String msg = "The lane is not failing. This operation should only be performed if the lane is failing, it should first be allowed to catchup on it's own.";
+                String msg = "The lane is not failing. This operation should only be performed if the lane is failing, it should first be allowed to catch up on it's own.";
                 log.warn(msg);
                 return msg;
             }
 
-            log.info("Running a forced catchup for indexing lane [{}]. ", name);
+            log.info("Running a forced catch-up for indexing lane [{}]. ", name);
             // First we need to abort and pause the running indexing task
             this.abortAndPause();
             log.info("Aborted and paused async indexing for lane [{}]", name);
             // Release lease for the paused lane
             this.releaseLeaseForPausedLane();
             log.info("Released lease for paused lane [{}]", name);
-            String newReferenceCheckpoint = store.checkpoint(lifetime, ImmutableMap.of(
+            String newReferenceCheckpoint = store.checkpoint(lifetime, Map.of(
                     "creator", AsyncIndexUpdate.class.getSimpleName(),
                     "created", now(),
                     "thread", Thread.currentThread().getName(),
                     "name", name + "-forceModified"));
             String existingReferenceCheckpoint = this.referenceCp;
             log.info("Modifying the referred checkpoint for lane [{}] from {} to {}." +
-                    " This means that any content modifications b/w these checkpoints will not reflect in the indexes on this lane." +
-                    " Reindexing would be needed to get this content indexed.", name, existingReferenceCheckpoint, newReferenceCheckpoint);
+                    " This means that any content modifications between these checkpoints will not reflect in the indexes on this lane." +
+                    " Reindexing is needed to get this content indexed.", name, existingReferenceCheckpoint, newReferenceCheckpoint);
             NodeBuilder builder = store.getRoot().builder();
             builder.child(ASYNC).setProperty(name, newReferenceCheckpoint);
             this.referenceCp = newReferenceCheckpoint;
@@ -1287,7 +1287,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
             // Resume the paused lane;
             this.resume();
             log.info("Resumed async indexing for lane [{}]", name);
-            return ("Lane successfully forced to catchup. New reference checkpoint is " + newReferenceCheckpoint + " . Please make sure to perform reindexing to get the diff content indexed.");
+            return "Lane successfully forced to catch-up. New reference checkpoint is " + newReferenceCheckpoint + " . Please make sure to perform reindexing to get the diff content indexed.";
         }
 
         void setProcessedCheckpoint(String checkpoint) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -596,7 +596,7 @@ public class AsyncIndexUpdateTest {
 
         NodeBuilder builder = store.getRoot().builder();
         createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
-                "rootIndex", true, false, ImmutableSet.of("foo"), null)
+                "rootIndex", true, false, Set.of("foo"), null)
                 .setProperty(ASYNC_PROPERTY_NAME, "async");
         builder.child("testRoot").setProperty("foo", "abc");
 
@@ -622,7 +622,7 @@ public class AsyncIndexUpdateTest {
         assertFalse(root.getChildNode(INDEX_DEFINITIONS_NAME).hasChildNode(
                 ":conflict"));
         PropertyIndexLookup lookup = new PropertyIndexLookup(root);
-        assertEquals(ImmutableSet.of("testRoot", "testRoot1"), find(lookup, "foo", "abc"));
+        assertEquals(Set.of("testRoot", "testRoot1"), find(lookup, "foo", "abc"));
 
         // Run force index catchup with correct confirm message
         // But the async lane is NOT failing
@@ -639,7 +639,7 @@ public class AsyncIndexUpdateTest {
         assertFalse(root.getChildNode(INDEX_DEFINITIONS_NAME).hasChildNode(
                 ":conflict"));
         lookup = new PropertyIndexLookup(root);
-        assertEquals(ImmutableSet.of("testRoot", "testRoot1", "testRoot2"), find(lookup, "foo", "abc"));
+        assertEquals(Set.of("testRoot", "testRoot1", "testRoot2"), find(lookup, "foo", "abc"));
 
 
         // Now run force index update on a failing lane with correct confirm message
@@ -661,7 +661,7 @@ public class AsyncIndexUpdateTest {
         lookup = new PropertyIndexLookup(root);
         // testRoot3 will not be indexed, because it was created after the last successfully run index update and before the forceUpdate was called.
         // So it lands in the missing content diff that needs to be reindexed.
-        assertEquals(ImmutableSet.of("testRoot", "testRoot1", "testRoot2", "testRoot4"), find(lookup, "foo", "abc"));
+        assertEquals(Set.of("testRoot", "testRoot1", "testRoot2", "testRoot4"), find(lookup, "foo", "abc"));
         // Check if failing index update is fixed
         assertFalse(async.isFailing());
     }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -612,7 +612,7 @@ public class AsyncIndexUpdateTest {
 
         // Run pretend index catchup with an incorrect confirm message
         // This will skip the operation and testRoot1 should be indexed in the next async run.
-        async.getIndexStats().pretendIndexLaneCatchup("ok");
+        async.getIndexStats().forceIndexLaneCatchup("ok");
         async.run();
         root = store.getRoot();
 
@@ -629,7 +629,7 @@ public class AsyncIndexUpdateTest {
         // testRoot3 should be in the result set since it's created after the pretend index catchup is called.
         builder.child("testRoot2").setProperty("foo", "abc");
         store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-        async.getIndexStats().pretendIndexLaneCatchup("CONFIRM");
+        async.getIndexStats().forceIndexLaneCatchup("CONFIRM");
         builder.child("testRoot3").setProperty("foo", "abc");
         store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
         async.run();

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -590,7 +590,7 @@ public class AsyncIndexUpdateTest {
     }
 
     @Test
-    public void testForceModifyReferenceCheckpoint() throws CommitFailedException {
+    public void testForceUpdateAsyncLane() throws CommitFailedException {
         NodeStore store = new MemoryNodeStore();
         IndexEditorProvider provider = new PropertyIndexEditorProvider();
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -610,7 +610,7 @@ public class AsyncIndexUpdateTest {
         builder.child("testRoot1").setProperty("foo", "abc");
         store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
 
-        // Run pretend index catchup with an incorrect confirm message
+        // Run force index catchup with an incorrect confirm message
         // This will skip the operation and testRoot1 should be indexed in the next async run.
         async.getIndexStats().forceIndexLaneCatchup("ok");
         async.run();
@@ -624,14 +624,13 @@ public class AsyncIndexUpdateTest {
         PropertyIndexLookup lookup = new PropertyIndexLookup(root);
         assertEquals(ImmutableSet.of("testRoot", "testRoot1"), find(lookup, "foo", "abc"));
 
-        // Run pretend index catchup with correct confirm message
-        // Due to this the new node testRoot2 will not be indexed, because the reference checkpoint will point to a state after this node was created.
-        // testRoot3 should be in the result set since it's created after the pretend index catchup is called.
+        // Run force index catchup with correct confirm message
+        // But the async lane is NOT failing
+        // Due to this the force update should be skipped and the
+        // new node testRoot2 will  be indexed.
         builder.child("testRoot2").setProperty("foo", "abc");
         store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
         async.getIndexStats().forceIndexLaneCatchup("CONFIRM");
-        builder.child("testRoot3").setProperty("foo", "abc");
-        store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
         async.run();
         root = store.getRoot();
 
@@ -640,9 +639,31 @@ public class AsyncIndexUpdateTest {
         assertFalse(root.getChildNode(INDEX_DEFINITIONS_NAME).hasChildNode(
                 ":conflict"));
         lookup = new PropertyIndexLookup(root);
-        assertEquals(ImmutableSet.of("testRoot", "testRoot1", "testRoot3"), find(lookup, "foo", "abc"));
+        assertEquals(ImmutableSet.of("testRoot", "testRoot1", "testRoot2"), find(lookup, "foo", "abc"));
 
 
+        // Now run force index update on a failing lane with correct confirm message
+        builder.child("testRoot3").setProperty("foo", "abc");
+        store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        async.getIndexStats().failed(new Exception("Mock index update failure"));
+        assertTrue(async.isFailing());
+        async.getIndexStats().forceIndexLaneCatchup("CONFIRM");
+        builder.child("testRoot4").setProperty("foo", "abc");
+        store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+
+        async.run();
+        root = store.getRoot();
+
+        checkPathExists(root, INDEX_DEFINITIONS_NAME, "rootIndex",
+                INDEX_CONTENT_NODE_NAME);
+        assertFalse(root.getChildNode(INDEX_DEFINITIONS_NAME).hasChildNode(
+                ":conflict"));
+        lookup = new PropertyIndexLookup(root);
+        // testRoot3 will not be indexed, because it was created after the last successfully run index update and before the forceUpdate was called.
+        // So it lands in the missing content diff that needs to be reindexed.
+        assertEquals(ImmutableSet.of("testRoot", "testRoot1", "testRoot2", "testRoot4"), find(lookup, "foo", "abc"));
+        // Check if failing index update is fixed
+        assertFalse(async.isFailing());
     }
 
     private void assertNoConflictMarker(NodeBuilder builder) {


### PR DESCRIPTION
For scenarios where the async indexing lanes might be lagging for a large amount of time (let's assume days) and it might not be possible for the lane to catchup normally on it's own due to -
1. Large content diff to process leading to OOM and continuous failed async cycles
2. Possibility of old reference checkpoint no longer being present in the system and the async lane thus doing a complete reindex of the whole repo.

In such cases, it might be required to make the async lane think that it is up to date by setting it's reference checkpoint to a more recent one. 
This PR introduces a jmx function to - 
1. Pause and Abort the lagging async lane
2. Clear it's lease
3. Create a new checkpoint 
4. Set the new checkpoint as reference checkpoint for the lane
5. delete the old checkpoint
6. resume the async indexing on the lane.

If this operation is performed the async lane should start async indexing from the newly created checkpoint. But the diff of the content that was missed would need to be reindexed separately using oak-run's offline reindexing. 


To prevent unintentional misuse of this function, 

1. It will specifically ask the user to enter "CONFIRM" before proceeding so that the user knows what he is doing.
2. It will not skip in case the lane on which it is called is not failing.