### PR TITLE
OAK-11006 - indexing-job: better logging of text extraction and indexing statistics

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -39,12 +39,10 @@ import org.apache.jackrabbit.guava.common.cache.CacheLoader;
 import org.apache.jackrabbit.guava.common.cache.RemovalCause;
 import org.apache.jackrabbit.guava.common.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
-import org.apache.jackrabbit.oak.cache.CacheLIRS.EvictionCallback;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.StringUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
 import org.apache.jackrabbit.oak.commons.io.FileTreeTraverser;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +112,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                 } else {
                     InputStream is = null;
                     boolean threw = true;
-                    long startMillis = System.nanoTime() / 1_000_000;
+                    long startNanos = System.nanoTime();
                     try {
                         is = loader.load(key);
                         copyInputStreamToFile(is, cachedFile);
@@ -126,7 +124,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                         Closeables.close(is, threw);
                     }
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Loaded file: {} in {}", key, System.nanoTime() / 1_000_000 - startMillis);
+                        LOG.debug("Loaded file: {} in {}", key, (System.nanoTime() - startNanos) / 1_000_000);
                     }
                     return cachedFile;
                 }
@@ -174,7 +172,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         }
         return new FileCache() {
 
-            private final Cache<?,?> cache = new CacheLIRS<>(0);
+            private final Cache<?, ?> cache = new CacheLIRS<>(0);
 
             @Override public void put(String key, File file) {
             }

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -86,18 +86,14 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     /**
      * Convert the size calculation to KB to support max file size of 2 TB
      */
-    private static final Weigher<String, File> weigher = new Weigher<String, File>() {
-        @Override public int weigh(String key, File value) {
-            // convert to number of 4 KB blocks
-            return Math.round(value.length() / (4 * 1024));
-        }};
+    private static final Weigher<String, File> weigher = (key, value) -> {
+        // convert to number of 4 KB blocks
+        return Math.round(value.length() / (4 * 1024));
+    };
 
     //Rough estimate of the in-memory key, value pair
-    private static final Weigher<String, File> memWeigher = new Weigher<String, File>() {
-        @Override public int weigh(String key, File value) {
-            return (StringUtils.estimateMemoryUsage(key) +
-                StringUtils.estimateMemoryUsage(value.getAbsolutePath()) + 48);
-        }};
+    private static final Weigher<String, File> memWeigher = (key, value) -> (StringUtils.estimateMemoryUsage(key) +
+        StringUtils.estimateMemoryUsage(value.getAbsolutePath()) + 48);
 
     private FileCache(long maxSize /* bytes */, File root,
         final CacheLoader<String, InputStream> loader, @Nullable final ExecutorService executor) {
@@ -108,8 +104,9 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         // convert to number of 4 KB blocks
         long size = Math.round(maxSize / (1024L * 4));
 
-        cacheLoader = new CacheLoader<String, File>() {
-            @Override public File load(String key) throws Exception {
+        cacheLoader = new CacheLoader<>() {
+            @Override
+            public File load(String key) throws Exception {
                 // Fetch from local cache directory and if not found load from backend
                 File cachedFile = DataStoreCacheUtils.getFile(key, cacheRoot);
                 if (cachedFile.exists()) {
@@ -117,6 +114,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                 } else {
                     InputStream is = null;
                     boolean threw = true;
+                    long startMillis = System.nanoTime() / 1_000_000;
                     try {
                         is = loader.load(key);
                         copyInputStreamToFile(is, cachedFile);
@@ -126,6 +124,9 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                         throw e;
                     } finally {
                         Closeables.close(is, threw);
+                    }
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Loaded file: {} in {}", key, System.nanoTime() / 1_000_000 - startMillis);
                     }
                     return cachedFile;
                 }
@@ -137,21 +138,17 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
             .recordStats()
             .weigher(weigher)
             .segmentCount(SEGMENT_COUNT)
-            .evictionCallback(new EvictionCallback<String, File>() {
-                @Override
-                public void evicted(@NotNull String key, @Nullable File cachedFile,
-                    @NotNull RemovalCause cause) {
-                    try {
-                        if (cachedFile != null && cachedFile.exists()
-                            && cause != RemovalCause.REPLACED) {
-                            DataStoreCacheUtils.recursiveDelete(cachedFile, cacheRoot);
-                            LOG.info("File [{}] evicted with reason [{}]", cachedFile, cause
-                                .toString());
-                        }
-                    } catch (IOException e) {
-                        LOG.info("Cached file deletion failed after eviction", e);
+            .evictionCallback((key, cachedFile, cause) -> {
+                try {
+                    if (cachedFile != null && cachedFile.exists()
+                        && cause != RemovalCause.REPLACED) {
+                        DataStoreCacheUtils.recursiveDelete(cachedFile, cacheRoot);
+                        LOG.info("File [{}] evicted with reason [{}]", cachedFile, cause);
                     }
-                }})
+                } catch (IOException e) {
+                    LOG.info("Cached file deletion failed after eviction", e);
+                }
+            })
             .build();
 
         this.cacheStats =
@@ -190,7 +187,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                 return null;
             }
 
-            @Override public File get(String key) throws IOException {
+            @Override public File get(String key) {
                 return null;
             }
 
@@ -291,7 +288,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     /**
      * Called to initialize the in-memory cache from the fs folder
      */
-    private class CacheBuildJob implements Callable {
+    private class CacheBuildJob implements Callable<Integer> {
         @Override
         public Integer call() {
             Stopwatch watch = Stopwatch.createStarted();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
@@ -21,6 +21,14 @@ import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import java.util.concurrent.TimeUnit;
 
 public class FormattingUtils {
+    public static String formatNanosToSeconds(long nanos) {
+        return formatToSeconds(nanos/1_000_000_000);
+    }
+
+    public static String formatMillisToSeconds(long millis) {
+        return formatToSeconds(millis/1000);
+    }
+
     public static String formatToSeconds(Stopwatch stopwatch) {
         return formatToSeconds(stopwatch.elapsed(TimeUnit.SECONDS));
     }
@@ -32,14 +40,6 @@ public class FormattingUtils {
         long secondsPart = TimeUnit.SECONDS.toSeconds(absSeconds) % 60;
         String sign = seconds < 0 ? "-" : "";
         return String.format("%s%02d:%02d:%02d", sign, hoursPart, minutesPart, secondsPart);
-    }
-
-    public static String formatMillisToSeconds(long millis) {
-        return formatToSeconds(millis/1000);
-    }
-
-    public static String formatNanosToSeconds(long nanos) {
-        return formatToSeconds(nanos/1_000_000_000);
     }
 
     public static String formatToMillis(Stopwatch stopwatch) {
@@ -57,4 +57,7 @@ public class FormattingUtils {
         return denominator == 0 ? -1 : (double) numerator / denominator * 100;
     }
 
+    public static double safeComputeAverage(long totalTime, long numberOfEvents) {
+        return numberOfEvents == 0 ? -1 : ((double)totalTime / numberOfEvents);
+    }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
@@ -34,6 +34,14 @@ public class FormattingUtils {
         return String.format("%s%02d:%02d:%02d", sign, hoursPart, minutesPart, secondsPart);
     }
 
+    public static String formatMillisToSeconds(long millis) {
+        return formatToSeconds(millis/1000);
+    }
+
+    public static String formatNanosToSeconds(long nanos) {
+        return formatToSeconds(nanos/1_000_000_000);
+    }
+
     public static String formatToMillis(Stopwatch stopwatch) {
         long millis = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         long absMillis = Math.abs(millis);
@@ -44,4 +52,9 @@ public class FormattingUtils {
         String sign = millis < 0 ? "-" : "";
         return String.format("%s%02d:%02d:%02d.%03d", sign, hoursPart, minutesPart, secondsPart, millisPart);
     }
+
+    public static double safeComputePercentage(long numerator, long denominator) {
+        return denominator == 0 ? -1 : (double) numerator / denominator * 100;
+    }
+
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
@@ -166,10 +166,6 @@ public class IndexingProgressReporter implements NodeTraversalCallback {
         return indexUpdateStates.values().stream().anyMatch(st -> st.updateCount.get() > 0);
     }
 
-    public long getTotalUpdatesCount() {
-        return indexUpdateStates.values().stream().mapToLong(st -> st.updateCount.get()).sum();
-    }
-
     public void setTraversalRateEstimator(TraversalRateEstimator traversalRate) {
         this.traversalRateEstimator = traversalRate;
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
@@ -166,6 +166,10 @@ public class IndexingProgressReporter implements NodeTraversalCallback {
         return indexUpdateStates.values().stream().anyMatch(st -> st.updateCount.get() > 0);
     }
 
+    public long getTotalUpdatesCount() {
+        return indexUpdateStates.values().stream().mapToLong(st -> st.updateCount.get()).sum();
+    }
+
     public void setTraversalRateEstimator(TraversalRateEstimator traversalRate) {
         this.traversalRateEstimator = traversalRate;
     }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtilsTest.java
@@ -85,4 +85,22 @@ public class FormattingUtilsTest {
         ticker.set(nanos);
         assertEquals(expected, FormattingUtils.formatToMillis(sw));
     }
+
+    @Test
+    public void testSafeComputePercentage() {
+        assertEquals(50.0, FormattingUtils.safeComputePercentage(50, 100), 0.001);
+        assertEquals(0.0, FormattingUtils.safeComputePercentage(0, 100), 0.001);
+        assertEquals(-1.0, FormattingUtils.safeComputePercentage(50, 0), 0.001);
+        assertEquals(100.0, FormattingUtils.safeComputePercentage(100, 100), 0.001);
+        assertEquals(33.333, FormattingUtils.safeComputePercentage(1, 3), 0.001);
+    }
+
+    @Test
+    public void testSafeComputeAverage() {
+        assertEquals(50.0, FormattingUtils.safeComputeAverage(100, 2), 0.001);
+        assertEquals(0.0, FormattingUtils.safeComputeAverage(0, 100), 0.001);
+        assertEquals(-1.0, FormattingUtils.safeComputeAverage(100, 0), 0.001);
+        assertEquals(100.0, FormattingUtils.safeComputeAverage(100, 1), 0.001);
+        assertEquals(33.333, FormattingUtils.safeComputeAverage(100, 3), 0.001);
+    }
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/CompositeIndexer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/CompositeIndexer.java
@@ -42,6 +42,13 @@ public class CompositeIndexer implements NodeStateIndexer {
     }
 
     @Override
+    public void onIndexingStarting() {
+        for (NodeStateIndexer indexer : indexers) {
+            indexer.onIndexingStarting();
+        }
+    }
+
+    @Override
     public boolean shouldInclude(String path) {
         return indexers.stream().anyMatch(indexer -> indexer.shouldInclude(path));
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -358,6 +358,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
                 } else if (flatFileStores.size() == 1) {
                     FlatFileStore flatFileStore = flatFileStores.get(0);
                     TopKSlowestPaths slowestTopKElements = new TopKSlowestPaths(TOP_SLOWEST_PATHS_TO_LOG);
+                    indexer.onIndexingStarting();
                     long entryStart = System.nanoTime();
                     for (NodeStateEntry entry : flatFileStore) {
                         reportDocumentRead(entry.getPath(), progressReporter);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -12,7 +12,7 @@ public final class IndexerStatisticsTracker {
     private long startIndexingNanos = 0;
     // Time spent indexing entries. Should be almost the same as totalMakeDocumentTimeNanos+totalWriteTimeNanos
     private long totalIndexingTimeNanos = 0;
-    // Time making generating the Lucene document.
+    // Time generating the Lucene document.
     private long totalMakeDocumentTimeNanos = 0;
     // Time writing the Lucene document to disk.
     private long totalWriteTimeNanos = 0;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -77,7 +77,7 @@ public final class IndexerStatisticsTracker {
     public String formatStats() {
         long endTimeNanos = System.nanoTime();
         long totalTimeNanos = endTimeNanos - startIndexingNanos;
-        double avgTimePerDocumentMicros = FormattingUtils.safeComputeAverage(totalIndexingTimeNanos/1000, nodesIndexed);
+        long avgTimePerDocumentMicros = Math.round(FormattingUtils.safeComputeAverage(totalIndexingTimeNanos/1000, nodesIndexed));
         double percentageIndexing = FormattingUtils.safeComputePercentage(totalIndexingTimeNanos, totalTimeNanos);
         double percentageMakingDocument = FormattingUtils.safeComputePercentage(totalMakeDocumentTimeNanos, totalIndexingTimeNanos);
         double percentageWritingToIndex = FormattingUtils.safeComputePercentage(totalWriteTimeNanos, totalIndexingTimeNanos);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -1,0 +1,72 @@
+package org.apache.jackrabbit.oak.index.indexer.document;
+
+import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
+import org.slf4j.Logger;
+
+public final class IndexerStatisticsTracker {
+    private static final int SLOW_DOCUMENT_LOG_THRESHOLD = Integer.getInteger("oak.lucene.slowDocumentLogThreshold", 1000);
+
+    private final Logger logger;
+
+    // Timestamp of when indexing started.
+    private long startIndexingNanos = 0;
+    // Time spent indexing entries. Should be almost the same as totalMakeDocumentTimeNanos+totalWriteTimeNanos
+    private long totalIndexingTimeNanos = 0;
+    // Time making generating the Lucene document.
+    private long totalMakeDocumentTimeNanos = 0;
+    // Time writing the Lucene document to disk.
+    private long totalWriteTimeNanos = 0;
+    private long nodesIndexed = 0;
+
+    // Timestamp of when the current entry started being indexed
+    private long startEntryNanos = 0;
+    // Timestamp of when the current entry finished the makeDocument phase.
+    private long endEntryMakeDocumentNanos = 0;
+
+    public IndexerStatisticsTracker(Logger logger) {
+        this.logger = logger;
+    }
+
+    public void onIndexingStarting() {
+        this.startIndexingNanos = System.nanoTime();
+    }
+
+    public void onEntryStart() {
+        startEntryNanos = System.nanoTime();
+    }
+
+    public void onEntryEndMakeDocument() {
+        endEntryMakeDocumentNanos = System.nanoTime();
+    }
+
+    public void onEntryEnd(String entryPath) {
+        long endEntryWriteNanos = System.nanoTime();
+        nodesIndexed++;
+        long entryIndexingTimeNanos = endEntryWriteNanos - startEntryNanos;
+        long entryMakeDocumentTimeNanos = endEntryMakeDocumentNanos - startEntryNanos;
+        long entryWriteTimeNanos = endEntryWriteNanos - endEntryMakeDocumentNanos;
+        totalIndexingTimeNanos += entryIndexingTimeNanos;
+        totalMakeDocumentTimeNanos += entryMakeDocumentTimeNanos;
+        totalWriteTimeNanos += entryWriteTimeNanos;
+        if (entryIndexingTimeNanos >= (long) SLOW_DOCUMENT_LOG_THRESHOLD * 1_000_000) {
+            logger.info("Slow document: {}. Times: total={}ms, makeDocument={}ms, writeToIndex={}ms",
+                    entryPath, entryIndexingTimeNanos / 1_000_000, entryMakeDocumentTimeNanos / 1_000_000, entryWriteTimeNanos / 1_000_000);
+        }
+        startEntryNanos = 0;
+        endEntryMakeDocumentNanos = 0;
+    }
+
+    public String formatStats() {
+        long endTimeNanos = System.nanoTime();
+        long totalTimeNanos = endTimeNanos - startIndexingNanos;
+        long avgTimePerDocumentMicros = nodesIndexed == 0 ? -1 : (totalIndexingTimeNanos / nodesIndexed) / 1000;
+        double percentageIndexing = FormattingUtils.safeComputePercentage(totalIndexingTimeNanos, totalTimeNanos);
+        double percentageMakingDocument = FormattingUtils.safeComputePercentage(totalMakeDocumentTimeNanos, totalIndexingTimeNanos);
+        double percentageWritingToIndex = FormattingUtils.safeComputePercentage(totalWriteTimeNanos, totalIndexingTimeNanos);
+        return String.format("Indexed %d nodes in %s. Avg per node: %d microseconds. indexingTime: %s (%2.1f%% of total time). Breakup of indexing time: makeDocument: %s (%2.1f%%), writeIndex: %s (%2.1f%%)",
+                nodesIndexed, FormattingUtils.formatNanosToSeconds(totalTimeNanos), avgTimePerDocumentMicros,
+                FormattingUtils.formatNanosToSeconds(totalIndexingTimeNanos), percentageIndexing,
+                FormattingUtils.formatNanosToSeconds(totalMakeDocumentTimeNanos), percentageMakingDocument,
+                FormattingUtils.formatNanosToSeconds(totalWriteTimeNanos), percentageWritingToIndex);
+    }
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document;
 
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -4,7 +4,7 @@ import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.slf4j.Logger;
 
 public final class IndexerStatisticsTracker {
-    private static final int SLOW_DOCUMENT_LOG_THRESHOLD = Integer.getInteger("oak.lucene.slowDocumentLogThreshold", 1000);
+    private static final int SLOW_DOCUMENT_LOG_THRESHOLD = Integer.getInteger("oak.indexer.slowDocumentLogThreshold", 1000);
 
     private final Logger logger;
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -77,7 +77,7 @@ public final class IndexerStatisticsTracker {
     public String formatStats() {
         long endTimeNanos = System.nanoTime();
         long totalTimeNanos = endTimeNanos - startIndexingNanos;
-        long avgTimePerDocumentMicros = nodesIndexed == 0 ? -1 : (totalIndexingTimeNanos / nodesIndexed) / 1000;
+        double avgTimePerDocumentMicros = FormattingUtils.safeComputeAverage(totalIndexingTimeNanos/1000, nodesIndexed);
         double percentageIndexing = FormattingUtils.safeComputePercentage(totalIndexingTimeNanos, totalTimeNanos);
         double percentageMakingDocument = FormattingUtils.safeComputePercentage(totalMakeDocumentTimeNanos, totalIndexingTimeNanos);
         double percentageWritingToIndex = FormattingUtils.safeComputePercentage(totalWriteTimeNanos, totalIndexingTimeNanos);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -77,7 +77,7 @@ public final class IndexerStatisticsTracker {
     public String formatStats() {
         long endTimeNanos = System.nanoTime();
         long totalTimeNanos = endTimeNanos - startIndexingNanos;
-        long avgTimePerDocumentMicros = Math.round(FormattingUtils.safeComputeAverage(totalIndexingTimeNanos/1000, nodesIndexed));
+        long avgTimePerDocumentMicros = Math.round(FormattingUtils.safeComputeAverage(totalIndexingTimeNanos / 1000, nodesIndexed));
         double percentageIndexing = FormattingUtils.safeComputePercentage(totalIndexingTimeNanos, totalTimeNanos);
         double percentageMakingDocument = FormattingUtils.safeComputePercentage(totalMakeDocumentTimeNanos, totalIndexingTimeNanos);
         double percentageWritingToIndex = FormattingUtils.safeComputePercentage(totalWriteTimeNanos, totalIndexingTimeNanos);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateIndexer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateIndexer.java
@@ -28,6 +28,8 @@ import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 
 public interface NodeStateIndexer extends Closeable{
 
+    default void onIndexingStarting() {}
+
     boolean shouldInclude(String path);
 
     boolean shouldInclude(NodeDocument doc);

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
@@ -65,6 +65,11 @@ public class ElasticIndexer implements NodeStateIndexer {
     }
 
     @Override
+    public void onIndexingStarting() {
+        binaryTextExtractor.resetStartTime();
+    }
+
+    @Override
     public boolean shouldInclude(String path) {
         return getFilterResult(path) != PathFilter.Result.EXCLUDE;
     }

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
@@ -33,6 +33,8 @@ import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWr
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Set;
@@ -43,6 +45,7 @@ import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefini
 NodeStateIndexer for Elastic. Indexes entries from a given nodestate.
  */
 public class ElasticIndexer implements NodeStateIndexer {
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticIndexer.class);
 
     private final IndexDefinition definition;
     private final FulltextBinaryTextExtractor binaryTextExtractor;
@@ -51,6 +54,7 @@ public class ElasticIndexer implements NodeStateIndexer {
     private final FulltextIndexWriter<ElasticDocument> indexWriter;
     private final ElasticIndexEditorProvider elasticIndexEditorProvider;
     private final IndexHelper indexHelper;
+    private final IndexerStatisticsTracker indexerStatisticsTracker = new IndexerStatisticsTracker(LOG);
 
     public ElasticIndexer(IndexDefinition definition, FulltextBinaryTextExtractor binaryTextExtractor,
                           NodeBuilder definitionBuilder, IndexingProgressReporter progressReporter,
@@ -66,6 +70,7 @@ public class ElasticIndexer implements NodeStateIndexer {
 
     @Override
     public void onIndexingStarting() {
+        indexerStatisticsTracker.onIndexingStarting();
         binaryTextExtractor.resetStartTime();
     }
 
@@ -82,7 +87,7 @@ public class ElasticIndexer implements NodeStateIndexer {
 
     public void provisionIndex() {
         FulltextIndexEditor editor = (FulltextIndexEditor) elasticIndexEditorProvider.getIndexEditor(
-                TYPE_ELASTICSEARCH, definitionBuilder, indexHelper.getNodeStore().getRoot(), new ReportingCallback(definition.getIndexPath(),false));
+                TYPE_ELASTICSEARCH, definitionBuilder, indexHelper.getNodeStore().getRoot(), new ReportingCallback(definition.getIndexPath(), false));
         editor.getContext().enableReindexMode();
     }
 
@@ -97,12 +102,14 @@ public class ElasticIndexer implements NodeStateIndexer {
         if (indexingRule == null) {
             return false;
         }
+        indexerStatisticsTracker.onEntryStart();
         ElasticDocumentMaker maker = newDocumentMaker(indexingRule, entry.getPath());
 
         ElasticDocument doc = maker.makeDocument(entry.getNodeState());
-
+        indexerStatisticsTracker.onEntryEndMakeDocument();
         if (doc != null) {
             writeToIndex(doc, entry.getPath());
+            indexerStatisticsTracker.onEntryEnd(entry.getPath());
             progressReporter.indexUpdate(definition.getIndexPath());
             return true;
         }
@@ -121,6 +128,8 @@ public class ElasticIndexer implements NodeStateIndexer {
 
     @Override
     public void close() throws IOException {
+        LOG.info("Statistics: {}", indexerStatisticsTracker.formatStats());
+        binaryTextExtractor.logStats();
         indexWriter.close(System.currentTimeMillis());
     }
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
@@ -124,6 +124,7 @@ public class FulltextBinaryTextExtractor {
                 metadata.set(Metadata.CONTENT_ENCODING, encoding);
             }
         }
+
         for (Blob v : property.getValue(Type.BINARIES)) {
             String value = parseStringValue(v, metadata, path, property.getName());
             if (value == null) {
@@ -353,4 +354,5 @@ public class FulltextBinaryTextExtractor {
             return sourceInfo;
         }
     }
+
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
@@ -18,13 +18,13 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.search.spi.binary;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.io.CountingInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.io.LazyInputStream;
 import org.apache.jackrabbit.oak.plugins.index.fulltext.ExtractedText;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
@@ -51,10 +51,10 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.jackrabbit.JcrConstants.JCR_DATA;
@@ -64,68 +64,76 @@ import static org.apache.jackrabbit.oak.plugins.index.search.spi.editor.Fulltext
  *
  */
 public class FulltextBinaryTextExtractor {
-  private final static String TEXT_EXTRACTION_TIMER_METRIC_NAME = "TEXT_EXTRACTION_TIME";
+    private final static String TEXT_EXTRACTION_TIMER_METRIC_NAME = "TEXT_EXTRACTION_TIME";
 
-  private static final Logger log = LoggerFactory.getLogger(FulltextBinaryTextExtractor.class);
-  private static final Parser defaultParser = createDefaultParser();
-  private static final long SMALL_BINARY = Long.getLong("oak.search.smallBinary", 16 * 1024);
-  private final TextExtractionStats textExtractionStats = new TextExtractionStats();
-  private final ExtractedTextCache extractedTextCache;
-  private final IndexDefinition definition;
-  private final boolean reindex;
-  private Parser parser;
-  private TikaConfigHolder tikaConfig;
-  /**
-   * The media types supported by the parser used.
-   */
-  private Set<MediaType> supportedMediaTypes;
-  private Set<MediaType> nonIndexedMediaType;
+    private static final Logger LOG = LoggerFactory.getLogger(FulltextBinaryTextExtractor.class);
+    private static final Parser defaultParser = createDefaultParser();
+    private static final long SMALL_BINARY = Long.getLong("oak.search.smallBinary", 16 * 1024);
+    private final TextExtractionStats textExtractionStats = new TextExtractionStats();
+    private final ExtractedTextCache extractedTextCache;
+    private final IndexDefinition definition;
+    private final boolean reindex;
+    private Parser parser;
+    private TikaConfigHolder tikaConfig;
+    /**
+     * The media types supported by the parser used.
+     */
+    private Set<MediaType> supportedMediaTypes;
+    private Set<MediaType> nonIndexedMediaType;
 
-  public FulltextBinaryTextExtractor(ExtractedTextCache extractedTextCache, IndexDefinition definition, boolean reindex) {
-    this.extractedTextCache = extractedTextCache;
-    this.definition = definition;
-    this.reindex = reindex;
-  }
-
-  public void done(boolean reindex){
-    textExtractionStats.log(reindex);
-    textExtractionStats.collectStats(extractedTextCache);
-  }
-
-  public List<String> newBinary(
-      PropertyState property, NodeState state, String path) {
-    List<String> values = Lists.newArrayList();
-    Metadata metadata = new Metadata();
-
-    //jcr:mimeType is mandatory for a binary to be indexed
-    String type = state.getString(JcrConstants.JCR_MIMETYPE);
-    type = definition.getTikaMappedMimeType(type);
-
-    if (type == null || !isSupportedMediaType(type)) {
-      log.trace(
-          "[{}] Ignoring binary content for node {} due to unsupported (or null) jcr:mimeType [{}]",
-          getIndexName(), path, type);
-      return values;
+    public FulltextBinaryTextExtractor(ExtractedTextCache extractedTextCache, IndexDefinition definition, boolean reindex) {
+        this.extractedTextCache = extractedTextCache;
+        this.definition = definition;
+        this.reindex = reindex;
     }
 
-    metadata.set(Metadata.CONTENT_TYPE, type);
-    if (JCR_DATA.equals(property.getName())) {
-      String encoding = state.getString(JcrConstants.JCR_ENCODING);
-      if (encoding != null) { // not mandatory
-        metadata.set(Metadata.CONTENT_ENCODING, encoding);
-      }
+    public void resetStartTime() {
+        textExtractionStats.reset();
     }
 
-    for (Blob v : property.getValue(Type.BINARIES)) {
-      String value = parseStringValue(v, metadata, path, property.getName());
-      if (value == null){
-        continue;
-      }
-
-      values.add(value);
+    public void done(boolean reindex){
+        textExtractionStats.log(reindex);
+        textExtractionStats.collectStats(extractedTextCache);
     }
-    return values;
-  }
+
+    public void logStats() {
+        LOG.info("[{}] Text extraction statistics: {}", getIndexName(), textExtractionStats.formatStats());
+        CacheStats cacheStats = extractedTextCache.getCacheStats();
+        LOG.info("[{}] Text extraction cache statistics: {}",
+                getIndexName(), cacheStats == null ? "N/A" : cacheStats.cacheInfoAsString());
+    }
+
+    public List<String> newBinary(PropertyState property, NodeState state, String path) {
+        List<String> values = new ArrayList<>();
+        Metadata metadata = new Metadata();
+
+        //jcr:mimeType is mandatory for a binary to be indexed
+        String type = state.getString(JcrConstants.JCR_MIMETYPE);
+        type = definition.getTikaMappedMimeType(type);
+
+        if (type == null || !isSupportedMediaType(type)) {
+            LOG.trace("[{}] Ignoring binary content for node {} due to unsupported (or null) jcr:mimeType [{}]",
+                    getIndexName(), path, type);
+            return values;
+        }
+
+        metadata.set(Metadata.CONTENT_TYPE, type);
+        if (JCR_DATA.equals(property.getName())) {
+            String encoding = state.getString(JcrConstants.JCR_ENCODING);
+            if (encoding != null) { // not mandatory
+                metadata.set(Metadata.CONTENT_ENCODING, encoding);
+            }
+        }
+        for (Blob v : property.getValue(Type.BINARIES)) {
+            String value = parseStringValue(v, metadata, path, property.getName());
+            if (value == null) {
+                continue;
+            }
+
+            values.add(value);
+        }
+        return values;
+    }
 
     private String parseStringValue(Blob v, Metadata metadata, String path, String propertyName) {
         String text = extractedTextCache.get(path, propertyName, v, reindex);
@@ -144,214 +152,205 @@ public class FulltextBinaryTextExtractor {
         return text;
     }
 
-  private String parseStringValue0(Blob v, Metadata metadata, String path) {
-    WriteOutContentHandler handler = new WriteOutContentHandler(definition.getMaxExtractLength());
-    long start = System.currentTimeMillis();
-    long bytesRead = 0;
-    long length = v.length();
-    if (log.isDebugEnabled()) {
-      log.debug("Extracting {}, {} bytes, id {}", path, length, v.getContentIdentity());
-    }
-    try {
-      CountingInputStream stream = new CountingInputStream(new LazyInputStream(() -> v.getNewStream()));
-      try {
-        if (length > SMALL_BINARY) {
-          String name = "Extracting " + path + ", " + length + " bytes";
-          extractedTextCache.process(name, new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-              getParser().parse(stream, handler, metadata, new ParseContext());
-              return null;
+    private String parseStringValue0(Blob blob, Metadata metadata, String path) {
+        WriteOutContentHandler handler = new WriteOutContentHandler(definition.getMaxExtractLength());
+        long bytesRead = 0;
+        long blobLength = blob.length();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Extracting {}. Length: {}, reference: {}", path, blobLength, blob.getReference());
+        }
+        textExtractionStats.startExtraction();
+        try {
+            CountingInputStream stream = new CountingInputStream(new LazyInputStream(blob::getNewStream));
+            try {
+                if (blobLength > SMALL_BINARY) {
+                    // Extracting can take a long time, so if a binary is large enough, delegate extraction to the
+                    // ExtractedTextCache#process, which may execute the extraction with a timeout (depends on configuration).
+                    String threadName = "Extracting " + path + ", " + blobLength + " bytes";
+                    extractedTextCache.process(threadName, () -> {
+                        getParser().parse(stream, handler, metadata, new ParseContext());
+                        return null;
+                    });
+                } else {
+                    getParser().parse(stream, handler, metadata, new ParseContext());
+                }
+            } finally {
+                bytesRead = stream.getCount();
+                stream.close();
             }
-          });
-        } else {
-          getParser().parse(stream, handler, metadata, new ParseContext());
+        } catch (LinkageError e) {
+            // Capture errors caused by extraction libraries
+            // not being present. This is equivalent to disabling
+            // selected media types in configuration, so we can simply
+            // ignore these errors.
+            String format = "[{}] Failed to extract text from a binary property: {}. "
+                    + "This often happens when the media types is disabled by configuration.";
+            String indexName = getIndexName();
+            LOG.info(format, indexName, path);
+            LOG.debug(format, indexName, path, e);
+            extractedTextCache.put(blob, ExtractedText.ERROR);
+            return TEXT_EXTRACTION_ERROR;
+        } catch (TimeoutException t) {
+            LOG.warn("[{}] Failed to extract text from a binary property due to timeout: {}.",
+                    getIndexName(), path);
+            extractedTextCache.put(blob, ExtractedText.ERROR);
+            extractedTextCache.putTimeout(blob, ExtractedText.ERROR);
+            return TEXT_EXTRACTION_ERROR;
+        } catch (Throwable t) {
+            // Capture and report any other full text extraction problems.
+            // The special STOP exception is used for normal termination.
+            if (!WriteLimitReachedException.isWriteLimitReached(t)) {
+                String format = "[{}] Failed to extract text from a binary property: {}. "
+                        + "This is quite common, and usually nothing to worry about.";
+                String indexName = getIndexName();
+                LOG.info(format + " Error: " + t, indexName, path);
+                LOG.debug(format, indexName, path, t);
+                extractedTextCache.put(blob, ExtractedText.ERROR);
+                return TEXT_EXTRACTION_ERROR;
+            } else {
+                LOG.debug("Extracted text size exceeded configured limit({})", definition.getMaxExtractLength());
+            }
         }
-      } finally {
-        bytesRead = stream.getCount();
-        stream.close();
-      }
-    } catch (LinkageError e) {
-      // Capture errors caused by extraction libraries
-      // not being present. This is equivalent to disabling
-      // selected media types in configuration, so we can simply
-      // ignore these errors.
-      String format = "[{}] Failed to extract text from a binary property: {}. "
-                + "This often happens when the media types is disabled by configuration.";
-      String indexName = getIndexName();
-      log.info(format, indexName, path);
-      log.debug(format, indexName, path, e);
-      extractedTextCache.put(v, ExtractedText.ERROR);
-      return TEXT_EXTRACTION_ERROR;
-    } catch (TimeoutException t) {
-      log.warn(
-          "[{}] Failed to extract text from a binary property due to timeout: {}.",
-          getIndexName(), path);
-      extractedTextCache.put(v, ExtractedText.ERROR);
-      extractedTextCache.putTimeout(v, ExtractedText.ERROR);
-      return TEXT_EXTRACTION_ERROR;
-    } catch (Throwable t) {
-      // Capture and report any other full text extraction problems.
-      // The special STOP exception is used for normal termination.
-      if (!WriteLimitReachedException.isWriteLimitReached(t)) {
-        String format = "[{}] Failed to extract text from a binary property: {}. "
-                  + "This is quite common, and usually nothing to worry about.";
-        String indexName = getIndexName();
-        log.info(format, indexName, path);
-        log.debug(format, indexName, path, t);
-        extractedTextCache.put(v, ExtractedText.ERROR);
-        return TEXT_EXTRACTION_ERROR;
-      } else {
-        log.debug("Extracted text size exceeded configured limit({})", definition.getMaxExtractLength());
-      }
-    }
-    String result = handler.toString();
-    if (bytesRead > 0) {
-      long time = System.currentTimeMillis() - start;
-      int len = result.length();
-      recordTextExtractionStats(time, bytesRead, len);
-      if (log.isDebugEnabled()) {
-        log.debug("Extracting {} took {} ms, {} bytes read, {} text size",
-            path, time, bytesRead, len);
-      }
-    }
-    extractedTextCache.put(v,  new ExtractedText(ExtractedText.ExtractionResult.SUCCESS, result));
-    return result;
-  }
-
-  private void recordTextExtractionStats(long timeInMillis, long bytesRead, int textLength) {
-    textExtractionStats.addStats(timeInMillis, bytesRead, textLength);
-  }
-
-  private String getIndexName() {
-    return definition.getIndexName();
-  }
-
-  //~-------------------------------------------< Tika >
-
-  public TikaConfig getTikaConfig(){
-    if (tikaConfig == null) {
-      tikaConfig = initializeTikaConfig(definition);
-    }
-    return tikaConfig.config;
-  }
-
-  private Parser getParser() {
-    if (parser == null){
-      parser = initializeTikaParser(definition);
-    }
-    return parser;
-  }
-
-  private boolean isSupportedMediaType(String type) {
-    if (supportedMediaTypes == null) {
-      supportedMediaTypes = getParser().getSupportedTypes(new ParseContext());
-      nonIndexedMediaType = getNonIndexedMediaTypes();
-    }
-    MediaType mediaType = MediaType.parse(type);
-    return supportedMediaTypes.contains(mediaType) && !nonIndexedMediaType.contains(mediaType);
-  }
-
-  private Set<MediaType> getNonIndexedMediaTypes() {
-    InputStream configStream = null;
-    String configSource = null;
-    try {
-      if (definition.hasCustomTikaConfig()) {
-        configSource = String.format("Custom config at %s", definition.getIndexPath());
-        configStream = definition.getTikaConfig();
-      } else {
-        URL configUrl = FulltextIndexEditorContext.class.getResource("tika-config.xml");
-        configSource = "Default : tika-config.xml";
-        if (configUrl != null) {
-          configStream = configUrl.openStream();
+        String result = handler.toString();
+        if (bytesRead > 0) {
+            int len = result.length();
+            long extractionTimeMillis = textExtractionStats.finishExtraction(bytesRead, len);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Extracted {}. Time: {} ms, Bytes read: {}, Text size: {}", path, extractionTimeMillis, bytesRead, len);
+            }
         }
-      }
-
-      if (configStream != null) {
-        return TikaParserConfig.getNonIndexedMediaTypes(configStream);
-      }
-    } catch (TikaException | IOException | SAXException e) {
-        log.warn("Tika configuration not available : {}", configSource, e);
-    } finally {
-      IOUtils.closeQuietly(configStream);
+        extractedTextCache.put(blob, new ExtractedText(ExtractedText.ExtractionResult.SUCCESS, result));
+        return result;
     }
-    return Collections.emptySet();
-  }
 
+    private String getIndexName() {
+        return definition.getIndexName();
+    }
 
-  private static TikaConfigHolder initializeTikaConfig(@Nullable IndexDefinition definition) {
-    ClassLoader current = Thread.currentThread().getContextClassLoader();
-    InputStream configStream = null;
-    String configSource = null;
+    //~-------------------------------------------< Tika >
 
-    try {
-      Thread.currentThread().setContextClassLoader(FulltextIndexEditorContext.class.getClassLoader());
-      if (definition != null && definition.hasCustomTikaConfig()) {
-        log.debug("[{}] Using custom tika config", definition.getIndexName());
-        configSource = "Custom config at " + definition.getIndexPath();
-        configStream = definition.getTikaConfig();
-      } else {
-        URL configUrl = FulltextIndexEditorContext.class.getResource("tika-config.xml");
-        if (configUrl != null) {
-          configSource = configUrl.toString();
-          configStream = configUrl.openStream();
+    public TikaConfig getTikaConfig() {
+        if (tikaConfig == null) {
+            tikaConfig = initializeTikaConfig(definition);
         }
-      }
-
-      if (configStream != null) {
-        return new TikaConfigHolder(new TikaConfig(configStream), configSource);
-      }
-    } catch (TikaException | IOException | SAXException e) {
-        log.warn("Tika configuration not available : {}", configSource, e);
-    } finally {
-      IOUtils.closeQuietly(configStream);
-      Thread.currentThread().setContextClassLoader(current);
-    }
-    return new TikaConfigHolder(TikaConfig.getDefaultConfig(), "Default Config");
-  }
-
-  private Parser initializeTikaParser(IndexDefinition definition) {
-    ClassLoader current = Thread.currentThread().getContextClassLoader();
-    try {
-      if (definition.hasCustomTikaConfig()) {
-        Thread.currentThread().setContextClassLoader(FulltextIndexEditorContext.class.getClassLoader());
-        return new AutoDetectParser(getTikaConfig());
-      }
-    } finally {
-      Thread.currentThread().setContextClassLoader(current);
-    }
-    return defaultParser;
-  }
-
-  private static AutoDetectParser createDefaultParser() {
-    ClassLoader current = Thread.currentThread().getContextClassLoader();
-    TikaConfigHolder configHolder = null;
-    try {
-      configHolder = initializeTikaConfig(null);
-      Thread.currentThread().setContextClassLoader(FulltextIndexEditorContext.class.getClassLoader());
-      log.info("Loaded default Tika Config from classpath {}", configHolder);
-      return new AutoDetectParser(configHolder.config);
-    } catch (Exception e) {
-        log.warn("Tika configuration not available : {}", configHolder, e);
-    } finally {
-      Thread.currentThread().setContextClassLoader(current);
-    }
-    return new AutoDetectParser();
-  }
-
-  private static final class TikaConfigHolder{
-    final TikaConfig config;
-    final String sourceInfo;
-
-    public TikaConfigHolder(TikaConfig config, String sourceInfo) {
-      this.config = config;
-      this.sourceInfo = sourceInfo;
+        return tikaConfig.config;
     }
 
-    @Override
-    public String toString() {
-      return sourceInfo;
+    private Parser getParser() {
+        if (parser == null) {
+            parser = initializeTikaParser(definition);
+        }
+        return parser;
     }
-  }
 
+    private boolean isSupportedMediaType(String type) {
+        if (supportedMediaTypes == null) {
+            supportedMediaTypes = getParser().getSupportedTypes(new ParseContext());
+            nonIndexedMediaType = getNonIndexedMediaTypes();
+        }
+        MediaType mediaType = MediaType.parse(type);
+        return supportedMediaTypes.contains(mediaType) && !nonIndexedMediaType.contains(mediaType);
+    }
+
+    private Set<MediaType> getNonIndexedMediaTypes() {
+        InputStream configStream = null;
+        String configSource = null;
+        try {
+            if (definition.hasCustomTikaConfig()) {
+                configSource = String.format("Custom config at %s", definition.getIndexPath());
+                configStream = definition.getTikaConfig();
+            } else {
+                URL configUrl = FulltextIndexEditorContext.class.getResource("tika-config.xml");
+                configSource = "Default : tika-config.xml";
+                if (configUrl != null) {
+                    configStream = configUrl.openStream();
+                }
+            }
+
+            if (configStream != null) {
+                return TikaParserConfig.getNonIndexedMediaTypes(configStream);
+            }
+        } catch (TikaException | IOException | SAXException e) {
+            LOG.warn("Tika configuration not available : {}", configSource, e);
+        } finally {
+            IOUtils.closeQuietly(configStream);
+        }
+        return Collections.emptySet();
+    }
+
+
+    private static TikaConfigHolder initializeTikaConfig(@Nullable IndexDefinition definition) {
+        ClassLoader current = Thread.currentThread().getContextClassLoader();
+        InputStream configStream = null;
+        String configSource = null;
+
+        try {
+            Thread.currentThread().setContextClassLoader(FulltextIndexEditorContext.class.getClassLoader());
+            if (definition != null && definition.hasCustomTikaConfig()) {
+                LOG.debug("[{}] Using custom tika config", definition.getIndexName());
+                configSource = "Custom config at " + definition.getIndexPath();
+                configStream = definition.getTikaConfig();
+            } else {
+                URL configUrl = FulltextIndexEditorContext.class.getResource("tika-config.xml");
+                if (configUrl != null) {
+                    configSource = configUrl.toString();
+                    configStream = configUrl.openStream();
+                }
+            }
+
+            if (configStream != null) {
+                return new TikaConfigHolder(new TikaConfig(configStream), configSource);
+            }
+        } catch (TikaException | IOException | SAXException e) {
+            LOG.warn("Tika configuration not available : {}", configSource, e);
+        } finally {
+            IOUtils.closeQuietly(configStream);
+            Thread.currentThread().setContextClassLoader(current);
+        }
+        return new TikaConfigHolder(TikaConfig.getDefaultConfig(), "Default Config");
+    }
+
+    private Parser initializeTikaParser(IndexDefinition definition) {
+        ClassLoader current = Thread.currentThread().getContextClassLoader();
+        try {
+            if (definition.hasCustomTikaConfig()) {
+                Thread.currentThread().setContextClassLoader(FulltextIndexEditorContext.class.getClassLoader());
+                return new AutoDetectParser(getTikaConfig());
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(current);
+        }
+        return defaultParser;
+    }
+
+    private static AutoDetectParser createDefaultParser() {
+        ClassLoader current = Thread.currentThread().getContextClassLoader();
+        TikaConfigHolder configHolder = null;
+        try {
+            configHolder = initializeTikaConfig(null);
+            Thread.currentThread().setContextClassLoader(FulltextIndexEditorContext.class.getClassLoader());
+            LOG.info("Loaded default Tika Config from classpath {}", configHolder);
+            return new AutoDetectParser(configHolder.config);
+        } catch (Exception e) {
+            LOG.warn("Tika configuration not available : {}", configHolder, e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(current);
+        }
+        return new AutoDetectParser();
+    }
+
+    private static final class TikaConfigHolder {
+        final TikaConfig config;
+        final String sourceInfo;
+
+        public TikaConfigHolder(TikaConfig config, String sourceInfo) {
+            this.config = config;
+            this.sourceInfo = sourceInfo;
+        }
+
+        @Override
+        public String toString() {
+            return sourceInfo;
+        }
+    }
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.jackrabbit.oak.commons.IOUtils.humanReadableByteCount;
 
 final class TextExtractionStats {
-    private static final Logger LOG = LoggerFactory.getLogger(TextExtractionStats.class);
+    private static final Logger log = LoggerFactory.getLogger(TextExtractionStats.class);
     /**
      * Log stats only if time spent is more than 1 min
      */
@@ -44,7 +44,7 @@ final class TextExtractionStats {
     private long startTimeNanos = System.nanoTime();
 
     public void reset() {
-        LOG.info("Resetting statistics");
+        log.info("Resetting statistics");
         this.numberOfExtractions = 0;
         this.totalBytesRead = 0;
         this.totalExtractedTextLength = 0;
@@ -58,10 +58,10 @@ final class TextExtractionStats {
     }
 
     public void log(boolean reindex) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Text extraction stats {}", this);
+        if (log.isDebugEnabled()) {
+            log.debug("Text extraction stats {}", this);
         } else if (anyParsingDone() && (reindex || isTakingLotsOfTime())) {
-            LOG.info("Text extraction stats {}", this);
+            log.info("Text extraction stats {}", this);
         }
     }
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
@@ -71,15 +71,15 @@ final class TextExtractionStats {
         totalBytesRead += bytesRead;
         totalExtractedTextLength += extractedTextLength;
         totalExtractionTimeNanos += elapsedNanos;
-        return elapsedNanos/1_000_000;
+        return elapsedNanos / 1_000_000;
     }
 
     public void collectStats(ExtractedTextCache cache) {
-        cache.addStats(numberOfExtractions, totalExtractionTimeNanos/1_000_000, totalBytesRead, totalExtractedTextLength);
+        cache.addStats(numberOfExtractions, totalExtractionTimeNanos / 1_000_000, totalBytesRead, totalExtractedTextLength);
     }
 
     private boolean isTakingLotsOfTime() {
-        return totalExtractionTimeNanos > LOGGING_THRESHOLD*1_000_000;
+        return totalExtractionTimeNanos > LOGGING_THRESHOLD * 1_000_000;
     }
 
     private boolean anyParsingDone() {
@@ -98,7 +98,7 @@ final class TextExtractionStats {
     public String formatStats() {
         long timeSinceStartNanos = System.nanoTime() - startTimeNanos;
         double timeExtractingPercentage = FormattingUtils.safeComputePercentage(totalExtractionTimeNanos, timeSinceStartNanos);
-        long avgExtractionTimeMillis = numberOfExtractions == 0 ? -1 : (totalExtractionTimeNanos/ 1_000_000 / numberOfExtractions);
+        long avgExtractionTimeMillis = numberOfExtractions == 0 ? -1 : (totalExtractionTimeNanos / 1_000_000 / numberOfExtractions);
 
         return String.format("{extractions: %d, timeExtracting: %s (%2.1f%%), totalTime: %s, " +
                         "avgExtractionTime: %s ms, bytesRead: %s, extractedTextSize: %s}",

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
@@ -98,7 +98,7 @@ final class TextExtractionStats {
     public String formatStats() {
         long timeSinceStartNanos = System.nanoTime() - startTimeNanos;
         double timeExtractingPercentage = FormattingUtils.safeComputePercentage(totalExtractionTimeNanos, timeSinceStartNanos);
-        long avgExtractionTimeMillis = numberOfExtractions == 0 ? -1 : (totalExtractionTimeNanos / 1_000_000 / numberOfExtractions);
+        double avgExtractionTimeMillis = FormattingUtils.safeComputeAverage(totalExtractionTimeNanos / 1_000_000, numberOfExtractions);
 
         return String.format("{extractions: %d, timeExtracting: %s (%2.1f%%), totalTime: %s, " +
                         "avgExtractionTime: %s ms, bytesRead: %s, extractedTextSize: %s}",

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
@@ -21,57 +21,96 @@ package org.apache.jackrabbit.oak.plugins.index.search.spi.binary;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.jackrabbit.oak.commons.IOUtils.humanReadableByteCount;
 
-class TextExtractionStats {
-    private static final Logger log = LoggerFactory.getLogger(TextExtractionStats.class);
+final class TextExtractionStats {
+    private static final Logger LOG = LoggerFactory.getLogger(TextExtractionStats.class);
     /**
      * Log stats only if time spent is more than 1 min
      */
     private static final long LOGGING_THRESHOLD = TimeUnit.MINUTES.toMillis(1);
-    private int count;
-    private long totalBytesRead;
-    private long totalTime;
-    private long totalTextLength;
 
-    public void addStats(long timeInMillis, long bytesRead, int textLength) {
-        count++;
-        totalBytesRead += bytesRead;
-        totalTime += timeInMillis;
-        totalTextLength += textLength;
+    private static long systemNanoAsMillis() {
+        return System.nanoTime() / 1_000_000;
+    }
+
+    private int numberOfExtractions;
+    private long totalBytesRead;
+    private long totalExtractedTextLength;
+    private long totalExtractionTimeMillis;
+    private long currentExtractionStartMillis = 0;
+    private long startTimeMillis = systemNanoAsMillis();
+
+    public void reset() {
+        LOG.info("Resetting statistics");
+        this.numberOfExtractions = 0;
+        this.totalBytesRead = 0;
+        this.totalExtractedTextLength = 0;
+        this.totalExtractionTimeMillis = 0;
+        this.currentExtractionStartMillis = 0;
+        this.startTimeMillis = systemNanoAsMillis();
+    }
+
+    public void startExtraction() {
+        currentExtractionStartMillis = systemNanoAsMillis();
     }
 
     public void log(boolean reindex) {
-        if (log.isDebugEnabled()) {
-            log.debug("Text extraction stats {}", this);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Text extraction stats {}", this);
         } else if (anyParsingDone() && (reindex || isTakingLotsOfTime())) {
-            log.info("Text extraction stats {}", this);
+            LOG.info("Text extraction stats {}", this);
         }
     }
 
-    public void collectStats(ExtractedTextCache cache){
-        cache.addStats(count, totalTime, totalBytesRead, totalTextLength);
+    public long finishExtraction(long bytesRead, int extractedTextLength) {
+        long elapsedMillis = systemNanoAsMillis() - currentExtractionStartMillis;
+        numberOfExtractions++;
+        totalBytesRead += bytesRead;
+        totalExtractedTextLength += extractedTextLength;
+        totalExtractionTimeMillis += elapsedMillis;
+        return elapsedMillis;
+    }
+
+    public void collectStats(ExtractedTextCache cache) {
+        cache.addStats(numberOfExtractions, totalExtractionTimeMillis, totalBytesRead, totalExtractedTextLength);
     }
 
     private boolean isTakingLotsOfTime() {
-        return totalTime > LOGGING_THRESHOLD;
+        return totalExtractionTimeMillis > LOGGING_THRESHOLD;
     }
 
     private boolean anyParsingDone() {
-        return count > 0;
+        return numberOfExtractions > 0;
     }
 
     @Override
     public String toString() {
         return String.format(" %d (Time Taken %s, Bytes Read %s, Extracted text size %s)",
-                count,
-                timeInWords(totalTime),
+                numberOfExtractions,
+                timeInWords(totalExtractionTimeMillis),
                 humanReadableByteCount(totalBytesRead),
-                humanReadableByteCount(totalTextLength));
+                humanReadableByteCount(totalExtractedTextLength));
+    }
+
+    public String formatStats() {
+        long timeSinceStartMillis = systemNanoAsMillis() - startTimeMillis;
+        double timeExtractingPercentage = timeSinceStartMillis == 0 ? -1 : (totalExtractionTimeMillis * 100.0) / timeSinceStartMillis;
+        long avgExtractionTimeMillis = numberOfExtractions == 0 ? -1 : totalExtractionTimeMillis / numberOfExtractions;
+
+        return String.format("{extractions: %d, timeExtracting: %s (%2.1f%%), totalTime: %s, " +
+                        "avgExtractionTime: %s ms, bytesRead: %s, extractedTextSize: %s}",
+                numberOfExtractions,
+                FormattingUtils.formatToSeconds(totalExtractionTimeMillis / 1000),
+                timeExtractingPercentage,
+                FormattingUtils.formatToSeconds(timeSinceStartMillis / 1000),
+                avgExtractionTimeMillis,
+                humanReadableByteCount(totalBytesRead), humanReadableByteCount(totalExtractedTextLength));
     }
 
     private static String timeInWords(long millis) {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
@@ -98,7 +98,7 @@ final class TextExtractionStats {
     public String formatStats() {
         long timeSinceStartNanos = System.nanoTime() - startTimeNanos;
         double timeExtractingPercentage = FormattingUtils.safeComputePercentage(totalExtractionTimeNanos, timeSinceStartNanos);
-        double avgExtractionTimeMillis = FormattingUtils.safeComputeAverage(totalExtractionTimeNanos / 1_000_000, numberOfExtractions);
+        long avgExtractionTimeMillis = Math.round(FormattingUtils.safeComputeAverage(totalExtractionTimeNanos / 1_000_000, numberOfExtractions));
 
         return String.format("{extractions: %d, timeExtracting: %s (%2.1f%%), totalTime: %s, " +
                         "avgExtractionTime: %s ms, bytesRead: %s, extractedTextSize: %s}",


### PR DESCRIPTION
Collect and prints statistics in
- FullTextBinaryTextExtractor
- LuceneIndexer
- ElasticIndexer

Example of the new log lines with statistics:
```
09:31:40.818 [main] INFO  o.a.j.o.i.i.document.LuceneIndexer - Statistics: Indexed 2437527 nodes in 00:45:07. Avg per node: 1079 microseconds. indexingTime: 00:43:50 (97.2% of total time). Breakup of indexing time: makeDocument: 00:21:32 (49.2%), writeIndex: 00:22:17 (50.8%), other: 00:00:00 (0.0%)
09:31:40.818 [main] INFO  o.a.j.o.p.i.s.s.b.FulltextBinaryTextExtractor - [/oak:index/damAssetLucene-11] Text extraction statistics: {extractions: 1701, timeExtracting: 00:01:06 (2.4%), totalTime: 00:45:07, avgExtractionTime: 38 ms, bytesRead: 11.8 MB, extractedTextSize: 11.8 MB}
09:31:40.823 [main] INFO  o.a.j.o.p.i.s.s.b.FulltextBinaryTextExtractor - [/oak:index/damAssetLucene-11] Text extraction cache statistics: CacheStats{hitCount=1999208, hitRate=1.00, missCount=1701, missRate=0.00, requestCount=2000909, loadCount=0, loadSuccessCount=0, loadExceptionCount=0, totalLoadTime=0 min, 0 sec, averageLoadPenalty=0.00 ns, evictionCount=1036, elementCount=665, totalWeight=5.2 MB, maxWeight=5.2 MB}
```