### PR TITLE
OAK-10803 - Fix memory consumption of uncompress properties

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * PropertyState implementation with lazy parsing of the JSOP encoded value.
+ * PropertyState compression implementation with lazy parsing of the JSOP encoded value.
  */
 public final class CompressedDocumentPropertyState implements PropertyState {
 
@@ -341,10 +341,3 @@ public final class CompressedDocumentPropertyState implements PropertyState {
         return createProperty(name, values, Type.fromTag(type, true));
     }
 }
-
-
-
-
-
-
-

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
@@ -16,36 +16,20 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static java.util.Collections.emptyList;
-import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-
-import javax.jcr.PropertyType;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.Compression;
-import org.apache.jackrabbit.oak.commons.LongUtils;
 import org.apache.jackrabbit.oak.commons.json.JsopReader;
 import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
 import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
-import org.apache.jackrabbit.oak.json.TypeCodes;
 import org.apache.jackrabbit.oak.plugins.memory.AbstractPropertyState;
-import org.apache.jackrabbit.oak.plugins.memory.BinaryPropertyState;
-import org.apache.jackrabbit.oak.plugins.memory.BooleanPropertyState;
-import org.apache.jackrabbit.oak.plugins.memory.DoublePropertyState;
-import org.apache.jackrabbit.oak.plugins.memory.LongPropertyState;
-import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
-import org.apache.jackrabbit.oak.plugins.memory.StringPropertyState;
-import org.apache.jackrabbit.oak.plugins.value.Conversions;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
@@ -24,12 +24,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import javax.jcr.PropertyType;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.Compression;
@@ -296,7 +296,7 @@ public final class CompressedDocumentPropertyState implements PropertyState {
      */
     static PropertyState readArrayProperty(String name, DocumentNodeStore store, JsopReader reader) {
         int type = PropertyType.STRING;
-        List<Object> values = Lists.newArrayList();
+        List<Object> values = new ArrayList<>();
         while (!reader.matches(']')) {
             if (reader.matches(JsopReader.NUMBER)) {
                 String number = reader.getToken();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
@@ -66,7 +66,6 @@ public final class CompressedDocumentPropertyState implements PropertyState {
     private PropertyState parsed;
     private final byte[] compressedValue;
     private final Compression compression;
-    private String decompressedValue;
 
     private static int COMPRESSION_THRESHOLD = SystemPropertySupplier
             .create("oak.documentMK.stringCompressionThreshold ", -1).loggingTo(LOG).get();
@@ -159,15 +158,12 @@ public final class CompressedDocumentPropertyState implements PropertyState {
     }
 
     private String decompress(byte[] value) {
-        if (decompressedValue == null) {
-            try {
-                decompressedValue = new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                LOG.error("Failed to decompress property {} value: ", getName(), e);
-                decompressedValue = "\"{}\"";
-            }
+        try {
+            return new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOG.error("Failed to decompress property {} value: ", getName(), e);
+            return "\"{}\"";
         }
-        return decompressedValue;
     }
 
     byte[] getCompressedValue() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyState.java
@@ -19,6 +19,12 @@ package org.apache.jackrabbit.oak.plugins.document;
 import static java.util.Collections.emptyList;
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.jcr.PropertyType;
@@ -26,8 +32,11 @@ import javax.jcr.PropertyType;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.Compression;
+import org.apache.jackrabbit.oak.commons.LongUtils;
 import org.apache.jackrabbit.oak.commons.json.JsopReader;
 import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.json.TypeCodes;
 import org.apache.jackrabbit.oak.plugins.memory.AbstractPropertyState;
 import org.apache.jackrabbit.oak.plugins.memory.BinaryPropertyState;
@@ -38,11 +47,15 @@ import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.apache.jackrabbit.oak.plugins.memory.StringPropertyState;
 import org.apache.jackrabbit.oak.plugins.value.Conversions;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PropertyState implementation with lazy parsing of the JSOP encoded value.
  */
-final class DocumentPropertyState implements PropertyState {
+public final class CompressedDocumentPropertyState implements PropertyState {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CompressedDocumentPropertyState.class);
 
     private final DocumentNodeStore store;
 
@@ -51,11 +64,37 @@ final class DocumentPropertyState implements PropertyState {
     private final String value;
 
     private PropertyState parsed;
+    private final byte[] compressedValue;
+    private final Compression compression;
+    private String decompressedValue;
 
-    DocumentPropertyState(DocumentNodeStore store, String name, String value) {
+    private static int COMPRESSION_THRESHOLD = SystemPropertySupplier
+            .create("oak.documentMK.stringCompressionThreshold ", -1).loggingTo(LOG).get();
+
+    CompressedDocumentPropertyState(DocumentNodeStore store, String name, String value, Compression compression) {
         this.store = store;
         this.name = name;
+        this.compression = compression;
+        int size = value.length();
+        byte[] compressedValue = null;
+        if (size > COMPRESSION_THRESHOLD) {
+            try {
+                compressedValue = compress(value.getBytes(StandardCharsets.UTF_8));
+                value = null;
+            } catch (IOException e) {
+                LOG.warn("Failed to compress property {} value: ", name, e);
+            }
+        }
         this.value = value;
+        this.compressedValue = compressedValue;
+    }
+
+    private byte[] compress(byte[] value) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        OutputStream compressionOutputStream = compression.getOutputStream(out);
+        compressionOutputStream.write(value);
+        compressionOutputStream.close();
+        return out.toByteArray();
     }
 
     @NotNull
@@ -116,7 +155,23 @@ final class DocumentPropertyState implements PropertyState {
      */
     @NotNull
     String getValue() {
-        return value;
+        return value != null ? value : decompress(this.compressedValue);
+    }
+
+    private String decompress(byte[] value) {
+        if (decompressedValue == null) {
+            try {
+                decompressedValue = new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                LOG.error("Failed to decompress property {} value: ", getName(), e);
+                decompressedValue = "\"{}\"";
+            }
+        }
+        return decompressedValue;
+    }
+
+    byte[] getCompressedValue() {
+        return compressedValue;
     }
 
     //------------------------------------------------------------< Object >--
@@ -125,10 +180,20 @@ final class DocumentPropertyState implements PropertyState {
     public boolean equals(Object object) {
         if (this == object) {
             return true;
-        } else if (object instanceof DocumentPropertyState) {
-            DocumentPropertyState other = (DocumentPropertyState) object;
-            return this.name.equals(other.name)
-                    && this.value.equals(other.value);
+        } else if (object instanceof CompressedDocumentPropertyState) {
+            CompressedDocumentPropertyState other = (CompressedDocumentPropertyState) object;
+            if (!this.name.equals(other.name) || !Arrays.equals(this.compressedValue, other.compressedValue)) {
+                return false;
+            }
+            if (this.compressedValue == null && other.compressedValue == null) {
+                return value.equals(other.value);
+            } else {
+                // Compare length and content of compressed values
+                if (this.compressedValue.length != other.compressedValue.length) {
+                    return false;
+                }
+                return Arrays.equals(this.compressedValue, other.compressedValue);
+            }
         }
         // fall back to default equality check in AbstractPropertyState
         return object instanceof PropertyState
@@ -145,11 +210,15 @@ final class DocumentPropertyState implements PropertyState {
         return AbstractPropertyState.toString(this);
     }
 
+    static void setCompressionThreshold(int compressionThreshold) {
+        COMPRESSION_THRESHOLD = compressionThreshold;
+    }
+
     //----------------------------< internal >----------------------------------
 
     private PropertyState parsed() {
         if (parsed == null) {
-            JsopReader reader = new JsopTokenizer(value);
+            JsopReader reader = new JsopTokenizer(getValue());
             if (reader.matches('[')) {
                 parsed = readArrayProperty(name, reader);
             } else {
@@ -180,10 +249,11 @@ final class DocumentPropertyState implements PropertyState {
     static PropertyState readProperty(String name, DocumentNodeStore store, JsopReader reader) {
         if (reader.matches(JsopReader.NUMBER)) {
             String number = reader.getToken();
-            try {
-                return new LongPropertyState(name, Long.parseLong(number));
-            } catch (NumberFormatException e) {
+            Long maybeLong = LongUtils.tryParse(number);
+            if (maybeLong == null) {
                 return new DoublePropertyState(name, Double.parseDouble(number));
+            } else {
+                return new LongPropertyState(name, maybeLong);
             }
         } else if (reader.matches(JsopReader.TRUE)) {
             return BooleanPropertyState.booleanProperty(name, true);
@@ -238,12 +308,13 @@ final class DocumentPropertyState implements PropertyState {
         while (!reader.matches(']')) {
             if (reader.matches(JsopReader.NUMBER)) {
                 String number = reader.getToken();
-                try {
-                    type = PropertyType.LONG;
-                    values.add(Long.parseLong(number));
-                } catch (NumberFormatException e) {
+                Long maybeLong = LongUtils.tryParse(number);
+                if (maybeLong == null) {
                     type = PropertyType.DOUBLE;
                     values.add(Double.parseDouble(number));
+                } else {
+                    type = PropertyType.LONG;
+                    values.add(maybeLong);
                 }
             } else if (reader.matches(JsopReader.TRUE)) {
                 type = PropertyType.BOOLEAN;
@@ -278,3 +349,10 @@ final class DocumentPropertyState implements PropertyState {
         return createProperty(name, values, Type.fromTag(type, true));
     }
 }
+
+
+
+
+
+
+

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -1353,7 +1353,7 @@ public final class DocumentNodeStore
 
     @NotNull
     public PropertyState createPropertyState(String name, String value){
-        return new DocumentPropertyState(this, name, checkNotNull(value));
+        return DocumentPropertyStateFactory.createPropertyState(this, name, checkNotNull(value));
     }
 
     /**
@@ -3214,8 +3214,7 @@ public final class DocumentNodeStore
         if (json == null) {
             return -1;
         }
-        PropertyState p = new DocumentPropertyState(
-                DocumentNodeStore.this, "p", json);
+        PropertyState p = DocumentPropertyStateFactory.createPropertyState(DocumentNodeStore.this, "p", json);
         if (p.getType().tag() != PropertyType.BINARY) {
             return -1;
         }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -77,7 +77,6 @@ import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.cache.CacheStats;
-import org.apache.jackrabbit.oak.commons.Compression;
 import org.apache.jackrabbit.oak.commons.PerfLogger;
 import org.apache.jackrabbit.oak.commons.json.JsopStream;
 import org.apache.jackrabbit.oak.commons.json.JsopWriter;
@@ -1354,7 +1353,7 @@ public final class DocumentNodeStore
 
     @NotNull
     public PropertyState createPropertyState(String name, String value){
-        return DocumentPropertyStateFactory.createPropertyState(this, name, value, Compression.NONE);
+        return new DocumentPropertyState(this, name, checkNotNull(value));
     }
 
     /**
@@ -3215,7 +3214,8 @@ public final class DocumentNodeStore
         if (json == null) {
             return -1;
         }
-        PropertyState p = DocumentPropertyStateFactory.createPropertyState(this, "p", json, Compression.NONE);
+        PropertyState p = new DocumentPropertyState(
+                DocumentNodeStore.this, "p", json);
         if (p.getType().tag() != PropertyType.BINARY) {
             return -1;
         }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -77,6 +77,7 @@ import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.cache.CacheStats;
+import org.apache.jackrabbit.oak.commons.Compression;
 import org.apache.jackrabbit.oak.commons.PerfLogger;
 import org.apache.jackrabbit.oak.commons.json.JsopStream;
 import org.apache.jackrabbit.oak.commons.json.JsopWriter;
@@ -1353,7 +1354,7 @@ public final class DocumentNodeStore
 
     @NotNull
     public PropertyState createPropertyState(String name, String value){
-        return new DocumentPropertyState(this, name, checkNotNull(value));
+        return DocumentPropertyStateFactory.createPropertyState(this, name, value, Compression.NONE);
     }
 
     /**
@@ -3214,8 +3215,7 @@ public final class DocumentNodeStore
         if (json == null) {
             return -1;
         }
-        PropertyState p = new DocumentPropertyState(
-                DocumentNodeStore.this, "p", json);
+        PropertyState p = DocumentPropertyStateFactory.createPropertyState(this, "p", json, Compression.NONE);
         if (p.getType().tag() != PropertyType.BINARY) {
             return -1;
         }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
@@ -19,11 +19,11 @@ package org.apache.jackrabbit.oak.plugins.document;
 import static java.util.Collections.emptyList;
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.PropertyType;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.LongUtils;
@@ -236,7 +236,7 @@ final class DocumentPropertyState implements PropertyState {
      */
     static PropertyState readArrayProperty(String name, DocumentNodeStore store, JsopReader reader) {
         int type = PropertyType.STRING;
-        List<Object> values = Lists.newArrayList();
+        List<Object> values = new ArrayList();
         while (!reader.matches(']')) {
             if (reader.matches(JsopReader.NUMBER)) {
                 String number = reader.getToken();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
@@ -166,7 +166,13 @@ final class DocumentPropertyState implements PropertyState {
      */
     @NotNull
     String getValue() {
-        return value != null ? value : decompress(this.compressedValue);
+        if (value != null) {
+            return value;
+        }
+        if (decompressedValue == null) {
+            decompressedValue = decompress(this.compressedValue);
+        }
+        return decompressedValue;
     }
 
     private String decompress(byte[] value) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
@@ -66,6 +66,7 @@ final class DocumentPropertyState implements PropertyState {
     private PropertyState parsed;
     private final byte[] compressedValue;
     private final Compression compression;
+    private String decompressedValue;
 
     private static int COMPRESSION_THRESHOLD = SystemPropertySupplier
             .create("oak.documentMK.stringCompressionThreshold ", -1).loggingTo(LOG).get();
@@ -169,12 +170,15 @@ final class DocumentPropertyState implements PropertyState {
     }
 
     private String decompress(byte[] value) {
-        try {
-            return new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            LOG.error("Failed to decompress property {} value: ", getName(), e);
-            return "\"{}\"";
+        if (decompressedValue == null) {
+            try {
+                return new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                LOG.error("Failed to decompress property {} value: ", getName(), e);
+                return "\"{}\"";
+            }
         }
+        return decompressedValue;
     }
 
     byte[] getCompressedValue() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
@@ -166,13 +166,7 @@ final class DocumentPropertyState implements PropertyState {
      */
     @NotNull
     String getValue() {
-        if (value != null) {
-            return value;
-        }
-        if (decompressedValue == null) {
-            decompressedValue = decompress(this.compressedValue);
-        }
-        return decompressedValue;
+        return value != null ? value : decompress(this.compressedValue);
     }
 
     private String decompress(byte[] value) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyState.java
@@ -172,10 +172,10 @@ final class DocumentPropertyState implements PropertyState {
     private String decompress(byte[] value) {
         if (decompressedValue == null) {
             try {
-                return new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
+                decompressedValue = new String(compression.getInputStream(new ByteArrayInputStream(value)).readAllBytes(), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 LOG.error("Failed to decompress property {} value: ", getName(), e);
-                return "\"{}\"";
+                decompressedValue = "\"{}\"";
             }
         }
         return decompressedValue;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
@@ -1,15 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jackrabbit.oak.plugins.document;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.Compression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DocumentPropertyStateFactory {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DocumentPropertyStateFactory.class);
+
     public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value, Compression compression) {
-        if (compression != null && !compression.equals(Compression.NONE)) {
-            return new CompressedDocumentPropertyState(store, name, value, compression);
+
+        if (compression != null && !compression.equals(Compression.NONE) && value.length() > CompressedDocumentPropertyState.getCompressionThreshold()) {
+            try {
+                return new CompressedDocumentPropertyState(store, name, value, compression);
+            } catch (Exception e) {
+                LOG.warn("Failed to compress property {} value: ", name, e);
+                return new DocumentPropertyState(store, name, value);
+            }
+
         } else {
             return new DocumentPropertyState(store, name, value);
         }
+    }
+
+    public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value) {
+        return createPropertyState(store, name, value, Compression.GZIP);
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
@@ -41,6 +41,6 @@ public class DocumentPropertyStateFactory {
     }
 
     public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value) {
-        return createPropertyState(store, name, value, Compression.NONE);
+        return createPropertyState(store, name, value, Compression.GZIP);
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
@@ -27,7 +27,9 @@ public class DocumentPropertyStateFactory {
 
     public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value, Compression compression) {
 
-        if (compression != null && !compression.equals(Compression.NONE) && value.length() > CompressedDocumentPropertyState.getCompressionThreshold()) {
+        if (compression != null && !compression.equals(Compression.NONE) &&
+                value.length() > CompressedDocumentPropertyState.getCompressionThreshold()
+             && CompressedDocumentPropertyState.getCompressionThreshold() != -1) {
             try {
                 return new CompressedDocumentPropertyState(store, name, value, compression);
             } catch (Exception e) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
@@ -1,0 +1,15 @@
+package org.apache.jackrabbit.oak.plugins.document;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.commons.Compression;
+
+public class DocumentPropertyStateFactory {
+
+    public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value, Compression compression) {
+        if (compression != null && !compression.equals(Compression.NONE)) {
+            return new CompressedDocumentPropertyState(store, name, value, compression);
+        } else {
+            return new DocumentPropertyState(store, name, value);
+        }
+    }
+}

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
@@ -41,6 +41,6 @@ public class DocumentPropertyStateFactory {
     }
 
     public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value) {
-        return createPropertyState(store, name, value, Compression.GZIP);
+        return createPropertyState(store, name, value, Compression.NONE);
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactory.java
@@ -28,8 +28,8 @@ public class DocumentPropertyStateFactory {
     public static PropertyState createPropertyState(DocumentNodeStore store, String name, String value, Compression compression) {
 
         if (compression != null && !compression.equals(Compression.NONE) &&
-                value.length() > CompressedDocumentPropertyState.getCompressionThreshold()
-             && CompressedDocumentPropertyState.getCompressionThreshold() != -1) {
+                CompressedDocumentPropertyState.getCompressionThreshold() != -1
+                && value.length() > CompressedDocumentPropertyState.getCompressionThreshold()) {
             try {
                 return new CompressedDocumentPropertyState(store, name, value, compression);
             } catch (Exception e) {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
@@ -155,7 +155,9 @@ public class CompressedDocumentPropertyStateTest {
 
         // Create a PropertyState instance with an uncompressed value
         CompressedDocumentPropertyState.setCompressionThreshold(-1);
-        PropertyState state2 = DocumentPropertyStateFactory.createPropertyState(store, name, value);
+        PropertyState state2 = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"");
+
+        assertEquals(state1, state2);
 
         // Decompress the value of the first instance
         String decompressedValue1 = state1.getValue(Type.STRING);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -49,7 +49,7 @@ public class CompressedDocumentPropertyStateTest {
     @Rule
     public DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
 
-    private Set<String> reads = newHashSet();
+    private Set<String> reads = new HashSet<>();
 
     private BlobStore bs = new MemoryBlobStore() {
         @Override

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
@@ -157,7 +157,7 @@ public class CompressedDocumentPropertyStateTest {
         CompressedDocumentPropertyState.setCompressionThreshold(-1);
         PropertyState state2 = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"");
 
-        assertEquals(state1, state2);
+        assertEquals(state2, state1);
 
         // Decompress the value of the first instance
         String decompressedValue1 = state1.getValue(Type.STRING);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
+import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.jackrabbit.oak.api.Blob;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.Compression;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoTestUtils;
+import org.apache.jackrabbit.oak.spi.blob.BlobStore;
+import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.junit.*;
+
+import com.mongodb.ReadPreference;
+
+public class CompressedDocumentPropertyStateTest {
+
+    private static final int BLOB_SIZE = 16 * 1024;
+    private static final String TEST_NODE = "test";
+    private static final String STRING_HUGEVALUE = RandomStringUtils.random(10050, "dummytest");
+    private static final int DEFAULT_COMPRESSION_THRESHOLD = 1024;
+    private static final int DISABLED_COMPRESSION = -1;
+
+    @Rule
+    public DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
+
+    private Set<String> reads = newHashSet();
+
+    private BlobStore bs = new MemoryBlobStore() {
+        @Override
+        public InputStream getInputStream(String blobId)
+                throws IOException {
+            reads.add(blobId);
+            return super.getInputStream(blobId);
+        }
+    };
+
+    private DocumentNodeStore ns;
+
+    @Before
+    public void before() throws Exception {
+        ns = builderProvider.newBuilder().setBlobStore(bs).getNodeStore();
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            ns.dispose();
+        } finally {
+            CompressedDocumentPropertyState.setCompressionThreshold(DISABLED_COMPRESSION);
+        }
+    }
+
+    // OAK-5462
+    @Test
+    public void multiValuedBinarySize() throws Exception {
+        NodeBuilder builder = ns.getRoot().builder();
+        List<Blob> blobs = newArrayList();
+        for (int i = 0; i < 3; i++) {
+            blobs.add(builder.createBlob(new RandomStream(BLOB_SIZE, i)));
+        }
+        builder.child("test").setProperty("p", blobs, Type.BINARIES);
+        TestUtils.merge(ns, builder);
+
+        PropertyState p = ns.getRoot().getChildNode("test").getProperty("p");
+        assertEquals(Type.BINARIES, p.getType());
+        assertEquals(3, p.count());
+
+        reads.clear();
+        assertEquals(BLOB_SIZE, p.size(0));
+        // must not read the blob via stream
+        assertEquals(0, reads.size());
+    }
+
+    @Test
+    public void multiValuedAboveThresholdSize() throws Exception {
+        NodeBuilder builder = ns.getRoot().builder();
+        List<Blob> blobs = newArrayList();
+        for (int i = 0; i < 13; i++) {
+            blobs.add(builder.createBlob(new RandomStream(BLOB_SIZE, i)));
+        }
+        builder.child(TEST_NODE).setProperty("p", blobs, Type.BINARIES);
+        TestUtils.merge(ns, builder);
+
+        PropertyState p = ns.getRoot().getChildNode(TEST_NODE).getProperty("p");
+        assertEquals(Type.BINARIES, Objects.requireNonNull(p).getType());
+        assertEquals(13, p.count());
+
+        reads.clear();
+        assertEquals(BLOB_SIZE, p.size(0));
+        // must not read the blob via stream
+        assertEquals(0, reads.size());
+    }
+
+    @Test
+    public void stringBelowThresholdSize() throws Exception {
+        NodeBuilder builder = ns.getRoot().builder();
+        builder.child(TEST_NODE).setProperty("p", "dummy", Type.STRING);
+        TestUtils.merge(ns, builder);
+
+        PropertyState p = ns.getRoot().getChildNode(TEST_NODE).getProperty("p");
+        assertEquals(Type.STRING, Objects.requireNonNull(p).getType());
+        assertEquals(1, p.count());
+
+        reads.clear();
+        assertEquals(5, p.size(0));
+        // must not read the string via stream
+        assertEquals(0, reads.size());
+    }
+
+    @Test
+    public void stringAboveThresholdSize() throws Exception {
+        NodeBuilder builder = ns.getRoot().builder();
+        builder.child(TEST_NODE).setProperty("p", STRING_HUGEVALUE, Type.STRING);
+        TestUtils.merge(ns, builder);
+
+        PropertyState p = ns.getRoot().getChildNode(TEST_NODE).getProperty("p");
+        assertEquals(Type.STRING, Objects.requireNonNull(p).getType());
+        assertEquals(1, p.count());
+
+        reads.clear();
+        assertEquals(10050, p.size(0));
+        // must not read the string via streams
+        assertEquals(0, reads.size());
+    }
+
+    @Test
+    public void compressValueThrowsException() throws IOException, NoSuchFieldException, IllegalAccessException {
+        DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
+        Compression mockCompression = mock(Compression.class);
+        when(mockCompression.getOutputStream(any(OutputStream.class))).thenThrow(new IOException("Compression failed"));
+
+        CompressedDocumentPropertyState.setCompressionThreshold(DEFAULT_COMPRESSION_THRESHOLD);
+        CompressedDocumentPropertyState documentPropertyState = new CompressedDocumentPropertyState(mockDocumentStore, "p", "\"" + STRING_HUGEVALUE + "\"", mockCompression);
+
+        assertEquals(documentPropertyState.getValue(Type.STRING), STRING_HUGEVALUE);
+
+        verify(mockCompression, times(1)).getOutputStream(any(OutputStream.class));
+    }
+
+    @Test
+    public void uncompressValueThrowsException() throws IOException, NoSuchFieldException, IllegalAccessException {
+
+        DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
+        Compression mockCompression = mock(Compression.class);
+        OutputStream mockOutputStream= mock(OutputStream.class);
+        when(mockCompression.getOutputStream(any(OutputStream.class))).thenReturn(mockOutputStream);
+        when(mockCompression.getInputStream(any(InputStream.class))).thenThrow(new IOException("Compression failed"));
+
+        CompressedDocumentPropertyState.setCompressionThreshold(DEFAULT_COMPRESSION_THRESHOLD);
+        CompressedDocumentPropertyState documentPropertyState = new CompressedDocumentPropertyState(mockDocumentStore, "p", STRING_HUGEVALUE, mockCompression);
+
+        assertEquals(documentPropertyState.getValue(Type.STRING), "{}");
+
+        verify(mockCompression, times(1)).getInputStream(any(InputStream.class));
+    }
+
+    @Test
+    public void stringAboveThresholdSizeNoCompression() {
+        DocumentNodeStore store = mock(DocumentNodeStore.class);
+
+        CompressedDocumentPropertyState.setCompressionThreshold(DEFAULT_COMPRESSION_THRESHOLD);
+
+        CompressedDocumentPropertyState state = new CompressedDocumentPropertyState(store, "propertyName", "\"" + STRING_HUGEVALUE + "\"", Compression.NONE);
+
+        byte[] result = state.getCompressedValue();
+
+        assertEquals(result.length, STRING_HUGEVALUE.length() + 2 );
+
+        assertEquals(state.getValue(Type.STRING), STRING_HUGEVALUE);
+        assertEquals(STRING_HUGEVALUE, state.getValue(Type.STRING));
+    }
+
+    @Test
+    public void testInterestingStringsWithoutCompression() {
+        DocumentNodeStore store = mock(DocumentNodeStore.class);
+        String[] tests = new String[] { "simple:foo", "cr:a\n\b", "dquote:a\"b", "bs:a\\b", "euro:a\u201c", "gclef:\uD834\uDD1E",
+                "tab:a\tb", "nul:a\u0000b"};
+
+        for (String test : tests) {
+            CompressedDocumentPropertyState state = new CompressedDocumentPropertyState(store, "propertyName", test, Compression.GZIP);
+            assertEquals(test, state.getValue());
+        }
+    }
+
+    @Test
+    public void testInterestingStringsWithCompression() {
+        DocumentNodeStore store = mock(DocumentNodeStore.class);
+        String[] tests = new String[]{"simple:foo", "cr:a\n\b", "dquote:a\"b", "bs:a\\b", "euro:a\u201c", "gclef:\uD834\uDD1E",
+                "tab:a\tb", "nul:a\u0000b"};
+
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        for (String test : tests) {
+            CompressedDocumentPropertyState state = new CompressedDocumentPropertyState(store, "propertyName", test, Compression.GZIP);
+            assertEquals(test, state.getValue());
+        }
+    }
+
+    @Test
+    public void testBrokenSurrogateWithoutCompressionForMongo() throws CommitFailedException {
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, false);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithoutCompressionForRDB() throws CommitFailedException {
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, false);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithoutCompressionForInMemory() throws CommitFailedException {
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, false);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithCompressionForMongo() throws CommitFailedException {
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, true);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithCompressionForRDB() throws CommitFailedException {
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, true);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithCompressionForInMemory() throws CommitFailedException {
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, true);
+    }
+
+    private void getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture fixture, boolean compressionEnabled) throws CommitFailedException {
+        assumeTrue(fixture.isAvailable());
+        String test = "brokensurrogate:dfsa\ud800";
+        DocumentStore store = null;
+        DocumentNodeStore nodeStore = null;
+
+        try {
+            store = fixture.createDocumentStore();
+
+            if (store instanceof MongoDocumentStore) {
+                // Enforce primary read preference, otherwise tests may fail on a
+                // replica set with a read preference configured to secondary.
+                // Revision GC usually runs with a modified range way in the past,
+                // which means changes made it to the secondary, but not in this
+                // test using a virtual clock
+                MongoTestUtils.setReadPreference(store, ReadPreference.primary());
+            }
+            nodeStore = new DocumentMK.Builder().setDocumentStore(store).getNodeStore();
+
+            createPropAndCheckValue(nodeStore, test, compressionEnabled);
+
+        } finally {
+            if (nodeStore != null) {
+                nodeStore.dispose();
+            }
+        }
+
+    }
+
+    private void createPropAndCheckValue(DocumentNodeStore nodeStore, String test, boolean compressionEnabled) throws CommitFailedException {
+        NodeBuilder builder = nodeStore.getRoot().builder();
+        if (compressionEnabled) {
+            CompressedDocumentPropertyState.setCompressionThreshold(1);
+        }
+        builder.child(TEST_NODE).setProperty("p", test, Type.STRING);
+        TestUtils.merge(nodeStore, builder);
+
+        PropertyState p = nodeStore.getRoot().getChildNode(TEST_NODE).getProperty("p");
+        assertEquals(Objects.requireNonNull(p).getValue(Type.STRING), test);
+    }
+
+    @Test
+    public void testEqualsWithoutCompression() {
+        DocumentNodeStore store = mock(DocumentNodeStore.class);
+        String name = "propertyName";
+        String value = "testValue";
+        Compression compression = Compression.GZIP;
+
+        CompressedDocumentPropertyState state1 = new CompressedDocumentPropertyState(store, name, value, compression);
+        CompressedDocumentPropertyState state2 = new CompressedDocumentPropertyState(store, name, value, compression);
+
+        assertEquals(state1, state2);
+
+        // Test for inequality
+        CompressedDocumentPropertyState state4 = new CompressedDocumentPropertyState(store, "differentName", value, compression);
+        assertNotEquals(state1, state4);
+    }
+
+    @Test
+    public void testEqualsWithCompression() throws IOException {
+        DocumentNodeStore store = mock(DocumentNodeStore.class);
+        String name = "propertyName";
+        String value = "testValue";
+        Compression compression = Compression.GZIP;
+
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        // Create two DocumentPropertyState instances with the same properties
+        CompressedDocumentPropertyState state1 = new CompressedDocumentPropertyState(store, name, value, compression);
+        CompressedDocumentPropertyState state2 = new CompressedDocumentPropertyState(store, name, value, compression);
+
+        // Check that the compressed values are not null
+        assertNotNull(state1.getCompressedValue());
+        assertNotNull(state2.getCompressedValue());
+
+        // Check that the equals method returns true
+        assertEquals(state1, state2);
+
+        // Decompress the values
+        String decompressedValue1 = state1.getValue();
+        String decompressedValue2 = state2.getValue();
+
+        // Check that the decompressed values are equal to the original value
+        assertEquals(value, decompressedValue1);
+        assertEquals(value, decompressedValue2);
+
+        // Check that the equals method still returns true after decompression
+        assertEquals(state1, state2);
+    }
+}

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
@@ -158,6 +158,7 @@ public class CompressedDocumentPropertyStateTest {
         PropertyState state2 = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"");
 
         assertEquals(state2, state1);
+        assertEquals(state1, state2);
 
         // Decompress the value of the first instance
         String decompressedValue1 = state1.getValue(Type.STRING);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CompressedDocumentPropertyStateTest.java
@@ -83,22 +83,6 @@ public class CompressedDocumentPropertyStateTest {
         }
     }
 
-    @Test
-    public void stringBelowThresholdSize() throws Exception {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-        CompressedDocumentPropertyState.setCompressionThreshold(10000);
-
-        CompressedDocumentPropertyState state = new CompressedDocumentPropertyState(store, "p", "\"" + STRING_HUGEVALUE + "\"", Compression.GZIP);
-
-        assertEquals(Type.STRING, state.getType());
-        assertEquals(1, state.count());
-
-        reads.clear();
-        assertEquals(10050, state.size(0));
-        // must not read the string via streams
-        assertEquals(0, reads.size());
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void compressValueThrowsException() throws IOException {
         DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.document;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.Compression;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DocumentPropertyStateFactoryTest {
+
+    @Test
+    public void createPropertyStateWithCompressionNone() {
+        DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
+        String name = "testName";
+        String value = "testValue";
+
+        PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"", Compression.NONE);
+
+        assertTrue(propertyState instanceof DocumentPropertyState);
+        assertEquals(name, propertyState.getName());
+        assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+
+    @Test
+    public void createPropertyStateWithCompressionGzip() {
+        DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
+        String name = "testName";
+        String value = "testValue";
+
+        PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"", Compression.GZIP);
+
+        assertTrue(propertyState instanceof CompressedDocumentPropertyState);
+        assertEquals(name, propertyState.getName());
+        assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+
+    @Test
+    public void createPropertyStateWithDefaultCompression() {
+        DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
+        String name = "testName";
+        String value = "testValue";
+
+        PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"");
+
+        assertTrue(propertyState instanceof DocumentPropertyState);
+        assertEquals(name, propertyState.getName());
+        assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+
+    @Test
+    public void createPropertyStateWithCompressionThresholdExceeded() {
+        DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
+        String name = "testName";
+        String value = "a".repeat(CompressedDocumentPropertyState.getCompressionThreshold() + 1);
+
+        PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"", Compression.GZIP);
+
+        assertTrue(propertyState instanceof CompressedDocumentPropertyState);
+        assertEquals(name, propertyState.getName());
+        assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+
+    @Test
+    public void createPropertyStateWithCompressionThresholdNotExceeded() {
+        DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
+        String name = "testName";
+        CompressedDocumentPropertyState.setCompressionThreshold(15);
+        String value = "testValue";
+
+        PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"", Compression.GZIP);
+
+        assertTrue(propertyState instanceof DocumentPropertyState);
+        assertEquals(name, propertyState.getName());
+        assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+}

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
@@ -19,6 +19,8 @@ package org.apache.jackrabbit.oak.plugins.document;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.Compression;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -34,6 +36,19 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 
 public class DocumentPropertyStateFactoryTest {
+
+    private static final int COMPRESSION_THRESHOLD = 5;
+    private static final int DISABLED_COMPRESSION = -1;
+
+    @Before
+    public void before() throws Exception {
+        CompressedDocumentPropertyState.setCompressionThreshold(COMPRESSION_THRESHOLD);
+    }
+
+    @After
+    public void tearDown() {
+        CompressedDocumentPropertyState.setCompressionThreshold(DISABLED_COMPRESSION);
+    }
 
     @Test
     public void createPropertyStateWithCompressionNone() {
@@ -67,9 +82,10 @@ public class DocumentPropertyStateFactoryTest {
         String name = "testName";
         String value = "testValue";
 
+        assertEquals(CompressedDocumentPropertyState.getCompressionThreshold(), COMPRESSION_THRESHOLD);
         PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"");
 
-        assertTrue(propertyState instanceof DocumentPropertyState);
+        assertTrue(propertyState instanceof CompressedDocumentPropertyState);
         assertEquals(name, propertyState.getName());
         assertEquals(value, propertyState.getValue(Type.STRING));
     }
@@ -102,7 +118,7 @@ public class DocumentPropertyStateFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void createPropertyStateWithCompressionThresholdExceededFail() throws IOException {
+    public void createPropertyStateWithCompressionThrowsException() throws IOException {
         DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
         Compression mockCompression = mock(Compression.class);
         when(mockCompression.getOutputStream(any(OutputStream.class))).thenThrow(new IOException("Compression failed"));

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
@@ -132,16 +132,16 @@ public class DocumentPropertyStateFactoryTest {
         assertEquals(STRING_HUGEVALUE, state.getValue(Type.STRING));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createPropertyStateWithCompressionThrowsException() throws IOException {
         DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
         Compression mockCompression = mock(Compression.class);
-        when(mockCompression.getOutputStream(any(OutputStream.class))).thenThrow(new IOException("Compression failed"));
+        when(mockCompression.getOutputStream(any(OutputStream.class))).thenThrow(new IllegalArgumentException("Compression failed"));
 
         CompressedDocumentPropertyState.setCompressionThreshold(5);
-        CompressedDocumentPropertyState documentPropertyState = new CompressedDocumentPropertyState(mockDocumentStore, "p", "\"" + "testValue" + "\"", mockCompression);
+        PropertyState documentPropertyState = DocumentPropertyStateFactory.createPropertyState(mockDocumentStore, "p", "\"" + "testValue" + "\"", mockCompression);
 
-        assertEquals(documentPropertyState.getValue(Type.STRING), "tesValue");
+        assertEquals(documentPropertyState.getValue(Type.STRING), "testValue");
 
         verify(mockCompression, times(1)).getOutputStream(any(OutputStream.class));
     }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.Compression;
@@ -39,6 +40,7 @@ public class DocumentPropertyStateFactoryTest {
 
     private static final int COMPRESSION_THRESHOLD = 5;
     private static final int DISABLED_COMPRESSION = -1;
+    private static final String STRING_HUGEVALUE = RandomStringUtils.random(10050, "dummytest");
 
     @Before
     public void before() throws Exception {
@@ -107,14 +109,27 @@ public class DocumentPropertyStateFactoryTest {
     public void createPropertyStateWithCompressionThresholdNotExceeded() {
         DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
         String name = "testName";
-        CompressedDocumentPropertyState.setCompressionThreshold(15);
         String value = "testValue";
+        CompressedDocumentPropertyState.setCompressionThreshold(15);
 
         PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"", Compression.GZIP);
 
         assertTrue(propertyState instanceof DocumentPropertyState);
         assertEquals(name, propertyState.getName());
         assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+
+    @Test
+    public void defaultValueSetToMinusOne() {
+        DocumentNodeStore store = mock(DocumentNodeStore.class);
+        String name = "propertyNameNew";
+
+        CompressedDocumentPropertyState.setCompressionThreshold(-1);
+        PropertyState state = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + STRING_HUGEVALUE + "\"");
+
+        assertTrue(state instanceof DocumentPropertyState);
+        assertEquals(name, state.getName());
+        assertEquals(STRING_HUGEVALUE, state.getValue(Type.STRING));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
@@ -70,7 +70,7 @@ public class DocumentPropertyStateFactoryTest {
     public void createPropertyStateWithCompressionThresholdExceeded() {
         DocumentNodeStore store = Mockito.mock(DocumentNodeStore.class);
         String name = "testName";
-        String value = "a".repeat(CompressedDocumentPropertyState.getCompressionThreshold() + 1);
+        String value = "testValue";
 
         PropertyState propertyState = DocumentPropertyStateFactory.createPropertyState(store, name, "\"" + value + "\"", Compression.GZIP);
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateFactoryTest.java
@@ -22,8 +22,16 @@ import org.apache.jackrabbit.oak.commons.Compression;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 public class DocumentPropertyStateFactoryTest {
 
@@ -91,5 +99,19 @@ public class DocumentPropertyStateFactoryTest {
         assertTrue(propertyState instanceof DocumentPropertyState);
         assertEquals(name, propertyState.getName());
         assertEquals(value, propertyState.getValue(Type.STRING));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createPropertyStateWithCompressionThresholdExceededFail() throws IOException {
+        DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
+        Compression mockCompression = mock(Compression.class);
+        when(mockCompression.getOutputStream(any(OutputStream.class))).thenThrow(new IOException("Compression failed"));
+
+        CompressedDocumentPropertyState.setCompressionThreshold(5);
+        CompressedDocumentPropertyState documentPropertyState = new CompressedDocumentPropertyState(mockDocumentStore, "p", "\"" + "testValue" + "\"", mockCompression);
+
+        assertEquals(documentPropertyState.getValue(Type.STRING), "tesValue");
+
+        verify(mockCompression, times(1)).getOutputStream(any(OutputStream.class));
     }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateTest.java
@@ -16,24 +16,18 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
-import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
-import com.mongodb.ReadPreference;
 import org.apache.jackrabbit.oak.api.Blob;
-import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoTestUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -48,7 +42,7 @@ public class DocumentPropertyStateTest {
     @Rule
     public DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
 
-    private Set<String> reads = newHashSet();
+    private Set<String> reads = new HashSet<>();
 
     private BlobStore bs = new MemoryBlobStore() {
         @Override
@@ -70,7 +64,7 @@ public class DocumentPropertyStateTest {
     @Test
     public void multiValuedBinarySize() throws Exception {
         NodeBuilder builder = ns.getRoot().builder();
-        List<Blob> blobs = newArrayList();
+        List<Blob> blobs = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             blobs.add(builder.createBlob(new RandomStream(BLOB_SIZE, i)));
         }
@@ -85,80 +79,5 @@ public class DocumentPropertyStateTest {
         assertEquals(BLOB_SIZE, p.size(0));
         // must not read the blob via stream
         assertEquals(0, reads.size());
-    }
-
-    @Test
-    public void testBrokenSurrogateWithoutCompressionForMongo() throws CommitFailedException {
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, false);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithoutCompressionForRDB() throws CommitFailedException {
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, false);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithoutCompressionForInMemory() throws CommitFailedException {
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, false);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithCompressionForMongo() throws CommitFailedException {
-        CompressedDocumentPropertyState.setCompressionThreshold(1);
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, true);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithCompressionForRDB() throws CommitFailedException {
-        CompressedDocumentPropertyState.setCompressionThreshold(1);
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, true);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithCompressionForInMemory() throws CommitFailedException {
-        CompressedDocumentPropertyState.setCompressionThreshold(1);
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, true);
-    }
-
-    private void getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture fixture, boolean compressionEnabled) throws CommitFailedException {
-        assumeTrue(fixture.isAvailable());
-        String test = "brokensurrogate:dfsa\ud800";
-        DocumentStore store = null;
-        DocumentNodeStore nodeStore = null;
-
-        try {
-            store = fixture.createDocumentStore();
-
-            if (store instanceof MongoDocumentStore) {
-                // Enforce primary read preference, otherwise tests may fail on a
-                // replica set with a read preference configured to secondary.
-                // Revision GC usually runs with a modified range way in the past,
-                // which means changes made it to the secondary, but not in this
-                // test using a virtual clock
-                MongoTestUtils.setReadPreference(store, ReadPreference.primary());
-            }
-            nodeStore = new DocumentMK.Builder().setDocumentStore(store).getNodeStore();
-
-            createPropAndCheckValue(nodeStore, test, compressionEnabled);
-
-        } finally {
-            if (nodeStore != null) {
-                nodeStore.dispose();
-            }
-        }
-
-    }
-
-    private void createPropAndCheckValue(DocumentNodeStore nodeStore, String test, boolean compressionEnabled) throws CommitFailedException {
-        NodeBuilder builder = nodeStore.getRoot().builder();
-
-        if (compressionEnabled) {
-            CompressedDocumentPropertyState.setCompressionThreshold(1);
-        }
-        builder.child("test").setProperty("p", test, Type.STRING);
-        TestUtils.merge(nodeStore, builder);
-
-        PropertyState p = nodeStore.getRoot().getChildNode("test").getProperty("p");
-        assertEquals(Objects.requireNonNull(p).getValue(Type.STRING), test);
     }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateTest.java
@@ -19,16 +19,21 @@ package org.apache.jackrabbit.oak.plugins.document;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.lang3.RandomStringUtils;
+import com.mongodb.ReadPreference;
 import org.apache.jackrabbit.oak.api.Blob;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.mongo.MongoTestUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -80,5 +85,80 @@ public class DocumentPropertyStateTest {
         assertEquals(BLOB_SIZE, p.size(0));
         // must not read the blob via stream
         assertEquals(0, reads.size());
+    }
+
+    @Test
+    public void testBrokenSurrogateWithoutCompressionForMongo() throws CommitFailedException {
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, false);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithoutCompressionForRDB() throws CommitFailedException {
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, false);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithoutCompressionForInMemory() throws CommitFailedException {
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, false);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithCompressionForMongo() throws CommitFailedException {
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, true);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithCompressionForRDB() throws CommitFailedException {
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, true);
+    }
+
+    @Test
+    public void testBrokenSurrogateWithCompressionForInMemory() throws CommitFailedException {
+        CompressedDocumentPropertyState.setCompressionThreshold(1);
+        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, true);
+    }
+
+    private void getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture fixture, boolean compressionEnabled) throws CommitFailedException {
+        assumeTrue(fixture.isAvailable());
+        String test = "brokensurrogate:dfsa\ud800";
+        DocumentStore store = null;
+        DocumentNodeStore nodeStore = null;
+
+        try {
+            store = fixture.createDocumentStore();
+
+            if (store instanceof MongoDocumentStore) {
+                // Enforce primary read preference, otherwise tests may fail on a
+                // replica set with a read preference configured to secondary.
+                // Revision GC usually runs with a modified range way in the past,
+                // which means changes made it to the secondary, but not in this
+                // test using a virtual clock
+                MongoTestUtils.setReadPreference(store, ReadPreference.primary());
+            }
+            nodeStore = new DocumentMK.Builder().setDocumentStore(store).getNodeStore();
+
+            createPropAndCheckValue(nodeStore, test, compressionEnabled);
+
+        } finally {
+            if (nodeStore != null) {
+                nodeStore.dispose();
+            }
+        }
+
+    }
+
+    private void createPropAndCheckValue(DocumentNodeStore nodeStore, String test, boolean compressionEnabled) throws CommitFailedException {
+        NodeBuilder builder = nodeStore.getRoot().builder();
+
+        if (compressionEnabled) {
+            CompressedDocumentPropertyState.setCompressionThreshold(1);
+        }
+        builder.child("test").setProperty("p", test, Type.STRING);
+        TestUtils.merge(nodeStore, builder);
+
+        PropertyState p = nodeStore.getRoot().getChildNode("test").getProperty("p");
+        assertEquals(Objects.requireNonNull(p).getValue(Type.STRING), test);
     }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentPropertyStateTest.java
@@ -19,49 +19,26 @@ package org.apache.jackrabbit.oak.plugins.document;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assume.assumeTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.jackrabbit.oak.api.Blob;
-import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.commons.Compression;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.mongo.MongoTestUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.mongodb.ReadPreference;
-
 public class DocumentPropertyStateTest {
 
     private static final int BLOB_SIZE = 16 * 1024;
-    private static final String TEST_NODE = "test";
-    private static final String STRING_HUGEVALUE = RandomStringUtils.random(10050, "dummytest");
-    private static final int DEFAULT_COMPRESSION_THRESHOLD = 1024;
-    private static final int DISABLED_COMPRESSION = -1;
 
     @Rule
     public DocumentMKBuilderProvider builderProvider = new DocumentMKBuilderProvider();
@@ -84,15 +61,6 @@ public class DocumentPropertyStateTest {
         ns = builderProvider.newBuilder().setBlobStore(bs).getNodeStore();
     }
 
-    @After
-    public void tearDown() {
-        try {
-            ns.dispose();
-        } finally {
-            DocumentPropertyState.setCompressionThreshold(DISABLED_COMPRESSION);
-        }
-    }
-
     // OAK-5462
     @Test
     public void multiValuedBinarySize() throws Exception {
@@ -112,288 +80,5 @@ public class DocumentPropertyStateTest {
         assertEquals(BLOB_SIZE, p.size(0));
         // must not read the blob via stream
         assertEquals(0, reads.size());
-    }
-
-    @Test
-    public void multiValuedAboveThresholdSize() throws Exception {
-        NodeBuilder builder = ns.getRoot().builder();
-        List<Blob> blobs = newArrayList();
-        for (int i = 0; i < 13; i++) {
-            blobs.add(builder.createBlob(new RandomStream(BLOB_SIZE, i)));
-        }
-        builder.child(TEST_NODE).setProperty("p", blobs, Type.BINARIES);
-        TestUtils.merge(ns, builder);
-
-        PropertyState p = ns.getRoot().getChildNode(TEST_NODE).getProperty("p");
-        assertEquals(Type.BINARIES, Objects.requireNonNull(p).getType());
-        assertEquals(13, p.count());
-
-        reads.clear();
-        assertEquals(BLOB_SIZE, p.size(0));
-        // must not read the blob via stream
-        assertEquals(0, reads.size());
-    }
-
-    @Test
-    public void stringBelowThresholdSize() throws Exception {
-        NodeBuilder builder = ns.getRoot().builder();
-        builder.child(TEST_NODE).setProperty("p", "dummy", Type.STRING);
-        TestUtils.merge(ns, builder);
-
-        PropertyState p = ns.getRoot().getChildNode(TEST_NODE).getProperty("p");
-        assertEquals(Type.STRING, Objects.requireNonNull(p).getType());
-        assertEquals(1, p.count());
-
-        reads.clear();
-        assertEquals(5, p.size(0));
-        // must not read the string via stream
-        assertEquals(0, reads.size());
-    }
-
-    @Test
-    public void stringAboveThresholdSize() throws Exception {
-        NodeBuilder builder = ns.getRoot().builder();
-        builder.child(TEST_NODE).setProperty("p", STRING_HUGEVALUE, Type.STRING);
-        TestUtils.merge(ns, builder);
-
-        PropertyState p = ns.getRoot().getChildNode(TEST_NODE).getProperty("p");
-        assertEquals(Type.STRING, Objects.requireNonNull(p).getType());
-        assertEquals(1, p.count());
-
-        reads.clear();
-        assertEquals(10050, p.size(0));
-        // must not read the string via streams
-        assertEquals(0, reads.size());
-    }
-
-    @Test
-    public void compressValueThrowsException() throws IOException, NoSuchFieldException, IllegalAccessException {
-        DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
-        Compression mockCompression = mock(Compression.class);
-        when(mockCompression.getOutputStream(any(OutputStream.class))).thenThrow(new IOException("Compression failed"));
-
-        DocumentPropertyState.setCompressionThreshold(DEFAULT_COMPRESSION_THRESHOLD);
-        DocumentPropertyState documentPropertyState = new DocumentPropertyState(mockDocumentStore, "p", "\"" + STRING_HUGEVALUE + "\"", mockCompression);
-
-        assertEquals(documentPropertyState.getValue(Type.STRING), STRING_HUGEVALUE);
-
-        verify(mockCompression, times(1)).getOutputStream(any(OutputStream.class));
-    }
-
-    @Test
-    public void uncompressValueThrowsException() throws IOException, NoSuchFieldException, IllegalAccessException {
-
-        DocumentNodeStore mockDocumentStore = mock(DocumentNodeStore.class);
-        Compression mockCompression = mock(Compression.class);
-        OutputStream mockOutputStream= mock(OutputStream.class);
-        when(mockCompression.getOutputStream(any(OutputStream.class))).thenReturn(mockOutputStream);
-        when(mockCompression.getInputStream(any(InputStream.class))).thenThrow(new IOException("Compression failed"));
-
-        DocumentPropertyState.setCompressionThreshold(DEFAULT_COMPRESSION_THRESHOLD);
-        DocumentPropertyState documentPropertyState = new DocumentPropertyState(mockDocumentStore, "p", STRING_HUGEVALUE, mockCompression);
-
-        assertEquals(documentPropertyState.getValue(Type.STRING), "{}");
-
-        verify(mockCompression, times(1)).getInputStream(any(InputStream.class));
-    }
-
-    @Test
-    public void defaultValueSetToMinusOne() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-
-        DocumentPropertyState.setCompressionThreshold(-1);
-        DocumentPropertyState state = new DocumentPropertyState(store, "propertyNameNew", "\"" + STRING_HUGEVALUE + "\"", Compression.GZIP);
-
-        byte[] result = state.getCompressedValue();
-
-        assertNull(result);
-        assertEquals(state.getValue(Type.STRING), STRING_HUGEVALUE);
-    }
-
-    @Test
-    public void stringAboveThresholdSizeNoCompression() {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-
-        DocumentPropertyState.setCompressionThreshold(DEFAULT_COMPRESSION_THRESHOLD);
-
-        DocumentPropertyState state = new DocumentPropertyState(store, "propertyName", "\"" + STRING_HUGEVALUE + "\"", Compression.NONE);
-
-        byte[] result = state.getCompressedValue();
-
-        assertEquals(result.length, STRING_HUGEVALUE.length() + 2 );
-
-        assertEquals(state.getValue(Type.STRING), STRING_HUGEVALUE);
-        assertEquals(STRING_HUGEVALUE, state.getValue(Type.STRING));
-    }
-
-    @Test
-    public void testInterestingStringsWithoutCompression() {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-        String[] tests = new String[] { "simple:foo", "cr:a\n\b", "dquote:a\"b", "bs:a\\b", "euro:a\u201c", "gclef:\uD834\uDD1E",
-                "tab:a\tb", "nul:a\u0000b"};
-
-        for (String test : tests) {
-            DocumentPropertyState state = new DocumentPropertyState(store, "propertyName", test, Compression.GZIP);
-            assertEquals(test, state.getValue());
-        }
-    }
-
-    @Test
-    public void testInterestingStringsWithCompression() {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-        String[] tests = new String[]{"simple:foo", "cr:a\n\b", "dquote:a\"b", "bs:a\\b", "euro:a\u201c", "gclef:\uD834\uDD1E",
-                "tab:a\tb", "nul:a\u0000b"};
-
-        DocumentPropertyState.setCompressionThreshold(1);
-        for (String test : tests) {
-            DocumentPropertyState state = new DocumentPropertyState(store, "propertyName", test, Compression.GZIP);
-            assertEquals(test, state.getValue());
-        }
-    }
-
-    @Test
-    public void testBrokenSurrogateWithoutCompressionForMongo() throws CommitFailedException {
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, false);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithoutCompressionForRDB() throws CommitFailedException {
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, false);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithoutCompressionForInMemory() throws CommitFailedException {
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, false);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithCompressionForMongo() throws CommitFailedException {
-        DocumentPropertyState.setCompressionThreshold(1);
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MONGO, true);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithCompressionForRDB() throws CommitFailedException {
-        DocumentPropertyState.setCompressionThreshold(1);
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.RDB_H2, true);
-    }
-
-    @Test
-    public void testBrokenSurrogateWithCompressionForInMemory() throws CommitFailedException {
-        DocumentPropertyState.setCompressionThreshold(1);
-        getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture.MEMORY, true);
-    }
-
-    private void getBrokenSurrogateAndInitializeDifferentStores(DocumentStoreFixture fixture, boolean compressionEnabled) throws CommitFailedException {
-        assumeTrue(fixture.isAvailable());
-        String test = "brokensurrogate:dfsa\ud800";
-        DocumentStore store = null;
-        DocumentNodeStore nodeStore = null;
-
-        try {
-            store = fixture.createDocumentStore();
-
-            if (store instanceof MongoDocumentStore) {
-                // Enforce primary read preference, otherwise tests may fail on a
-                // replica set with a read preference configured to secondary.
-                // Revision GC usually runs with a modified range way in the past,
-                // which means changes made it to the secondary, but not in this
-                // test using a virtual clock
-                MongoTestUtils.setReadPreference(store, ReadPreference.primary());
-            }
-            nodeStore = new DocumentMK.Builder().setDocumentStore(store).getNodeStore();
-
-            createPropAndCheckValue(nodeStore, test, compressionEnabled);
-
-        } finally {
-            if (nodeStore != null) {
-                nodeStore.dispose();
-            }
-        }
-
-    }
-
-    private void createPropAndCheckValue(DocumentNodeStore nodeStore, String test, boolean compressionEnabled) throws CommitFailedException {
-        NodeBuilder builder = nodeStore.getRoot().builder();
-        if (compressionEnabled) {
-            DocumentPropertyState.setCompressionThreshold(1);
-        }
-        builder.child(TEST_NODE).setProperty("p", test, Type.STRING);
-        TestUtils.merge(nodeStore, builder);
-
-        PropertyState p = nodeStore.getRoot().getChildNode(TEST_NODE).getProperty("p");
-        assertEquals(Objects.requireNonNull(p).getValue(Type.STRING), test);
-    }
-
-    @Test
-    public void testEqualsWithoutCompression() {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-        String name = "propertyName";
-        String value = "testValue";
-        Compression compression = Compression.GZIP;
-
-        DocumentPropertyState state1 = new DocumentPropertyState(store, name, value, compression);
-        DocumentPropertyState state2 = new DocumentPropertyState(store, name, value, compression);
-
-        assertEquals(state1, state2);
-
-        // Test for inequality
-        DocumentPropertyState state4 = new DocumentPropertyState(store, "differentName", value, compression);
-        assertNotEquals(state1, state4);
-    }
-
-    @Test
-    public void testEqualsWithCompression() throws IOException {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-        String name = "propertyName";
-        String value = "testValue";
-        Compression compression = Compression.GZIP;
-
-        DocumentPropertyState.setCompressionThreshold(1);
-        // Create two DocumentPropertyState instances with the same properties
-        DocumentPropertyState state1 = new DocumentPropertyState(store, name, value, compression);
-        DocumentPropertyState state2 = new DocumentPropertyState(store, name, value, compression);
-
-        // Check that the compressed values are not null
-        assertNotNull(state1.getCompressedValue());
-        assertNotNull(state2.getCompressedValue());
-
-        // Check that the equals method returns true
-        assertEquals(state1, state2);
-
-        // Decompress the values
-        String decompressedValue1 = state1.getValue();
-        String decompressedValue2 = state2.getValue();
-
-        // Check that the decompressed values are equal to the original value
-        assertEquals(value, decompressedValue1);
-        assertEquals(value, decompressedValue2);
-
-        // Check that the equals method still returns true after decompression
-        assertEquals(state1, state2);
-    }
-
-    @Test
-    public void testOneCompressOtherUncompressInEquals() throws IOException {
-        DocumentNodeStore store = mock(DocumentNodeStore.class);
-        String name = "propertyName";
-        String value = "testValue";
-        Compression compression = Compression.GZIP;
-
-        // Create a DocumentPropertyState instance with a compressed value
-        DocumentPropertyState.setCompressionThreshold(1);
-        DocumentPropertyState state1 = new DocumentPropertyState(store, name, value, compression);
-
-        // Create a DocumentPropertyState instance with an uncompressed value
-        DocumentPropertyState.setCompressionThreshold(-1);
-        DocumentPropertyState state2 = new DocumentPropertyState(store, name, value, compression);
-
-        assertNotEquals(state1, state2);
-
-        // Decompress the value of the first instance
-        String decompressedValue1 = state1.getValue();
-
-        // Check that the decompressed value is equal to the original value
-        assertEquals(value, decompressedValue1);
     }
 }


### PR DESCRIPTION
In [OAK-10803](https://issues.apache.org/jira/browse/OAK-10803) we introduce the possibility of compressing property values. During its development we encountered performance issues, namely with repeated decompression calls, even just during getNodeAtRevision. Before we can confidentially enable and use compression, we need to revisit performance first. Likely we'll have to make further tweaks before we can use it.