### PR TITLE
OAK-10951 - Make cache size in PersistedLinkedList class configurable

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateEntry.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateEntry.java
@@ -30,7 +30,7 @@ public class NodeStateEntry {
     private final long lastModified;
     private final String id;
 
-    private NodeStateEntry(NodeState nodeState, String path, long memUsage, long lastModified, String id) {
+    public NodeStateEntry(NodeState nodeState, String path, long memUsage, long lastModified, String id) {
         this.nodeState = nodeState;
         this.path = path;
         this.memUsage = memUsage;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
@@ -27,10 +27,10 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry.NodeStateEntryBuilder;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.FlatFileBufferLinkedList;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.NodeStateEntryList;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.PersistedLinkedList;
+import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.ConfigHelper;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.slf4j.Logger;
@@ -39,16 +39,22 @@ import org.slf4j.LoggerFactory;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 
 class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements Iterator<NodeStateEntry>, Closeable {
-    private final Logger log = LoggerFactory.getLogger(getClass());
-    private final Iterator<NodeStateEntry> baseItr;
-    private final NodeStateEntryList buffer;
-    private NodeStateEntry current;
-    private final Set<String> preferredPathElements;
-    private int maxBufferSize;
-    static final String BUFFER_MEM_LIMIT_CONFIG_NAME = "oak.indexer.memLimitInMB";
+    private static final Logger log = LoggerFactory.getLogger(FlatFileStoreIterator.class);
 
+    static final String BUFFER_MEM_LIMIT_CONFIG_NAME = "oak.indexer.memLimitInMB";
     // by default, use the PersistedLinkedList
     private static final int DEFAULT_BUFFER_MEM_LIMIT_IN_MB = 0;
+    static final String PERSISTED_LINKED_LIST_CACHE_SIZE = "oak.indexer.persistedLinkedList.cacheSize";
+    static final int DEFAULT_PERSISTED_LINKED_LIST_CACHE_SIZE = 1000;
+
+
+    private final Iterator<NodeStateEntry> baseItr;
+    private final NodeStateEntryList buffer;
+    private final Set<String> preferredPathElements;
+
+    private NodeStateEntry current;
+    private int maxBufferSize;
+    private long maxBufferSizeBytes;
 
     public FlatFileStoreIterator(BlobStore blobStore, String fileName, Iterator<NodeStateEntry> baseItr, Set<String> preferredPathElements) {
         this(blobStore, fileName, baseItr, preferredPathElements,
@@ -63,7 +69,8 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
             log.info("Using a key-value store buffer: {}", fileName);
             NodeStateEntryReader reader = new NodeStateEntryReader(blobStore);
             NodeStateEntryWriter writer = new NodeStateEntryWriter(blobStore);
-            this.buffer = new PersistedLinkedList(fileName, writer, reader, 1000);
+            int cacheSize = ConfigHelper.getSystemPropertyAsInt(PERSISTED_LINKED_LIST_CACHE_SIZE, DEFAULT_PERSISTED_LINKED_LIST_CACHE_SIZE);
+            this.buffer = new PersistedLinkedList(fileName, writer, reader, cacheSize);
         } else if (memLimitConfig < 0) {
             log.info("Setting buffer memory limit unbounded");
             this.buffer = new FlatFileBufferLinkedList();
@@ -73,7 +80,7 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
         }
     }
 
-    int getBufferSize(){
+    int getBufferSize() {
         return buffer.size();
     }
 
@@ -86,7 +93,7 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
         //TODO Add some checks on expected ordering
         current = computeNextEntry();
         if (current == null) {
-            log.info("Max buffer size in complete traversal is [{}]", maxBufferSize);
+            log.info("Max buffer size in complete traversal is [{} / {}]", maxBufferSize, maxBufferSizeBytes);
             return endOfData();
         } else {
             return current;
@@ -97,7 +104,12 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
         if (buffer.size() > maxBufferSize) {
             maxBufferSize = buffer.size();
             log.info("Max buffer size changed {} (estimated memory usage: {} bytes) for path {}",
-                    maxBufferSize, buffer.estimatedMemoryUsage(), current.getPath());
+                    maxBufferSize, maxBufferSizeBytes, current.getPath());
+        }
+        if (buffer.estimatedMemoryUsage() > maxBufferSizeBytes) {
+            maxBufferSizeBytes = buffer.estimatedMemoryUsage();
+            log.info("Max buffer size changed {} (estimated memory usage: {} bytes) for path {}",
+                    maxBufferSize, maxBufferSizeBytes, current.getPath());
         }
         if (!buffer.isEmpty()) {
             NodeStateEntry e = buffer.remove();
@@ -112,7 +124,7 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
     private NodeStateEntry wrap(NodeStateEntry baseEntry) {
         NodeState state = new LazyChildrenNodeState(baseEntry.getNodeState(),
                 new ChildNodeStateProvider(getEntries(), baseEntry.getPath(), preferredPathElements));
-        return new NodeStateEntryBuilder(state, baseEntry.getPath()).withMemUsage(baseEntry.estimatedMemUsage()).build();
+        return new NodeStateEntry(state, baseEntry.getPath(), baseEntry.estimatedMemUsage(), 0, "");
     }
 
     private Iterable<NodeStateEntry> getEntries() {
@@ -121,7 +133,7 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
 
     private Iterator<NodeStateEntry> queueIterator() {
         Iterator<NodeStateEntry> qitr = buffer.iterator();
-        return new AbstractIterator<NodeStateEntry>() {
+        return new AbstractIterator<>() {
             @Override
             protected NodeStateEntry computeNext() {
                 //If queue is empty try to append by getting entry from base

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/linkedList/FlatFileBufferLinkedList.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/linkedList/FlatFileBufferLinkedList.java
@@ -32,7 +32,7 @@ import java.util.Iterator;
  */
 public class FlatFileBufferLinkedList implements NodeStateEntryList {
 
-    private ListNode head = new ListNode();
+    private final ListNode head = new ListNode();
     private ListNode tail = head;
 
     private int size = 0;
@@ -52,9 +52,8 @@ public class FlatFileBufferLinkedList implements NodeStateEntryList {
         long incomingSize = item.estimatedMemUsage();
         long memUsage = estimatedMemoryUsage();
         Preconditions.checkState(memUsage + incomingSize <= memLimit,
-                String.format(
                 "Adding item (%s) estimated with %s bytes would increase mem usage beyond upper limit (%s)." +
-                        " Current estimated mem usage is %s bytes", item.getPath(), incomingSize, memLimit, memUsage));
+                        " Current estimated mem usage is %s bytes", item.getPath(), incomingSize, memLimit, memUsage);
         tail.next = new ListNode(item);
         tail = tail.next;
         size++;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/linkedList/NodeStateEntryList.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/linkedList/NodeStateEntryList.java
@@ -28,26 +28,26 @@ public interface NodeStateEntryList {
     /**
      * Add an item at the tail of the list.
      */
-    public void add(@NotNull NodeStateEntry item);
+    void add(@NotNull NodeStateEntry item);
 
     /**
      * Remove the first item from the list.
      *
      * @return the removed item
      */
-    public NodeStateEntry remove();
+    NodeStateEntry remove();
 
-    public long estimatedMemoryUsage();
+    long estimatedMemoryUsage();
 
-    public int size();
+    int size();
 
     /**
      * Get an iterator to iterate over the whole list
      */
-    public Iterator<NodeStateEntry> iterator();
+    Iterator<NodeStateEntry> iterator();
 
-    public boolean isEmpty();
+    boolean isEmpty();
 
-    public void close();
+    void close();
 
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/linkedList/PersistedLinkedList.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/linkedList/PersistedLinkedList.java
@@ -51,9 +51,7 @@ public class PersistedLinkedList implements NodeStateEntryList {
     private final NodeStateEntryWriter writer;
     private final NodeStateEntryReader reader;
     private final String storeFileName;
-    private final int compactStoreMillis = Integer.getInteger(
-            COMPACT_STORE_MILLIS_NAME,
-            60 * 1000);
+    private final int compactStoreMillis = Integer.getInteger(COMPACT_STORE_MILLIS_NAME, 60 * 1000);
 
     private MVStore store;
     private MVMap<Long, String> map;
@@ -66,11 +64,9 @@ public class PersistedLinkedList implements NodeStateEntryList {
     private long cacheHits, cacheMisses;
 
     public PersistedLinkedList(String fileName, NodeStateEntryWriter writer, NodeStateEntryReader reader, int cacheSize) {
-        LOG.info("Opening store " + fileName);
+        LOG.info("Opening store {}", fileName);
         this.storeFileName = fileName;
-        this.cache =
-                new LinkedHashMap<Long, NodeStateEntry>(cacheSize + 1, .75F, true) {
-            private static final long serialVersionUID = 1L;
+        this.cache = new LinkedHashMap<>(cacheSize + 1, .75F, true) {
             @Override
             public boolean removeEldestEntry(Map.Entry<Long, NodeStateEntry> eldest) {
                 return size() > cacheSize;
@@ -78,7 +74,7 @@ public class PersistedLinkedList implements NodeStateEntryList {
         };
         File oldFile = new File(fileName);
         if (oldFile.exists()) {
-            LOG.info("Deleting " + fileName);
+            LOG.info("Deleting {}", fileName);
             try {
                 FileUtils.forceDelete(oldFile);
             } catch (IOException e) {
@@ -107,8 +103,7 @@ public class PersistedLinkedList implements NodeStateEntryList {
         long sizeBytes = store.getFileStore().size();
         long now = System.currentTimeMillis();
         if (now >= lastLog + 10000) {
-            LOG.info("Entries: " + size + " map size: " + map.sizeAsLong() + " file size: "
-                    + sizeBytes + " bytes");
+            LOG.info("Entries: {} map size: {} file size: {} bytes", size, map.sizeAsLong(), sizeBytes);
             lastLog = now;
         }
         boolean compactNow = now >= lastCompact + compactStoreMillis;
@@ -119,7 +114,7 @@ public class PersistedLinkedList implements NodeStateEntryList {
             MVStoreTool.compact(storeFileName, true);
             openStore();
             lastCompact = System.currentTimeMillis();
-            LOG.info("New size=" + store.getFileStore().size() + " bytes");
+            LOG.info("New size={} bytes", store.getFileStore().size());
         }
     }
 


### PR DESCRIPTION
Add a new configuration property
- `oak.indexer.persistedLinkedList.cacheSize` - sets the cache size of the PersistedLinkedList used to traverse the FFS. This controls the number FFS entries kept in memory.

Minor code cleanups.