### PR TITLE
OAK-10903 - When parallel download is enabled, the dump may miss documents updated during the download

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -218,6 +218,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     private Instant lastDelayedEnqueueWarningMessageLoggedTimestamp = Instant.now();
     private MongoParallelDownloadCoordinator mongoParallelDownloadCoordinator;
 
+    // For testing purposes
+    static final String OAK_INDEXER_PIPELINED_MONGO_BATCH_SIZE = "oak.indexer.pipelined.mongoBatchSize";
+    private final int mongoBatchSize = Integer.getInteger(OAK_INDEXER_PIPELINED_MONGO_BATCH_SIZE, -1);
+
     public PipelinedMongoDownloadTask(MongoClientURI mongoClientURI,
                                       MongoDocumentStore docStore,
                                       int maxBatchSizeBytes,
@@ -699,6 +703,10 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         }
 
         void download(FindIterable<NodeDocument> mongoIterable) throws InterruptedException, TimeoutException {
+            if (mongoBatchSize != -1) {
+                LOG.info("Setting Mongo batch size to {}", mongoBatchSize);
+                mongoIterable.batchSize(mongoBatchSize);
+            }
             try (MongoCursor<NodeDocument> cursor = mongoIterable.iterator()) {
                 NodeDocument[] batch = new NodeDocument[maxBatchNumberOfDocuments];
                 int nextIndex = 0;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -589,7 +589,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
         private final MongoParallelDownloadCoordinator parallelDownloadCoordinator;
         private long documentsDownloadedTotalBytes;
         private long documentsDownloadedTotal;
-        private long totalEnqueueWaitTimeMillis;
         private long nextLastModified;
         private String lastIdDownloaded;
         private long firstModifiedValueSeen = -1;
@@ -610,7 +609,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
             this.parallelDownloadCoordinator = parallelDownloadCoordinator;
             this.documentsDownloadedTotalBytes = 0;
             this.documentsDownloadedTotal = 0;
-            this.totalEnqueueWaitTimeMillis = 0;
             this.nextLastModified = downloadOrder.downloadInAscendingOrder() ? 0 : Long.MAX_VALUE;
             this.lastIdDownloaded = null;
         }
@@ -827,7 +825,6 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                     throw new TimeoutException("Timeout trying to enqueue batch of MongoDB documents. Waited " + MONGO_QUEUE_OFFER_TIMEOUT);
                 }
                 long enqueueDelay = enqueueDelayStopwatch.elapsed(TimeUnit.MILLISECONDS);
-                this.totalEnqueueWaitTimeMillis += enqueueDelay;
                 downloadStageStatistics.incrementTotalEnqueueWaitTimeMillis(enqueueDelay);
                 if (enqueueDelay > 1) {
                     logWithRateLimit(() ->

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
@@ -111,7 +111,7 @@ public class PipelinedMongoServerSelector implements ServerSelector, ClusterList
             }
         }
         // All secondaries are already assigned to some thread
-        LOG.info("All available Mongo secondaries are assigned. Returning empty list.");
+        LOG.debug("All available Mongo secondaries are assigned. Returning empty list.");
         return List.of();
     }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoServerSelector.java
@@ -111,7 +111,7 @@ public class PipelinedMongoServerSelector implements ServerSelector, ClusterList
             }
         }
         // All secondaries are already assigned to some thread
-        LOG.debug("All available Mongo secondaries are assigned. Returning empty list.");
+        LOG.info("All available Mongo secondaries are assigned. Returning empty list.");
         return List.of();
     }
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoConnectionFailureIT.java
@@ -22,9 +22,16 @@ import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
 import eu.rekawek.toxiproxy.model.toxic.LimitData;
+import org.apache.jackrabbit.guava.common.base.Stopwatch;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
 import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDockerRule;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -33,6 +40,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MongoDBContainer;
@@ -43,12 +52,18 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP_SECONDARIES_ONLY;
+import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy.OAK_INDEXER_PIPELINED_MONGO_DOC_BATCH_MAX_NUMBER_OF_DOCUMENTS;
 
+@RunWith(Parameterized.class)
 public class PipelinedMongoConnectionFailureIT {
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoConnectionFailureIT.class);
 
@@ -56,6 +71,20 @@ public class PipelinedMongoConnectionFailureIT {
     // We cannot use the MongoDockerRule/MongoConnectionFactory because they don't allow customizing the docker network
     // used to launch the Mongo container.
     private static final int MONGODB_DEFAULT_PORT = 27017;
+
+    @Parameterized.Parameters(name = "parallelDump={0}, testUpdateContent={1}")
+    public static Collection<Object[]> parameters() {
+        return List.of(
+                new Object[]{true, false},
+                new Object[]{false, false},
+                new Object[]{true, true},
+                new Object[]{false, true}
+        );
+    }
+
+    final boolean parallelDump;
+    final boolean testUpdateContent;
+
     @Rule
     public final Network network = Network.newNetwork();
     @Rule
@@ -73,7 +102,14 @@ public class PipelinedMongoConnectionFailureIT {
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     private Proxy proxy;
-    private String mongoUri;
+    private String mongoUriFlaky;
+
+    private String mongoUriReliable;
+
+    public PipelinedMongoConnectionFailureIT(boolean parallelDump, boolean testUpdateContent) {
+        this.parallelDump = parallelDump;
+        this.testUpdateContent = testUpdateContent;
+    }
 
     @BeforeClass
     public static void setup() throws IOException {
@@ -83,63 +119,150 @@ public class PipelinedMongoConnectionFailureIT {
     @Before
     public void before() throws Exception {
         ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+        // For the logic under test
         this.proxy = toxiproxyClient.createProxy("mongo", "0.0.0.0:8666", "mongo:" + MONGODB_DEFAULT_PORT);
-        this.mongoUri = "mongodb://" + toxiproxy.getHost() + ":" + toxiproxy.getMappedPort(8666) + "/" + MongoUtils.DB;
+        this.mongoUriFlaky = "mongodb://" + toxiproxy.getHost() + ":" + toxiproxy.getMappedPort(8666) + "/" + MongoUtils.DB;
+
+        // For the operations that prepare and update the test data.
+        toxiproxyClient.createProxy("mongo-reliable", "0.0.0.0:8667", "mongo:" + MONGODB_DEFAULT_PORT);
+        this.mongoUriReliable = "mongodb://" + toxiproxy.getHost() + ":" + toxiproxy.getMappedPort(8667) + "/" + MongoUtils.DB;
     }
 
     @Test
     public void mongoDisconnectTest() throws Exception {
-        // Testcontainers' MongoDBContainer starts a Mongo replica set of one node. If parallel dump is enabled, the
-        // Mongo server selector will refuse to connect to the primary node, which is the only node, so it will forever
-        // fail to connect to Mongo. For the time being, we test reconnections without parallel dump
+        // Testcontainers' MongoDBContainer starts a Mongo replica set of one node. In this configuration we cannot
+        // configure the downloader with the replica selection policy that avoids downloading from the primary, using
+        // only the secondaries. So we disable that policy here. the unit tests in PipelinedMongoDownloadTaskTest cover
+        // that case.
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP_SECONDARIES_ONLY, "false");
 
-        // TODO: Update the server selector policy to also connect to the primary in case there are no secondaries after some
-        // grace period to allow for the discovery of replicas to complete.
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP, String.valueOf(parallelDump));
+        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_DOC_BATCH_MAX_NUMBER_OF_DOCUMENTS, String.valueOf(100));
 
-        // Add a test case with more data to test the reconnection logic
-        System.setProperty(OAK_INDEXER_PIPELINED_MONGO_PARALLEL_DUMP, "false");
+        try (MongoTestBackend rwBackend = PipelineITUtil.createNodeStore(false, mongoUriReliable, builderProvider)) {
+            createContent(rwBackend.documentNodeStore);
 
-        try (MongoTestBackend rwBackend = PipelineITUtil.createNodeStore(false, mongoUri, builderProvider)) {
-            PipelineITUtil.createContent(rwBackend.documentNodeStore);
-            rwBackend.documentNodeStore.dispose();
-            rwBackend.mongoDocumentStore.dispose();
-        }
-
-        Path resultWithoutInterruption;
-        LOG.info("Creating a FFS: reference run without failures.");
-        try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUri, builderProvider)) {
-            PipelinedStrategy strategy = createStrategy(roBackend);
-            resultWithoutInterruption = strategy.createSortedStoreFile().toPath();
-        }
-
-        Path resultWithInterruption;
-        LOG.info("Creating a FFS: test run with disconnection to Mongo.");
-        try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUri, builderProvider)) {
-            LimitData cutConnectionUpstream = proxy.toxics()
-                    .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.DOWNSTREAM, 30000L);
-            ScheduledExecutorService scheduleExecutor = Executors.newSingleThreadScheduledExecutor();
-            try {
-                scheduleExecutor.schedule(() -> {
-                    try {
-                        LOG.info("Removing connection block");
-                        cutConnectionUpstream.remove();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }, 5, TimeUnit.SECONDS);
-
+            Path resultWithoutInterruption;
+            LOG.info("Creating a FFS: reference run without failures.");
+            try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUriReliable, builderProvider)) {
                 PipelinedStrategy strategy = createStrategy(roBackend);
-                resultWithInterruption = strategy.createSortedStoreFile().toPath();
-            } finally {
-                scheduleExecutor.shutdown();
+                resultWithoutInterruption = strategy.createSortedStoreFile().toPath();
             }
-        }
 
-        LOG.info("Comparing resulting FFS with and without Mongo disconnections: {} {}", resultWithoutInterruption, resultWithInterruption);
-        Assert.assertEquals(Files.readAllLines(resultWithoutInterruption), Files.readAllLines(resultWithInterruption));
+            Path resultWithInterruption;
+            LOG.info("Creating a FFS: test run with disconnection to Mongo.");
+            try (MongoTestBackend roBackend = PipelineITUtil.createNodeStore(true, mongoUriFlaky, builderProvider)) {
+                // Closes connections after transmitting 50KB. This is per connection. The reconnect attempts by
+                // the download task will succeed, but the new connections will once again be closed after 50KB of data.
+                LimitData cutConnectionUpstream = proxy.toxics()
+                        .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.DOWNSTREAM, 50_000L);
+
+                ScheduledExecutorService scheduleExecutor = Executors.newScheduledThreadPool(2);
+                try {
+                    // Wait some time to allow the download to start and then start a task to update the content
+                    // in a loop. When the download starts, the descending download thread will go down by order of
+                    // _modified value, starting with the highest value at the time that the download starts. If a node
+                    // that was not yet downloaded is modified and there is a connection failure, this node will not be
+                    // downloaded in the reconnection attempt because the thread will continue downloading going down
+                    // from the last _modified value seen. Therefore, once the downloader finishes the ascending/descending
+                    // downloads, it must make one final pass to download any new nodes that were modified after the
+                    // download starts.
+                    ScheduledFuture<?> updateTask = null;
+                    UpdateContentTask updateContentTask = null;
+                    if (testUpdateContent) {
+                        updateContentTask = new UpdateContentTask(rwBackend.documentNodeStore);
+                        updateTask = scheduleExecutor.schedule(updateContentTask, 1, TimeUnit.SECONDS);
+                    }
+
+                    // Removes the connection block after some time
+                    var removeToxicTask = scheduleExecutor.schedule(() -> {
+                        try {
+                            LOG.info("Removing connection block");
+                            cutConnectionUpstream.remove();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }, 3, TimeUnit.SECONDS);
+
+                    PipelinedStrategy strategy = createStrategy(roBackend);
+                    resultWithInterruption = strategy.createSortedStoreFile().toPath();
+                    // Retrieve the results to raise an exception if the tasks failed
+                    if (updateTask != null) {
+                        updateContentTask.stop();
+                        try {
+                            updateTask.get();
+                        } catch (InterruptedException e) {
+                            // Ignore, expected.
+                        }
+                    }
+                    removeToxicTask.get();
+                } finally {
+                    scheduleExecutor.shutdown();
+                    var terminated = scheduleExecutor.awaitTermination(5, TimeUnit.SECONDS);
+                    if (!terminated) {
+                        LOG.warn("Executor did not terminate in time");
+                    }
+                }
+            }
+
+            LOG.info("Comparing resulting FFS with and without Mongo disconnections: {} {}", resultWithoutInterruption, resultWithInterruption);
+            Assert.assertEquals(Files.readAllLines(resultWithoutInterruption), Files.readAllLines(resultWithInterruption));
+        }
     }
 
     private PipelinedStrategy createStrategy(MongoTestBackend roStore) throws IOException {
         return PipelineITUtil.createStrategy(roStore, s -> true, null, sortFolder.newFolder());
     }
+
+
+    private static void createContent(NodeStore rwNodeStore) throws CommitFailedException {
+        LOG.info("Creating content");
+        Stopwatch start = Stopwatch.createStarted();
+        @NotNull NodeBuilder rootBuilder = rwNodeStore.getRoot().builder();
+        for (int i = 0; i < 100; i++) {
+            @NotNull NodeBuilder parent = rootBuilder.child("content").child("dam").child("parent" + i);
+            for (int j = 0; j < 100; j++) {
+                parent.child("node-" + j).setProperty("p1", "original-" + j);
+            }
+        }
+        rwNodeStore.merge(rootBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+        LOG.info("Done creating content in {} ms", start.elapsed(TimeUnit.MILLISECONDS));
+    }
+
+
+    private static class UpdateContentTask implements Runnable {
+        private final NodeStore rwNodeStore;
+        private volatile boolean stop = false;
+
+        public UpdateContentTask(NodeStore rwNodeStore) {
+            this.rwNodeStore = rwNodeStore;
+        }
+
+        public void stop() {
+            LOG.info("Stopping update content task");
+            this.stop = true;
+        }
+
+        @Override
+        public void run() {
+            try {
+                for (int loop = 0; !stop; loop++) {
+                    LOG.info("Updating content, loop {}", loop);
+                    for (int i = 40; i < 100 && !stop; i++) {
+                        @NotNull NodeBuilder rootBuilder = rwNodeStore.getRoot().builder();
+                        @NotNull NodeBuilder parent = rootBuilder.child("content").child("dam").child("parent" + i);
+                        for (int j = 0; j < 100; j++) {
+                            parent.child("node-" + j).setProperty("p1", "modified-" + loop);
+                        }
+                        rwNodeStore.merge(rootBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+                    }
+                    Thread.sleep(100);
+                }
+                LOG.info("Done updating content, stop requested");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
 }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTaskTest.java
@@ -21,8 +21,6 @@ package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 import com.mongodb.MongoClient;
 import com.mongodb.client.model.Filters;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.MongoRegexPathFilterFactory.MongoFilterPaths;
-import org.apache.jackrabbit.oak.plugins.document.Collection;
-import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.bson.BsonDocument;
@@ -49,14 +47,6 @@ public class PipelinedMongoDownloadTaskTest {
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     private MongoRegexPathFilterFactory regexFilterBuilder;
-
-    private NodeDocument newBasicDBObject(String id, long modified, DocumentStore docStore) {
-        NodeDocument obj = Collection.NODES.newDocument(docStore);
-        obj.put(NodeDocument.ID, "3:/content/dam/asset" + id);
-        obj.put(NodeDocument.MODIFIED_IN_SECS, modified);
-        obj.put(NodeDocumentCodec.SIZE_FIELD, 100);
-        return obj;
-    }
 
     @Before
     public void setUp() {


### PR DESCRIPTION
When using parallel download, after the ascending and descending tasks terminate, do another query to download all documents that were modified since the download started. Documents modified during the download might be missed because their new modified value will be higher than what the descending download thread saw at the start of the download, so if they are modified before the download thread downloaded them, they will not be included in the initial traversals. 
The final catchup query downloads in ascending order all the documents with `_modified >= H`, where H is the highest modified value seen by the descending traversal thread, that is, the first element that it downloaded. This will include some documents twice, both those with `_modified=H`, but also those that were downloaded by the initial traversals and then were modified before the download completed. This is not a problem for correctness, as the merge-sort phase de-duplicates entries, but will increase the number of documents and entries processed.

Add new configuration properties:
- `oak.indexer.pipelined.mongoParallelDump.secondariesOnly` - enables/disables the mongo replica selection policy that restricts parallel downloads to secondaries only, one connection per secondary. Disabling this is useful for testing parallel download without having to setup a replicated cluster.
- `oak.indexer.pipelined.mongoBatchSize` - *internal property, for testing only*. Sets the limit for the number of elements in a batch returned by Mongo during iteration over query results. This is useful for the connection interruption tests, to ensure that we get a first response from Mongo before the connection is broken.
