### PR TITLE
OAK-11031 - Improve logging of indexer statistics

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/FormattingUtils.java
@@ -22,11 +22,11 @@ import java.util.concurrent.TimeUnit;
 
 public class FormattingUtils {
     public static String formatNanosToSeconds(long nanos) {
-        return formatToSeconds(nanos/1_000_000_000);
+        return formatToSeconds(nanos / 1_000_000_000);
     }
 
     public static String formatMillisToSeconds(long millis) {
-        return formatToSeconds(millis/1000);
+        return formatToSeconds(millis / 1000);
     }
 
     public static String formatToSeconds(Stopwatch stopwatch) {
@@ -58,6 +58,6 @@ public class FormattingUtils {
     }
 
     public static double safeComputeAverage(long totalTime, long numberOfEvents) {
-        return numberOfEvents == 0 ? -1 : ((double)totalTime / numberOfEvents);
+        return numberOfEvents == 0 ? -1 : ((double) totalTime / numberOfEvents);
     }
 }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexer.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexer.java
@@ -116,7 +116,7 @@ public class LuceneIndexer implements NodeStateIndexer, FacetsConfigProvider {
 
     @Override
     public void close() throws IOException {
-        LOG.info("Statistics: {}", indexerStatisticsTracker.formatStats());
+        LOG.info("[{}] Statistics: {}", definition.getIndexName(), indexerStatisticsTracker.formatStats());
         binaryTextExtractor.logStats();
         indexWriter.close(System.currentTimeMillis());
     }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/TextExtractionStats.java
@@ -100,8 +100,8 @@ final class TextExtractionStats {
         double timeExtractingPercentage = FormattingUtils.safeComputePercentage(totalExtractionTimeNanos, timeSinceStartNanos);
         long avgExtractionTimeMillis = Math.round(FormattingUtils.safeComputeAverage(totalExtractionTimeNanos / 1_000_000, numberOfExtractions));
 
-        return String.format("{extractions: %d, timeExtracting: %s (%2.1f%%), totalTime: %s, " +
-                        "avgExtractionTime: %s ms, bytesRead: %s, extractedTextSize: %s}",
+        return String.format("extractions: %d, timeExtracting: %s (%2.1f%%), totalTime: %s, " +
+                        "avgExtractionTime: %s ms, bytesRead: %s, extractedTextSize: %s",
                 numberOfExtractions,
                 FormattingUtils.formatNanosToSeconds(totalExtractionTimeNanos),
                 timeExtractingPercentage,


### PR DESCRIPTION
Include the index name in the log messages with Lucene index statistics.
Fix formatting in FormattingUtils class.