### PR TITLE
OAK-10996 - indexing-job: cache interned strings in a local hashmap to avoid calling String.intern too frequently

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
@@ -48,6 +48,7 @@ public final class SortKey {
     );
 
     private static final int MAX_INTERN_CACHE = 1024;
+    private static final int MAX_INTERNED_STRING_LENGTH = 1024;
     private static final HashMap<String, String> INTERN_CACHE = new HashMap<>(512);
 
     public static String[] genSortKeyPathElements(String path) {
@@ -59,7 +60,7 @@ public final class SortKey {
             // It is not worth to intern all levels because at lower levels the names are more likely to be less diverse,
             // often even unique, so interning them would fill up the interned string hashtable with useless entries.
             if ((i < 3 || part.length() == 1 || part.startsWith("dam:") || part.startsWith("jcr:") || COMMON_PATH_WORDS.contains(part)) &&
-                    INTERN_CACHE.size() < MAX_INTERN_CACHE) {
+                    INTERN_CACHE.size() < MAX_INTERN_CACHE && part.length() < MAX_INTERNED_STRING_LENGTH) {
                 pathElements[i] = INTERN_CACHE.computeIfAbsent(part, String::intern);
             } else {
                 pathElements[i] = part;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import org.apache.jackrabbit.oak.commons.PathUtils;
 
+import java.util.HashMap;
 import java.util.Set;
 
 import static org.apache.jackrabbit.oak.commons.PathUtils.elements;
@@ -34,12 +35,6 @@ public final class SortKey {
             "dam",
             "data",
             "items",
-            "jcr:content",
-            "jcr:created",
-            "jcr:primaryType",
-            "jcr:system",
-            "jcr:uuid",
-            "jcr:versionStorage",
             "libs",
             "master",
             "metadata",
@@ -52,6 +47,9 @@ public final class SortKey {
             "var"
     );
 
+    private static final int MAX_INTERN_CACHE = 1024;
+    private static final HashMap<String, String> INTERN_CACHE = new HashMap<>(512);
+
     public static String[] genSortKeyPathElements(String path) {
         String[] pathElements = new String[PathUtils.getDepth(path)];
         int i = 0;
@@ -60,8 +58,9 @@ public final class SortKey {
             // Interning these strings should provide a big reduction in memory usage.
             // It is not worth to intern all levels because at lower levels the names are more likely to be less diverse,
             // often even unique, so interning them would fill up the interned string hashtable with useless entries.
-            if (i < 3 || part.length() == 1 || COMMON_PATH_WORDS.contains(part)) {
-                pathElements[i] = part.intern();
+            if ((i < 3 || part.length() == 1 || part.startsWith("dam:") || part.startsWith("jcr:") || COMMON_PATH_WORDS.contains(part)) &&
+                    INTERN_CACHE.size() < MAX_INTERN_CACHE) {
+                pathElements[i] = INTERN_CACHE.computeIfAbsent(part, String::intern);
             } else {
                 pathElements[i] = part;
             }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
@@ -59,7 +59,7 @@ public final class SortKey {
             // Interning these strings should provide a big reduction in memory usage.
             // It is not worth to intern all levels because at lower levels the names are more likely to be less diverse,
             // often even unique, so interning them would fill up the interned string hashtable with useless entries.
-            if ((i < 3 || part.length() == 1 || part.startsWith("dam:") || part.startsWith("jcr:") || COMMON_PATH_WORDS.contains(part)) &&
+            if ((i < 3 || part.length() == 1 || part.startsWith("jcr:") || COMMON_PATH_WORDS.contains(part)) &&
                     INTERN_CACHE.size() < MAX_INTERN_CACHE && part.length() < MAX_INTERNED_STRING_LENGTH) {
                 pathElements[i] = INTERN_CACHE.computeIfAbsent(part, String::intern);
             } else {


### PR DESCRIPTION
Cache in a HashMap in the heap interned to avoid calling `String.intern()` for every String that should be interned. Calls to `String.intern()` are much more expensive than calls to `HashMap.get()`.

In a test reading 10 million paths from a file and calling `SortKey.genSortKeyPathElements(path)` for each of them, the times are the following:
- calling String.intern for every String: 25 seconds
- caching interned Strings in a map (this PR): 19.5 seconds
- no interning: 19 seconds.

The HashMap cache removed almost all of the overhead of interning the strings.