### PR TITLE
OAK-10915: Avoid deleting expired checkpoints when running FullGC on a read-only NodeStore

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Checkpoints.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Checkpoints.java
@@ -204,6 +204,10 @@ class Checkpoints {
         return rv;
     }
 
+    DocumentNodeStore getNodeStore() {
+        return nodeStore;
+    }
+
     void setInfoProperty(@NotNull String checkpoint, @NotNull String key, @Nullable String value) {
         Revision r = Revision.fromString(checkNotNull(checkpoint));
         Info info = getCheckpoints().get(r);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Checkpoints.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Checkpoints.java
@@ -118,7 +118,7 @@ class Checkpoints {
      */
     @SuppressWarnings("unchecked")
     @Nullable
-    public Revision getOldestRevisionToKeep() {
+    public Revision getOldestRevisionToKeep(boolean performCleanup) {
         //Get uncached doc
         SortedMap<Revision, Info> checkpoints = getCheckpoints();
 
@@ -145,7 +145,7 @@ class Checkpoints {
             }
         }
 
-        if (op.hasChanges()) {
+        if (performCleanup && op.hasChanges()) {
             try {
                 store.findAndUpdate(Collection.SETTINGS, op);
                 LOG.debug("Purged {} expired checkpoints", op.getChanges().size());
@@ -156,6 +156,17 @@ class Checkpoints {
         }
 
         return lastAliveRevision;
+    }
+
+    /**
+     * Backwards compatible method to get the oldest revision to keep
+     * with cleanup.
+     *
+     * @return oldest valid checkpoint registered. Might return null if no valid
+     * checkpoint found
+     */
+    public Revision getOldestRevisionToKeep() {
+        return getOldestRevisionToKeep(true);
     }
 
     @SuppressWarnings("unchecked")
@@ -202,10 +213,6 @@ class Checkpoints {
             rv = expand(r);
         }
         return rv;
-    }
-
-    DocumentNodeStore getNodeStore() {
-        return nodeStore;
     }
 
     void setInfoProperty(@NotNull String checkpoint, @NotNull String key, @Nullable String value) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Checkpoints.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Checkpoints.java
@@ -109,9 +109,8 @@ class Checkpoints {
     }
 
     /**
-     * Returns the oldest valid checkpoint registered.
-     *
-     * <p>It also performs cleanup of expired checkpoint
+     * Returns the oldest valid checkpoint registered
+     * @param performCleanup if true, it will perform cleanup of expired checkpoint
      *
      * @return oldest valid checkpoint registered. Might return null if no valid
      * checkpoint found
@@ -159,8 +158,9 @@ class Checkpoints {
     }
 
     /**
-     * Backwards compatible method to get the oldest revision to keep
-     * with cleanup.
+     * Returns the oldest valid checkpoint registered.
+     *
+     * <p>It also performs cleanup of expired checkpoint
      *
      * @return oldest valid checkpoint registered. Might return null if no valid
      * checkpoint found

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGCRecommendations.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGCRecommendations.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollector.VersionGCStats;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.util.TimeInterval;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.gc.GCMonitor;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGCRecommendations.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGCRecommendations.java
@@ -20,7 +20,6 @@ package org.apache.jackrabbit.oak.plugins.document;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -30,7 +29,6 @@ import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.gc.GCMonitor;
 import org.apache.jackrabbit.oak.stats.Clock;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
@@ -367,7 +367,8 @@ public class VersionGarbageCollector {
         long maxRevisionAgeInMillis = unit.toMillis(maxRevisionAge);
         long now = nodeStore.getClock().getTime();
         VersionGCRecommendations rec = new VersionGCRecommendations(maxRevisionAgeInMillis, nodeStore.getCheckpoints(),
-                nodeStore.getClock(), versionStore, options, gcMonitor, fullGCEnabled, isFullGCDryRun);
+                !nodeStore.isReadOnlyMode(), nodeStore.getClock(), versionStore, options, gcMonitor, fullGCEnabled,
+                isFullGCDryRun);
         int estimatedIterations = -1;
         if (rec.suggestedIntervalMs > 0) {
             estimatedIterations = (int)Math.ceil((double) (now - rec.scope.toMs) / rec.suggestedIntervalMs);
@@ -747,7 +748,8 @@ public class VersionGarbageCollector {
             VersionGCStats stats = new VersionGCStats();
             stats.active.start();
             VersionGCRecommendations rec = new VersionGCRecommendations(maxRevisionAgeInMillis, nodeStore.getCheckpoints(),
-                    nodeStore.getClock(), versionStore, options, gcMonitor, fullGCEnabled, isFullGCDryRun);
+                    !nodeStore.isReadOnlyMode(), nodeStore.getClock(), versionStore, options, gcMonitor, fullGCEnabled,
+                    isFullGCDryRun);
             GCPhases phases = new GCPhases(cancel, stats, gcMonitor);
             try {
                 if (!isFullGCDryRun) {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGCTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGCTest.java
@@ -373,8 +373,8 @@ public class VersionGCTest {
 
         VersionGCSupport localgcsupport = fakeVersionGCSupport(ns.getDocumentStore(), oneYearAgo, twelveTimesTheLimit);
 
-        VersionGCRecommendations rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), ns.getClock(), localgcsupport,
-                options, new TestGCMonitor(), false, false);
+        VersionGCRecommendations rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), true, ns.getClock(),
+                localgcsupport, options, new TestGCMonitor(), false, false);
 
         // should select a duration of roughly one month
         long duration= rec.scope.getDurationMs();
@@ -387,8 +387,8 @@ public class VersionGCTest {
         rec.evaluate(stats);
         assertTrue(stats.needRepeat);
 
-        rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), ns.getClock(), localgcsupport, options,
-                new TestGCMonitor(), false, false);
+        rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), true, ns.getClock(), localgcsupport,
+                options, new TestGCMonitor(), false, false);
 
         // new duration should be half
         long nduration = rec.scope.getDurationMs();
@@ -416,8 +416,8 @@ public class VersionGCTest {
 
         // loop until the recommended interval is at 60s (precisionMS)
         do {
-            rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), ns.getClock(), localgcsupport, options,
-                    testmonitor, false, false);
+            rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), true, ns.getClock(), localgcsupport,
+                    options, testmonitor, false, false);
             stats = new VersionGCStats();
             stats.limitExceeded = true;
             rec.evaluate(stats);
@@ -433,8 +433,8 @@ public class VersionGCTest {
             int deleted = (int) (rec.scope.getDurationMs() / TimeUnit.SECONDS.toMillis(1));
             deletedCount -= deleted;
             localgcsupport = fakeVersionGCSupport(ns.getDocumentStore(), oldestDeleted, deletedCount);
-            rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), ns.getClock(), localgcsupport, options,
-                    testmonitor, false, false);
+            rec = new VersionGCRecommendations(secondsPerDay, ns.getCheckpoints(), true, ns.getClock(), localgcsupport,
+                    options, testmonitor, false, false);
             stats = new VersionGCStats();
             stats.limitExceeded = false;
             stats.deletedDocGCCount = deleted;


### PR DESCRIPTION
I'm introducing a similar method `getLastAliveRevision` in **VersionGCRecommendations**. Alternatively, I could modify the logic or add another method directly to the `Checkpoints` class, but since the scope of this change is very focused on oak-run FullGC I preferred to keep most of the logic directly in **VersionGCRecommendations**.

I'm open to change it if you think it should be done differently.