### PR TITLE
OAK-10989 - Performance improvements to JSON parsing

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryReader.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryReader.java
@@ -20,7 +20,6 @@
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry.NodeStateEntryBuilder;
 import org.apache.jackrabbit.oak.json.BlobDeserializer;
 import org.apache.jackrabbit.oak.json.JsonDeserializer;
 import org.apache.jackrabbit.oak.plugins.blob.serializer.BlobIdSerializer;
@@ -30,20 +29,21 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import static org.apache.jackrabbit.oak.commons.StringUtils.estimateMemoryUsage;
 
 public class NodeStateEntryReader {
-    private final BlobDeserializer blobDeserializer;
+    private final JsonDeserializer des;
 
     public NodeStateEntryReader(BlobStore blobStore) {
-        this.blobDeserializer = new BlobIdSerializer(blobStore);
+        BlobDeserializer blobDeserializer = new BlobIdSerializer(blobStore);
+        this.des = new JsonDeserializer(blobDeserializer);
     }
 
     public NodeStateEntry read(String line) {
         String[] parts = NodeStateEntryWriter.getParts(line);
         long memUsage = estimateMemoryUsage(parts[0]) + estimateMemoryUsage(parts[1]);
-        return new NodeStateEntryBuilder(parseState(parts[1]), parts[0]).withMemUsage(memUsage).build();
+        NodeState nodeState = parseState(parts[1]);
+        return new NodeStateEntry(nodeState, parts[0], memUsage, 0, "");
     }
 
     protected NodeState parseState(String part) {
-        JsonDeserializer des = new JsonDeserializer(blobDeserializer);
         return des.deserialize(part);
     }
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryWriter.java
@@ -32,12 +32,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
-
 public class NodeStateEntryWriter {
     private static final boolean SORTED_PROPERTIES = Boolean.getBoolean("oak.NodeStateEntryWriter.sort");
     private static final String OAK_CHILD_ORDER = ":childOrder";
     public static final String DELIMITER = "|";
+    public static final char DELIMITER_CHAR = '|';
     private final JsopBuilder jw = new JsopBuilder();
     private final JsonSerializer serializer;
     private final Joiner pathJoiner = Joiner.on('/');
@@ -61,7 +60,7 @@ public class NodeStateEntryWriter {
     }
 
     public String toString(String path, String nodeStateAsJson) {
-        return path + DELIMITER + nodeStateAsJson;
+        return path + DELIMITER_CHAR + nodeStateAsJson;
     }
 
     public String toString(List<String> pathElements, String nodeStateAsJson) {
@@ -69,7 +68,7 @@ public class NodeStateEntryWriter {
         StringBuilder sb = new StringBuilder(nodeStateAsJson.length() + pathStringSize + pathElements.size() + 1);
         sb.append('/');
         pathJoiner.appendTo(sb, pathElements);
-        sb.append(DELIMITER).append(nodeStateAsJson);
+        sb.append(DELIMITER_CHAR).append(nodeStateAsJson);
         return sb.toString();
     }
 
@@ -117,8 +116,10 @@ public class NodeStateEntryWriter {
     }
 
     private static int getDelimiterPosition(String entryLine) {
-        int indexOfPipe = entryLine.indexOf(NodeStateEntryWriter.DELIMITER);
-        checkState(indexOfPipe > 0, "Invalid path entry [%s]", entryLine);
+        int indexOfPipe = entryLine.indexOf(NodeStateEntryWriter.DELIMITER_CHAR);
+        if (indexOfPipe <= 0) {
+            throw new IllegalStateException("Invalid path entry " + entryLine);
+        }
         return indexOfPipe;
     }
 }

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/json/JsonDeserializer.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/json/JsonDeserializer.java
@@ -19,12 +19,12 @@
 
 package org.apache.jackrabbit.oak.json;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import javax.jcr.PropertyType;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.LongUtils;
@@ -39,8 +39,6 @@ import org.apache.jackrabbit.oak.plugins.value.Conversions;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
-import static org.apache.jackrabbit.guava.common.collect.ImmutableSet.of;
-import static java.util.Collections.emptyList;
 import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
@@ -48,26 +46,45 @@ import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 
 public class JsonDeserializer {
-    public static final String OAK_CHILD_ORDER = ":childOrder";
-    private final BlobDeserializer blobHandler;
-    private final NodeBuilder builder;
-    private final DeserializationSupport deserializationSupport;
+    /**
+     * Provides support for inferring types for some common property name and types
+     */
+    private static final Set<String> NAME_PROPS = Set.of(JCR_PRIMARYTYPE, JCR_MIXINTYPES);
+    private static final String ORDERABLE_TYPE = NT_UNSTRUCTURED;
+    private static final String OAK_CHILD_ORDER = ":childOrder";
 
-    private JsonDeserializer(BlobDeserializer blobHandler, NodeBuilder builder, DeserializationSupport support) {
-        this.blobHandler = blobHandler;
-        this.builder = builder;
-        this.deserializationSupport = support;
+    private static Type<?> inferPropertyType(String propertyName, String jsonString) {
+        if (NAME_PROPS.contains(propertyName) && hasSingleColon(jsonString)) {
+            return Type.NAME;
+        }
+        return Type.UNDEFINED;
     }
+
+    private static boolean hasOrderableChildren(NodeBuilder builder) {
+        PropertyState primaryType = builder.getProperty(JCR_PRIMARYTYPE);
+        return primaryType != null && ORDERABLE_TYPE.equals(primaryType.getValue(Type.NAME));
+    }
+
+    private static boolean hasSingleColon(String jsonString) {
+        // In case the primaryType was encoded then it would be like
+        // "nam:oak:Unstructured". So check if there is only one occurrence
+        // of ':'.
+        int colonCount = 0;
+        for (int i = 0; i < jsonString.length() && colonCount < 2; i++) {
+            if (jsonString.charAt(i) == ':') {
+                colonCount += 1;
+            }
+        }
+        return colonCount == 1;
+    }
+
+    private final BlobDeserializer blobHandler;
 
     public JsonDeserializer(BlobDeserializer blobHandler) {
-        this(blobHandler, EMPTY_NODE.builder(), DeserializationSupport.INSTANCE);
+        this.blobHandler = blobHandler;
     }
 
-    public JsonDeserializer(BlobDeserializer blobHandler, NodeBuilder builder) {
-        this(blobHandler, builder, DeserializationSupport.INSTANCE);
-    }
-
-    public NodeState deserialize(String json){
+    public NodeState deserialize(String json) {
         JsopReader reader = new JsopTokenizer(json);
         reader.read('{');
         NodeState state = deserialize(reader);
@@ -75,13 +92,14 @@ public class JsonDeserializer {
         return state;
     }
 
-    public NodeState deserialize(JsopReader reader){
+    public NodeState deserialize(JsopReader reader) {
+        NodeBuilder builder = EMPTY_NODE.builder();
         readNode(reader, builder);
         return builder.getNodeState();
     }
 
     private void readNode(JsopReader reader, NodeBuilder builder) {
-        List<String> childNames = Lists.newArrayList();
+        List<String> childNames = new ArrayList<>();
         if (!reader.matches('}')) {
             do {
                 String key = reader.readString();
@@ -98,8 +116,7 @@ public class JsonDeserializer {
             reader.read('}');
         }
 
-        if (deserializationSupport.hasOrderableChildren(builder)
-                && !builder.hasProperty(OAK_CHILD_ORDER)){
+        if (hasOrderableChildren(builder) && !builder.hasProperty(OAK_CHILD_ORDER)) {
             builder.setProperty(OAK_CHILD_ORDER, childNames, Type.NAMES);
         }
 
@@ -112,7 +129,35 @@ public class JsonDeserializer {
      * @return new property state
      */
     private PropertyState readProperty(String name, JsopReader reader) {
-        if (reader.matches(JsopReader.NUMBER)) {
+        // Test for the most common types first
+        if (reader.matches(JsopReader.STRING)) {
+            String jsonString = reader.getToken();
+            Type<?> inferredType = inferPropertyType(name, jsonString);
+            if (jsonString.startsWith(TypeCodes.EMPTY_ARRAY)) {
+                int type = PropertyType.valueFromName(jsonString.substring(TypeCodes.EMPTY_ARRAY.length()));
+                return PropertyStates.createProperty(name, List.of(), Type.fromTag(type, true));
+            }
+            int split = TypeCodes.split(jsonString);
+            if (split != -1) {
+                int type = TypeCodes.decodeType(split, jsonString);
+                String value = TypeCodes.decodeName(split, jsonString);
+                if (type == PropertyType.BINARY) {
+                    return BinaryPropertyState.binaryProperty(name, blobHandler.deserialize(value));
+                } else {
+                    //It can happen that a value like oak:Unstructured is also interpreted
+                    //as type code. So if oakType is not undefined then use raw value
+                    //Also default to STRING in case of UNDEFINED
+                    if (type == PropertyType.UNDEFINED) {
+                        Type<?> oakType = inferredType != Type.UNDEFINED ? inferredType : Type.STRING;
+                        return createProperty(name, jsonString, oakType);
+                    }
+                    return createProperty(name, value, type);
+                }
+            } else {
+                Type<?> oakType = inferredType != Type.UNDEFINED ? inferredType : Type.STRING;
+                return createProperty(name, jsonString, oakType);
+            }
+        } else if (reader.matches(JsopReader.NUMBER)) {
             String number = reader.getToken();
             Long maybeLong = LongUtils.tryParse(number);
             if (maybeLong == null) {
@@ -124,36 +169,6 @@ public class JsonDeserializer {
             return BooleanPropertyState.booleanProperty(name, true);
         } else if (reader.matches(JsopReader.FALSE)) {
             return BooleanPropertyState.booleanProperty(name, false);
-        } else if (reader.matches(JsopReader.STRING)) {
-            String jsonString = reader.getToken();
-            Type inferredType = deserializationSupport.inferPropertyType(name, jsonString);
-            if (jsonString.startsWith(TypeCodes.EMPTY_ARRAY)) {
-                int type = PropertyType.valueFromName(
-                        jsonString.substring(TypeCodes.EMPTY_ARRAY.length()));
-                return PropertyStates.createProperty(
-                        name, emptyList(), Type.fromTag(type, true));
-            }
-            int split = TypeCodes.split(jsonString);
-            if (split != -1) {
-                int type = TypeCodes.decodeType(split, jsonString);
-                String value = TypeCodes.decodeName(split, jsonString);
-                if (type == PropertyType.BINARY) {
-                    return  BinaryPropertyState.binaryProperty(
-                            name, blobHandler.deserialize(value));
-                } else {
-                    //It can happen that a value like oak:Unstructured is also interpreted
-                    //as type code. So if oakType is not undefined then use raw value
-                    //Also default to STRING in case of UNDEFINED
-                    if (type == PropertyType.UNDEFINED){
-                        Type oakType = inferredType != Type.UNDEFINED ? inferredType : Type.STRING;
-                        return createProperty(name, jsonString, oakType);
-                    }
-                    return createProperty(name, value, type);
-                }
-            } else {
-                Type oakType = inferredType != Type.UNDEFINED ? inferredType : Type.STRING;
-                return createProperty(name, jsonString, oakType);
-            }
         } else {
             throw new IllegalArgumentException("Unexpected token: " + reader.getToken());
         }
@@ -167,27 +182,12 @@ public class JsonDeserializer {
      */
     private PropertyState readArrayProperty(String name, JsopReader reader) {
         int type = PropertyType.STRING;
-        List<Object> values = Lists.newArrayList();
+        List<Object> values = new ArrayList<>();
         while (!reader.matches(']')) {
-            if (reader.matches(JsopReader.NUMBER)) {
-                String number = reader.getToken();
-                Long maybeLong = LongUtils.tryParse(number);
-                if (maybeLong == null) {
-                    type = PropertyType.DOUBLE;
-                    values.add(Double.parseDouble(number));
-                } else {
-                    type = PropertyType.LONG;
-                    values.add(maybeLong);
-                }
-            } else if (reader.matches(JsopReader.TRUE)) {
-                type = PropertyType.BOOLEAN;
-                values.add(true);
-            } else if (reader.matches(JsopReader.FALSE)) {
-                type = PropertyType.BOOLEAN;
-                values.add(false);
-            } else if (reader.matches(JsopReader.STRING)) {
+            // Test for the most common types first
+            if (reader.matches(JsopReader.STRING)) {
                 String jsonString = reader.getToken();
-                Type inferredType = deserializationSupport.inferPropertyType(name, jsonString);
+                Type<?> inferredType = inferPropertyType(name, jsonString);
                 int split = TypeCodes.split(jsonString);
                 if (split != -1) {
                     type = TypeCodes.decodeType(split, jsonString);
@@ -199,7 +199,7 @@ public class JsonDeserializer {
                     } else if (type == PropertyType.DECIMAL) {
                         values.add(Conversions.convert(value).toDecimal());
                     } else {
-                        if (type == PropertyType.UNDEFINED){
+                        if (type == PropertyType.UNDEFINED) {
                             //If determine type is undefined then check if inferred type is defined
                             //else default to STRING
                             type = inferredType != Type.UNDEFINED ? inferredType.tag() : PropertyType.STRING;
@@ -212,6 +212,22 @@ public class JsonDeserializer {
                     type = inferredType != Type.UNDEFINED ? inferredType.tag() : PropertyType.STRING;
                     values.add(jsonString);
                 }
+            } else if (reader.matches(JsopReader.NUMBER)) {
+                String number = reader.getToken();
+                Long maybeLong = LongUtils.tryParse(number);
+                if (maybeLong == null) {
+                    type = PropertyType.DOUBLE;
+                    values.add(Double.parseDouble(number));
+                } else {
+                    type = PropertyType.LONG;
+                    values.add(maybeLong);
+                }
+            } else if (reader.matches(JsopReader.TRUE)) {
+                type = PropertyType.BOOLEAN;
+                values.add(Boolean.TRUE);
+            } else if (reader.matches(JsopReader.FALSE)) {
+                type = PropertyType.BOOLEAN;
+                values.add(Boolean.FALSE);
             } else {
                 throw new IllegalArgumentException("Unexpected token: " + reader.getToken());
             }
@@ -219,40 +235,4 @@ public class JsonDeserializer {
         }
         return createProperty(name, values, Type.fromTag(type, true));
     }
-
-
-    /**
-     * Provides support for inferring types for some common property name and types
-     */
-    private static class DeserializationSupport {
-        static final Set<String> NAME_PROPS = of(JCR_PRIMARYTYPE, JCR_MIXINTYPES);
-        static final Set<String> ORDERABLE_TYPES = of(NT_UNSTRUCTURED);
-        static final DeserializationSupport INSTANCE = new DeserializationSupport();
-
-        Type inferPropertyType(String propertyName, String jsonString) {
-            if (NAME_PROPS.contains(propertyName) && hasSingleColon(jsonString)) {
-                return Type.NAME;
-            }
-            return Type.UNDEFINED;
-        }
-
-        boolean hasOrderableChildren(NodeBuilder builder) {
-            PropertyState primaryType = builder.getProperty(JCR_PRIMARYTYPE);
-            return primaryType != null && ORDERABLE_TYPES.contains(primaryType.getValue(Type.NAME));
-        }
-
-        private boolean hasSingleColon(String jsonString) {
-            // In case the primaryType was encoded then it would be like
-            // "nam:oak:Unstructured". So check if there is only one occurrence
-            // of ':'.
-            int colonCount = 0;
-            for (int i = 0; i < jsonString.length() && colonCount < 2; i++) {
-                if (jsonString.charAt(i) == ':') {
-                    colonCount += 1;
-                }
-            }
-            return colonCount == 1;
-        }
-    }
-
 }


### PR DESCRIPTION
In JsonDeserializer:
- when reading a property, check for the most common types first (String).
- make instances reusable by creating a new MemoryNodeBuilder for every call to deserialize
- Remove usages of Guava collections.
- Move the methods in the inner class DeserializationSupport to top level methods in JsonDeserializer, as these inner class was not accessed anywhere outside JsonDeserializer and did not contain any state.