### PR TITLE
OAK-10971 - Add a method to test if a path is a direct ancestor of another: PathUtils.isDirectAncestor() 

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
@@ -384,22 +384,9 @@ public final class PathUtils {
      * @return true if the path is a direct offspring of the ancestor
      */
     public static boolean isDirectAncestor(String ancestor, String path) {
-        assert isValid(ancestor) : "Invalid parent path [" + ancestor + "]";
-        assert isValid(path) : "Invalid path [" + path + "]";
-        if (ancestor.isEmpty() || path.isEmpty()) {
-            return false;
-        }
-        // The root is never a child of another path
-        if (PathUtils.denotesRoot(path)) {
-            return false;
-        }
-        int idx = path.lastIndexOf('/');
-        if (idx == 0) {
-            // path is a top level path. So it is only an immediate child of root
-            return PathUtils.denotesRoot(ancestor);
-        } else {
-            return idx == ancestor.length() && path.regionMatches(0, ancestor, 0, idx);
-        }
+        int lastSlashInPath = path.lastIndexOf('/');
+        return ((PathUtils.denotesRoot(ancestor) && lastSlashInPath == 0) || lastSlashInPath == ancestor.length())
+                && isAncestor(ancestor, path);
     }
 
     /**

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PathUtils.java
@@ -377,6 +377,32 @@ public final class PathUtils {
     }
 
     /**
+     * Check if a path is a direct ancestor of another path.
+     *
+     * @param ancestor the ancestor path
+     * @param path     the potential direct offspring path
+     * @return true if the path is a direct offspring of the ancestor
+     */
+    public static boolean isDirectAncestor(String ancestor, String path) {
+        assert isValid(ancestor) : "Invalid parent path [" + ancestor + "]";
+        assert isValid(path) : "Invalid path [" + path + "]";
+        if (ancestor.isEmpty() || path.isEmpty()) {
+            return false;
+        }
+        // The root is never a child of another path
+        if (PathUtils.denotesRoot(path)) {
+            return false;
+        }
+        int idx = path.lastIndexOf('/');
+        if (idx == 0) {
+            // path is a top level path. So it is only an immediate child of root
+            return PathUtils.denotesRoot(ancestor);
+        } else {
+            return idx == ancestor.length() && path.regionMatches(0, ancestor, 0, idx);
+        }
+    }
+
+    /**
      * Relativize a path wrt. a parent path such that
      * {@code relativize(parentPath, concat(parentPath, path)) == paths}
      * holds.

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/package-info.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("2.0.0")
+@Version("2.1.0")
 package org.apache.jackrabbit.oak.commons;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/PathUtilsTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/PathUtilsTest.java
@@ -232,6 +232,28 @@ public class PathUtilsTest extends TestCase {
         assertFalse(PathUtils.isAncestor(parent, child));
         assertFalse(PathUtils.isAncestor("/" + parent, "/" + parent + "123"));
         assertFalse(PathUtils.isAncestor("/" + parent, "/" + parent + "123/foo"));
+        assertTrue(PathUtils.isAncestor("/" + parent, "/" + parent + "/foo"));
+        assertFalse(PathUtils.isAncestor("/" + parent + "/foo", "/" + parent + "/foo"));
+        assertTrue(PathUtils.isAncestor("/" + parent, "/" + parent + "/foo/bar"));
+
+        // isDirectAncestor
+        assertFalse(PathUtils.isDirectAncestor("/", "/"));
+        assertFalse(PathUtils.isDirectAncestor("/" + parent, "/" + parent));
+        assertFalse(PathUtils.isDirectAncestor(parent, parent));
+        assertTrue(PathUtils.isDirectAncestor("/", "/" + parent));
+        assertFalse(PathUtils.isDirectAncestor("/", "/" + parent + "/foo1"));
+        assertFalse(PathUtils.isDirectAncestor("/", "/" + parent + "/foo1/foo2"));
+        assertTrue(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "/foo1"));
+        assertFalse(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "/foo1/foo2"));
+        assertFalse(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "/foo1/foo2/foo3"));
+        assertTrue(PathUtils.isDirectAncestor(parent, parent + "/" + child));
+        assertFalse(PathUtils.isDirectAncestor("/", parent + "/" + child));
+        assertTrue(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "/" + child));
+        assertFalse(PathUtils.isDirectAncestor(parent, child));
+        assertFalse(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "123"));
+        assertFalse(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "123/foo"));
+        assertTrue(PathUtils.isDirectAncestor("/" + parent, "/" + parent + "/foo"));
+        assertFalse(PathUtils.isDirectAncestor("/" + parent + "/foo", "/" + parent + "/foo"));
 
         // relativize
         assertEquals("", PathUtils.relativize("/", "/"));


### PR DESCRIPTION
Replaces https://github.com/apache/jackrabbit-oak/pull/1597, the git history of this older PR is messed up.