### PR TITLE
OAK-10995 - When accessing the backing array of a ByteBuffer directly, use ByteBuffer.arrayOffset() in index calculations

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedSortBatchTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedSortBatchTask.java
@@ -165,7 +165,7 @@ class PipelinedSortBatchTask implements Callable<PipelinedSortBatchTask.Result> 
             int pathLength = buffer.getInt();
             totalPathSize += pathLength;
             // Create the String directly from the buffer without creating an intermediate byte[]
-            String path = new String(buffer.array(), buffer.position(), pathLength, StandardCharsets.UTF_8);
+            String path = new String(buffer.array(), buffer.arrayOffset() + buffer.position(), pathLength, StandardCharsets.UTF_8);
             buffer.position(buffer.position() + pathLength);
             // Skip the json
             int entryLength = buffer.getInt();


### PR DESCRIPTION
In the common case, a `ByteBuffer` backed by an array will use the array starting from position 0. But in some cases, especially when using `ByteBuffer.slice()`, the first position of the buffer might not correspond to the start of the array. In this case, whenever accessing directly the array, we must offset any accesses by `ByteBuffer.arrayOffset()`.

We are not using slice() or any other operation that would result in a non-zero arrayOffset(), but it's better to do the correct calculation to future-proof the code. 