### PR TITLE
OAK-10945: Remove usage of Guava Function interface

### DIFF
--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -29,7 +29,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -46,8 +45,8 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
@@ -463,13 +462,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
     @Override
     public Iterator<DataIdentifier> getAllIdentifiers() throws DataStoreException {
         return new RecordsIterator<DataIdentifier>(
-                new Function<AzureBlobInfo, DataIdentifier>() {
-                    @Override
-                    public DataIdentifier apply(AzureBlobInfo input) {
-                        return new DataIdentifier(getIdentifierName(input.getName()));
-                    }
-                }
-        );
+                input -> new DataIdentifier(getIdentifierName(input.getName())));
     }
 
 

--- a/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
+++ b/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -89,7 +90,6 @@ import com.amazonaws.services.s3.transfer.Copy;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.util.StringUtils;
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.cache.Cache;
@@ -441,13 +441,7 @@ public class S3Backend extends AbstractSharedBackend {
     @Override
     public Iterator<DataIdentifier> getAllIdentifiers()
             throws DataStoreException {
-        return new RecordsIterator<DataIdentifier>(
-            new Function<S3ObjectSummary, DataIdentifier>() {
-                @Override
-                public DataIdentifier apply(S3ObjectSummary input) {
-                    return new DataIdentifier(getIdentifierName(input.getKey()));
-                }
-        });
+        return new RecordsIterator<DataIdentifier>(input -> new DataIdentifier(getIdentifierName(input.getKey())));
     }
 
     @Override
@@ -642,14 +636,8 @@ public class S3Backend extends AbstractSharedBackend {
     public Iterator<DataRecord> getAllRecords() {
         final AbstractSharedBackend backend = this;
         return new RecordsIterator<DataRecord>(
-            new Function<S3ObjectSummary, DataRecord>() {
-                @Override
-                public DataRecord apply(S3ObjectSummary input) {
-                    return new S3DataRecord(backend, s3service, bucket,
-                        new DataIdentifier(getIdentifierName(input.getKey())),
-                        input.getLastModified().getTime(), input.getSize(), s3ReqDecorator);
-                }
-            });
+                input -> new S3DataRecord(backend, s3service, bucket, new DataIdentifier(getIdentifierName(input.getKey())),
+                        input.getLastModified().getTime(), input.getSize(), s3ReqDecorator));
     }
 
     @Override

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/AbstractSharedCachingDataStore.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/AbstractSharedCachingDataStore.java
@@ -56,7 +56,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
@@ -277,11 +276,7 @@ public abstract class AbstractSharedCachingDataStore extends AbstractDataStore
     @Override
     public Iterator<DataIdentifier> getAllIdentifiers() throws DataStoreException {
         return Iterators.concat(Iterators.transform(cache.getStagingCache().getAllIdentifiers(),
-            new Function<String, DataIdentifier>() {
-                @Nullable @Override public DataIdentifier apply(@Nullable String id) {
-                    return new DataIdentifier(id);
-                }
-            }), backend.getAllIdentifiers());
+            id -> new DataIdentifier(id)), backend.getAllIdentifiers());
     }
 
     @Override

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/MarkSweepGarbageCollector.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/MarkSweepGarbageCollector.java
@@ -51,7 +51,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.base.StandardSystemProperty;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
@@ -264,22 +263,14 @@ public class MarkSweepGarbageCollector implements BlobGarbageCollector {
             List<DataRecord> refFiles =
                 ((SharedDataStore) blobStore).getAllMetadataRecords(SharedStoreRecordType.REFERENCES.getType());
             ImmutableListMultimap<String, DataRecord> references =
-                FluentIterable.from(refFiles).index(new Function<DataRecord, String>() {
-                    @Override public String apply(DataRecord input) {
-                        return SharedStoreRecordType.REFERENCES.getIdFromName(input.getIdentifier().toString());
-
-                    }
-                });
+                FluentIterable.from(refFiles).index(
+                        input -> SharedStoreRecordType.REFERENCES.getIdFromName(input.getIdentifier().toString()));
 
             // Get all the markers available
             List<DataRecord> markerFiles =
                 ((SharedDataStore) blobStore).getAllMetadataRecords(SharedStoreRecordType.MARKED_START_MARKER.getType());
-            Map<String, DataRecord> markers = Maps.uniqueIndex(markerFiles, new Function<DataRecord, String>() {
-                @Override
-                public String apply(DataRecord input) {
-                    return input.getIdentifier().toString().substring(SharedStoreRecordType.MARKED_START_MARKER.getType().length() + 1);
-                }
-            });
+            Map<String, DataRecord> markers = Maps.uniqueIndex(markerFiles,
+                    input -> input.getIdentifier().toString().substring(SharedStoreRecordType.MARKED_START_MARKER.getType().length() + 1));
 
             // Get all the repositories registered
             List<DataRecord> repoFiles =
@@ -645,16 +636,12 @@ public class MarkSweepGarbageCollector implements BlobGarbageCollector {
                                 final Joiner delimJoiner = Joiner.on(DELIM).skipNulls();
                                 Iterator<List<String>> partitions = Iterators.partition(idIter, getBatchCount());
                                 while (partitions.hasNext()) {
-                                    List<String> idBatch = Lists.transform(partitions.next(), new Function<String,
-                                        String>() {
-                                        @Nullable @Override
-                                        public String apply(@Nullable String id) {
+                                    List<String> idBatch = Lists.transform(partitions.next(), id -> {
                                             if (logPath) {
                                                 return delimJoiner.join(id, nodeId);
                                             }
                                             return id;
-                                        }
-                                    });
+                                        });
                                     if (debugMode) {
                                         LOG.trace("chunkIds : {}", idBatch);
                                     }
@@ -891,7 +878,7 @@ public class MarkSweepGarbageCollector implements BlobGarbageCollector {
                 List<DataRecord> repoFiles =
                     ((SharedDataStore) blobStore).getAllMetadataRecords(SharedStoreRecordType.REPOSITORY.getType());
                 LOG.info("Repositories registered {}", repoFiles);
-                
+
                 // Retrieve repos for which reference files have not been created
                 Set<String> unAvailRepos =
                         SharedDataStoreUtils.refsNotAvailableFromRepos(repoFiles, refFiles);

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/BlobIdTracker.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/BlobIdTracker.java
@@ -24,14 +24,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -76,7 +74,6 @@ import static org.apache.jackrabbit.oak.commons.FileIOUtils.writeStrings;
 import static org.apache.jackrabbit.oak.plugins.blob.datastore.BlobIdTracker.BlobIdStore.Type.GENERATION;
 import static org.apache.jackrabbit.oak.plugins.blob.datastore.BlobIdTracker.BlobIdStore.Type.IN_PROCESS;
 import static org.apache.jackrabbit.oak.plugins.blob.datastore.BlobIdTracker.BlobIdStore.Type.REFS;
-
 
 /**
  * Tracks the blob ids available or added in the blob store using the {@link BlobIdStore} .
@@ -271,8 +268,7 @@ public class BlobIdTracker implements Closeable, BlobTracker {
             Iterable<DataRecord> refRecords = datastore.getAllMetadataRecords(fileNamePrefix);
 
             // Download all the corresponding files for the records
-            List<File> refFiles = newArrayList(transform(refRecords, new Function<DataRecord, File>() {
-                @Override public File apply(DataRecord input) {
+            List<File> refFiles = newArrayList(transform(refRecords, input -> {
                     InputStream inputStream = null;
                     try {
                         inputStream = input.getStream();
@@ -283,8 +279,7 @@ public class BlobIdTracker implements Closeable, BlobTracker {
                         closeQuietly(inputStream);
                     }
                     return null;
-                }
-            }));
+                }));
             LOG.info("Retrieved all blob id files in [{}]", watch.elapsed(TimeUnit.MILLISECONDS));
 
             // Merge all the downloaded files in to the local store

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStore.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStore.java
@@ -78,7 +78,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
@@ -525,15 +525,12 @@ public class DataStoreBlobStore
                 }
                 return false;
             }
-        }), new Function<DataRecord, String>() {
-            @Override
-            public String apply(DataRecord input) {
+        }), input -> {
                 if (encodeLengthInId) {
                     return BlobId.of(input).encodedValue();
                 }
                 return input.getIdentifier().toString();
-            }
-        });
+            });
     }
 
     @Override
@@ -775,18 +772,14 @@ public class DataStoreBlobStore
         Iterator<DataRecord> result = delegate instanceof SharedDataStore ?
                 ((SharedDataStore) delegate).getAllRecords() :
                 Iterators.transform(delegate.getAllIdentifiers(),
-                        new Function<DataIdentifier, DataRecord>() {
-                            @Nullable
-                            @Override
-                            public DataRecord apply(@Nullable DataIdentifier input) {
+                        input -> {
                                 try {
                                     return delegate.getRecord(input);
                                 } catch (DataStoreException e) {
                                     log.warn("Error occurred while fetching DataRecord for identifier {}", input, e);
                                 }
                                 return null;
-                            }
-                        });
+                            });
 
         if (stats instanceof ExtendedBlobStatsCollector) {
             ((ExtendedBlobStatsCollector) stats).getAllRecordsCalled(System.nanoTime() - start, TimeUnit.NANOSECONDS);

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/SharedDataStoreUtils.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/SharedDataStoreUtils.java
@@ -18,9 +18,9 @@ package org.apache.jackrabbit.oak.plugins.blob.datastore;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.base.Splitter;
 import org.apache.jackrabbit.guava.common.collect.FluentIterable;
@@ -61,7 +61,7 @@ public class SharedDataStoreUtils {
                     public Long apply(@NotNull DataRecord input) {
                         return input.getLastModified();
                     }
-                }).min(recs);
+                }::apply).min(recs);
     }
 
     /**
@@ -73,22 +73,10 @@ public class SharedDataStoreUtils {
      */
     public static Set<String> refsNotAvailableFromRepos(List<DataRecord> repos,
             List<DataRecord> refs) {
-        return Sets.difference(FluentIterable.from(repos).uniqueIndex(
-                new Function<DataRecord, String>() {
-                    @Override
-                    @Nullable
-                    public String apply(@NotNull DataRecord input) {
-                        return SharedStoreRecordType.REPOSITORY.getIdFromName(input.getIdentifier().toString());
-                    }
-                }).keySet(),
-                FluentIterable.from(refs).index(
-                        new Function<DataRecord, String>() {
-                            @Override
-                            @Nullable
-                            public String apply(@NotNull DataRecord input) {
-                                return SharedStoreRecordType.REFERENCES.getIdFromName(input.getIdentifier().toString());
-                            }
-                        }).keySet());
+        return Sets.difference(FluentIterable.from(repos)
+                .uniqueIndex(input -> SharedStoreRecordType.REPOSITORY.getIdFromName(input.getIdentifier().toString())).keySet(),
+                FluentIterable.from(refs)
+                        .index(input -> SharedStoreRecordType.REFERENCES.getIdFromName(input.getIdentifier().toString())).keySet());
     }
 
     /**

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/SharedDataStoreUtilsTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/SharedDataStoreUtilsTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
@@ -49,7 +48,6 @@ import org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreUtils;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreUtils.SharedStoreRecordType;
 import org.apache.jackrabbit.oak.stats.Clock;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -481,11 +479,7 @@ public class SharedDataStoreUtilsTest {
         }
 
         Set<String> retrieved = newHashSet(Iterables.transform(newHashSet(dataStore.getAllRecords()),
-            new Function<DataRecord, String>() {
-                @Nullable @Override public String apply(@Nullable DataRecord input) {
-                    return input.getIdentifier().toString();
-                }
-            }));
+            input -> input.getIdentifier().toString()));
         assertEquals(added, retrieved);
     }
 
@@ -515,11 +509,7 @@ public class SharedDataStoreUtilsTest {
         }
 
         Set<String> retrieved = newHashSet(Iterables.transform(newHashSet(dataStore.getAllRecords()),
-            new Function<DataRecord, String>() {
-                @Nullable @Override public String apply(@Nullable DataRecord input) {
-                    return input.getIdentifier().toString();
-                }
-            }));
+                input -> input.getIdentifier().toString()));
         assertEquals(added, retrieved);
     }
 

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStoreTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStoreTest.java
@@ -29,7 +29,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -44,7 +43,6 @@ import org.apache.jackrabbit.oak.plugins.blob.BlobStoreBlob;
 import org.apache.jackrabbit.oak.spi.blob.AbstractBlobStoreTest;
 import org.apache.jackrabbit.oak.spi.blob.BlobStoreInputStream;
 import org.apache.jackrabbit.oak.spi.blob.stats.BlobStatsCollector;
-import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -174,13 +172,7 @@ public class DataStoreBlobStoreTest extends AbstractBlobStoreTest {
         DataIdentifier d30 = new DataIdentifier("d-30");
         List<DataIdentifier> dis = ImmutableList.of(d10, d20, d30);
         List<DataRecord> recs = Lists.newArrayList(
-            Iterables.transform(dis, new Function<DataIdentifier, DataRecord>() {
-                @Nullable
-                @Override
-                public DataRecord apply(@Nullable DataIdentifier input) {
-                    return new TimeDataRecord(input);
-                }
-        }));
+            Iterables.transform(dis, input -> new TimeDataRecord(input)));
         OakFileDataStore mockedDS = mock(OakFileDataStore.class);
         when(mockedDS.getAllRecords()).thenReturn(recs.iterator());
         when(mockedDS.getRecord(new DataIdentifier("d-10"))).thenReturn(new TimeDataRecord(d10));

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/OakFileDataStoreTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/OakFileDataStoreTest.java
@@ -24,14 +24,12 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.FileDataStore;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -77,12 +75,7 @@ public class OakFileDataStoreTest {
         fds.init(null);
 
         Iterator<DataIdentifier> dis = fds.getAllIdentifiers();
-        Set<String> fileNames = Sets.newHashSet(Iterators.transform(dis, new Function<DataIdentifier, String>() {
-            @Override
-            public String apply(@Nullable DataIdentifier input) {
-                return input.toString();
-            }
-        }));
+        Set<String> fileNames = Sets.newHashSet(Iterators.transform(dis, input -> input.toString()));
 
         Set<String> expectedNames = Sets.newHashSet("abcdef","bcdefg","cdefgh");
         assertEquals(expectedNames, fileNames);

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/SharedDataStoreTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/SharedDataStoreTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -47,7 +46,6 @@ import org.apache.jackrabbit.core.data.FileDataStore;
 import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.apache.jackrabbit.oak.plugins.blob.SharedDataStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.SharedDataStoreTest.FixtureHelper.DATA_STORE;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -146,12 +144,7 @@ public class SharedDataStoreTest {
         fds.init(null);
 
         Iterator<DataIdentifier> dis = fds.getAllIdentifiers();
-        Set<String> fileNames = Sets.newHashSet(Iterators.transform(dis, new Function<DataIdentifier, String>() {
-            @Override
-            public String apply(@Nullable DataIdentifier input) {
-                return input.toString();
-            }
-        }));
+        Set<String> fileNames = Sets.newHashSet(Iterators.transform(dis, input-> input.toString()));
 
         Set<String> expectedNames = Sets.newHashSet("abcdef","bcdefg","cdefgh");
         assertEquals(expectedNames, fileNames);

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/FileIOUtilsTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/FileIOUtilsTest.java
@@ -60,7 +60,6 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Splitter;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.guava.common.collect.Sets;
@@ -192,11 +191,7 @@ public class FileIOUtilsTest {
         }
 
         Iterator<Long> boxedEntries = Longs.asList(entries).iterator();
-        Iterator<String> hexEntries = Iterators.transform(boxedEntries, new Function<Long, String>() {
-                    @Nullable @Override public String apply(@Nullable Long input) {
-                        return Long.toHexString(input);
-                    }
-                });
+        Iterator<String> hexEntries = Iterators.transform(boxedEntries, input -> Long.toHexString(input));
         File f = assertWrite(hexEntries, false, numEntries);
 
         Comparator<String> prefixComparator = new Comparator<String>() {

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/mount/MountInfo.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/mount/MountInfo.java
@@ -26,13 +26,12 @@ import java.util.List;
 import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.transform;
-import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newTreeSet;
 import static org.apache.jackrabbit.oak.commons.PathUtils.getParentPath;
 import static org.apache.jackrabbit.oak.commons.PathUtils.isAncestor;
@@ -141,7 +140,7 @@ public final class MountInfo implements Mount {
 
     private static TreeSet<String> cleanCopy(Collection<String> includedPaths) {
         // ensure that paths don't have trailing slashes - this triggers an assertion in PathUtils isAncestor
-        return newTreeSet(transform(includedPaths, SANITIZE_PATH));
+        return newTreeSet(transform(includedPaths, SANITIZE_PATH::apply));
     }
 
     public Set<String> getPathsSupportingFragments() {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -50,7 +50,6 @@ import javax.management.ObjectName;
 import javax.management.StandardMBean;
 import javax.security.auth.login.LoginException;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -701,16 +700,13 @@ public class Oak {
         // FIXME: OAK-810 move to proper workspace initialization
         // initialize default workspace
         Iterable<WorkspaceInitializer> workspaceInitializers = Iterables.transform(securityProvider.getConfigurations(),
-                new Function<SecurityConfiguration, WorkspaceInitializer>() {
-                    @Override
-                    public WorkspaceInitializer apply(SecurityConfiguration sc) {
+                sc -> {
                         WorkspaceInitializer wi = sc.getWorkspaceInitializer();
                         if (wi instanceof QueryIndexProviderAware) {
                             ((QueryIndexProviderAware) wi).setQueryIndexProvider(indexProvider);
                         }
                         return wi;
-                    }
-                });
+                    });
         OakInitializer.initialize(workspaceInitializers, store, defaultWorkspaceName, initHook);
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/SecureNodeState.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/SecureNodeState.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.core;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryChildNodeEntry;
@@ -32,6 +31,9 @@ import org.jetbrains.annotations.Nullable;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.filter;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.transform;
+
+import java.util.function.Function;
+
 import static java.util.Collections.emptyList;
 
 class SecureNodeState extends AbstractNodeState {
@@ -144,7 +146,7 @@ class SecureNodeState extends AbstractNodeState {
         } else if (treePermission.canRead()) {
             Iterable<ChildNodeEntry> readable = transform(
                     state.getChildNodeEntries(),
-                    new WrapChildEntryFunction());
+                    new WrapChildEntryFunction()::apply);
             return filter(readable, new IterableNodePredicate());
         } else {
             return emptyList();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/management/RepositoryManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/management/RepositoryManager.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.management;
 
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
@@ -32,11 +31,11 @@ import static org.apache.jackrabbit.oak.commons.jmx.ManagementOperation.Status.u
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.api.jmx.FileStoreBackupRestoreMBean;
 import org.apache.jackrabbit.oak.api.jmx.RepositoryManagementMBean;
 import org.apache.jackrabbit.oak.api.jmx.SessionMBean;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/identifier/IdentifierManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/identifier/IdentifierManager.java
@@ -20,10 +20,11 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Function;
+
 import javax.jcr.PropertyType;
 import javax.jcr.query.Query;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.JcrConstants;
@@ -237,7 +238,7 @@ public class IdentifierManager {
         return new Iterable<String>() {
             @Override
             public Iterator<String> iterator() {
-                return Iterators.concat(transform(result.getRows().iterator(), new RowToPaths()));
+                return Iterators.concat(transform(result.getRows().iterator(), new RowToPaths()::apply));
             }
 
             class RowToPaths implements Function<ResultRow, Iterator<String>> {
@@ -271,7 +272,7 @@ public class IdentifierManager {
                     if (!rowPath.startsWith(VersionConstants.VERSION_STORE_PATH)) {
                             if (propertyName == null) {
                                 return filter(
-                                        transform(root.getTree(rowPath).getProperties().iterator(), new PropertyToPath()),
+                                        transform(root.getTree(rowPath).getProperties().iterator(), new PropertyToPath()::apply),
                                         notNull());
                             } else {
                                 // for a fixed property name, we don't need to look for it, but just assume that
@@ -318,7 +319,7 @@ public class IdentifierManager {
                             QueryEngine.INTERNAL_SQL2_QUERY,
                     Query.JCR_SQL2, bindings, NO_MAPPINGS);
 
-            Iterable<Tree> resultTrees = Iterables.transform(result.getRows(), (Function<ResultRow, Tree>) row -> row.getTree(null));
+            Iterable<Tree> resultTrees = Iterables.transform(result.getRows(), row -> row.getTree(null));
             return Iterables.filter(resultTrees, tree1 -> !tree1.getPath().startsWith(VersionConstants.VERSION_STORE_PATH)
             );
         } catch (ParseException e) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexInfoServiceImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexInfoServiceImpl.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index;
 
 import java.io.IOException;
@@ -24,7 +23,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
@@ -71,19 +69,16 @@ public class IndexInfoServiceImpl implements IndexInfoService{
         } else {
             activeIndexes.addAll(allIndexes);
         }
-        return Iterables.filter(Iterables.transform(indexPathService.getIndexPaths(), new Function<String, IndexInfo>() {
-            @Override
-            public IndexInfo apply(String indexPath) {
-                try {
-                    IndexInfo info = getInfo(indexPath);
-                    if (info != null) {
-                        info.setActive(activeIndexes.contains(indexPath));
-                    }
-                    return info;
-                } catch (Exception e) {
-                    log.warn("Error occurred while capturing IndexInfo for path {}", indexPath, e);
-                    return null;
+        return Iterables.filter(Iterables.transform(indexPathService.getIndexPaths(), indexPath -> {
+            try {
+                IndexInfo info = getInfo(indexPath);
+                if (info != null) {
+                    info.setActive(activeIndexes.contains(indexPath));
                 }
+                return info;
+            } catch (Exception e) {
+                log.warn("Error occurred while capturing IndexInfo for path {}", indexPath, e);
+                return null;
             }
         }), notNull());
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/aggregate/AggregateIndex.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/aggregate/AggregateIndex.java
@@ -35,7 +35,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 
 import static org.apache.jackrabbit.oak.spi.query.QueryIndex.AdvanceFulltextQueryIndex;
@@ -208,13 +207,8 @@ public class AggregateIndex implements AdvanceFulltextQueryIndex {
             public boolean visit(FullTextOr or) {
                 final int[] index = new int[1];
                 List<Cursor> cursors = Lists.transform(or.list,
-                        new Function<FullTextExpression, Cursor>() {
-                            @Override
-                            public Cursor apply(FullTextExpression input) {
-                                return flatten(input, plan, filter, state,
-                                        path + " or(" + index[0]++ + ")");
-                            }
-                        });
+                        input -> flatten(input, plan, filter, state,
+                                        path + " or(" + index[0]++ + ")"));
                 result.set(Cursors.newConcatCursor(cursors,
                         filter.getQueryLimits()));
                 return true;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/cursor/AncestorCursor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/cursor/AncestorCursor.java
@@ -20,11 +20,9 @@ import java.util.Iterator;
 
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.spi.query.Cursor;
-import org.apache.jackrabbit.oak.spi.query.IndexRow;
 import org.apache.jackrabbit.oak.spi.query.QueryLimits;
 import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 
@@ -39,12 +37,7 @@ class AncestorCursor extends PathCursor {
 
     private static Iterator<String> transform(Cursor cursor, final int level) {
         Iterator<String> unfiltered = Iterators.transform(cursor,
-                new Function<IndexRow, String>() {
-            @Override
-            public String apply(@Nullable IndexRow input) {
-                return input != null ? input.getPath() : null;
-            }
-        });
+                input -> input != null ? input.getPath() : null);
         Iterator<String> filtered = Iterators.filter(unfiltered,
                 new Predicate<String>() {
             @Override
@@ -52,11 +45,7 @@ class AncestorCursor extends PathCursor {
                 return input != null && PathUtils.getDepth(input) >= level;
             }
         });
-        return Iterators.transform(filtered, new Function<String, String>() {
-            @Override
-            public String apply(String input) {
-                return PathUtils.getAncestorPath(input, level);
-            }
-        });
+        return Iterators.transform(filtered,
+                input -> PathUtils.getAncestorPath(input, level));
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/reference/ReferenceIndex.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/reference/ReferenceIndex.java
@@ -45,7 +45,6 @@ import org.apache.jackrabbit.oak.spi.query.Filter.PropertyRestriction;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -147,12 +146,7 @@ class ReferenceIndex implements QueryIndex {
                 }
             });
         }
-        paths = transform(paths, new Function<String, String>() {
-            @Override
-            public String apply(String path) {
-                return getParentPath(path);
-            }
-        });
+        paths = transform(paths, path -> getParentPath(path));
         return newPathCursor(paths, filter.getQueryLimits());
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/AbstractDecoratedNodeState.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/migration/AbstractDecoratedNodeState.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.migration;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicates;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -38,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
 import static org.apache.jackrabbit.guava.common.base.Predicates.notNull;
 import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 
@@ -139,23 +139,16 @@ public abstract class AbstractDecoratedNodeState extends AbstractNodeState {
     @Override
     @NotNull
     public Iterable<? extends ChildNodeEntry> getChildNodeEntries() {
-        final Iterable<ChildNodeEntry> transformed = Iterables.transform(
-                delegate.getChildNodeEntries(),
-                new Function<ChildNodeEntry, ChildNodeEntry>() {
-                    @Nullable
-                    @Override
-                    public ChildNodeEntry apply(@Nullable final ChildNodeEntry childNodeEntry) {
-                        if (childNodeEntry != null) {
-                            final String name = childNodeEntry.getName();
-                            final NodeState nodeState = decorate(name, childNodeEntry.getNodeState());
-                            if (nodeState.exists()) {
-                                return new MemoryChildNodeEntry(name, nodeState);
-                            }
-                        }
-                        return null;
-                    }
+        final Iterable<ChildNodeEntry> transformed = Iterables.transform(delegate.getChildNodeEntries(), childNodeEntry -> {
+            if (childNodeEntry != null) {
+                final String name = childNodeEntry.getName();
+                final NodeState nodeState = decorate(name, childNodeEntry.getNodeState());
+                if (nodeState.exists()) {
+                    return new MemoryChildNodeEntry(name, nodeState);
                 }
-        );
+            }
+            return null;
+        });
         return Iterables.filter(transformed, notNull());
     }
 
@@ -179,14 +172,7 @@ public abstract class AbstractDecoratedNodeState extends AbstractNodeState {
     public Iterable<? extends PropertyState> getProperties() {
         final Iterable<PropertyState> propertyStates = Iterables.transform(
                 delegate.getProperties(),
-                new Function<PropertyState, PropertyState>() {
-                    @Override
-                    @Nullable
-                    public PropertyState apply(@Nullable final PropertyState propertyState) {
-                        return decorate(propertyState);
-                    }
-                }
-        );
+                propertyState -> decorate(propertyState));
         return Iterables.filter(Iterables.concat(propertyStates, getNewPropertyStates()), notNull());
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/EffectiveNodeTypeImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/EffectiveNodeTypeImpl.java
@@ -44,7 +44,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Maps;
@@ -227,14 +226,8 @@ class EffectiveNodeTypeImpl implements EffectiveNodeType {
     @NotNull
     @Override
     public Iterable<NodeDefinition> getNamedNodeDefinitions(@NotNull final String oakName) {
-        return Iterables.concat(Iterables.transform(
-                nodeTypes.values(),
-                new Function<NodeTypeImpl, Iterable<NodeDefinition>>() {
-                    @Override
-                    public Iterable<NodeDefinition> apply(NodeTypeImpl input) {
-                        return input.getDeclaredNamedNodeDefinitions(oakName);
-                    }
-                }));
+        return Iterables.concat(Iterables.transform(nodeTypes.values(),
+                input -> input.getDeclaredNamedNodeDefinitions(oakName)));
     }
 
     /**

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractTree.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -320,13 +319,10 @@ public abstract class AbstractTree implements Tree {
     @NotNull
     public Iterable<Tree> getChildren() {
         Iterable<Tree> children = transform(getChildNames(),
-            new Function<String, Tree>() {
-                @Override
-                public Tree apply(String name) {
+                name ->  {
                     AbstractTree child = createChild(name);
                     return child.exists() ? child : null;
-                }
-            });
+                });
         return filter(children, notNull());
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionHook.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionHook.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.version;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitHook;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
@@ -26,11 +25,11 @@ import org.apache.jackrabbit.oak.spi.commit.EditorHook;
 import org.apache.jackrabbit.oak.spi.commit.EditorProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Component;
 
 import java.util.List;
 import java.util.Set;
+
 import static org.apache.jackrabbit.guava.common.collect.Collections2.transform;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
@@ -77,12 +76,6 @@ public class VersionHook implements CommitHook {
         providers.add(new VersionableCollector.Provider(existingVersionables));
         providers.add(new OrphanedVersionCleaner.Provider(existingVersionables));
 
-        return compose(transform(providers, new Function<EditorProvider, CommitHook>() {
-            @Nullable
-            @Override
-            public CommitHook apply(@Nullable EditorProvider input) {
-                return new EditorHook(input);
-            }
-        })).processCommit(before, after, info);
+        return compose(transform(providers, input -> new EditorHook(input))).processCommit(before, after, info);
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/LowerCaseImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/LowerCaseImpl.java
@@ -30,8 +30,6 @@ import org.apache.jackrabbit.oak.plugins.memory.PropertyValues;
 import org.apache.jackrabbit.oak.spi.query.QueryConstants;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex.OrderEntry;
 
-import org.apache.jackrabbit.guava.common.base.Function;
-
 import static org.apache.jackrabbit.guava.common.collect.Iterables.transform;
 import static org.apache.jackrabbit.oak.api.Type.STRING;
 import static org.apache.jackrabbit.oak.api.Type.STRINGS;
@@ -60,12 +58,12 @@ public class LowerCaseImpl extends DynamicOperandImpl {
     public String toString() {
         return "lower(" + operand + ')';
     }
-    
+
     @Override
     public PropertyExistenceImpl getPropertyExistence() {
         return operand.getPropertyExistence();
     }
-    
+
     @Override
     public Set<SelectorImpl> getSelectors() {
         return operand.getSelectors();
@@ -80,12 +78,7 @@ public class LowerCaseImpl extends DynamicOperandImpl {
         // TODO toLowerCase(): document the Turkish locale problem
         if (p.getType().isArray()) {
             Iterable<String> lowerCase = transform(p.getValue(STRINGS),
-                    new Function<String, String>() {
-                        @Override
-                        public String apply(String input) {
-                            return input.toLowerCase();
-                        }
-                    });
+                    input -> input.toLowerCase());
             return PropertyValues.newString(lowerCase);
         } else {
             String value = p.getValue(STRING);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/principal/PrincipalProviderImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/principal/PrincipalProviderImpl.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.security.principal;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.api.security.principal.ItemBasedPrincipal;
 import org.apache.jackrabbit.api.security.user.Authorizable;
@@ -45,6 +44,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * The {@code PrincipalProviderImpl} is a principal provider implementation
@@ -144,7 +144,7 @@ class PrincipalProviderImpl implements PrincipalProvider {
         }
         try {
             Iterator<Authorizable> authorizables = findAuthorizables(nameHint, searchType, offset, limit);
-            Iterator<Principal> principals = Iterators.filter(Iterators.transform(authorizables, new AuthorizableToPrincipal()), Objects::nonNull);
+            Iterator<Principal> principals = Iterators.filter(Iterators.transform(authorizables, new AuthorizableToPrincipal()::apply), Objects::nonNull);
             return EveryoneFilter.filter(principals, nameHint, searchType, offset, limit);
         } catch (RepositoryException e) {
             log.debug(e.getMessage());

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/AuthorizableIterator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/AuthorizableIterator.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.security.user;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.oak.api.Tree;
@@ -33,6 +32,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -50,7 +50,8 @@ final class AuthorizableIterator implements Iterator<Authorizable> {
     static AuthorizableIterator create(@NotNull Iterator<Tree> authorizableTrees,
                                        @NotNull UserManagerImpl userManager,
                                        @NotNull AuthorizableType authorizableType) {
-        Iterator<Authorizable> it = Iterators.transform(authorizableTrees, new TreeToAuthorizable(userManager, authorizableType));
+        Iterator<Authorizable> it = Iterators.transform(authorizableTrees,
+                new TreeToAuthorizable(userManager, authorizableType)::apply);
         long size = getSize(authorizableTrees);
         return new AuthorizableIterator(it, size, false);
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserPrincipalProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserPrincipalProvider.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.security.user;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicates;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.api.security.principal.ItemBasedPrincipal;
@@ -51,6 +50,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.apache.jackrabbit.oak.api.QueryEngine.NO_BINDINGS;
 import static org.apache.jackrabbit.oak.api.Type.STRING;
@@ -184,7 +184,7 @@ class UserPrincipalProvider implements PrincipalProvider {
                     limit, offset, NO_BINDINGS, namePathMapper.getSessionLocalMappings());
 
             Iterator<Principal> principals = Iterators.filter(
-                    Iterators.transform(result.getRows().iterator(), new ResultRowToPrincipal()),
+                    Iterators.transform(result.getRows().iterator(), new ResultRowToPrincipal()::apply),
                     Predicates.notNull());
 
             // everyone is injected only in complete set, not on pages

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/autosave/AuthorizableWrapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/autosave/AuthorizableWrapper.java
@@ -17,8 +17,8 @@
 package org.apache.jackrabbit.oak.security.user.autosave;
 
 import java.util.Iterator;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
@@ -41,10 +41,10 @@ final class AuthorizableWrapper<T extends Authorizable> implements Function<T, T
     }
 
     static Iterator<Authorizable> createIterator(Iterator<Authorizable> dlgs, AutoSaveEnabledManager mgr) {
-        return Iterators.transform(dlgs, new AuthorizableWrapper<>(mgr));
+        return Iterators.transform(dlgs, new AuthorizableWrapper<Authorizable>(mgr)::apply);
     }
 
     static Iterator<Group> createGroupIterator(Iterator<Group> dlgs, AutoSaveEnabledManager mgr) {
-        return Iterators.transform(dlgs, new AuthorizableWrapper<>(mgr));
+        return Iterators.transform(dlgs, new AuthorizableWrapper<Group>(mgr)::apply);
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/ResultRowToAuthorizable.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/ResultRowToAuthorizable.java
@@ -16,20 +16,19 @@
  */
 package org.apache.jackrabbit.oak.security.user.query;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.oak.api.ResultRow;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.security.user.UserManagerImpl;
-import org.apache.jackrabbit.oak.spi.query.QueryConstants;
 import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
 import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Function;
 
 import javax.jcr.RepositoryException;
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManager.java
@@ -273,7 +273,8 @@ public class UserQueryManager {
                     statement, javax.jcr.query.Query.XPATH, limit, offset,
                     NO_BINDINGS, namePathMapper.getSessionLocalMappings());
             Iterable<? extends ResultRow> resultRows = query.getRows();
-            Iterator<Authorizable> authorizables = Iterators.transform(resultRows.iterator(), new ResultRowToAuthorizable(userManager, root, type, query.getSelectorNames()));
+            Iterator<Authorizable> authorizables = Iterators.transform(resultRows.iterator(),
+                    new ResultRowToAuthorizable(userManager, root, type, query.getSelectorNames())::apply);
             return Iterators.filter(authorizables, new UniqueResultPredicate());
         } catch (ParseException e) {
             throw new RepositoryException("Invalid user query "+statement, e);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/impl/ImmutableTreeTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/impl/ImmutableTreeTest.java
@@ -19,7 +19,7 @@
 package org.apache.jackrabbit.oak.plugins.tree.impl;
 
 import java.util.List;
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.JcrConstants;
@@ -34,7 +34,6 @@ import org.apache.jackrabbit.oak.spi.security.authorization.AuthorizationConfigu
 import org.apache.jackrabbit.oak.util.NodeUtil;
 import org.apache.jackrabbit.util.Text;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -264,13 +263,7 @@ public class ImmutableTreeTest extends AbstractSecurityTest {
     }
 
     private static void assertSequence(Iterable<Tree> trees, String... names) {
-        List<String> actual = Lists.newArrayList(Iterables.transform(trees, new Function<Tree, String>() {
-            @Nullable
-            @Override
-            public String apply(Tree input) {
-                return input.getName();
-            }
-        }));
+        List<String> actual = Lists.newArrayList(Iterables.transform(trees, input -> input.getName()));
         assertEquals(Lists.newArrayList(names), actual);
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/ChildOrderPropertyTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/ChildOrderPropertyTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
@@ -34,7 +33,6 @@ import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -101,13 +99,7 @@ public class ChildOrderPropertyTest extends AbstractOakCoreTest {
         assertFalse(aTree.hasProperty(JcrConstants.JCR_PRIMARYTYPE));
 
         List<String> expected = ImmutableList.of("/a/bb", "/a/b");
-        Iterable<String> childPaths = Iterables.transform(aTree.getChildren(), new Function<Tree, String>() {
-            @Nullable
-            @Override
-            public String apply(Tree input) {
-                return input.getPath();
-            }
-        });
+        Iterable<String> childPaths = Iterables.transform(aTree.getChildren(), input -> input.getPath());
         assertTrue(childPaths.toString(), Iterables.elementsEqual(expected, childPaths));
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/privilege/JcrAllTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/privilege/JcrAllTest.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import javax.jcr.security.Privilege;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
 import org.apache.jackrabbit.oak.AbstractSecurityTest;
@@ -30,7 +29,6 @@ import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeBits;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeBitsProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConfiguration;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull;
@@ -71,12 +69,7 @@ public class JcrAllTest extends AbstractSecurityTest implements PrivilegeConstan
         Iterable<Privilege> declaredAggr = Arrays.asList(pMgr.getPrivilege(JCR_ALL).getDeclaredAggregatePrivileges());
         String[] allAggregates = Iterables.toArray(Iterables.transform(
                 declaredAggr,
-                new Function<Privilege, String>() {
-                    @Override
-                    public String apply(@Nullable Privilege privilege) {
-                        return checkNotNull(privilege).getName();
-                    }
-                }), String.class);
+                privilege -> checkNotNull(privilege).getName()), String.class);
         PrivilegeBits all2 = bitsProvider.getBits(allAggregates);
 
         assertEquals(all, all2);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/privilege/PrivilegeImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/privilege/PrivilegeImplTest.java
@@ -19,7 +19,6 @@ package org.apache.jackrabbit.oak.security.privilege;
 import java.util.Set;
 import javax.jcr.security.Privilege;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -32,7 +31,6 @@ import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeDefinition;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -69,13 +67,7 @@ public class PrivilegeImplTest extends AbstractSecurityTest implements Privilege
         assertEquals(expectedNames.length, aggr.length);
 
         Set<String> expected = Sets.newHashSet(expectedNames);
-        Set<String> result = Sets.newHashSet(Iterables.transform(ImmutableSet.copyOf(aggr), new Function<Privilege, String>() {
-            @Nullable
-            @Override
-            public String apply(Privilege input) {
-                return input.getName();
-            }
-        }));
+        Set<String> result = Sets.newHashSet(Iterables.transform(ImmutableSet.copyOf(aggr), input -> input.getName()));
 
         assertEquals(expected, result);
     }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/util/NodeUtil.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/util/NodeUtil.java
@@ -22,7 +22,6 @@ import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -221,12 +220,7 @@ public class NodeUtil {
     }
 
     public void setNames(String propertyName, String... values) {
-        tree.setProperty(propertyName, Lists.transform(Arrays.asList(values), new Function<String, String>() {
-            @Override
-            public String apply(String jcrName) {
-                return getOakName(jcrName);
-            }
-        }), NAMES);
+        tree.setProperty(propertyName, Lists.transform(Arrays.asList(values), jcrName -> getOakName(jcrName)), NAMES);
     }
 
     public void setDate(String name, long time) {

--- a/oak-exercise/src/main/java/org/apache/jackrabbit/oak/exercise/security/authentication/external/CustomExternalIdentityProvider.java
+++ b/oak-exercise/src/main/java/org/apache/jackrabbit/oak/exercise/security/authentication/external/CustomExternalIdentityProvider.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.exercise.security.authentication.external;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -28,7 +27,6 @@ import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalId
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalUser;
 import org.apache.jackrabbit.util.Text;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -155,13 +153,8 @@ public class CustomExternalIdentityProvider implements ExternalIdentityProvider 
                     if (groupIds == null || groupIds.isEmpty()) {
                         return ImmutableSet.of();
                     } else {
-                        return Iterables.transform(groupIds, new Function<String, ExternalIdentityRef>() {
-                            @Nullable
-                            @Override
-                            public ExternalIdentityRef apply(String input) {
-                                return new ExternalIdentityRef(input, getName());
-                            }
-                        });
+                        return Iterables.transform(groupIds,
+                                input -> new ExternalIdentityRef(input, getName()));
                     }
                 }
 

--- a/oak-exercise/src/test/java/org/apache/jackrabbit/oak/exercise/security/privilege/L4_CustomPrivilegeTest.java
+++ b/oak-exercise/src/test/java/org/apache/jackrabbit/oak/exercise/security/privilege/L4_CustomPrivilegeTest.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.UUID;
 import javax.jcr.security.Privilege;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
@@ -29,7 +28,6 @@ import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
 import org.apache.jackrabbit.oak.AbstractSecurityTest;
 import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -118,13 +116,8 @@ public class L4_CustomPrivilegeTest extends AbstractSecurityTest {
             fail();
         }
 
-        Iterable<String> resultNames = Iterables.transform(Sets.newHashSet(result), new Function<Privilege, String>() {
-            @Nullable
-            @Override
-            public String apply(Privilege input) {
-                return input.toString();
-            }
-        });
+        Iterable<String> resultNames = Iterables.transform(Sets.newHashSet(result),
+                input -> input.toString());
 
         Iterables.removeAll(resultNames, expectedNames);
         assertFalse(resultNames.iterator().hasNext());

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreTest.java
@@ -658,7 +658,7 @@ public class CompositeNodeStoreTest {
         deepMountBuilder.child("new").setProperty("store", "deepMounted", Type.STRING);
         deepMountedStore.merge(deepMountBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
 
-        List<ChildNodeEntry> children = newArrayList(filter(store.getRoot().getChildNodeEntries(), compose(Predicates.equalTo("new"), GET_NAME)));
+        List<ChildNodeEntry> children = newArrayList(filter(store.getRoot().getChildNodeEntries(), compose(Predicates.equalTo("new"), GET_NAME::apply)));
         assertEquals(1, children.size());
         assertEquals("global", children.get(0).getNodeState().getString("store"));
 

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/NodeDelegate.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/NodeDelegate.java
@@ -61,6 +61,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.jcr.InvalidItemStateException;
 import javax.jcr.ItemNotFoundException;
@@ -71,7 +72,6 @@ import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.nodetype.NoSuchNodeTypeException;
 import javax.jcr.security.AccessControlException;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 
 import org.apache.jackrabbit.JcrConstants;
@@ -299,12 +299,7 @@ public class NodeDelegate extends ItemDelegate {
     @NotNull
     public Iterator<PropertyDelegate> getProperties() throws InvalidItemStateException {
         return transform(getTree().getProperties().iterator(),
-                new Function<PropertyState, PropertyDelegate>() {
-                    @Override
-                    public PropertyDelegate apply(PropertyState propertyState) {
-                        return new PropertyDelegate(sessionDelegate, tree, propertyState.getName());
-                    }
-                });
+                propertyState -> new PropertyDelegate(sessionDelegate, tree, propertyState.getName()));
     }
 
     /**
@@ -355,12 +350,7 @@ public class NodeDelegate extends ItemDelegate {
                         return tree.exists();
                     }
                 }),
-                new Function<Tree, NodeDelegate>() {
-                    @Override
-                    public NodeDelegate apply(Tree tree) {
-                        return new NodeDelegate(sessionDelegate, tree);
-                    }
-                });
+                tree -> new NodeDelegate(sessionDelegate, tree));
     }
 
     public void orderBefore(String source, String target)

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/VersionHistoryDelegate.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/VersionHistoryDelegate.java
@@ -29,7 +29,6 @@ import javax.jcr.RepositoryException;
 import javax.jcr.version.LabelExistsVersionException;
 import javax.jcr.version.VersionException;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 
 import org.apache.jackrabbit.JcrConstants;
@@ -162,12 +161,8 @@ public class VersionHistoryDelegate extends NodeDelegate {
             }
         });
         final Tree thisTree = getTree();
-        return Iterators.transform(versions.iterator(), new Function<NodeDelegate, VersionDelegate>() {
-            @Override
-            public VersionDelegate apply(NodeDelegate nd) {
-                return VersionDelegate.create(sessionDelegate, thisTree.getChild(nd.getName()));
-            }
-        });
+        return Iterators.transform(versions.iterator(),
+                nd -> VersionDelegate.create(sessionDelegate, thisTree.getChild(nd.getName())));
     }
 
     @NotNull

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
@@ -64,7 +64,7 @@ import javax.jcr.version.Version;
 import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
@@ -823,14 +823,11 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
                 Iterable<String> propertyOakPaths = idManager.getReferences(weak, node.getTree(), name); // TODO: oak name?
                 Iterable<Property> properties = Iterables.transform(
                         propertyOakPaths,
-                        new Function<String, Property>() {
-                            @Override
-                            public Property apply(String oakPath) {
+                        oakPath -> {
                                 PropertyDelegate pd = sessionDelegate.getProperty(oakPath);
                                 return pd == null ? null : new PropertyImpl(pd, sessionContext);
                             }
-                        }
-                );
+                        );
 
                 return new PropertyIteratorAdapter(sessionDelegate.sync(properties.iterator()));
             }
@@ -1374,23 +1371,13 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
     private Iterator<Node> nodeIterator(Iterator<NodeDelegate> childNodes) {
         return sessionDelegate.sync(transform(
                 childNodes,
-                new Function<NodeDelegate, Node>() {
-                    @Override
-                    public Node apply(NodeDelegate nodeDelegate) {
-                        return new NodeImpl<NodeDelegate>(nodeDelegate, sessionContext);
-                    }
-                }));
+                nodeDelegate -> new NodeImpl<NodeDelegate>(nodeDelegate, sessionContext)));
     }
 
     private Iterator<Property> propertyIterator(Iterator<PropertyDelegate> properties) {
         return sessionDelegate.sync(transform(
                 properties,
-                new Function<PropertyDelegate, Property>() {
-                    @Override
-                    public Property apply(PropertyDelegate propertyDelegate) {
-                        return new PropertyImpl(propertyDelegate, sessionContext);
-                    }
-                }));
+                propertyDelegate -> new PropertyImpl(propertyDelegate, sessionContext)));
     }
 
     private void checkValidWorkspace(String workspaceName)

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/version/VersionHistoryImpl.java
@@ -34,7 +34,6 @@ import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.commons.iterator.FrozenNodeIteratorAdapter;
 import org.apache.jackrabbit.commons.iterator.VersionIteratorAdapter;
 import org.apache.jackrabbit.oak.jcr.delegate.VersionDelegate;
@@ -88,12 +87,7 @@ public class VersionHistoryImpl extends NodeImpl<VersionHistoryDelegate>
             @Override
             public VersionIterator perform() throws RepositoryException {
                 Iterator<Version> versions = transform(dlg.getAllLinearVersions(),
-                        new Function<VersionDelegate, Version>() {
-                            @Override
-                            public Version apply(VersionDelegate input) {
-                                return new VersionImpl(input, sessionContext);
-                            }
-                        });
+                        input -> new VersionImpl(input, sessionContext));
                 return new VersionIteratorAdapter(sessionDelegate.sync(versions));
             }
         });
@@ -106,12 +100,7 @@ public class VersionHistoryImpl extends NodeImpl<VersionHistoryDelegate>
             @Override
             public VersionIterator perform() throws RepositoryException {
                 Iterator<Version> versions = transform(dlg.getAllVersions(),
-                        new Function<VersionDelegate, Version>() {
-                    @Override
-                    public Version apply(VersionDelegate input) {
-                        return new VersionImpl(input, sessionContext);
-                    }
-                });
+                        input -> new VersionImpl(input, sessionContext));
                 return new VersionIteratorAdapter(sessionDelegate.sync(versions));
             }
         });

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.UUID;
+import java.util.function.Function;
 
 import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.ItemExistsException;
@@ -36,7 +37,6 @@ import javax.jcr.nodetype.NodeDefinition;
 import javax.jcr.nodetype.PropertyDefinition;
 import javax.jcr.version.VersionException;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicates;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -309,7 +309,7 @@ public class ImporterImpl implements Importer {
                     return null;
                 }
             }
-        }), Predicates.notNull());
+        }::apply), Predicates.notNull());
     }
 
     private Iterable<ProtectedNodeImporter> getNodeImporters() {
@@ -323,7 +323,7 @@ public class ImporterImpl implements Importer {
                     return null;
                 }
             }
-        }), Predicates.notNull());
+        }::apply), Predicates.notNull());
     }
 
     //-----------------------------------------------------------< Importer >---

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImporterImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 import java.util.UUID;
-import java.util.function.Function;
 
 import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.ItemExistsException;
@@ -299,31 +298,23 @@ public class ImporterImpl implements Importer {
     }
 
     private Iterable<ProtectedPropertyImporter> getPropertyImporters() {
-        return Iterables.filter(Iterables.transform(pItemImporters, new Function<ProtectedItemImporter, ProtectedPropertyImporter>() {
-            @Nullable
-            @Override
-            public ProtectedPropertyImporter apply(@Nullable ProtectedItemImporter importer) {
+        return Iterables.filter(Iterables.transform(pItemImporters, importer -> {
                 if (importer instanceof ProtectedPropertyImporter) {
                     return (ProtectedPropertyImporter) importer;
                 } else {
                     return null;
                 }
-            }
-        }::apply), Predicates.notNull());
+            }), Predicates.notNull());
     }
 
     private Iterable<ProtectedNodeImporter> getNodeImporters() {
-        return Iterables.filter(Iterables.transform(pItemImporters, new Function<ProtectedItemImporter, ProtectedNodeImporter>() {
-            @Nullable
-            @Override
-            public ProtectedNodeImporter apply(@Nullable ProtectedItemImporter importer) {
+        return Iterables.filter(Iterables.transform(pItemImporters, importer -> {
                 if (importer instanceof ProtectedNodeImporter) {
                     return (ProtectedNodeImporter) importer;
                 } else {
                     return null;
                 }
-            }
-        }::apply), Predicates.notNull());
+            }), Predicates.notNull());
     }
 
     //-----------------------------------------------------------< Importer >---

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionableTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/version/VersionableTest.java
@@ -28,15 +28,12 @@ import javax.jcr.version.VersionException;
 import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionManager;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.test.AbstractJCRTest;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Test;
 
 import java.util.Set;
 
@@ -442,17 +439,12 @@ public class VersionableTest extends AbstractJCRTest {
     }
 
     private static Set<String> getNames(Version[] versions) {
-        return newHashSet(transform(asList(versions), new Function<Version, String>() {
-            @Nullable
-            @Override
-            public String apply(@Nullable Version input) {
-                try {
-                    return input.getName();
-                } catch (RepositoryException e) {
-                    return null;
-                }
+        return newHashSet(transform(asList(versions), input -> {
+            try {
+                return input.getName();
+            } catch (RepositoryException e) {
+                return null;
             }
         }));
     }
-
 }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopier.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopier.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
 import java.io.Closeable;
@@ -41,7 +40,6 @@ import javax.management.openmbean.TabularData;
 import javax.management.openmbean.TabularDataSupport;
 import javax.management.openmbean.TabularType;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.guava.common.util.concurrent.Monitor;
@@ -612,12 +610,7 @@ public class IndexCopier implements CopyOnReadStatsMBean, Closeable {
     @Override
     public String[] getGarbageDetails() {
         return toArray(transform(failedToDeleteFiles.values(),
-                new Function<LocalIndexFile, String>() {
-                    @Override
-                    public String apply(LocalIndexFile input) {
-                        return input.deleteLog();
-                    }
-                }), String.class);
+                input -> input.deleteLog()), String.class);
     }
 
     @Override
@@ -661,12 +654,7 @@ public class IndexCopier implements CopyOnReadStatsMBean, Closeable {
     @Override
     public String[] getCopyInProgressDetails() {
         return toArray(transform(copyInProgressFiles,
-                new Function<LocalIndexFile, String>() {
-                    @Override
-                    public String apply(LocalIndexFile input) {
-                        return input.copyLog();
-                    }
-                }), String.class);
+                input -> input.copyLog()), String.class);
     }
 
     @Override

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/IndexedPaths.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/IndexedPaths.java
@@ -35,18 +35,18 @@ class IndexedPaths implements JournalProperty, Iterable<IndexedPathInfo> {
 
     @Override
     public Iterator<IndexedPathInfo> iterator() {
-        return Iterators.transform(indexedPaths.asMap().entrySet().iterator(),
-                input -> new IndexedPathInfo() {
-                    @Override
-                    public String getPath() {
-                        return input.getKey();
-                    }
+        return Iterators.transform(indexedPaths.asMap().entrySet().iterator(), input ->
+            new IndexedPathInfo() {
+                @Override
+                public String getPath() {
+                    return input.getKey();
+                }
 
-                    @Override
-                    public Iterable<String> getIndexPaths() {
-                        return input.getValue();
-                    }
-                });
+                @Override
+                public Iterable<String> getIndexPaths() {
+                    return input.getValue();
+                }
+            });
     }
 
     @Override

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/IndexedPaths.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/IndexedPaths.java
@@ -16,14 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.lucene.hybrid;
 
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.Map;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.guava.common.collect.Multimap;
 import org.apache.jackrabbit.oak.plugins.document.spi.JournalProperty;
@@ -40,10 +36,7 @@ class IndexedPaths implements JournalProperty, Iterable<IndexedPathInfo> {
     @Override
     public Iterator<IndexedPathInfo> iterator() {
         return Iterators.transform(indexedPaths.asMap().entrySet().iterator(),
-                new Function<Map.Entry<String, Collection<String>>, IndexedPathInfo>() {
-            @Override
-            public IndexedPathInfo apply(final Map.Entry<String, Collection<String>> input) {
-                return new IndexedPathInfo() {
+                input -> new IndexedPathInfo() {
                     @Override
                     public String getPath() {
                         return input.getKey();
@@ -53,9 +46,7 @@ class IndexedPaths implements JournalProperty, Iterable<IndexedPathInfo> {
                     public Iterable<String> getIndexPaths() {
                         return input.getValue();
                     }
-                };
-            }
-        });
+                });
     }
 
     @Override

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LuceneDocumentHolder.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LuceneDocumentHolder.java
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.lucene.hybrid;
 
 import java.util.Collection;
 import java.util.Map;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ArrayListMultimap;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.ListMultimap;
@@ -117,21 +115,19 @@ public class LuceneDocumentHolder implements JournalProperty {
     }
 
     private static Iterable<? extends LuceneDocInfo> asLuceneDocInfo(ListMultimap<String, String> docs) {
-        return Iterables.transform(docs.entries(), new Function<Map.Entry<String, String>, LuceneDocInfo>() {
-            @Override
-            public LuceneDocInfo apply(final Map.Entry<String, String> input) {
-                return new LuceneDocInfo() {
-                    @Override
-                    public String getIndexPath() {
-                        return input.getKey();
-                    }
+        return Iterables.transform(docs.entries(),
+                input -> {
+                    return new LuceneDocInfo() {
+                        @Override
+                        public String getIndexPath() {
+                            return input.getKey();
+                        }
 
-                    @Override
-                    public String getDocPath() {
-                        return input.getValue();
-                    }
-                };
-            }
-        });
+                        @Override
+                        public String getDocPath() {
+                            return input.getValue();
+                        }
+                    };
+                });
     }
 }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LuceneDocumentHolder.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LuceneDocumentHolder.java
@@ -115,19 +115,18 @@ public class LuceneDocumentHolder implements JournalProperty {
     }
 
     private static Iterable<? extends LuceneDocInfo> asLuceneDocInfo(ListMultimap<String, String> docs) {
-        return Iterables.transform(docs.entries(),
-                input -> {
-                    return new LuceneDocInfo() {
-                        @Override
-                        public String getIndexPath() {
-                            return input.getKey();
-                        }
+        return Iterables.transform(docs.entries(), input -> {
+                return new LuceneDocInfo() {
+                    @Override
+                    public String getIndexPath() {
+                        return input.getKey();
+                    }
 
-                        @Override
-                        public String getDocPath() {
-                            return input.getValue();
-                        }
-                    };
-                });
+                    @Override
+                    public String getDocPath() {
+                        return input.getValue();
+                    }
+                };
+            });
     }
 }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/ResultCountingIndexProvider.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/ResultCountingIndexProvider.java
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.Result;
 import org.apache.jackrabbit.oak.spi.query.Cursor;
@@ -32,6 +30,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+
 class ResultCountingIndexProvider implements QueryIndexProvider {
     private final QueryIndexProvider delegate;
     private final CountingCursorFactory cursorFactory;
@@ -65,15 +64,11 @@ class ResultCountingIndexProvider implements QueryIndexProvider {
     @Override
     public List<? extends QueryIndex> getQueryIndexes(NodeState nodeState) {
         if (shouldCount) {
-            return Lists.transform(delegate.getQueryIndexes(nodeState), new Function<QueryIndex, QueryIndex>() {
-                @NotNull
-                @Override
-                public QueryIndex apply(@NotNull  QueryIndex input) {
-                    if (input instanceof AdvanceFulltextQueryIndex) {
-                        return new CountingIndex((AdvanceFulltextQueryIndex)input, cursorFactory);
-                    } else {
-                        return input;
-                    }
+            return Lists.transform(delegate.getQueryIndexes(nodeState), input -> {
+                if (input instanceof AdvanceFulltextQueryIndex) {
+                    return new CountingIndex((AdvanceFulltextQueryIndex) input, cursorFactory);
+                } else {
+                    return input;
                 }
             });
         } else {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
@@ -35,15 +35,12 @@ import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStoreHelper;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.bson.conversions.Bson;
-import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.primitives.Longs;
 import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
@@ -156,13 +153,8 @@ public class DocumentNodeStoreHelper {
                     mds, Collection.NODES);
             Bson query = Filters.eq(NodeDocument.HAS_BINARY_FLAG, NodeDocument.HAS_BINARY_VAL);
             FindIterable<BasicDBObject> cursor = dbCol.find(query);
-            return Iterables.transform(cursor, new Function<DBObject, NodeDocument>() {
-                @Nullable
-                @Override
-                public NodeDocument apply(DBObject input) {
-                    return MongoDocumentStoreHelper.convertFromDBObject(mds, Collection.NODES, input);
-                }
-            });
+            return Iterables.transform(cursor,
+                    input -> MongoDocumentStoreHelper.convertFromDBObject(mds, Collection.NODES, input));
         } else {
             return Utils.getSelectedDocuments(store,
                     NodeDocument.HAS_BINARY_FLAG, NodeDocument.HAS_BINARY_VAL);

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AbstractSegmentTarExplorerBackend.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AbstractSegmentTarExplorerBackend.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.explorer;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.oak.api.Blob;
@@ -29,7 +28,6 @@ import org.apache.jackrabbit.oak.segment.SegmentId;
 import org.apache.jackrabbit.oak.segment.SegmentNodeState;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStateHelper;
 import org.apache.jackrabbit.oak.segment.SegmentPropertyState;
-import org.apache.jackrabbit.oak.segment.file.JournalEntry;
 import org.apache.jackrabbit.oak.segment.file.JournalReader;
 import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
@@ -84,12 +82,7 @@ public abstract class AbstractSegmentTarExplorerBackend implements ExplorerBacke
         try {
             journalReader = new JournalReader(journal);
             Iterator<String> revisionIterator = Iterators.transform(journalReader,
-                    new Function<JournalEntry, String>() {
-                        @Override
-                        public String apply(JournalEntry entry) {
-                            return entry.getRevision();
-                        }
-                    });
+                    entry -> entry.getRevision());
 
             try {
                 revs = newArrayList(revisionIterator);

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileBinaryResourceProvider.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileBinaryResourceProvider.java
@@ -16,15 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.tika;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.FluentIterable;
 import org.apache.jackrabbit.guava.common.io.Closer;
@@ -75,7 +74,7 @@ class CSVFileBinaryResourceProvider implements BinaryResourceProvider, Closeable
         CSVParser parser = CSVParser.parse(dataFile, StandardCharsets.UTF_8, FORMAT);
         closer.register(parser);
         return FluentIterable.from(parser)
-                .transform(new RecordTransformer())
+                .transform(new RecordTransformer()::apply)
                 .filter(notNull())
                 .filter(new Predicate<BinaryResource>() {
                     @Override

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/NodeStoreBinaryResourceProvider.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/NodeStoreBinaryResourceProvider.java
@@ -19,7 +19,6 @@
 
 package org.apache.jackrabbit.oak.plugins.tika;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.FluentIterable;
 import org.apache.jackrabbit.guava.common.collect.TreeTraverser;
 import org.apache.jackrabbit.JcrConstants;
@@ -37,6 +36,8 @@ import static org.apache.jackrabbit.guava.common.base.Predicates.notNull;
 import static org.apache.jackrabbit.oak.plugins.tree.factories.TreeFactory.createReadOnlyTree;
 import static org.apache.jackrabbit.oak.spi.state.NodeStateUtils.getNode;
 
+import java.util.function.Function;
+
 class NodeStoreBinaryResourceProvider implements BinaryResourceProvider {
     private static final Logger log = LoggerFactory.getLogger(NodeStoreBinaryResourceProvider.class);
     private final NodeStore nodeStore;
@@ -50,7 +51,7 @@ class NodeStoreBinaryResourceProvider implements BinaryResourceProvider {
     public FluentIterable<BinaryResource> getBinaries(String path) {
         return new OakTreeTraverser()
                 .preOrderTraversal(createReadOnlyTree(getNode(nodeStore.getRoot(), path)))
-                .transform(new TreeToBinarySource())
+                .transform(new TreeToBinarySource()::apply)
                 .filter(notNull());
     }
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCheckCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/DataStoreCheckCommand.java
@@ -45,7 +45,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.base.Splitter;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/PrintingDiff.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/PrintingDiff.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.jackrabbit.oak.run;
 
 import static org.apache.jackrabbit.guava.common.collect.Iterables.transform;
@@ -28,8 +27,8 @@ import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.MISSING_NODE;
 
 import java.io.PrintWriter;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -127,7 +126,7 @@ final class PrintingDiff implements NodeStateDiff {
             String v = BLOB_LENGTH.apply(ps.getValue(BINARY));
             val.append(" = {").append(v).append("}");
         } else if (ps.getType() == BINARIES) {
-            String v = transform(ps.getValue(BINARIES), BLOB_LENGTH).toString();
+            String v = transform(ps.getValue(BINARIES), BLOB_LENGTH::apply).toString();
             val.append("[").append(ps.count()).append("] = ").append(v);
         } else if (ps.isArray()) {
             val.append("[").append(ps.count()).append("] = ").append(ps.getValue(STRINGS));

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/BinarySourceMapper.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/BinarySourceMapper.java
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.tika;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+import java.util.function.Function;
 
 public enum BinarySourceMapper implements Function<BinaryResource, String> {
     BY_BLOBID {

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileBinaryResourceProviderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileBinaryResourceProviderTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.tika;
 
 import java.io.File;
@@ -52,12 +51,12 @@ public class CSVFileBinaryResourceProviderTest {
 
         CSVFileBinaryResourceProvider provider = new CSVFileBinaryResourceProvider(dataFile, new MemoryBlobStore());
 
-        Map<String, BinaryResource> binaries = provider.getBinaries("/").uniqueIndex(BinarySourceMapper.BY_BLOBID);
+        Map<String, BinaryResource> binaries = provider.getBinaries("/").uniqueIndex(BinarySourceMapper.BY_BLOBID::apply);
         assertEquals(3, binaries.size());
         assertEquals("a", binaries.get("a").getBlobId());
         assertEquals("/a", binaries.get("a").getPath());
 
-        binaries = provider.getBinaries("/a").uniqueIndex(BinarySourceMapper.BY_BLOBID);
+        binaries = provider.getBinaries("/a").uniqueIndex(BinarySourceMapper.BY_BLOBID::apply);
         assertEquals(1, binaries.size());
 
         provider.close();

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCheckTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCheckTest.java
@@ -39,7 +39,6 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -67,7 +66,6 @@ import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
-import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -444,20 +442,14 @@ public class DataStoreCheckTest {
     }
 
     private static Set<String> encodedIds(Set<String> ids, String dsOption) {
-        return Sets.newHashSet(Iterators.transform(ids.iterator(), new Function<String, String>() {
-            @Nullable @Override public String apply(@Nullable String input) {
-                return DataStoreCheckCommand.encodeId(input, "--"+dsOption);
-            }
-        }));
+        return Sets.newHashSet(Iterators.transform(ids.iterator(),
+                input -> DataStoreCheckCommand.encodeId(input, "--" + dsOption)));
     }
 
     private static Set<String> encodedIdsAndPath(Set<String> ids, String dsOption, Map<String, String> blobsAddedWithNodes) {
-        return Sets.newHashSet(Iterators.transform(ids.iterator(), new Function<String, String>() {
-            @Nullable @Override public String apply(@Nullable String input) {
-                return Joiner.on(",").join(
+        return Sets.newHashSet(Iterators.transform(ids.iterator(),
+                input -> Joiner.on(",").join(
                     DataStoreCheckCommand.encodeId(input, "--"+dsOption),
-                    blobsAddedWithNodes.get(input));
-            }
-        }));
+                    blobsAddedWithNodes.get(input))));
     }
 }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCommandTest.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import ch.qos.logback.classic.Level;
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.base.Splitter;
 import org.apache.jackrabbit.guava.common.base.Strings;
@@ -87,7 +86,6 @@ import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.stats.Clock;
-import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -936,19 +934,13 @@ public class DataStoreCommandTest {
     private static Set<String> encodedIdsAndPath(Set<String> ids, Type dsOption, Map<String, String> idToNodes,
         boolean encodeId) {
 
-        return Sets.newHashSet(Iterators.transform(ids.iterator(), new Function<String, String>() {
-            @Nullable @Override public String apply(@Nullable String input) {
-                return Joiner.on(",").join(encodeId ? encodeId(input, dsOption) : input, idToNodes.get(input));
-            }
-        }));
+        return Sets.newHashSet(Iterators.transform(ids.iterator(),
+                input -> Joiner.on(",").join(encodeId ? encodeId(input, dsOption) : input, idToNodes.get(input))));
     }
 
     private static Set<String> encodeIds(Set<String> ids, Type dsOption) {
-        return Sets.newHashSet(Iterators.transform(ids.iterator(), new Function<String, String>() {
-            @Nullable @Override public String apply(@Nullable String input) {
-                return encodeId(input, dsOption);
-            }
-        }));
+        return Sets.newHashSet(Iterators.transform(ids.iterator(),
+                input -> encodeId(input, dsOption)));
     }
 
 

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/AggregateTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/AggregateTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ArrayListMultimap;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.ListMultimap;
@@ -106,7 +105,7 @@ public class AggregateTest {
         NodeState state = nb.getNodeState();
         final AtomicInteger counter = new AtomicInteger();
         Iterable<? extends ChildNodeEntry> countingIterator = Iterables.transform(state.getChildNodeEntries(),
-                (Function<ChildNodeEntry, ChildNodeEntry>) input -> {
+                input -> {
                     counter.incrementAndGet();
                     return input;
                 });

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/CompositeConfiguration.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/CompositeConfiguration.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.spi.security;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -51,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 
 /**
  * Abstract base implementation for {@link SecurityConfiguration}s that can
@@ -205,34 +205,22 @@ public abstract class CompositeConfiguration<T extends SecurityConfiguration> im
     @NotNull
     @Override
     public WorkspaceInitializer getWorkspaceInitializer() {
-        return new CompositeWorkspaceInitializer(Lists.transform(getConfigurations(), new Function<T, WorkspaceInitializer>() {
-            @Override
-            public WorkspaceInitializer apply(T securityConfiguration) {
-                return securityConfiguration.getWorkspaceInitializer();
-            }
-        }));
+        return new CompositeWorkspaceInitializer(Lists.transform(getConfigurations(),
+                securityConfiguration -> securityConfiguration.getWorkspaceInitializer()));
     }
 
     @NotNull
     @Override
     public RepositoryInitializer getRepositoryInitializer() {
-        return new CompositeInitializer(Lists.transform(getConfigurations(), new Function<T, RepositoryInitializer>() {
-            @Override
-            public RepositoryInitializer apply(T securityConfiguration) {
-                return securityConfiguration.getRepositoryInitializer();
-            }
-        }));
+        return new CompositeInitializer(Lists.transform(getConfigurations(),
+                securityConfiguration -> securityConfiguration.getRepositoryInitializer()));
     }
 
     @NotNull
     @Override
     public List<? extends CommitHook> getCommitHooks(@NotNull final String workspaceName) {
-        Iterable<CommitHook> t = Iterables.concat(Lists.transform(getConfigurations(), new Function<T, List<? extends CommitHook>>() {
-            @Override
-            public List<? extends CommitHook> apply(T securityConfiguration) {
-                return securityConfiguration.getCommitHooks(workspaceName);
-            }
-        }));
+        Iterable<CommitHook> t = Iterables.concat(Lists.transform(getConfigurations(),
+                securityConfiguration -> securityConfiguration.getCommitHooks(workspaceName)));
         return ImmutableList.copyOf(t);
     }
 
@@ -252,12 +240,8 @@ public abstract class CompositeConfiguration<T extends SecurityConfiguration> im
     @NotNull
     @Override
     public List<ProtectedItemImporter> getProtectedItemImporters() {
-        Iterable<ProtectedItemImporter> t = Iterables.concat(Lists.transform(getConfigurations(), new Function<T, List<? extends ProtectedItemImporter>>() {
-            @Override
-            public List<? extends ProtectedItemImporter> apply(T securityConfiguration) {
-                return securityConfiguration.getProtectedItemImporters();
-            }
-        }));
+        Iterable<ProtectedItemImporter> t = Iterables.concat(Lists.transform(getConfigurations(),
+                securityConfiguration -> securityConfiguration.getProtectedItemImporters()));
         return ImmutableList.copyOf(t);
     }
 
@@ -307,7 +291,7 @@ public abstract class CompositeConfiguration<T extends SecurityConfiguration> im
 
         private void refresh(@NotNull List<? extends SecurityConfiguration> configurations) {
             Set<Context> s = Sets.newLinkedHashSetWithExpectedSize(configurations.size());
-            for (Context c : Iterables.transform(configurations, ContextFunction.INSTANCE)) {
+            for (Context c : Iterables.transform(configurations, ContextFunction.INSTANCE::apply)) {
                 if (DEFAULT != c) {
                     s.add(c);
                 }

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/credentials/SimpleCredentialsSupport.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/credentials/SimpleCredentialsSupport.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import javax.jcr.Credentials;
 import javax.jcr.SimpleCredentials;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 
@@ -66,13 +65,8 @@ public final class SimpleCredentialsSupport implements CredentialsSupport {
     public Map<String, ?> getAttributes(@NotNull Credentials credentials) {
         if (credentials instanceof SimpleCredentials) {
             final SimpleCredentials sc = (SimpleCredentials) credentials;
-            return Maps.asMap(ImmutableSet.copyOf(sc.getAttributeNames()), new Function<String, Object>() {
-                @Nullable
-                @Override
-                public Object apply(String input) {
-                    return sc.getAttribute(input);
-                }
-            });
+            return Maps.asMap(ImmutableSet.copyOf(sc.getAttributeNames()),
+                    input -> sc.getAttribute(input));
         } else {
             return Collections.emptyMap();
         }

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/token/CompositeTokenConfiguration.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/token/CompositeTokenConfiguration.java
@@ -17,7 +17,7 @@
 package org.apache.jackrabbit.oak.spi.security.authentication.token;
 
 import java.util.List;
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.spi.security.CompositeConfiguration;
@@ -40,12 +40,8 @@ public class CompositeTokenConfiguration extends CompositeConfiguration<TokenCon
     @NotNull
     @Override
     public TokenProvider getTokenProvider(@NotNull final Root root) {
-        List<TokenProvider> providers = Lists.transform(getConfigurations(), new Function<TokenConfiguration, TokenProvider>() {
-            @Override
-            public TokenProvider apply(TokenConfiguration tokenConfiguration) {
-                return tokenConfiguration.getTokenProvider(root);
-            }
-        });
+        List<TokenProvider> providers = Lists.transform(getConfigurations(),
+                tokenConfiguration -> tokenConfiguration.getTokenProvider(root));
         return CompositeTokenProvider.newInstance(providers);
     }
 }

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/privilege/PrivilegeBitsProvider.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/privilege/PrivilegeBitsProvider.java
@@ -22,10 +22,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+
 import javax.jcr.security.AccessControlException;
 import javax.jcr.security.Privilege;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicates;
 import org.apache.jackrabbit.guava.common.collect.FluentIterable;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
@@ -261,7 +262,7 @@ public final class PrivilegeBitsProvider implements PrivilegeConstants {
 
     @NotNull
     private Iterable<String> extractAggregatedPrivileges(@NotNull Iterable<String> privilegeNames) {
-        return FluentIterable.from(privilegeNames).transformAndConcat(new ExtractAggregatedPrivileges());
+        return FluentIterable.from(privilegeNames).transformAndConcat(new ExtractAggregatedPrivileges()::apply);
     }
 
     @NotNull

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/ToolUtils.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/ToolUtils.java
@@ -61,7 +61,6 @@ import org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache.Caching
 import org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache.PersistentCache;
 
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 
 import com.microsoft.azure.storage.StorageCredentials;
@@ -212,13 +211,8 @@ public class ToolUtils {
 
         if (journal.exists()) {
             try (JournalReader journalReader = new JournalReader(journal)) {
-                Iterator<String> revisionIterator = Iterators.transform(journalReader, new Function<JournalEntry, String>() {
-                    @NotNull
-                    @Override
-                    public String apply(JournalEntry entry) {
-                        return entry.getRevision();
-                    }
-                });
+                Iterator<String> revisionIterator = Iterators.transform(journalReader,
+                        entry -> entry.getRevision());
                 return newArrayList(revisionIterator);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CachingSegmentReader.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CachingSegmentReader.java
@@ -23,7 +23,6 @@ import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull
 
 import java.io.UnsupportedEncodingException;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Supplier;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.segment.util.SafeEncode;
@@ -98,13 +97,8 @@ public class CachingSegmentReader implements SegmentReader {
         final SegmentId segmentId = id.getSegmentId();
         long msb = segmentId.getMostSignificantBits();
         long lsb = segmentId.getLeastSignificantBits();
-        return stringCache.get(msb, lsb, id.getRecordNumber(), new Function<Integer, String>() {
-            @NotNull
-            @Override
-            public String apply(Integer offset) {
-                return segmentId.getSegment().readString(offset);
-            }
-        });
+        return stringCache.get(msb, lsb, id.getRecordNumber(),
+                offset -> segmentId.getSegment().readString(offset));
     }
 
     @NotNull
@@ -122,13 +116,8 @@ public class CachingSegmentReader implements SegmentReader {
         final SegmentId segmentId = id.getSegmentId();
         long msb = segmentId.getMostSignificantBits();
         long lsb = segmentId.getLeastSignificantBits();
-        return templateCache.get(msb, lsb, id.getRecordNumber(), new Function<Integer, Template>() {
-            @NotNull
-            @Override
-            public Template apply(Integer offset) {
-                return segmentId.getSegment().readTemplate(offset);
-            }
-        });
+        return templateCache.get(msb, lsb, id.getRecordNumber(),
+                offset -> segmentId.getSegment().readTemplate(offset));
     }
 
     private static String safeEncode(String value) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/ReaderCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/ReaderCache.java
@@ -23,6 +23,7 @@ import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull
 import static org.apache.jackrabbit.oak.segment.CacheWeights.OBJECT_HEADER_SIZE;
 
 import java.util.Arrays;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
@@ -30,7 +31,7 @@ import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 
 /**
  * A cache consisting of a fast and slow component. The fast cache for small items is based

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Revisions.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Revisions.java
@@ -16,10 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.segment;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriterCacheManager.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriterCacheManager.java
@@ -36,7 +36,6 @@ import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Supplier;
 
@@ -281,12 +280,8 @@ public abstract class WriterCacheManager {
             @NotNull
             @Override
             public Iterator<T> iterator() {
-                return transform(generations.values().iterator(), new Function<Supplier<T>, T>() {
-                    @Nullable @Override
-                    public T apply(Supplier<T> cacheFactory) {
-                        return cacheFactory.get();
-                    }
-                });
+                return transform(generations.values().iterator(),
+                        cacheFactory -> cacheFactory.get());
             }
 
             void evictGenerations(@NotNull Predicate<Integer> evict) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/ReadOnlyRevisions.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/ReadOnlyRevisions.java
@@ -25,8 +25,8 @@ import static org.apache.jackrabbit.oak.segment.file.FileStoreUtil.findPersisted
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.segment.RecordId;
 import org.apache.jackrabbit.oak.segment.Revisions;
 import org.apache.jackrabbit.oak.segment.SegmentIdProvider;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/TarRevisions.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/TarRevisions.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.file;
 
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
@@ -32,8 +31,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Supplier;
 import org.apache.jackrabbit.oak.segment.RecordId;
 import org.apache.jackrabbit.oak.segment.Revisions;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tooling/RevisionHistory.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tooling/RevisionHistory.java
@@ -27,8 +27,8 @@ import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreB
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.oak.json.BlobSerializer;
 import org.apache.jackrabbit.oak.json.JsonSerializer;
@@ -88,7 +88,7 @@ public class RevisionHistory {
                             NodeState node = getNode(store.getHead(), path);
                             return new HistoryElement(entry.getRevision(), node);
                         }
-                });
+                }::apply);
         }
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tooling/RevisionHistory.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tooling/RevisionHistory.java
@@ -27,7 +27,6 @@ import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreB
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.oak.json.BlobSerializer;
@@ -35,7 +34,6 @@ import org.apache.jackrabbit.oak.json.JsonSerializer;
 import org.apache.jackrabbit.oak.segment.SegmentNodeState;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
-import org.apache.jackrabbit.oak.segment.file.JournalEntry;
 import org.apache.jackrabbit.oak.segment.file.JournalReader;
 import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -80,15 +78,11 @@ public class RevisionHistory {
         checkNotNull(path);
 
         try (JournalReader journalReader = new JournalReader(checkNotNull(journal))) {
-            return Iterators.transform(journalReader,
-                    new Function<JournalEntry, HistoryElement>() {
-                        @NotNull @Override
-                        public HistoryElement apply(JournalEntry entry) {
+            return Iterators.transform(journalReader, entry -> {
                             store.setRevision(entry.getRevision());
                             NodeState node = getNode(store.getHead(), path);
                             return new HistoryElement(entry.getRevision(), node);
-                        }
-                }::apply);
+                        });
         }
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/memory/MemoryStoreRevisions.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/memory/MemoryStoreRevisions.java
@@ -23,8 +23,8 @@ import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 
 import java.io.IOException;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.segment.RecordId;
 import org.apache.jackrabbit.oak.segment.Revisions;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/PrintingDiff.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/PrintingDiff.java
@@ -28,8 +28,8 @@ import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.MISSING_NODE;
 
 import java.io.PrintWriter;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -112,7 +112,7 @@ final class PrintingDiff implements NodeStateDiff {
             String v = BLOB_LENGTH.apply(ps.getValue(BINARY));
             val.append(" = {").append(v).append("}");
         } else if (ps.getType() == BINARIES) {
-            String v = transform(ps.getValue(BINARIES), BLOB_LENGTH).toString();
+            String v = transform(ps.getValue(BINARIES), BLOB_LENGTH::apply).toString();
             val.append("[").append(ps.count()).append("] = ").append(v);
         } else if (ps.isArray()) {
             val.append("[").append(ps.count()).append("] = ").append(ps.getValue(STRINGS));

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/Utils.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/Utils.java
@@ -26,20 +26,17 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.oak.commons.json.JsonObject;
 import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
 import org.apache.jackrabbit.oak.segment.SegmentId;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
-import org.apache.jackrabbit.oak.segment.file.JournalEntry;
 import org.apache.jackrabbit.oak.segment.file.JournalReader;
 import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
 import org.apache.jackrabbit.oak.segment.file.tar.LocalJournalFile;
 import org.apache.jackrabbit.oak.segment.file.tooling.BasicReadOnlyBlobStore;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
-import org.jetbrains.annotations.NotNull;
 
 public final class Utils {
 
@@ -77,13 +74,8 @@ public final class Utils {
 
         if (journal.exists()) {
             try (JournalReader journalReader = new JournalReader(journal)) {
-                Iterator<String> revisionIterator = Iterators.transform(journalReader, new Function<JournalEntry, String>() {
-                    @NotNull
-                    @Override
-                    public String apply(JournalEntry entry) {
-                        return entry.getRevision();
-                    }
-                });
+                Iterator<String> revisionIterator = Iterators.transform(journalReader,
+                        entry -> entry.getRevision());
                 return newArrayList(revisionIterator);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/ReaderCacheTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/ReaderCacheTest.java
@@ -28,8 +28,6 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 public class ReaderCacheTest {
@@ -37,12 +35,9 @@ public class ReaderCacheTest {
     @Test
     public void empty() {
         final AtomicInteger counter = new AtomicInteger();
-        Function<Integer, String> loader = new Function<Integer, String>() {
-            @Override @NotNull
-            public String apply(@Nullable Integer input) {
+        Function<Integer, String> loader = input -> {
                 counter.incrementAndGet();
                 return valueOf(input);
-            }
         };
         StringCache c = new StringCache(0);
         for (int repeat = 0; repeat < 10; repeat++) {
@@ -60,12 +55,9 @@ public class ReaderCacheTest {
     public void largeEntries() {
         final AtomicInteger counter = new AtomicInteger();
         final String large = new String(new char[1024]);
-        Function<Integer, String> loader = new Function<Integer, String>() {
-            @Override @Nullable
-            public String apply(@Nullable Integer input) {
+        Function<Integer, String> loader = input -> {
                 counter.incrementAndGet();
                 return large + input;
-            }
         };
         StringCache c = new StringCache(1024);
         for (int repeat = 0; repeat < 10; repeat++) {
@@ -83,12 +75,7 @@ public class ReaderCacheTest {
     @Test
     public void clear() {
         final AtomicInteger counter = new AtomicInteger();
-        Function<Integer, String> uniqueLoader = new Function<Integer, String>() {
-            @Override @Nullable
-            public String apply(@Nullable Integer input) {
-                return valueOf(counter.incrementAndGet());
-            }
-        };
+        Function<Integer, String> uniqueLoader = input -> valueOf(counter.incrementAndGet());
         StringCache c = new StringCache(0);
         // load a new entry
         assertEquals("1", c.get(0, 0, 0, uniqueLoader));
@@ -106,12 +93,7 @@ public class ReaderCacheTest {
         int segmentCount = 10;
         for (int i = 0; i < segmentCount; i++) {
             final int x = i;
-            Function<Integer, String> loader = new Function<Integer, String>() {
-                @Override @Nullable
-                public String apply(@Nullable Integer input) {
-                    return "loader #" + x + " offset " + input;
-                }
-            };
+            Function<Integer, String> loader = input -> "loader #" + x + " offset " + input;
             loaderList.add(loader);
         }
         StringCache c = new StringCache(10);

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/ReaderCacheTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/ReaderCacheTest.java
@@ -26,12 +26,11 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
-
-import org.apache.jackrabbit.guava.common.base.Function;
 
 public class ReaderCacheTest {
 

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/TarRevisionsTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/TarRevisionsTest.java
@@ -34,8 +34,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Functions;
 import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
 import org.apache.jackrabbit.guava.common.util.concurrent.ListeningExecutorService;

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/CompositeChildrenCountTest.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/CompositeChildrenCountTest.java
@@ -34,12 +34,10 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.apache.jackrabbit.guava.common.collect.Iterables.cycle;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.limit;
@@ -240,14 +238,10 @@ public class CompositeChildrenCountTest {
         }
 
         private <T> Iterable<T> asCountingIterable(Iterable<T> input) {
-            return Iterables.transform(input, new Function<T, T>() {
-                @Nullable
-                @Override
-                public T apply(@Nullable T input) {
+            return Iterables.transform(input, inp -> {
                     fetchedChildren++;
-                    return input;
-                }
-            }::apply);
+                    return inp;
+            });
         }
     }
 }

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/CompositeChildrenCountTest.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/CompositeChildrenCountTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.composite;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 
@@ -40,6 +39,7 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.apache.jackrabbit.guava.common.collect.Iterables.cycle;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.limit;
@@ -224,13 +224,7 @@ public class CompositeChildrenCountTest {
                 Iterable<? extends ChildNodeEntry> childrenIterable = cycle(new MemoryChildNodeEntry("child", EMPTY_NODE));
                 return asCountingIterable(limit(childrenIterable, childrenCount == MAX_VALUE ? 1000 : (int) childrenCount));
             } else {
-                return asCountingIterable(transform(asList(children), new Function<String, ChildNodeEntry>() {
-                    @Nullable
-                    @Override
-                    public ChildNodeEntry apply(@Nullable String input) {
-                        return new MemoryChildNodeEntry(input, EMPTY_NODE);
-                    }
-                }));
+                return asCountingIterable(transform(asList(children), input -> new MemoryChildNodeEntry(input, EMPTY_NODE)));
             }
         }
 
@@ -253,7 +247,7 @@ public class CompositeChildrenCountTest {
                     fetchedChildren++;
                     return input;
                 }
-            });
+            }::apply);
         }
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Branch.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Branch.java
@@ -31,7 +31,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
@@ -279,12 +278,7 @@ class Branch {
                 return !input.getValue().isRebase()
                         && input.getKey().compareRevisionTime(r) <= 0;
             }
-        }), new Function<Map.Entry<Revision, BranchCommit>, Iterable<Path>>() {
-            @Override
-            public Iterable<Path> apply(Map.Entry<Revision, BranchCommit> input) {
-                return input.getValue().getModifiedPaths();
-            }
-        });
+        }), input -> input.getValue().getModifiedPaths());
         return Iterables.concat(paths);
     }
 
@@ -412,12 +406,7 @@ class Branch {
         @Override
         Iterable<Path> getModifiedPaths() {
             Iterable<Iterable<Path>> paths = transform(previous.values(),
-                    new Function<BranchCommit, Iterable<Path>>() {
-                @Override
-                public Iterable<Path> apply(BranchCommit branchCommit) {
-                    return branchCommit.getModifiedPaths();
-                }
-            });
+                    branchCommit -> branchCommit.getModifiedPaths());
             return Iterables.concat(paths);
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.oak.commons.json.JsopStream;
@@ -891,16 +890,8 @@ public class Commit {
         return bundledNodes.containsKey(path);
     }
 
-    private static final Function<UpdateOp.Key, String> KEY_TO_NAME =
-            new Function<UpdateOp.Key, String>() {
-        @Override
-        public String apply(UpdateOp.Key input) {
-            return input.getName();
-        }
-    };
-
     private static boolean hasContentChanges(UpdateOp op) {
         return filter(transform(op.getChanges().keySet(),
-                KEY_TO_NAME), Utils.PROPERTY_OR_DELETED).iterator().hasNext();
+                input -> input.getName()), Utils.PROPERTY_OR_DELETED).iterator().hasNext();
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeState.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.guava.common.collect.TreeTraverser;
@@ -47,7 +48,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
 
@@ -590,7 +591,7 @@ public class DocumentNodeState extends AbstractDocumentNodeState implements Cach
                     }
                 };
             }
-        });
+        }::apply);
     }
 
     private static Map<String, PropertyState> asMap(Iterable<? extends PropertyState> props){
@@ -772,7 +773,7 @@ public class DocumentNodeState extends AbstractDocumentNodeState implements Cach
                     }
                 };
             }
-        });
+        }::apply);
     }
 
     private static BundlingContext createBundlingContext(Map<String, PropertyState> properties,

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeState.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.guava.common.collect.TreeTraverser;
@@ -47,7 +46,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
@@ -574,24 +572,19 @@ public class DocumentNodeState extends AbstractDocumentNodeState implements Cach
     private Iterable<ChildNodeEntry> getChildNodeEntries(@NotNull String name,
                                                          int limit) {
         Iterable<? extends AbstractDocumentNodeState> children = store.getChildNodes(this, name, limit);
-        return Iterables.transform(children, new Function<AbstractDocumentNodeState, ChildNodeEntry>() {
-            @Override
-            public ChildNodeEntry apply(final AbstractDocumentNodeState input) {
+        return Iterables.transform(children, input -> {
                 return new AbstractChildNodeEntry() {
-                    @NotNull
                     @Override
                     public String getName() {
                         return input.getPath().getName();
                     }
 
-                    @NotNull
                     @Override
                     public NodeState getNodeState() {
                         return input;
                     }
                 };
-            }
-        }::apply);
+            });
     }
 
     private static Map<String, PropertyState> asMap(Iterable<? extends PropertyState> props){
@@ -755,25 +748,19 @@ public class DocumentNodeState extends AbstractDocumentNodeState implements Cach
     }
 
     private Iterator<ChildNodeEntry> getBundledChildren(){
-        return Iterators.transform(bundlingContext.getBundledChildNodeNames().iterator(),
-                new Function<String, ChildNodeEntry>() {
-            @Override
-            public ChildNodeEntry apply(final String childNodeName) {
+        return Iterators.transform(bundlingContext.getBundledChildNodeNames().iterator(), childNodeName -> {
                 return new AbstractChildNodeEntry() {
-                    @NotNull
                     @Override
                     public String getName() {
                         return childNodeName;
                     }
 
-                    @NotNull
                     @Override
                     public NodeState getNodeState() {
                         return createBundledState(childNodeName, bundlingContext.matcher.next(childNodeName));
                     }
                 };
-            }
-        }::apply);
+        });
     }
 
     private static BundlingContext createBundlingContext(Map<String, PropertyState> properties,

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -67,6 +67,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import javax.jcr.PropertyType;
 
@@ -126,7 +127,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.base.Strings;
@@ -493,7 +494,7 @@ public final class DocumentNodeStore
     };
 
     /**
-     * A predicate, which takes a String and returns {@code true} if the String
+     * A function, which takes a String and returns {@code true} if the String
      * is a serialized binary value of a {@link DocumentPropertyState}. The
      * apply method will throw an IllegalArgumentException if the String is
      * malformed.
@@ -1629,7 +1630,7 @@ public final class DocumentNodeStore
                     return e.toString();
                 }
             }
-        });
+        }::apply);
     }
 
     @Nullable
@@ -2229,12 +2230,7 @@ public final class DocumentNodeStore
             public boolean apply(Map.Entry<Revision,Checkpoints.Info> cp) {
                 return cp.getValue().getExpiryTime() > now;
             }
-        }), new Function<Map.Entry<Revision,Checkpoints.Info>, String>() {
-            @Override
-            public String apply(Map.Entry<Revision,Checkpoints.Info> cp) {
-                return cp.getKey().toString();
-            }
-        });
+        }), cp -> cp.getKey().toString());
     }
 
     @Nullable
@@ -2673,7 +2669,7 @@ public final class DocumentNodeStore
                 continue;
             }
             cleanCollisions(doc, collisionGarbageBatchSize);
-            Iterator<UpdateOp> it = doc.split(this, head, binarySize).iterator();
+            Iterator<UpdateOp> it = doc.split(this, head, binarySize::apply).iterator();
             while(it.hasNext()) {
                 UpdateOp op = it.next();
                 Path path = doc.getPath();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -493,19 +493,6 @@ public final class DocumentNodeStore
         }
     };
 
-    /**
-     * A function, which takes a String and returns {@code true} if the String
-     * is a serialized binary value of a {@link DocumentPropertyState}. The
-     * apply method will throw an IllegalArgumentException if the String is
-     * malformed.
-     */
-    private final Function<String, Long> binarySize = new Function<String, Long>() {
-        @Override
-        public Long apply(@Nullable String input) {
-            return getBinarySize(input);
-        }
-    };
-
     private final Clock clock;
 
     private final Checkpoints checkpoints;
@@ -2669,7 +2656,7 @@ public final class DocumentNodeStore
                 continue;
             }
             cleanCollisions(doc, collisionGarbageBatchSize);
-            Iterator<UpdateOp> it = doc.split(this, head, binarySize::apply).iterator();
+            Iterator<UpdateOp> it = doc.split(this, head, input -> getBinarySize(input)).iterator();
             while(it.hasNext()) {
                 UpdateOp op = it.next();
                 Path path = doc.getPath();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBranch.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBranch.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 
@@ -752,12 +751,7 @@ class DocumentNodeStoreBranch implements NodeStoreBranch {
             NodeDocument doc = Utils.getRootDocument(store.getDocumentStore());
             Set<Revision> collisions = Sets.newHashSet(doc.getLocalMap(COLLISIONS).keySet());
             Set<Revision> commits = Sets.newHashSet(Iterables.transform(b.getCommits(),
-                    new Function<Revision, Revision>() {
-                        @Override
-                        public Revision apply(Revision input) {
-                            return input.asTrunkRevision();
-                        }
-                    }));
+                    input -> input.asTrunkRevision()));
             Set<Revision> conflicts = Sets.intersection(collisions, commits);
             if (!conflicts.isEmpty()) {
                 throw new CommitFailedException(STATE, 2,

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreMBeanImpl.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreMBeanImpl.java
@@ -24,7 +24,6 @@ import java.util.TimeZone;
 
 import javax.management.openmbean.CompositeData;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 
 import org.apache.jackrabbit.api.stats.RepositoryStatistics;
@@ -96,12 +95,7 @@ final class DocumentNodeStoreMBeanImpl extends AnnotatedStandardMBean implements
             public boolean apply(ClusterNodeInfoDocument input) {
                 return !input.isActive();
             }
-        }), new Function<ClusterNodeInfoDocument, String>() {
-            @Override
-            public String apply(ClusterNodeInfoDocument input) {
-                return input.getClusterId() + "=" + input.getCreated();
-            }
-        }), String.class);
+        }), input -> input.getClusterId() + "=" + input.getCreated()), String.class);
     }
 
     @Override
@@ -112,12 +106,7 @@ final class DocumentNodeStoreMBeanImpl extends AnnotatedStandardMBean implements
             public boolean apply(ClusterNodeInfoDocument input) {
                 return input.isActive();
             }
-        }), new Function<ClusterNodeInfoDocument, String>() {
-            @Override
-            public String apply(ClusterNodeInfoDocument input) {
-                return input.getClusterId() + "=" + input.getLeaseEndTime();
-            }
-        }), String.class);
+        }), input -> input.getClusterId() + "=" + input.getLeaseEndTime()), String.class);
     }
 
     @Override
@@ -128,12 +117,7 @@ final class DocumentNodeStoreMBeanImpl extends AnnotatedStandardMBean implements
             public boolean apply(Revision input) {
                 return input.getClusterId() != getClusterId();
             }
-        }), new Function<Revision, String>() {
-            @Override
-            public String apply(Revision input) {
-                return input.getClusterId() + "=" + input.toString();
-            }
-        }), String.class);
+        }), input -> input.getClusterId() + "=" + input.toString()), String.class);
     }
 
     @Override

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/MissingBcSweeper2.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/MissingBcSweeper2.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.oak.commons.TimeDurationFormatter;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
@@ -38,7 +39,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 
 /**
@@ -161,7 +161,7 @@ final class MissingBcSweeper2 {
                 }
                 return immutableEntry(doc.getPath(), sweepOne(doc));
             }
-        }), new Predicate<Map.Entry<Path, UpdateOp>>() {
+        }::apply), new Predicate<Map.Entry<Path, UpdateOp>>() {
             @Override
             public boolean apply(Map.Entry<Path, UpdateOp> input) {
                 return input.getValue() != null;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
@@ -1351,16 +1351,12 @@ public final class NodeDocument extends Document {
             }
 
             // didn't find entry -> scan through remaining head ranges
-            return filter(transform(getPreviousRanges().headMap(revision).entrySet(),
-                    new Function<Map.Entry<Revision, Range>, NodeDocument>() {
-                @Override
-                public NodeDocument apply(Map.Entry<Revision, Range> input) {
+            return filter(transform(getPreviousRanges().headMap(revision).entrySet(), input -> {
                     if (input.getValue().includes(revision)) {
                        return getPreviousDoc(input.getKey(), input.getValue());
                     }
                     return null;
-                }
-            }::apply), new Predicate<NodeDocument>() {
+                }), new Predicate<NodeDocument>() {
                 @Override
                 public boolean apply(@Nullable NodeDocument input) {
                     return input != null && input.getValueMap(property).containsKey(revision);
@@ -1659,17 +1655,14 @@ public final class NodeDocument extends Document {
         if (ranges.isEmpty()) {
             return Collections.emptyList();
         }
-        final Function<Range, Iterable<Map.Entry<Revision, String>>> rangeToChanges =
-                new Function<Range, Iterable<Map.Entry<Revision, String>>>() {
-            @Override
-            public Iterable<Map.Entry<Revision, String>> apply(Range input) {
+
+        final Function<Range, Iterable<Map.Entry<Revision, String>>> rangeToChanges = input -> {
                 NodeDocument doc = getPreviousDoc(input.high, input);
                 if (doc == null) {
                     return Collections.emptyList();
                 }
                 return doc.getVisibleChanges(property, readRev);
-            }
-        };
+            };
 
         Iterable<Map.Entry<Revision, String>> changes;
         if (ranges.size() == 1) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
@@ -33,8 +33,8 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
@@ -1360,7 +1360,7 @@ public final class NodeDocument extends Document {
                     }
                     return null;
                 }
-            }), new Predicate<NodeDocument>() {
+            }::apply), new Predicate<NodeDocument>() {
                 @Override
                 public boolean apply(@Nullable NodeDocument input) {
                     return input != null && input.getValueMap(property).containsKey(revision);
@@ -1682,7 +1682,7 @@ public final class NodeDocument extends Document {
                 }
             };
         } else {
-            changes = Iterables.concat(transform(copyOf(ranges), rangeToChanges));
+            changes = Iterables.concat(transform(copyOf(ranges), rangeToChanges::apply));
         }
         return filter(changes, new Predicate<Entry<Revision, String>>() {
             @Override
@@ -1786,12 +1786,7 @@ public final class NodeDocument extends Document {
     @NotNull
     RevisionVector getSweepRevisions() {
         return new RevisionVector(transform(getLocalMap(SWEEP_REV).values(),
-                new Function<String, Revision>() {
-                    @Override
-                    public Revision apply(String s) {
-                        return Revision.fromString(s);
-                    }
-                }));
+                s -> Revision.fromString(s)));
     }
 
     //-------------------------< UpdateOp modifiers >---------------------------

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocumentSweeper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocumentSweeper.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 
 import org.apache.jackrabbit.oak.commons.TimeDurationFormatter;
@@ -165,18 +164,13 @@ final class NodeDocumentSweeper {
 
     private Iterable<Map.Entry<Path, UpdateOp>> sweepOperations(
             final Iterable<NodeDocument> docs) {
-        return filter(transform(docs,
-                new Function<NodeDocument, Map.Entry<Path, UpdateOp>>() {
-            @Override
-            public Map.Entry<Path, UpdateOp> apply(NodeDocument doc) {
-                return immutableEntry(doc.getPath(), sweepOne(doc));
-            }
-        }), new Predicate<Map.Entry<Path, UpdateOp>>() {
-            @Override
-            public boolean apply(Map.Entry<Path, UpdateOp> input) {
-                return input.getValue() != null;
-            }
-        });
+        return filter(transform(docs, doc -> immutableEntry(doc.getPath(), sweepOne(doc))),
+                new Predicate<Map.Entry<Path, UpdateOp>>() {
+                    @Override
+                    public boolean apply(Map.Entry<Path, UpdateOp> input) {
+                        return input.getValue() != null;
+                    }
+                });
     }
 
     private UpdateOp sweepOne(NodeDocument doc) throws DocumentStoreException {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/PropertyHistory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/PropertyHistory.java
@@ -24,8 +24,8 @@ import static java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicates;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
@@ -73,7 +73,7 @@ class PropertyHistory implements Iterable<NodeDocument> {
                 }
                 return new SimpleImmutableEntry<Revision, NodeDocument>(r, prev);
             }
-        }), Predicates.notNull()));
+        }::apply), Predicates.notNull()));
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/PropertyHistory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/PropertyHistory.java
@@ -24,7 +24,6 @@ import static java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.base.Predicates;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
@@ -58,11 +57,7 @@ class PropertyHistory implements Iterable<NodeDocument> {
 
     @Override
     public Iterator<NodeDocument> iterator() {
-        return ensureOrder(filter(transform(doc.getPreviousRanges().entrySet(),
-                new Function<Map.Entry<Revision, Range>, Map.Entry<Revision, NodeDocument>>() {
-            @Nullable
-            @Override
-            public Map.Entry<Revision, NodeDocument> apply(Map.Entry<Revision, Range> input) {
+        return ensureOrder(filter(transform(doc.getPreviousRanges().entrySet(), input -> {
                 Revision r = input.getKey();
                 int h = input.getValue().height;
                 String prevId = Utils.getPreviousIdFor(mainPath, r, h);
@@ -72,8 +67,7 @@ class PropertyHistory implements Iterable<NodeDocument> {
                     return null;
                 }
                 return new SimpleImmutableEntry<Revision, NodeDocument>(r, prev);
-            }
-        }::apply), Predicates.notNull()));
+            }), Predicates.notNull()));
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/SplitOperations.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/SplitOperations.java
@@ -26,6 +26,7 @@ import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
@@ -34,7 +35,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Supplier;
 import org.apache.jackrabbit.guava.common.base.Suppliers;
@@ -233,7 +233,7 @@ class SplitOperations {
     }
 
     private boolean hasBinaryPropertyForSplit(Iterable<String> values) {
-        return doc.hasBinary() && any(transform(values, binarySize), BINARY_FOR_SPLIT_THRESHOLD);
+        return doc.hasBinary() && any(transform(values, binarySize::apply), BINARY_FOR_SPLIT_THRESHOLD);
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UnsavedModifications.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UnsavedModifications.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.base.Supplier;
@@ -120,12 +119,7 @@ class UnsavedModifications {
                 public boolean apply(Map.Entry<Path, Revision> input) {
                     return start.compareRevisionTime(input.getValue()) < 1;
                 }
-            }), new Function<Map.Entry<Path, Revision>, Path>() {
-                @Override
-                public Path apply(Map.Entry<Path, Revision> input) {
-                    return input.getKey();
-                }
-            });
+            }), input -> input.getKey());
         }
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
@@ -51,7 +50,6 @@ import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 
 import org.apache.jackrabbit.oak.commons.sort.StringSort;
-import org.apache.jackrabbit.oak.plugins.document.NodeDocument.SplitDocType;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Key;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Operation;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Operation.Type;
@@ -2271,22 +2269,11 @@ public class VersionGarbageCollector {
                 // documents only.
                 final Path path = doc.getPath();
                 return Iterators.transform(prevRanges.entrySet().iterator(),
-                        new Function<Map.Entry<Revision, Range>, String>() {
-                    @Override
-                    public String apply(Map.Entry<Revision, Range> input) {
-                        int h = input.getValue().getHeight();
-                        return Utils.getPreviousIdFor(path, input.getKey(), h);
-                    }
-                });
+                        input -> Utils.getPreviousIdFor(path, input.getKey(), input.getValue().getHeight()));
             } else {
                 // need to fetch the previous documents to get their ids
                 return Iterators.transform(doc.getAllPreviousDocs(),
-                        new Function<NodeDocument, String>() {
-                    @Override
-                    public String apply(NodeDocument input) {
-                        return input.getId();
-                    }
-                });
+                        input -> input.getId());
             }
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -93,7 +93,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
@@ -1365,20 +1364,10 @@ public class MongoDocumentStore implements DocumentStore {
             }
         } catch (MongoException e) {
             throw handleException(e, collection, Iterables.transform(updateOps,
-                    new Function<UpdateOp, String>() {
-                @Override
-                public String apply(UpdateOp input) {
-                    return input.getId();
-                }
-            }));
+                    input -> input.getId()));
         } finally {
             stats.doneCreateOrUpdate(watch.elapsed(TimeUnit.NANOSECONDS),
-                    collection, Lists.transform(updateOps, new Function<UpdateOp, String>() {
-                @Override
-                public String apply(UpdateOp input) {
-                    return input.getId();
-                }
-            }));
+                    collection, Lists.transform(updateOps, input -> input.getId()));
         }
         List<T> resultList = new ArrayList<T>(results.values());
         log("createOrUpdate returns", resultList);
@@ -1538,12 +1527,7 @@ public class MongoDocumentStore implements DocumentStore {
     }
 
     private static Map<String, UpdateOp> createMap(List<UpdateOp> updateOps) {
-        return Maps.uniqueIndex(updateOps, new Function<UpdateOp, String>() {
-            @Override
-            public String apply(UpdateOp input) {
-                return input.getId();
-            }
-        });
+        return Maps.uniqueIndex(updateOps, input -> input.getId());
     }
 
     private <T extends Document> Map<String, T> findDocuments(Collection<T> collection, Set<String> keys) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.document.mongo;
 
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.exists;
 import static com.mongodb.client.model.Filters.gt;
-import static com.mongodb.client.model.Filters.not;
 import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Projections.include;
 import static java.util.Optional.empty;
@@ -73,7 +71,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.StandardSystemProperty;
@@ -337,17 +334,13 @@ public class MongoVersionGCSupport extends VersionGCSupport {
             // queries alone (15min is still long).
             Iterable<NodeDocument> iterable = filter(transform(getNodeCollection().find(query)
                     .maxTime(15, TimeUnit.MINUTES).hint(hint),
-                    new Function<BasicDBObject, NodeDocument>() {
-                @Override
-                public NodeDocument apply(BasicDBObject input) {
-                    return store.convertFromDBObject(NODES, input);
-                }
-            }), new Predicate<NodeDocument>() {
-                @Override
-                public boolean apply(NodeDocument input) {
-                    return !isDefaultNoBranchSplitNewerThan(input, sweepRevs);
-                }
-            });
+                    input -> store.convertFromDBObject(NODES, input)),
+                    new Predicate<NodeDocument>() {
+                        @Override
+                        public boolean apply(NodeDocument input) {
+                            return !isDefaultNoBranchSplitNewerThan(input, sweepRevs);
+                        }
+                    });
             allResults = concat(allResults, iterable);
         }
         return allResults;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCache.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.cache.CacheStats;
@@ -51,8 +52,6 @@ import org.h2.mvstore.type.DataType;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.jackrabbit.guava.common.base.Function;
 
 class NodeCache<K extends CacheValue, V extends  CacheValue>
         implements Cache<K, V>, GenerationCache, EvictionListener<K, V> {
@@ -175,7 +174,7 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
                 }
                 return null;
             }
-        });
+        }::apply);
     }
 
     private void write(final K key, final V value) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCache.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.cache.CacheStats;
@@ -47,7 +46,6 @@ import org.apache.jackrabbit.oak.plugins.document.persistentCache.async.CacheWri
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.apache.jackrabbit.oak.stats.TimerStats;
 import org.h2.mvstore.MVMap;
-import org.h2.mvstore.WriteBuffer;
 import org.h2.mvstore.type.DataType;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -161,10 +159,7 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
     }
 
     private void broadcast(final K key, final V value) {
-        cache.broadcast(type, new Function<WriteBuffer, Void>() {
-            @Override
-            @Nullable
-            public Void apply(@Nullable WriteBuffer buffer) {
+        cache.broadcast(type, buffer -> {
                 keyType.write(buffer, key);
                 if (value == null) {
                     buffer.put((byte) 0);
@@ -173,8 +168,7 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
                     valueType.write(buffer, value);
                 }
                 return null;
-            }
-        }::apply);
+            });
     }
 
     private void write(final K key, final V value) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/PersistentCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/PersistentCache.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheValue;
@@ -45,8 +46,6 @@ import org.h2.mvstore.MVStoreTool;
 import org.h2.mvstore.WriteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.jackrabbit.guava.common.base.Function;
 
 /**
  * A persistent cache for the document store.

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/PersistentCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/PersistentCache.java
@@ -51,13 +51,13 @@ import org.slf4j.LoggerFactory;
  * A persistent cache for the document store.
  */
 public class PersistentCache implements Broadcaster.Listener {
-    
+
     static final Logger LOG = LoggerFactory.getLogger(PersistentCache.class);
 
     private static final String FILE_PREFIX = "cache-";
     private static final String FILE_SUFFIX = ".data";
     private static final AtomicInteger COUNTER = new AtomicInteger();
-    
+
     private boolean cacheNodes = true;
     private boolean cacheChildren = true;
     private boolean cacheDiff = true;
@@ -69,7 +69,7 @@ public class PersistentCache implements Broadcaster.Listener {
     private boolean asyncDiffCache = false;
     private HashMap<CacheType, GenerationCache> caches = 
             new HashMap<CacheType, GenerationCache>();
-    
+
     private final String directory;
     private MapFactory writeStore;
     private MapFactory readStore;
@@ -86,7 +86,7 @@ public class PersistentCache implements Broadcaster.Listener {
     private DynamicBroadcastConfig broadcastConfig;
     private CacheActionDispatcher writeDispatcher;
     private Thread writeDispatcherThread;
-    
+
     {
         ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
         UUID uuid = UUID.randomUUID();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStore.java
@@ -88,7 +88,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
@@ -446,12 +445,7 @@ public class RDBDocumentStore implements DocumentStore {
             }
         }
         stats.doneCreateOrUpdate(watch.elapsed(TimeUnit.NANOSECONDS),
-                collection, Lists.transform(updateOps, new Function<UpdateOp, String>() {
-                    @Override
-                    public String apply(UpdateOp input) {
-                        return input.getId();
-                    }
-                }));
+                collection, Lists.transform(updateOps, input -> input.getId()));
         return new ArrayList<T>(results.values());
     }
 
@@ -1866,12 +1860,7 @@ public class RDBDocumentStore implements DocumentStore {
                     Iterator<RDBRow> res = db.queryAsIterator(ch, tmd, from, to, excludeKeyPatterns, conditions,
                             limit, sortBy);
                     returned.add(res);
-                    Iterator<T> tmp = Iterators.transform(res, new Function<RDBRow, T>() {
-                        @Override
-                        public T apply(RDBRow input) {
-                            return convertFromDBObject(collection, input);
-                        }
-                    });
+                    Iterator<T> tmp = Iterators.transform(res, input -> convertFromDBObject(collection, input));
                     return CloseableIterator.wrap(tmp, (Closeable) res);
                 } catch (SQLException ex) {
                     throw new RuntimeException(ex);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStoreJDBC.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStoreJDBC.java
@@ -61,7 +61,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -432,7 +431,7 @@ public class RDBDocumentStoreJDBC {
     }
 
     private static <T extends Document> void assertNoDuplicatedIds(List<T> documents) {
-        if (newHashSet(transform(documents, idExtractor)).size() < documents.size()) {
+        if (newHashSet(transform(documents, input -> input.getId())).size() < documents.size()) {
             throw new IllegalArgumentException("There are duplicated ids in the document list");
         }
     }
@@ -1127,11 +1126,4 @@ public class RDBDocumentStoreJDBC {
         });
         return result;
     }
-
-    private static final Function<Document, String> idExtractor = new Function<Document, String>() {
-        @Override
-        public String apply(Document input) {
-            return input.getId();
-        }
-    };
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/secondary/DelegatingDocumentNodeState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/secondary/DelegatingDocumentNodeState.java
@@ -19,7 +19,7 @@
 
 package org.apache.jackrabbit.oak.plugins.document.secondary;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -178,13 +178,8 @@ public class DelegatingDocumentNodeState extends AbstractDocumentNodeState {
     @NotNull
     @Override
     public Iterable<? extends ChildNodeEntry> getChildNodeEntries() {
-        return Iterables.transform(delegate.getChildNodeEntries(), new Function<ChildNodeEntry, ChildNodeEntry>() {
-            @Nullable
-            @Override
-            public ChildNodeEntry apply(ChildNodeEntry input) {
-                return new MemoryChildNodeEntry(input.getName(), decorate(input.getName(), input.getNodeState()));
-            }
-        });
+        return Iterables.transform(delegate.getChildNodeEntries(),
+                input -> new MemoryChildNodeEntry(input.getName(), decorate(input.getName(), input.getNodeState())));
     }
 
     @NotNull

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -38,7 +38,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.oak.commons.OakVersion;
@@ -983,12 +982,7 @@ public class Utils {
      */
     public static Iterable<StringValue> asStringValueIterable(
             @NotNull Iterable<String> values) {
-        return transform(values, new Function<String, StringValue>() {
-            @Override
-            public StringValue apply(String input) {
-                return new StringValue(input);
-            }
-        });
+        return transform(values, input -> new StringValue(input));
     }
 
     /**

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoVersionGCSupportDefaultNoBranchTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoVersionGCSupportDefaultNoBranchTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -58,7 +59,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Iterators;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/TestUtils.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/TestUtils.java
@@ -18,9 +18,8 @@ package org.apache.jackrabbit.oak.plugins.document;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NavigableMap;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Functions;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
@@ -97,7 +97,6 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
@@ -3275,12 +3274,7 @@ public class VersionGarbageCollectorIT {
         Long modCount = foo.getModCount();
         assertNotNull(modCount);
         List<String> prevIds = Lists.newArrayList(Iterators.transform(
-                foo.getPreviousDocLeaves(), new Function<NodeDocument, String>() {
-            @Override
-            public String apply(NodeDocument input) {
-                return input.getId();
-            }
-        }));
+                foo.getPreviousDocLeaves(), input -> input.getId()));
 
         // run gc on another document node store
         createSecondaryStore(LeaseCheckMode.LENIENT);

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MemoryChildNodeEntry.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MemoryChildNodeEntry.java
@@ -22,7 +22,6 @@ import static org.apache.jackrabbit.guava.common.base.Preconditions.checkNotNull
 
 import java.util.Map.Entry;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.spi.state.AbstractChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
@@ -33,16 +32,8 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
  */
 public class MemoryChildNodeEntry extends AbstractChildNodeEntry {
 
-    public static <E extends Entry<String, ? extends NodeState>> Iterable<ChildNodeEntry> iterable(
-            Iterable<E> set) {
-        return Iterables.transform(
-                set,
-                new Function<Entry<String, ? extends NodeState>, ChildNodeEntry>() {
-                    @Override
-                    public ChildNodeEntry apply(Entry<String, ? extends NodeState> entry) {
-                        return new MemoryChildNodeEntry(entry.getKey(), entry.getValue());
-                    }
-                });
+    public static <E extends Entry<String, ? extends NodeState>> Iterable<ChildNodeEntry> iterable(Iterable<E> set) {
+        return Iterables.transform(set, entry -> new MemoryChildNodeEntry(entry.getKey(), entry.getValue()));
     }
 
     private final String name;

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/ModifiedNodeState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/ModifiedNodeState.java
@@ -39,7 +39,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateDiff;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import org.apache.jackrabbit.guava.common.base.Predicate;
 import org.apache.jackrabbit.guava.common.base.Predicates;

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/ModifiedNodeState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/ModifiedNodeState.java
@@ -30,8 +30,8 @@ import static org.apache.jackrabbit.oak.plugins.memory.MemoryChildNodeEntry.iter
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.spi.state.AbstractNodeState;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
@@ -52,17 +52,7 @@ public class ModifiedNodeState extends AbstractNodeState {
     /**
      * Mapping from a PropertyState instance to its name.
      */
-    private static final Function<PropertyState, String> GET_NAME =
-            new Function<PropertyState, String>() {
-                @Override @Nullable
-                public String apply(@Nullable PropertyState input) {
-                    if (input != null) {
-                        return input.getName();
-                    } else {
-                        return null;
-                    }
-                }
-            };
+    private static final Function<PropertyState, String> GET_NAME = input -> (input != null) ? input.getName() : null;
 
     /**
      * Unwraps the given {@code NodeState} instance into the given internals
@@ -180,7 +170,7 @@ public class ModifiedNodeState extends AbstractNodeState {
                 properties = newHashMap(properties);
             }
             Predicate<PropertyState> predicate = Predicates.compose(
-                    not(in(properties.keySet())), GET_NAME);
+                    not(in(properties.keySet())), GET_NAME::apply);
             return concat(
                     filter(base.getProperties(), predicate),
                     filter(properties.values(), notNull()));
@@ -361,7 +351,7 @@ public class ModifiedNodeState extends AbstractNodeState {
             return base.getChildNodeEntries(); // shortcut
         } else {
             Predicate<ChildNodeEntry> predicate = Predicates.compose(
-                    not(in(nodes.keySet())), ChildNodeEntry.GET_NAME);
+                    not(in(nodes.keySet())), ChildNodeEntry.GET_NAME::apply);
             return concat(
                     filter(base.getChildNodeEntries(), predicate),
                     iterable(filterValues(nodes, NodeState.EXISTS).entrySet()));

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiPropertyState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiPropertyState.java
@@ -21,15 +21,12 @@ package org.apache.jackrabbit.oak.plugins.memory;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 import javax.jcr.PropertyType;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
-import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.value.Conversions.Converter;
 import org.jetbrains.annotations.NotNull;
@@ -62,89 +59,29 @@ abstract class MultiPropertyState<T> extends EmptyPropertyState {
     private <S> S  convertTo(Type<S> type) {
         switch (type.tag()) {
             case PropertyType.STRING:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toString();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toString());
             case PropertyType.BINARY:
-                return (S) Iterables.transform(values, new Function<T, Blob>() {
-                    @Override
-                    public Blob apply(T value) {
-                        return getConverter(value).toBinary();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toBinary());
             case PropertyType.LONG:
-                return (S) Iterables.transform(values, new Function<T, Long>() {
-                    @Override
-                    public Long apply(T value) {
-                        return getConverter(value).toLong();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toLong());
             case PropertyType.DOUBLE:
-                return (S) Iterables.transform(values, new Function<T, Double>() {
-                    @Override
-                    public Double apply(T value) {
-                        return getConverter(value).toDouble();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toDouble());
             case PropertyType.DATE:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toDate();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toDate());
             case PropertyType.BOOLEAN:
-                return (S) Iterables.transform(values, new Function<T, Boolean>() {
-                    @Override
-                    public Boolean apply(T value) {
-                        return getConverter(value).toBoolean();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toBoolean());
             case PropertyType.NAME:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toString();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toString());
             case PropertyType.PATH:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toString();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toString());
             case PropertyType.REFERENCE:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toString();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toString());
             case PropertyType.WEAKREFERENCE:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toString();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toString());
             case PropertyType.URI:
-                return (S) Iterables.transform(values, new Function<T, String>() {
-                    @Override
-                    public String apply(T value) {
-                        return getConverter(value).toString();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toString());
             case PropertyType.DECIMAL:
-                return (S) Iterables.transform(values, new Function<T, BigDecimal>() {
-                    @Override
-                    public BigDecimal apply(T value) {
-                        return getConverter(value).toDecimal();
-                    }
-                });
+                return (S) Iterables.transform(values, value -> getConverter(value).toDecimal());
             default: throw new IllegalArgumentException("Unknown type:" + type);
         }
     }

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/commit/ProgressNotificationEditor.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/commit/ProgressNotificationEditor.java
@@ -21,7 +21,8 @@ package org.apache.jackrabbit.oak.spi.commit;
 
 import static org.apache.jackrabbit.oak.commons.PathUtils.concat;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+import java.util.function.Function;
+
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/state/AbstractNodeState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/state/AbstractNodeState.java
@@ -33,7 +33,6 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 
 /**
@@ -289,14 +288,7 @@ public abstract class AbstractNodeState implements NodeState {
 
     @Override
     public Iterable<String> getChildNodeNames() {
-        return Iterables.transform(
-                getChildNodeEntries(),
-                new Function<ChildNodeEntry, String>() {
-                    @Override
-                    public String apply(ChildNodeEntry input) {
-                        return input.getName();
-                    }
-                });
+        return Iterables.transform(getChildNodeEntries(), input -> input.getName());
     }
 
     /**

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/state/ChildNodeEntry.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/state/ChildNodeEntry.java
@@ -16,8 +16,7 @@
  */
 package org.apache.jackrabbit.oak.spi.state;
 
-
-import org.apache.jackrabbit.guava.common.base.Function;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/state/ChildNodeEntry.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/state/ChildNodeEntry.java
@@ -19,7 +19,6 @@ package org.apache.jackrabbit.oak.spi.state;
 import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * A {@code ChildNodeEntry} instance represents the child node states of a
@@ -53,15 +52,11 @@ public interface ChildNodeEntry {
      * Mapping from a ChildNodeEntry instance to its name.
      */
     Function<ChildNodeEntry, String> GET_NAME =
-            new Function<ChildNodeEntry, String>() {
-                @Override @Nullable
-                public String apply(@Nullable ChildNodeEntry input) {
+            input -> {
                     if (input != null) {
                         return input.getName();
                     } else {
                         return null;
                     }
-                }
-            };
-
+                };
 }

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/RepositoryUpgrade.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/RepositoryUpgrade.java
@@ -59,7 +59,7 @@ import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.jcr.nodetype.PropertyDefinitionTemplate;
 import javax.jcr.security.Privilege;
 
-import org.apache.jackrabbit.guava.common.base.Function;
+
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.collect.HashBiMap;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
@@ -144,7 +144,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermDocs;
 import org.apache.lucene.index.TermEnum;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -777,15 +776,8 @@ public class RepositoryUpgrade {
             while (it.hasNext()) {
                 Privilege aggrPriv = it.next();
 
-                List<String> aggrNames = Lists.transform(
-                        ImmutableList.copyOf(aggrPriv.getDeclaredAggregatePrivileges()),
-                        new Function<Privilege, String>() {
-                            @Nullable
-                            @Override
-                            public String apply(@Nullable Privilege input) {
-                                return (input == null) ? null : input.getName();
-                            }
-                        });
+                List<String> aggrNames = Lists.transform(ImmutableList.copyOf(aggrPriv.getDeclaredAggregatePrivileges()),
+                        input -> (input == null) ? null : input.getName());
                 if (allAggregatesRegistered(pMgr, aggrNames)) {
                     pMgr.registerPrivilege(aggrPriv.getName(), aggrPriv.isAbstract(), aggrNames.toArray(new String[aggrNames.size()]));
                     it.remove();

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/SameNameSiblingsEditor.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/SameNameSiblingsEditor.java
@@ -44,7 +44,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.base.Predicate;
 
 /**
@@ -172,12 +171,7 @@ public class SameNameSiblingsEditor extends DefaultEditor {
             public boolean apply(ChildNodeEntry input) {
                 return predicate.apply(input.getNodeState());
             }
-        }), new Function<ChildNodeEntry, String>() {
-            @Override
-            public String apply(ChildNodeEntry input) {
-                return input.getName();
-            }
-        });
+        }), input -> input.getName());
     }
 
     /**

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/checkpoint/CheckpointRetriever.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/checkpoint/CheckpointRetriever.java
@@ -18,21 +18,19 @@
  */
 package org.apache.jackrabbit.oak.upgrade.checkpoint;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.plugins.document.DocumentCheckpointRetriever;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.segment.CheckpointAccessor;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStore;
-import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.upgrade.cli.node.FileStoreUtils;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+
 public final class CheckpointRetriever {
 
     public static class Checkpoint implements Comparable<Checkpoint> {
@@ -88,12 +86,7 @@ public final class CheckpointRetriever {
     }
 
     private static List<Checkpoint> getCheckpoints(NodeState checkpointRoot) {
-        return Lists.newArrayList(Iterables.transform(checkpointRoot.getChildNodeEntries(), new Function<ChildNodeEntry, Checkpoint>() {
-            @Nullable
-            @Override
-            public Checkpoint apply(@Nullable ChildNodeEntry input) {
-                return Checkpoint.createFromSegmentNode(input.getName(), input.getNodeState());
-            }
-        }));
+        return Lists.newArrayList(Iterables.transform(checkpointRoot.getChildNodeEntries(),
+                input -> Checkpoint.createFromSegmentNode(input.getName(), input.getNodeState())));
     }
 }

--- a/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/AbstractOak2OakTest.java
+++ b/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/AbstractOak2OakTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.function.Function;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -39,7 +40,6 @@ import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
 import javax.jcr.Value;
 
-import org.apache.jackrabbit.guava.common.base.Function;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.jackrabbit.oak.api.Blob;
@@ -199,7 +199,7 @@ public abstract class AbstractOak2OakTest {
                     return null;
                 }
             }
-        });
+        }::apply);
         assertTrue(values.contains("jcr:mixinTypes"));
         assertTrue(values.contains("jcr:primaryType"));
         assertEquals("false", nodeType.getProperty("jcr:isAbstract").getString());

--- a/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/AbstractOak2OakTest.java
+++ b/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/AbstractOak2OakTest.java
@@ -31,14 +31,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.function.Function;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.SimpleCredentials;
-import javax.jcr.Value;
 
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -61,7 +59,6 @@ import org.apache.jackrabbit.oak.upgrade.RepositorySidegrade;
 import org.apache.jackrabbit.oak.upgrade.cli.container.NodeStoreContainer;
 import org.apache.jackrabbit.oak.upgrade.cli.container.SegmentNodeStoreContainer;
 import org.apache.jackrabbit.oak.upgrade.cli.parser.CliArgumentException;
-import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -189,17 +186,13 @@ public abstract class AbstractOak2OakTest {
         Node nodeType = session.getNode("/jcr:system/jcr:nodeTypes/sling:OrderedFolder");
         assertEquals("rep:NodeType", nodeType.getProperty("jcr:primaryType").getString());
 
-        List<String> values = Lists.transform(Arrays.asList(nodeType.getProperty("rep:protectedProperties").getValues()), new Function<Value, String>() {
-            @Nullable
-            @Override
-            public String apply(@Nullable Value input) {
+        List<String> values = Lists.transform(Arrays.asList(nodeType.getProperty("rep:protectedProperties").getValues()), input -> {
                 try {
                     return input.getString();
                 } catch (RepositoryException e) {
                     return null;
                 }
-            }
-        }::apply);
+            });
         assertTrue(values.contains("jcr:mixinTypes"));
         assertTrue(values.contains("jcr:primaryType"));
         assertEquals("false", nodeType.getProperty("jcr:isAbstract").getString());


### PR DESCRIPTION
This replaces Guava Function with JDK Function.

Notable points:

- rewrote `apply()` implementations as lambda expressions (fwiw, that makes them compatible with both Function variants)
- when a Guava method needs a Guava Function, the JDK function can be "converted" with `::apply`

(next step would be to do the same for Predicates, but I'd like to do this step-by-step)