### PR TITLE
OAK-10966 - Avoid object creation in PathUtils.isAncestor

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
@@ -367,12 +367,13 @@ public final class PathUtils {
         if (denotesRoot(ancestor)) {
             if (denotesRoot(path)) {
                 return false;
+            } else {
+                return path.startsWith(ancestor);
             }
         } else {
             // Equivalent to path.startsWith(ancestor + "/") but avoids allocating a new string
             return path.startsWith(ancestor) && path.length() > ancestor.length() && path.charAt(ancestor.length()) == '/';
         }
-        return path.startsWith(ancestor);
     }
 
     /**

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
@@ -369,7 +369,8 @@ public final class PathUtils {
                 return false;
             }
         } else {
-            ancestor += "/";
+            // Equivalent to path.startsWith(ancestor + "/") but avoids allocating a new string
+            return path.startsWith(ancestor) && path.length() > ancestor.length() && path.charAt(ancestor.length()) == '/';
         }
         return path.startsWith(ancestor);
     }


### PR DESCRIPTION
The indexing logic makes a large number of calls to `PathUtils.isAncestor` when traversing the FFS. This was showing up in a JFR profiling of an indexing task as a significant percentage of the total execution time and of the total allocations. It is fairly easy to avoid allocating a new string inside this method, and this optimization will benefit many other areas of Oak.