### PR TITLE
OAK-10928: fix flaky ElasticIndexPlannerCommonTest.indexedButZeroWeightProps

### DIFF
--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexPlannerCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexPlannerCommonTest.java
@@ -74,11 +74,11 @@ import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConsta
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 import static org.apache.jackrabbit.oak.spi.query.QueryConstants.REP_FACET;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public abstract class IndexPlannerCommonTest {
@@ -545,25 +545,24 @@ public abstract class IndexPlannerCommonTest {
         IndexDefinition defn = getIndexDefinition(root, defnb.build(), "/oak:index/" + indexName);
         IndexNode node = createIndexNode(defn);
 
-        FilterImpl filter = createFilter("nt:base");
-        filter.restrictProperty("bar", Operator.EQUAL, PropertyValues.newString("a"));
-        FulltextIndexPlanner planner = getIndexPlanner(node, "/oak:index/" + indexName, filter, Collections.<QueryIndex.OrderEntry>emptyList());
-        //Even though foo is indexed it would not be considered for a query involving just foo
-        assertNull(planner.getPlan());
-
-        filter = createFilter("nt:base");
-        filter.restrictProperty("foo", Operator.EQUAL, PropertyValues.newString("a"));
-        planner = getIndexPlanner(node, "/oak:index/" + indexName, filter, Collections.<QueryIndex.OrderEntry>emptyList());
-        QueryIndex.IndexPlan plan1 = planner.getPlan();
-        assertNotNull(plan1);
-
-        final FilterImpl filter2 = createFilter("nt:base");
-        filter2.restrictProperty("foo", Operator.EQUAL, PropertyValues.newString("a"));
-        filter2.restrictProperty("bar", Operator.EQUAL, PropertyValues.newString("a"));
-
-
         TestUtil.assertEventually(() -> {
-            FulltextIndexPlanner planner2 = getIndexPlanner(node, "/oak:index/" + indexName, filter2, Collections.<QueryIndex.OrderEntry>emptyList());
+            FilterImpl filter = createFilter("nt:base");
+            filter.restrictProperty("bar", Operator.EQUAL, PropertyValues.newString("a"));
+            FulltextIndexPlanner planner = getIndexPlanner(node, "/oak:index/" + indexName, filter, Collections.emptyList());
+            //Even though foo is indexed it would not be considered for a query involving just foo
+            assertNull(planner.getPlan());
+
+            filter = createFilter("nt:base");
+            filter.restrictProperty("foo", Operator.EQUAL, PropertyValues.newString("a"));
+            planner = getIndexPlanner(node, "/oak:index/" + indexName, filter, Collections.emptyList());
+            QueryIndex.IndexPlan plan1 = planner.getPlan();
+            assertNotNull(plan1);
+
+            final FilterImpl filter2 = createFilter("nt:base");
+            filter2.restrictProperty("foo", Operator.EQUAL, PropertyValues.newString("a"));
+            filter2.restrictProperty("bar", Operator.EQUAL, PropertyValues.newString("a"));
+
+            FulltextIndexPlanner planner2 = getIndexPlanner(node, "/oak:index/" + indexName, filter2, Collections.emptyList());
             QueryIndex.IndexPlan plan2 = planner2.getPlan();
             assertNotNull(plan2);
             // Since, the index has no entries for "bar", estimated entry count for plan2 would be 0

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexPlannerCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexPlannerCommonTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.jackrabbit.oak.plugins.index;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
@@ -56,9 +56,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static javax.jcr.PropertyType.TYPENAME_STRING;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.guava.common.collect.ImmutableSet.of;
-import static javax.jcr.PropertyType.TYPENAME_STRING;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
 import static org.apache.jackrabbit.oak.api.Type.STRINGS;
@@ -73,8 +73,8 @@ import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConsta
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.ORDERED_PROP_NAMES;
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 import static org.apache.jackrabbit.oak.spi.query.QueryConstants.REP_FACET;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
The query plan needs to be requested in the eventual assertion since some values are cached.