### PR TITLE
OAK-11075: Add a Buffer#getShort() API

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/Buffer.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/Buffer.java
@@ -206,6 +206,10 @@ final public class Buffer {
     public short getShort(int pos) {
         return buffer.getShort(pos);
     }
+    
+    public short getShort() {
+        return buffer.getShort();
+    }
 
     public Buffer duplicate() {
         return new Buffer(buffer.duplicate());

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/package-info.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("2.1.0")
+@Version("2.2.0")
 package org.apache.jackrabbit.oak.commons;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Modifies `org.apache.jackrabbit.oak.commons.Buffer` to also support getting a short from the current position of the buffer, similarly to other APIs already provided such as `Buffer#getLong()`.

Closes OAK-11075