### PR TITLE
OAK-10988 - Minor performance improvements to NodeStateEntryReader/Writer

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryReader.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryReader.java
@@ -20,7 +20,6 @@
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry.NodeStateEntryBuilder;
 import org.apache.jackrabbit.oak.json.BlobDeserializer;
 import org.apache.jackrabbit.oak.json.JsonDeserializer;
 import org.apache.jackrabbit.oak.plugins.blob.serializer.BlobIdSerializer;
@@ -39,7 +38,8 @@ public class NodeStateEntryReader {
     public NodeStateEntry read(String line) {
         String[] parts = NodeStateEntryWriter.getParts(line);
         long memUsage = estimateMemoryUsage(parts[0]) + estimateMemoryUsage(parts[1]);
-        return new NodeStateEntryBuilder(parseState(parts[1]), parts[0]).withMemUsage(memUsage).build();
+        NodeState nodeState = parseState(parts[1]);
+        return new NodeStateEntry(nodeState, parts[0], memUsage, 0, "");
     }
 
     protected NodeState parseState(String part) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -32,12 +32,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
-
 public class NodeStateEntryWriter {
     private static final boolean SORTED_PROPERTIES = Boolean.getBoolean("oak.NodeStateEntryWriter.sort");
     private static final String OAK_CHILD_ORDER = ":childOrder";
     public static final String DELIMITER = "|";
+    public static final char DELIMITER_CHAR = '|';
     private final JsopBuilder jw = new JsopBuilder();
     private final JsonSerializer serializer;
     private final Joiner pathJoiner = Joiner.on('/');
@@ -61,7 +60,7 @@ public class NodeStateEntryWriter {
     }
 
     public String toString(String path, String nodeStateAsJson) {
-        return path + DELIMITER + nodeStateAsJson;
+        return path + DELIMITER_CHAR + nodeStateAsJson;
     }
 
     public String toString(List<String> pathElements, String nodeStateAsJson) {
@@ -69,7 +68,7 @@ public class NodeStateEntryWriter {
         StringBuilder sb = new StringBuilder(nodeStateAsJson.length() + pathStringSize + pathElements.size() + 1);
         sb.append('/');
         pathJoiner.appendTo(sb, pathElements);
-        sb.append(DELIMITER).append(nodeStateAsJson);
+        sb.append(DELIMITER_CHAR).append(nodeStateAsJson);
         return sb.toString();
     }
 
@@ -117,8 +116,10 @@ public class NodeStateEntryWriter {
     }
 
     private static int getDelimiterPosition(String entryLine) {
-        int indexOfPipe = entryLine.indexOf(NodeStateEntryWriter.DELIMITER);
-        checkState(indexOfPipe > 0, "Invalid path entry [%s]", entryLine);
+        int indexOfPipe = entryLine.indexOf(NodeStateEntryWriter.DELIMITER_CHAR);
+        if (indexOfPipe <= 0) {
+            throw new IllegalStateException("Invalid path entry " + entryLine);
+        }
         return indexOfPipe;
     }
 }


### PR DESCRIPTION
- Use char instead of single-char String for constant with delimiter of Flat File Store entries.
- Remove usages of Guava.
- Create NodeStateEntries directly without going through a builder