### PR TITLE
OAK-10984 - Improve invocations of logging API to follow best practices for parameter passing in search/indexing modules

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexTracker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexTracker.java
@@ -120,7 +120,7 @@ public class IndexTracker {
             try {
                 entry.getValue().close();
             } catch (IOException e) {
-                log.error("Failed to close the Lucene index at " + entry.getKey(), e);
+                log.error("Failed to close the Lucene index at {}", entry.getKey(), e);
             }
         }
     }
@@ -204,7 +204,7 @@ public class IndexTracker {
                         index.close();
                     }
                 } catch (IOException e) {
-                    log.error("Failed to close Lucene index at " + path, e);
+                    log.error("Failed to close Lucene index at {}", path, e);
                 }
             }
         }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -218,7 +218,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     }
 
     @Override
-    protected  boolean augmentCustomFields(final String path, final Document doc, final NodeState document) {
+    protected boolean augmentCustomFields(final String path, final Document doc, final NodeState document) {
         boolean dirty = false;
 
         if (augmentorFactory != null) {
@@ -264,7 +264,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     }
 
     @Override
-    protected boolean isFacetingEnabled(){
+    protected boolean isFacetingEnabled() {
         return facetsConfigProvider != null;
     }
 
@@ -318,7 +318,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
 
     /**
      * Returns a {@code BytesRef} object constructed from the given {@code String} value and also truncates the length
-     * of the {@code BytesRef} object to the specified {@code maxLength}, ensuring that the multi-byte sequences are 
+     * of the {@code BytesRef} object to the specified {@code maxLength}, ensuring that the multi-byte sequences are
      * properly truncated.
      *
      * <p>The {@code BytesRef} object is created from the provided {@code String} value using UTF-8 encoding. As a result, its length
@@ -356,8 +356,10 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         byte[] truncatedBytes = Arrays.copyOf(ref.bytes, end + 1);
         String truncated = new String(truncatedBytes, StandardCharsets.UTF_8);
         ref = new BytesRef(truncated);
-        log.trace("Truncated property {} at path:[{}] to {}", prop, path, ref.utf8ToString());
-        
+        if (log.isTraceEnabled()) {
+            log.trace("Truncated property {} at path:[{}] to {}", prop, path, ref.utf8ToString());
+        }
+
         while (ref.length > maxLength) {
             log.error("Truncation did not work: still {} bytes", ref.length);
             // this may not properly work with unicode surrogates:
@@ -368,7 +370,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         return ref;
     }
 
-    private FacetsConfig getFacetsConfig(){
+    private FacetsConfig getFacetsConfig() {
         return facetsConfigProvider.getFacetsConfig();
     }
 
@@ -426,10 +428,12 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         }
 
         if (added) {
-            log.trace(
-                    "Added augmented fields: {}[{}], {}",
-                    parent + "/", String.join(", ", tokens), confidence
-            );
+            if (log.isTraceEnabled()) {
+                log.trace(
+                        "Added augmented fields: {}[{}], {}",
+                        parent + "/", String.join(", ", tokens), confidence
+                );
+            }
         }
 
         return added;

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndex.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndex.java
@@ -153,10 +153,9 @@ import static org.apache.lucene.search.BooleanClause.Occur.SHOULD;
  */
 public class LuceneIndex implements AdvanceFulltextQueryIndex {
 
-    private static final Logger LOG = LoggerFactory
-            .getLogger(LuceneIndex.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LuceneIndex.class);
     public static final String NATIVE_QUERY_FUNCTION = "native*lucene";
-    private static double MIN_COST = 2.2;
+    private static final double MIN_COST = 2.2;
 
     /**
      * IndexPaln Attribute name which refers to the path of Lucene index to be used
@@ -210,7 +209,7 @@ public class LuceneIndex implements AdvanceFulltextQueryIndex {
         }
         Set<String> relPaths = getRelativePaths(ft);
         if (relPaths.size() > 1) {
-            LOG.warn("More than one relative parent for query " + filter.getQueryStatement());
+            LOG.warn("More than one relative parent for query {}", filter.getQueryStatement());
             // there are multiple "parents", as in
             // "contains(a/x, 'hello') and contains(b/x, 'world')"
             return Collections.emptyList();

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobCollectorFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobCollectorFactory.java
@@ -139,8 +139,8 @@ public class ActiveDeletedBlobCollectorFactory {
         try {
             FileUtils.forceMkdir(rootDirectory);
         } catch (IOException ioe) {
-            ActiveDeletedBlobCollectorImpl.LOG.warn("Disabling active blob collector as we couldn't not create folder: "
-                    + rootDirectory, ioe);
+            ActiveDeletedBlobCollectorImpl.LOG.warn("Disabling active blob collector as we couldn't not create folder: {}",
+                    rootDirectory, ioe);
             return NOOP;
         }
         if(!rootDirectory.canRead() || !rootDirectory.canWrite() || !rootDirectory.canExecute()) {
@@ -157,9 +157,9 @@ public class ActiveDeletedBlobCollectorFactory {
      * due deleted blob
      */
     static class ActiveDeletedBlobCollectorImpl implements ActiveDeletedBlobCollector {
-        private static PerfLogger PERF_LOG = new PerfLogger(
+        private static final PerfLogger PERF_LOG = new PerfLogger(
                 LoggerFactory.getLogger(ActiveDeletedBlobCollectorImpl.class.getName() + ".perf"));
-        private static Logger LOG = LoggerFactory.getLogger(ActiveDeletedBlobCollectorImpl.class.getName());
+        private static final Logger LOG = LoggerFactory.getLogger(ActiveDeletedBlobCollectorImpl.class.getName());
 
         private final Clock clock;
 
@@ -241,7 +241,7 @@ public class ActiveDeletedBlobCollectorFactory {
                 try {
                     timestamp = getTimestampFromBlobFileName(deletedBlobListFile.getName());
                 } catch (IllegalArgumentException iae) {
-                    LOG.warn("Couldn't extract timestamp from filename - " + deletedBlobListFile, iae);
+                    LOG.warn("Couldn't extract timestamp from filename - {}", deletedBlobListFile, iae);
                     continue;
                 }
                 if (timestamp < before) {
@@ -261,7 +261,7 @@ public class ActiveDeletedBlobCollectorFactory {
                             } else {
                                 String deletedBlobId = parsedDeletedBlobIdLine[0];
                                 try {
-                                    long blobDeletionTimestamp = Long.valueOf(parsedDeletedBlobIdLine[1]);
+                                    long blobDeletionTimestamp = Long.parseLong(parsedDeletedBlobIdLine[1]);
 
                                     if (blobDeletionTimestamp < lastCheckedBlobTimestamp) {
                                         continue;
@@ -291,19 +291,18 @@ public class ActiveDeletedBlobCollectorFactory {
                                         }
                                     }
                                 } catch (NumberFormatException nfe) {
-                                    LOG.warn("Couldn't parse blobTimestamp(" + parsedDeletedBlobIdLine[1] +
-                                            "). deletedBlobLine - " + deletedBlobLine +
-                                            "; file - " + deletedBlobListFile.getName(), nfe);
+                                    LOG.warn("Couldn't parse blobTimestamp({}). deletedBlobLine - {}; file - {}",
+                                            parsedDeletedBlobIdLine[1], deletedBlobLine, deletedBlobListFile.getName(), nfe);
                                 } catch (DataStoreException dse) {
-                                    LOG.debug("Exception occurred while attempting to delete blob " + deletedBlobId, dse);
+                                    LOG.debug("Exception occurred while attempting to delete blob {}", deletedBlobId, dse);
                                 } catch (Exception e) {
-                                    LOG.warn("Exception occurred while attempting to delete blob " + deletedBlobId, e);
+                                    LOG.warn("Exception occurred while attempting to delete blob {}", deletedBlobId, e);
                                 }
                             }
                         }
                     } catch (IOException ioe) {
                         //log error and continue
-                        LOG.warn("Couldn't read deleted blob list file - " + deletedBlobListFile, ioe);
+                        LOG.warn("Couldn't read deleted blob list file - {}", deletedBlobListFile, ioe);
                     } finally {
                         LineIterator.closeQuietly(blobLineIter);
                     }
@@ -390,9 +389,9 @@ public class ActiveDeletedBlobCollectorFactory {
             }
 
             try {
-                return Long.valueOf(resString);
+                return Long.parseLong(resString);
             } catch (NumberFormatException nfe) {
-                LOG.warn("Couldn't read last checked blob timestamp '" + resString + "' as long", nfe);
+                LOG.warn("Couldn't read last checked blob timestamp '{}' as long", resString, nfe);
                 return -1;
             }
         }
@@ -406,7 +405,7 @@ public class ActiveDeletedBlobCollectorFactory {
                 os = new BufferedOutputStream(new FileOutputStream(blobCollectorInfoFile));
                 p.store(os, "Last checked blob timestamp");
             } catch (IOException e) {
-                LOG.warn("Couldn't write out last checked blob timestamp(" + timestamp + ")", e);
+                LOG.warn("Couldn't write out last checked blob timestamp({})", timestamp, e);
             } finally {
                 org.apache.commons.io.IOUtils.closeQuietly(os);
             }
@@ -465,7 +464,7 @@ public class ActiveDeletedBlobCollectorFactory {
                         FileUtils.writeLines(outFile, localDeletedBlobs, true);
                         PERF_LOG.end(start, 1, "Flushing deleted blobs");
                     } catch (IOException e) {
-                        LOG.error("Couldn't write out to " + outFile, e);
+                        LOG.error("Couldn't write out to {}", outFile, e);
                     }
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Flushed {} blobs to {}", localDeletedBlobs.size(), outFile.getName());

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakDirectory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakDirectory.java
@@ -176,7 +176,7 @@ public class OakDirectory extends Directory {
             LOG.debug("Not marking {} under {} for active deletion", name, indexName);
         }
         if (f instanceof ReadOnlyBuilder) {
-            LOG.debug("Preserve read-only node: " + name);
+            LOG.debug("Preserve read-only node: {}", name);
         } else {
             f.remove();
         }
@@ -259,7 +259,7 @@ public class OakDirectory extends Directory {
         if (!readOnly && definition.saveDirListing()) {
             if (!fileNamesAtStart.equals(fileNames)) {
                 if (directoryBuilder instanceof ReadOnlyBuilder) {
-                    LOG.debug("Preserve files of read-only directory: " + fileNames);
+                    LOG.debug("Preserve files of read-only directory: {}", fileNames);
                 } else {
                     directoryBuilder.setProperty(createProperty(PROP_DIR_LISTING, fileNames, STRINGS));
                 }
@@ -306,7 +306,7 @@ public class OakDirectory extends Directory {
         if (file.exists()) {
             // overwrite potentially already existing child
             if (dest.directoryBuilder instanceof ReadOnlyBuilder) {
-                LOG.debug("Preserve read-only child: " + name);
+                LOG.debug("Preserve read-only child: {}", name);
             } else {
                 NodeBuilder destFile = dest.directoryBuilder.setChildNode(name, EMPTY_NODE);
                 for (PropertyState p : file.getProperties()) {

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/util/fv/SimSearchUtils.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/util/fv/SimSearchUtils.java
@@ -225,8 +225,10 @@ public class SimSearchUtils {
         if (expectedTruePositive >= 1.0 && similarity < 1) {
             builder.setMinimumNumberShouldMatch((int) (Math.ceil(minhashes.size() * similarity)));
         }
-        log.trace("similarity query with bands : {}, minShouldMatch : {}, no. of clauses : {}", bandSize,
-                builder.getMinimumNumberShouldMatch(), builder.clauses().size());
+        if (log.isTraceEnabled()) {
+            log.trace("similarity query with bands : {}, minShouldMatch : {}, no. of clauses : {}", bandSize,
+                    builder.getMinimumNumberShouldMatch(), builder.clauses().size());
+        }
         return builder;
 
     }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexCleaner.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexCleaner.java
@@ -145,7 +145,7 @@ public class ElasticIndexCleaner implements Runnable {
                 DeleteIndexResponse response = elasticConnection.getClient().indices().delete(i -> i.index(indicesToDelete));
                 LOG.info("Deleting remote indices {}", indicesToDelete);
                 if (!response.acknowledged()) {
-                    LOG.error("Could not delete remote indices " + indicesToDelete);
+                    LOG.error("Could not delete remote indices {}", indicesToDelete);
                 }
             }
         } catch (IOException e) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -338,7 +338,7 @@ class ElasticBulkProcessorHandler {
                 try {
                 	this.elasticConnection.getClient().indices().refresh(b -> b.index(indexName));
                 } catch (IOException e) {
-                    LOG.warn("Error refreshing index " + indexName, e);
+                    LOG.warn("Error refreshing index {}", indexName, e);
                 }
             }
             return closed;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -336,7 +335,7 @@ public class ElasticRequestHandler {
                 try {
                     bytes = new BlobByteSource(property).read();
                 } catch (IOException e) {
-                    LOG.error("Error reading bytes from property " + pd.name + " on " + text, e);
+                    LOG.error("Error reading bytes from property {} on {}", pd.name, text, e);
                     continue;
                 }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticSpellcheckIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticSpellcheckIterator.java
@@ -140,7 +140,7 @@ class ElasticSpellcheckIterator implements ElasticQueryIterator {
                 this.internalIterator = results.iterator();
             }
         } catch (IOException e) {
-            LOG.error("Error processing suggestions for " + searchRequest, e);
+            LOG.error("Error processing suggestions for {}", searchRequest, e);
         }
     }
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/ExtractedTextCache.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/ExtractedTextCache.java
@@ -136,7 +136,9 @@ public class ExtractedTextCache {
         //incremental indexing mode. As that would only contain older entries
         //That also avoid loading on various state (See DataStoreTextWriter)
         String propertyPath = concat(nodePath, propertyName);
-        log.trace("Looking for extracted text for [{}] with blobId [{}]", propertyPath, blob.getContentIdentity());
+        if (log.isTraceEnabled()) {
+            log.trace("Looking for extracted text for [{}] with blobId [{}]", propertyPath, blob.getContentIdentity());
+        }
         if ((reindexMode || alwaysUsePreExtractedCache) && extractedTextProvider != null){
             try {
                 ExtractedText text = extractedTextProvider.getText(propertyPath, blob);
@@ -346,7 +348,7 @@ public class ExtractedTextCache {
         if (executorService != null) {
             return;
         }
-        log.debug("ExtractedTextCache createExecutor " + this);
+        log.debug("ExtractedTextCache createExecutor {}", this);
         ThreadPoolExecutor executor = new ThreadPoolExecutor(1, EXTRACTION_MAX_THREADS,
                 60L, TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(), new ThreadFactory() {
@@ -378,7 +380,7 @@ public class ExtractedTextCache {
 
     private synchronized void closeExecutorService() {
         if (executorService != null) {
-            log.debug("ExtractedTextCache closeExecutorService " + this);
+            log.debug("ExtractedTextCache closeExecutorService {}", this);
             executorService.shutdown();
             try {
                 executorService.awaitTermination(1, TimeUnit.MINUTES);

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
@@ -271,7 +271,7 @@ public class FulltextBinaryTextExtractor {
         return TikaParserConfig.getNonIndexedMediaTypes(configStream);
       }
     } catch (TikaException | IOException | SAXException e) {
-      log.warn("Tika configuration not available : " + configSource, e);
+        log.warn("Tika configuration not available : {}", configSource, e);
     } finally {
       IOUtils.closeQuietly(configStream);
     }
@@ -302,7 +302,7 @@ public class FulltextBinaryTextExtractor {
         return new TikaConfigHolder(new TikaConfig(configStream), configSource);
       }
     } catch (TikaException | IOException | SAXException e) {
-      log.warn("Tika configuration not available : " + configSource, e);
+        log.warn("Tika configuration not available : {}", configSource, e);
     } finally {
       IOUtils.closeQuietly(configStream);
       Thread.currentThread().setContextClassLoader(current);
@@ -332,7 +332,7 @@ public class FulltextBinaryTextExtractor {
       log.info("Loaded default Tika Config from classpath {}", configHolder);
       return new AutoDetectParser(configHolder.config);
     } catch (Exception e) {
-      log.warn("Tika configuration not available : " + configHolder, e);
+        log.warn("Tika configuration not available : {}", configHolder, e);
     } finally {
       Thread.currentThread().setContextClassLoader(current);
     }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -236,11 +236,12 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         int idxDefinedTag = pd.getType();
         // Try converting type to the defined type in the index definition
         if (tag != idxDefinedTag) {
-            log.debug("[{}] Facet property defined with type {} differs from property {} with type {} in "
-                            + "path {}",
-                    getIndexName(),
-                    Type.fromTag(idxDefinedTag, false), property,
-                    Type.fromTag(tag, false), path);
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Facet property defined with type {} differs from property {} with type {} in path {}",
+                        getIndexName(),
+                        Type.fromTag(idxDefinedTag, false), property,
+                        Type.fromTag(tag, false), path);
+            }
             tag = idxDefinedTag;
         }
         return indexFacetProperty(doc, tag, property, pname);
@@ -401,12 +402,13 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         int idxDefinedTag = pd.getType();
         // Try converting type to the defined type in the index definition
         if (tag != idxDefinedTag) {
-            log.debug(
-                    "[{}] Ordered property defined with type {} differs from property {} with type {} in "
-                            + "path {}",
-                    getIndexName(),
-                    Type.fromTag(idxDefinedTag, false), property,
-                    Type.fromTag(tag, false), path);
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "[{}] Ordered property defined with type {} differs from property {} with type {} in path {}",
+                        getIndexName(),
+                        Type.fromTag(idxDefinedTag, false), property,
+                        Type.fromTag(tag, false), path);
+            }
             tag = idxDefinedTag;
         }
         return indexTypeOrderedFields(doc, pname, tag, property, pd);
@@ -682,7 +684,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 continue;
             }
             if (p.isArray()) {
-                log.warn(p.getName() + " is an array: {}", parentName);
+                log.warn("{} is an array: {}", p.getName(), parentName);
                 continue;
             }
             String dynaTagValue = p.getValue(Type.STRING);
@@ -692,18 +694,18 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 continue;
             }
             if (p.isArray()) {
-                log.warn(p.getName() + " is an array: {}", parentName);
+                log.warn("{} is an array: {}", p.getName(), parentName);
                 continue;
             }
             double dynaTagConfidence;
             try {
                 dynaTagConfidence = p.getValue(Type.DOUBLE);
             } catch (NumberFormatException e) {
-                log.warn(p.getName() + " parsing failed: {}", parentName, e);
+                log.warn("{} parsing failed: {}", p.getName(), parentName, e);
                 continue;
             }
             if (!Double.isFinite(dynaTagConfidence)) {
-                log.warn(p.getName() + " is not finite: {}", parentName);
+                log.warn("{} is not finite: {}", p.getName(), parentName);
                 continue;
             }
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndexPlanner.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndexPlanner.java
@@ -983,8 +983,10 @@ public class FulltextIndexPlanner {
                     return rule;
                 }
             }
-            log.trace("No applicable IndexingRule found for any of the superTypes {}",
-                    filter.getSupertypes());
+            if (log.isTraceEnabled()) {
+                log.trace("No applicable IndexingRule found for any of the superTypes {}",
+                        filter.getSupertypes());
+            }
         }
         return null;
     }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/IndexName.java
@@ -100,7 +100,7 @@ public class IndexName implements Comparable<IndexName> {
                 nextLogWarnClear = now + 5 * 60 * 1000;
             }
             if (LOGGED_WARN.add(nodeName)) {
-                LOG.warn("Index name format error: " + nodeName);
+                LOG.warn("Index name format error: {}", nodeName);
             }
             return new IndexName(nodeName, false);
         }


### PR DESCRIPTION
When calling the logging API:
- Always use templates to pass arguments.
- If logging at TRACE or DEBUG and some of the arguments are expensive to evaluate, check if the logging is enabled for that level before calling the logger.

Some of the unguarded calls to `log.trace` or `log.debug` are in the critical path of indexing, so these changes should slightly improve performance.