### PR TITLE
OAK-11079 - Parse a Flat File Store line without splitting the line into two strings

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryReader.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/NodeStateEntryReader.java
@@ -36,14 +36,11 @@ public class NodeStateEntryReader {
         this.des = new JsonDeserializer(blobDeserializer);
     }
 
-    public NodeStateEntry read(String line) {
-        String[] parts = NodeStateEntryWriter.getParts(line);
-        long memUsage = estimateMemoryUsage(parts[0]) + estimateMemoryUsage(parts[1]);
-        NodeState nodeState = parseState(parts[1]);
-        return new NodeStateEntry(nodeState, parts[0], memUsage, 0, "");
-    }
-
-    public NodeState parseState(String part) {
-        return des.deserialize(part);
+    public NodeStateEntry read(String ffsLine) {
+        long memUsage = estimateMemoryUsage(ffsLine);
+        var idx = ffsLine.indexOf('|');
+        var path = ffsLine.substring(0, idx);
+        NodeState nodeState = des.deserialize(ffsLine, idx + 1);
+        return new NodeStateEntry(nodeState, path, memUsage, 0, "");
     }
 }

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/json/JsonDeserializer.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/json/JsonDeserializer.java
@@ -85,7 +85,11 @@ public class JsonDeserializer {
     }
 
     public NodeState deserialize(String json) {
-        JsopReader reader = new JsopTokenizer(json);
+        return deserialize(json, 0);
+    }
+
+    public NodeState deserialize(String line, int pos) {
+        JsopReader reader = new JsopTokenizer(line, pos);
         reader.read('{');
         NodeState state = deserialize(reader);
         reader.read(JsopReader.END);


### PR DESCRIPTION
Parse FlatFileStore lines without splitting the line into two strings