### PR TITLE
OAK-10901 - Bypass the DocumentNodeState cache when resolving paths downloaded from Mongo.

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTransformTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTransformTask.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.NodeStateEntryWriter;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeState;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
+import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreHelper;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.Path;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
@@ -239,7 +240,7 @@ class PipelinedTransformTask implements Callable<PipelinedTransformTask.Result> 
 
     private void extractNodeStateEntries(NodeDocument doc, ArrayList<DocumentNodeState> nodeStateEntries) {
         Path path = doc.getPath();
-        DocumentNodeState nodeState = documentNodeStore.getNode(path, rootRevision);
+        DocumentNodeState nodeState = DocumentNodeStoreHelper.readNode(documentNodeStore, path, rootRevision);
         //At DocumentNodeState api level the nodeState can be null
         if (nodeState == null || !nodeState.exists()) {
             return;


### PR DESCRIPTION
The indexing job needs to resolve each of the paths found in documents downloaded from Mongo into DocumentNodeState instances. It does so using the DocumentNodeStore, which internally keeps a cache with previously resolved documents DocumentNodeState instances. But in the case of the indexing job, none of the paths that will be resolved will be found in the cache, because as part of the traversal of the repository, it resolves each path once and only once. Therefore, not only it is wasteful to check the cache for the presence of the path/revision pair, but it is also wasteful to put the resolved node in the cache. 

This PR bypasses this cache, by calling the internal method `DocumentNodeStore#readNode(Path, RevisionVector)` directly.  

For more details see here: https://github.com/apache/jackrabbit-oak/pull/1533
