### PR TITLE
OAK-11070 - WriteAccessController: avoid race condition

### DIFF
--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/WriteAccessController.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/WriteAccessController.java
@@ -36,6 +36,9 @@ public class WriteAccessController {
     public void checkWritingAllowed() {
         while (!isWritingAllowed) {
             synchronized (lock) {
+                if (isWritingAllowed) {
+                    return;
+                }
                 try {
                     lock.wait();
                 } catch (InterruptedException e) {


### PR DESCRIPTION
@smiroslav WDYT? We could also use a ReentrantLock but I don't think it makes any difference here.