### PR TITLE
OAK-10990 - In calls to Preconditions.checkState(), use string templates to avoid creating a string when the condition checked is true

### DIFF
--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -158,7 +158,7 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
     public String getPlanDescription(IndexPlan plan, NodeState root) {
         Filter filter = plan.getFilter();
         IndexNode index = acquireIndexNode(plan);
-        checkState(index != null, "The fulltext index of type " + getType() + "  index is not available");
+        checkState(index != null, "The fulltext index of type %s index is not available", getType());
         try {
             FullTextExpression ft = filter.getFullTextConstraint();
             StringBuilder sb = new StringBuilder();
@@ -411,7 +411,7 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
                                   final IndexPlan plan, QueryLimits settings, SizeEstimator sizeEstimator) {
             pathPrefix = plan.getPathPrefix();
             this.sizeEstimator = sizeEstimator;
-            Iterator<String> pathIterator = new Iterator<String>() {
+            Iterator<String> pathIterator = new Iterator<>() {
 
                 private int readCount;
                 private int rewoundCount;
@@ -556,7 +556,7 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
             return pathRow.getValue(columnName);
         }
 
-    };
+    }
 
     public interface IteratorRewoundStateProvider {
         int rewoundCount();

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -411,7 +411,7 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
                                   final IndexPlan plan, QueryLimits settings, SizeEstimator sizeEstimator) {
             pathPrefix = plan.getPathPrefix();
             this.sizeEstimator = sizeEstimator;
-            Iterator<String> pathIterator = new Iterator<>() {
+            Iterator<String> pathIterator = new Iterator<String>() {
 
                 private int readCount;
                 private int rewoundCount;
@@ -556,7 +556,7 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
             return pathRow.getValue(columnName);
         }
 
-    }
+    };
 
     public interface IteratorRewoundStateProvider {
         int rewoundCount();

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MemoryNodeBuilder.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MemoryNodeBuilder.java
@@ -339,7 +339,7 @@ public class MemoryNodeBuilder implements NodeBuilder {
     @NotNull
     @Override
     public NodeBuilder setChildNode(@NotNull String name, @NotNull NodeState state) {
-        checkState(exists(), "This builder does not exist: " + this.name);
+        checkState(exists(), "This builder does not exist: %s", name);
         head().getMutableNodeState().setChildNode(name, checkNotNull(state));
         MemoryNodeBuilder builder = createChildBuilder(name);
         updated();
@@ -505,7 +505,7 @@ public class MemoryNodeBuilder implements NodeBuilder {
     @NotNull
     @Override
     public NodeBuilder setProperty(@NotNull PropertyState property) {
-        checkState(exists(), "This builder does not exist: " + name);
+        checkState(exists(), "This builder does not exist: %s", name);
         head().getMutableNodeState().setProperty(checkNotNull(property));
         updated();
         return this;
@@ -528,7 +528,7 @@ public class MemoryNodeBuilder implements NodeBuilder {
     @NotNull
     @Override
     public NodeBuilder removeProperty(String name) {
-        checkState(exists(), "This builder does not exist: " + name);
+        checkState(exists(), "This builder does not exist: %s", name);
         if (head().getMutableNodeState().removeProperty(checkNotNull(name))) {
             updated();
         }


### PR DESCRIPTION
Some of these calls are on the critical path of creating Node objects, so it has a measurable impact on performance.