### PR TITLE
OAK-11042: bump elastic 8.15.0 / lucene 9.11.1

### DIFF
--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -33,8 +33,8 @@
   <description>Oak Elasticsearch integration subproject</description>
 
   <properties>
-    <elasticsearch.java.client.version>8.13.2</elasticsearch.java.client.version>
-    <lucene.version>9.10.0</lucene.version>
+    <elasticsearch.java.client.version>8.15.0</elasticsearch.java.client.version>
+    <lucene.version>9.11.1</lucene.version>
   </properties>
 
   <build>

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 class ElasticBulkProcessorHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticBulkProcessorHandler.class);
-    private final int FAILED_DOC_COUNT_FOR_STATUS_NODE = Integer.getInteger("oak.failedDocStatusLimit", 10000);
+    private static final int FAILED_DOC_COUNT_FOR_STATUS_NODE = Integer.getInteger("oak.failedDocStatusLimit", 10000);
 
     private static final int BULK_PROCESSOR_CONCURRENCY =
         Integer.getInteger("oak.indexer.elastic.bulkProcessorConcurrency", 1);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -87,6 +87,7 @@ class ElasticBulkProcessorHandler {
 
     protected long totalOperations;
 
+    // TODO: workaround for https://github.com/elastic/elasticsearch-java/pull/867 remove when fixed
     private final ScheduledExecutorService scheduler;
 
     private ElasticBulkProcessorHandler(@NotNull ElasticConnection elasticConnection,
@@ -161,7 +162,11 @@ class ElasticBulkProcessorHandler {
             if (indexDefinition.bulkFlushIntervalMs > 0) {
                 b = b.flushInterval(indexDefinition.bulkFlushIntervalMs, TimeUnit.MILLISECONDS);
             }
-            return b.scheduler(scheduler).maxConcurrentRequests(BULK_PROCESSOR_CONCURRENCY);
+
+            // TODO: workaround for https://github.com/elastic/elasticsearch-java/pull/867 remove when fixed
+            b = b.scheduler(scheduler);
+
+            return b.maxConcurrentRequests(BULK_PROCESSOR_CONCURRENCY);
         });
     }
 
@@ -217,6 +222,7 @@ class ElasticBulkProcessorHandler {
             }
         }
 
+        // TODO: workaround for https://github.com/elastic/elasticsearch-java/pull/867 remove when fixed
         scheduler.shutdownNow();
 
         checkFailures();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/TermQueryBuilderFactory.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/TermQueryBuilderFactory.java
@@ -70,27 +70,27 @@ public class TermQueryBuilderFactory {
         int depth = PathUtils.getDepth(path) + planResult.getParentDepth() + 1;
         return Query.of(q -> q.term(t -> t.field(PATH_DEPTH).value(v->v.longValue(depth))));
     }
-    
-    private static <R> Query newRangeQuery(String field, R first, R last, boolean firstIncluding,
-            boolean lastIncluding) {
 
-        return Query.of(fn -> fn.range(fnr -> {
+    private static <R> Query newRangeQuery(String field, R first, R last, boolean firstIncluding,
+                                           boolean lastIncluding) {
+
+        return Query.of(fn -> fn.range(fnr -> fnr.date(date -> {
             if (first != null) {
                 if (firstIncluding) {
-                    fnr.gte(JsonData.of(first));
+                    date.gte(first.toString());
                 } else {
-                    fnr.gt(JsonData.of(first));
+                    date.gt(first.toString());
                 }
             }
             if (last != null) {
                 if (lastIncluding) {
-                    fnr.lte(JsonData.of(last));
+                    date.lte(last.toString());
                 } else {
-                    fnr.lt(JsonData.of(last));
+                    date.lt(last.toString());
                 }
             }
-            return fnr.field(field);
-        }));
+            return date.field(field);
+        })));
     }
 
     private static <R> FieldValue toFieldValue(R value) {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestServer.java
@@ -49,9 +49,9 @@ public class ElasticTestServer implements AutoCloseable {
             "8.7.1.0", "80c8d34334b0cf4def79835ea6dab78b59ba9ee54c8f5f3cba0bde53123d7820",
             "8.10.4.0", "b2ae8faf1e272319594b4d47a72580fa4f61a5c11cbc8d3f13453fd34b153441",
             "8.11.0.0", "8d4d80b850c4da4da6dfe2d675b2e2355d2014307f8bdc54cc1b34323c81c7ae",
-            "8.11.1.0", "a00a920d4bc29f0deacde7c2ef3d3f70692b00b62bf7fb82b0fe18eeb1dafee9",
             "8.11.3.0", "1f14b496baf973fb5c64e77fc458d9814dd6905170d7b15350f9f1a009824f41",
-            "8.13.2.0", "586f553b109266d7996265f3f34a20914b569d494b49da2c0534428770e551f0");
+            "8.13.2.0", "586f553b109266d7996265f3f34a20914b569d494b49da2c0534428770e551f0",
+            "8.15.0.0", "6cbb54d68d654a3476df0b730856cfa3194bce5c6e1050a35e7a86ffec8a3e20");
 
     private static final ElasticTestServer SERVER = new ElasticTestServer();
     private static volatile ElasticsearchContainer CONTAINER;


### PR DESCRIPTION
Includes workaround for BulkIngester issue that should be addressed by this PR https://github.com/elastic/elasticsearch-java/pull/867