### PR TITLE
OAK-10920 - Simplify termination management of Mongo download thread

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -80,6 +80,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class);
 
     private static final Logger TRAVERSAL_LOG = LoggerFactory.getLogger(PipelinedMongoDownloadTask.class.getName() + ".traversal");
+    public static final NodeDocument[] SENTINEL_MONGO_DOCUMENT = new NodeDocument[0];
 
     public static class Result {
         private final long documentsDownloaded;
@@ -357,6 +358,8 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                         downloadWithNaturalOrdering();
                     }
                     downloadStartWatch.stop();
+                    // Signal the end of the download
+                    mongoDocQueue.put(SENTINEL_MONGO_DOCUMENT);
                     long durationMillis = downloadStartWatch.elapsed(TimeUnit.MILLISECONDS);
                     downloadStageStatistics.publishStatistics(statisticsProvider, reporter, durationMillis);
                     String metrics = downloadStageStatistics.formatStats(durationMillis);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -135,7 +135,6 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
     public static final String OAK_INDEXER_PIPELINED_SORT_BUFFER_MEMORY_PERCENTAGE = "oak.indexer.pipelined.sortBufferMemoryPercentage";
     public static final int DEFAULT_OAK_INDEXER_PIPELINED_SORT_BUFFER_MEMORY_PERCENTAGE = 25;
 
-    static final NodeDocument[] SENTINEL_MONGO_DOCUMENT = new NodeDocument[0];
     static final NodeStateEntryBatch SENTINEL_NSE_BUFFER = new NodeStateEntryBatch(ByteBuffer.allocate(0), 0);
     static final Path SENTINEL_SORTED_FILES_QUEUE = Paths.get("SENTINEL");
     static final Charset FLATFILESTORE_CHARSET = StandardCharsets.UTF_8;
@@ -451,10 +450,6 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
                             if (result instanceof PipelinedMongoDownloadTask.Result) {
                                 PipelinedMongoDownloadTask.Result downloadResult = (PipelinedMongoDownloadTask.Result) result;
                                 LOG.info("Download finished. Documents downloaded: {}", downloadResult.getDocumentsDownloaded());
-                                // Signal the end of documents to the transform threads.
-                                for (int i = 0; i < numberOfTransformThreads; i++) {
-                                    mongoDocQueue.put(SENTINEL_MONGO_DOCUMENT);
-                                }
                                 mergeSortTask.stopEagerMerging();
                                 downloadFuture = null;
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTransformTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTransformTask.java
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
-import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy.SENTINEL_MONGO_DOCUMENT;
 import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
 
 /**
@@ -134,7 +133,9 @@ class PipelinedTransformTask implements Callable<PipelinedTransformTask.Result> 
                 docQueueWaitStopwatch.reset().start();
                 NodeDocument[] nodeDocumentBatch = mongoDocQueue.take();
                 totalDocumentQueueWaitTimeMillis += docQueueWaitStopwatch.elapsed(TimeUnit.MILLISECONDS);
-                if (nodeDocumentBatch == SENTINEL_MONGO_DOCUMENT) {
+                if (nodeDocumentBatch == PipelinedMongoDownloadTask.SENTINEL_MONGO_DOCUMENT) {
+                    // So that other threads listening on this queue also get the sentinel
+                    mongoDocQueue.put(PipelinedMongoDownloadTask.SENTINEL_MONGO_DOCUMENT);
                     long totalDurationMillis = taskStartWatch.elapsed(TimeUnit.MILLISECONDS);
                     String totalDocumentQueueWaitPercentage = PipelinedUtils.formatAsPercentage(totalDocumentQueueWaitTimeMillis, totalDurationMillis);
                     String totalEnqueueDelayPercentage = PipelinedUtils.formatAsPercentage(totalEnqueueDelayMillis, totalDurationMillis);


### PR DESCRIPTION
The download thread should be the one adding the sentinel indicating end of download to the queue of NodeDocuments, so it does not have to rely on a client class doing this. 