### PR TITLE
OAK-11008 - AzureBlobStore: do not create a new CloudBlobContainer instance for every request to the backend

### DIFF
--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -100,7 +100,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
     private static final String REF_KEY = "reference.key";
     private static final String LAST_MODIFIED_KEY = "lastModified";
 
-    private static final long BUFFERED_STREAM_THRESHHOLD = 1024 * 1024;
+    private static final long BUFFERED_STREAM_THRESHOLD = 1024 * 1024;
     static final long MIN_MULTIPART_UPLOAD_PART_SIZE = 1024 * 1024 * 10; // 10MB
     static final long MAX_MULTIPART_UPLOAD_PART_SIZE = 1024 * 1024 * 100; // 100MB
     static final long MAX_SINGLE_PUT_UPLOAD_SIZE = 1024 * 1024 * 256; // 256MB, Azure limit
@@ -131,8 +131,17 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
         this.properties = properties;
     }
 
+    private volatile CloudBlobContainer azureContainer = null;
+
     protected CloudBlobContainer getAzureContainer() throws DataStoreException {
-        return azureBlobContainerProvider.getBlobContainer(getBlobRequestOptions());
+        if (azureContainer == null) {
+            synchronized (this) {
+                if (azureContainer == null) {
+                    azureContainer = azureBlobContainerProvider.getBlobContainer(getBlobRequestOptions());
+                }
+            }
+        }
+        return azureContainer;
     }
 
     @NotNull
@@ -210,8 +219,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
                 } else {
                     LOG.info("Reusing existing container. containerName={}", getContainerName());
                 }
-                LOG.debug("Backend initialized. duration={}",
-                          +(System.currentTimeMillis() - start));
+                LOG.debug("Backend initialized. duration={}", (System.currentTimeMillis() - start));
 
                 // settings pertaining to DataRecordAccessProvider functionality
                 String putExpiry = properties.getProperty(AzureConstants.PRESIGNED_HTTP_UPLOAD_URI_EXPIRY_SECONDS);
@@ -322,7 +330,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
 
                 BlobRequestOptions options = new BlobRequestOptions();
                 options.setConcurrentRequestCount(concurrentRequestCount);
-                boolean useBufferedStream = len < BUFFERED_STREAM_THRESHHOLD;
+                boolean useBufferedStream = len < BUFFERED_STREAM_THRESHOLD;
                 final InputStream in = useBufferedStream  ? new BufferedInputStream(new FileInputStream(file)) : new FileInputStream(file);
                 try {
                     blob.upload(in, len, null, options, null);
@@ -460,28 +468,23 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
     }
 
     @Override
-    public Iterator<DataIdentifier> getAllIdentifiers() throws DataStoreException {
-        return new RecordsIterator<DataIdentifier>(
+    public Iterator<DataIdentifier> getAllIdentifiers() {
+        return new RecordsIterator<>(
                 input -> new DataIdentifier(getIdentifierName(input.getName())));
     }
 
 
 
     @Override
-    public Iterator<DataRecord> getAllRecords() throws DataStoreException {
+    public Iterator<DataRecord> getAllRecords() {
         final AbstractSharedBackend backend = this;
-        return new RecordsIterator<DataRecord>(
-                new Function<AzureBlobInfo, DataRecord>() {
-                    @Override
-                    public DataRecord apply(AzureBlobInfo input) {
-                        return new AzureBlobStoreDataRecord(
-                            backend,
-                                azureBlobContainerProvider,
-                            new DataIdentifier(getIdentifierName(input.getName())),
-                            input.getLastModified(),
-                            input.getLength());
-                    }
-                }
+        return new RecordsIterator<>(
+                input -> new AzureBlobStoreDataRecord(
+                        backend,
+                        azureBlobContainerProvider,
+                        new DataIdentifier(getIdentifierName(input.getName())),
+                        input.getLastModified(),
+                        input.getLength())
         );
     }
 


### PR DESCRIPTION
Currently, whenever AzureBlobStoreBackend needs to make a call to Azure, it creates a new instance of CloudBlobContainer. But instances of this class can be reused and the configuration does not change after an instance of AzureBlobStoreBackend is created.

When making many calls to the Azure blob store, reusing the connection will likely speedup the calls to Azure.