### PR TITLE
OAK-11078: Remove usage of Guava checkArgument

### DIFF
--- a/oak-core/pom.xml
+++ b/oak-core/pom.xml
@@ -296,6 +296,10 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <optional>true</optional>

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ImmutableRoot.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/ImmutableRoot.java
@@ -18,12 +18,12 @@
  */
 package org.apache.jackrabbit.oak.core;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.oak.commons.PathUtils.elements;
 
 import java.io.InputStream;
 import java.util.Map;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.AuthInfo;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.ContentSession;
@@ -71,7 +71,7 @@ public final class ImmutableRoot implements Root, ReadOnly {
     }
 
     public ImmutableRoot(@NotNull ImmutableTree rootTree) {
-        checkArgument(rootTree.isRoot());
+        Validate.isTrue(rootTree.isRoot());
         this.rootTree = rootTree;
         this.authInfo = AuthInfo.EMPTY;
         this.wspName = null;
@@ -90,7 +90,7 @@ public final class ImmutableRoot implements Root, ReadOnly {
     @NotNull
     @Override
     public ImmutableTree getTree(@NotNull String path) {
-        checkArgument(PathUtils.isAbsolute(path));
+        Validate.isTrue(PathUtils.isAbsolute(path));
         ImmutableTree child = rootTree;
         for (String name : elements(path)) {
             child = child.getChild(name);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/core/MutableTree.java
@@ -19,10 +19,11 @@
 package org.apache.jackrabbit.oak.core;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
+
 import static org.apache.jackrabbit.oak.commons.PathUtils.elements;
 import static org.apache.jackrabbit.oak.commons.PathUtils.isAbsolute;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
@@ -284,7 +285,7 @@ final class MutableTree extends AbstractMutableTree {
      */
     @NotNull
     MutableTree getTree(@NotNull String path) {
-        checkArgument(isAbsolute(requireNonNull(path)));
+        Validate.isTrue(isAbsolute(requireNonNull(path)));
         beforeRead();
         MutableTree child = this;
         for (String name : elements(path)) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.namepath.impl;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
@@ -37,6 +36,7 @@ import java.util.Map.Entry;
 
 import javax.jcr.RepositoryException;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.namepath.NameMapper;
@@ -117,8 +117,8 @@ public class GlobalNameMapper implements NameMapper {
     public String getJcrName(@NotNull String oakName) {
         // Sanity checks, can be turned to assertions if needed for performance
         requireNonNull(oakName);
-        checkArgument(!isHiddenName(oakName), oakName);
-        checkArgument(!isExpandedName(oakName), oakName);
+        Validate.isTrue(!isHiddenName(oakName), oakName);
+        Validate.isTrue(!isExpandedName(oakName), oakName);
 
         return oakName;
     }
@@ -149,7 +149,7 @@ public class GlobalNameMapper implements NameMapper {
 
     @Nullable
     protected String getOakNameFromExpanded(String expandedName) {
-        checkArgument(expandedName.startsWith("{"));
+        Validate.isTrue(expandedName.startsWith("{"));
 
         int brace = expandedName.indexOf('}', 1);
         if (brace > 0) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/LocalNameMapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/LocalNameMapper.java
@@ -17,10 +17,10 @@
 package org.apache.jackrabbit.oak.namepath.impl;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.Root;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -55,8 +55,8 @@ public class LocalNameMapper extends GlobalNameMapper {
     @Override @NotNull
     public synchronized String getJcrName(@NotNull String oakName) {
         requireNonNull(oakName);
-        checkArgument(!oakName.startsWith(":"), oakName); // hidden name
-        checkArgument(!isExpandedName(oakName), oakName); // expanded name
+        Validate.isTrue(!oakName.startsWith(":"), oakName); // hidden name
+        Validate.isTrue(!isExpandedName(oakName), oakName); // expanded name
 
         if (!local.isEmpty()) {
             int colon = oakName.indexOf(':');

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/identifier/IdentifierManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/identifier/IdentifierManager.java
@@ -27,6 +27,7 @@ import javax.jcr.query.Query;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.PropertyValue;
@@ -50,7 +51,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.collect.Iterators.filter;
 import static org.apache.jackrabbit.guava.common.collect.Iterators.singletonIterator;
 import static org.apache.jackrabbit.guava.common.collect.Iterators.transform;
@@ -130,7 +130,7 @@ public class IdentifierManager {
                     ? identifier
                     : identifier.substring(0, k);
 
-            checkArgument(UUIDUtils.isValidUUID(uuid), "Not a valid identifier '" + identifier + '\'');
+            Validate.isTrue(UUIDUtils.isValidUUID(uuid), "Not a valid identifier '%s'", identifier);
 
             Tree tree = resolveUUIDToTree(createPropertyValue(uuid));
             if (tree == null) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.base.Throwables.getStackTraceAsString;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
@@ -51,6 +50,7 @@ import javax.management.openmbean.TabularData;
 
 import com.codahale.metrics.MetricRegistry;
 import org.apache.jackrabbit.guava.common.collect.Lists;
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.api.stats.TimeSeries;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -244,8 +244,8 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
         if (IndexConstants.ASYNC_REINDEX_VALUE.equals(asyncName)){
             return asyncName;
         }
-        checkArgument(asyncName.endsWith("async"), "async name [%s] does not confirm to " +
-                "naming pattern of ending with 'async'", asyncName);
+        Validate.isTrue(asyncName.endsWith("async"), "async name [%s] does not confirm to naming pattern of ending with 'async'",
+                asyncName);
         return asyncName;
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexerService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexerService.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index;
 
 import java.io.Closeable;
@@ -26,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.io.Closer;
 import org.apache.jackrabbit.oak.api.jmx.IndexStatsMBean;
@@ -54,7 +54,6 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils.registerMBean;
 
 @Component(
@@ -215,7 +214,7 @@ public class AsyncIndexerService {
         List<AsyncConfig> result = Lists.newArrayList();
         for (String config : configs) {
             int idOfEq = config.indexOf(CONFIG_SEP);
-            checkArgument(idOfEq > 0, "Invalid config provided [%s]", Arrays.toString(configs));
+            Validate.isTrue(idOfEq > 0, "Invalid config provided [%s]", Arrays.toString(configs));
 
             String[] configElements = config.split(String.valueOf(CONFIG_SEP));
             String name = configElements[0].trim();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
 import static org.apache.jackrabbit.oak.api.Type.NAME;
@@ -42,6 +41,7 @@ import java.util.stream.StreamSupport;
 
 import javax.jcr.RepositoryException;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
@@ -248,8 +248,7 @@ public final class IndexUtils {
             Set<String> asyncNames = Sets.newHashSet(async.getValue(Type.STRINGS));
             asyncNames.remove(IndexConstants.INDEXING_MODE_NRT);
             asyncNames.remove(IndexConstants.INDEXING_MODE_SYNC);
-            checkArgument(!asyncNames.isEmpty(), "No valid async name found for " +
-                    "index [%s], definition %s", indexPath, idxState);
+            Validate.isTrue(!asyncNames.isEmpty(), "No valid async name found for index [%s], definition %s", indexPath, idxState);
             return Iterables.getOnlyElement(asyncNames);
         }
         return null;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/cursor/Cursors.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/cursor/Cursors.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.plugins.index.cursor;
 
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.query.FilterIterators;
 import org.apache.jackrabbit.oak.spi.query.Cursor;
 import org.apache.jackrabbit.oak.spi.query.Filter;
@@ -26,7 +27,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.PrefetchNodeStore;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 /**
  * This utility class provides factory methods to create commonly used types of
@@ -105,7 +105,7 @@ public class Cursors {
      */
     public static Cursor newAncestorCursor(Cursor c, int level, QueryLimits settings) {
         requireNonNull(c);
-        checkArgument(level >= 1);
+        Validate.isTrue(level >= 1);
         return new AncestorCursor(c, level, settings);
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/datastore/DataStoreTextProviderService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/datastore/DataStoreTextProviderService.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.datastore;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.plugins.index.fulltext.PreExtractedTextProvider;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -33,7 +33,6 @@ import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Component(
@@ -65,7 +64,7 @@ public class DataStoreTextProviderService {
         String dirPath = config.dir();
         requireNonNull(dirPath, "Directory path not configured via 'dir'");
         File dir = new File(dirPath);
-        checkArgument(dir.exists(), "Directory %s does not exist", dir.getAbsolutePath());
+        Validate.isTrue(dir.exists(), "Directory %s does not exist", dir.getAbsolutePath());
         textWriter = new DataStoreTextWriter(dir, true);
         reg = context.registerService(PreExtractedTextProvider.class.getName(), textWriter, null);
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/datastore/DataStoreTextWriter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/datastore/DataStoreTextWriter.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.datastore;
 
 import java.io.BufferedWriter;
@@ -31,6 +30,7 @@ import java.util.concurrent.Callable;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreBlobStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.InMemoryDataRecord;
@@ -42,7 +42,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 
@@ -71,7 +70,7 @@ public class DataStoreTextWriter implements TextWriter, Closeable, PreExtractedT
 
     public DataStoreTextWriter(File directory, boolean readOnlyMode) throws IOException {
         if (!directory.exists()) {
-            checkArgument(directory.mkdirs(), "Cannot create directory %s", directory.getAbsolutePath());
+            Validate.isTrue(directory.mkdirs(), "Cannot create directory %s", directory.getAbsolutePath());
         }
         this.directory = directory;
         this.readOnlyMode = readOnlyMode;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexDefinitionUpdater.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexDefinitionUpdater.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.importer;
 
 import java.io.File;
@@ -27,6 +26,7 @@ import java.util.Set;
 
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -43,7 +43,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 import static org.apache.jackrabbit.oak.plugins.index.importer.NodeStoreUtils.childBuilder;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
@@ -57,7 +56,7 @@ public class IndexDefinitionUpdater {
     private final Map<String, NodeState> indexNodeStates;
 
     public IndexDefinitionUpdater(File file) throws IOException {
-        checkArgument(file.exists() && file.canRead(), "File [%s] cannot be read", file);
+        Validate.isTrue(file.exists() && file.canRead(), "File [%s] cannot be read", file);
         this.indexNodeStates = getIndexDefnStates(FileUtils.readFileToString(file, StandardCharsets.UTF_8));
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexImporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexImporter.java
@@ -19,6 +19,7 @@
 
 package org.apache.jackrabbit.oak.plugins.index.importer;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.collect.ArrayListMultimap;
 import org.apache.jackrabbit.guava.common.collect.ListMultimap;
@@ -55,7 +56,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.REINDEX_COUNT;
 import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.INDEXING_PHASE_LOGGER;
@@ -106,8 +106,7 @@ public class IndexImporter {
                          AsyncIndexerLock indexerLock, StatisticsProvider statisticsProvider, IndexingReporter indexingReporter) throws IOException {
         this.statisticsProvider = statisticsProvider;
         this.indexingReporter = indexingReporter;
-        checkArgument(indexDir.exists() && indexDir.isDirectory(), "Path [%s] does not point " +
-                "to existing directory", indexDir.getAbsolutePath());
+        Validate.isTrue(indexDir.exists() && indexDir.isDirectory(), "Path [%s] does not point to existing directory", indexDir.getAbsolutePath());
         this.nodeStore = nodeStore;
         this.indexDir = indexDir;
         this.indexEditorProvider = indexEditorProvider;
@@ -386,7 +385,7 @@ public class IndexImporter {
 
 
             NodeState indexState = indexDefinitionUpdater.getIndexState(indexPath);
-            checkArgument(indexState.exists(), "No index node found at path [%s]", indexPath);
+            Validate.isTrue(indexState.exists(), "No index node found at path [%s]", indexPath);
 
             boolean newIndex = !NodeStateUtils.getNode(rootState, indexPath).exists();
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexerInfo.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/IndexerInfo.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.importer;
 
 import java.io.File;
@@ -27,8 +26,8 @@ import java.util.Properties;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.lang3.Validate;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -93,8 +92,8 @@ public class IndexerInfo {
 
     public static IndexerInfo fromDirectory(File rootDir) throws IOException {
         File infoFile = new File(rootDir, INDEXER_META);
-        checkArgument(infoFile.exists(), "No [%s] file found in [%s]. Not a valid exported index " +
-                "directory", INDEXER_META, rootDir.getAbsolutePath());
+        Validate.isTrue(infoFile.exists(), "No [%s] file found in [%s]. Not a valid exported index directory", INDEXER_META,
+                rootDir.getAbsolutePath());
         Properties p = PropUtils.loadFromFile(infoFile);
         return new IndexerInfo(
                 rootDir,

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexInfoProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexInfoProvider.java
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.property;
 
 import java.io.IOException;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.IndexInfo;
 import org.apache.jackrabbit.oak.plugins.index.IndexInfoProvider;
@@ -31,8 +31,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeStateUtils;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 @Component
 public class PropertyIndexInfoProvider implements IndexInfoProvider {
@@ -58,7 +56,7 @@ public class PropertyIndexInfoProvider implements IndexInfoProvider {
     public IndexInfo getInfo(String indexPath) throws IOException {
         NodeState idxState = NodeStateUtils.getNode(nodeStore.getRoot(), indexPath);
 
-        checkArgument(PropertyIndexEditorProvider.TYPE.equals(idxState.getString(IndexConstants.TYPE_PROPERTY_NAME)),
+        Validate.isTrue(PropertyIndexEditorProvider.TYPE.equals(idxState.getString(IndexConstants.TYPE_PROPERTY_NAME)),
                 "Index definition at [%s] is not of type 'property'", indexPath);
         PropertyIndexInfo info = new PropertyIndexInfo(indexPath);
         computeCountEstimate(info, idxState);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/factories/TreeFactory.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/factories/TreeFactory.java
@@ -16,14 +16,13 @@
  */
 package org.apache.jackrabbit.oak.plugins.tree.factories;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.tree.impl.ImmutableTree;
 import org.apache.jackrabbit.oak.plugins.tree.impl.NodeBuilderTree;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 /**
  * Factory to obtain {@code Tree} objects from {@code NodeState}s
@@ -44,7 +43,7 @@ public final class TreeFactory {
     }
 
     public static Tree createReadOnlyTree(@NotNull Tree readOnlyParent, @NotNull String childName, @NotNull NodeState childState) {
-        checkArgument(readOnlyParent instanceof ImmutableTree);
+        Validate.isTrue(readOnlyParent instanceof ImmutableTree);
         return new ImmutableTree((ImmutableTree) readOnlyParent, childName, childState);
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractMutableTree.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/AbstractMutableTree.java
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.tree.impl;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayListWithCapacity;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
@@ -27,6 +25,7 @@ import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORD
 
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
@@ -69,7 +68,7 @@ public abstract class AbstractMutableTree extends AbstractTree {
     @NotNull
     @Override
     public Tree addChild(@NotNull String name) throws IllegalArgumentException {
-        checkArgument(!isHidden(name));
+        Validate.isTrue(!isHidden(name));
         if (!hasChild(name)) {
             NodeBuilder nodeBuilder = getNodeBuilder();
             nodeBuilder.setChildNode(name);
@@ -170,20 +169,20 @@ public abstract class AbstractMutableTree extends AbstractTree {
 
     @Override
     public void setProperty(@NotNull PropertyState property) {
-        checkArgument(!isHidden(requireNonNull(property).getName()));
+        Validate.isTrue(!isHidden(requireNonNull(property).getName()));
         getNodeBuilder().setProperty(property);
     }
 
     @Override
     public <T> void setProperty(@NotNull String name, @NotNull T value) throws IllegalArgumentException {
-        checkArgument(!isHidden(requireNonNull(name)));
+        Validate.isTrue(!isHidden(requireNonNull(name)));
         getNodeBuilder().setProperty(name, requireNonNull(value));
     }
 
     @Override
     public <T> void setProperty(@NotNull String name, @NotNull T value, @NotNull Type<T> type)
             throws IllegalArgumentException {
-        checkArgument(!isHidden(requireNonNull(name)));
+        Validate.isTrue(!isHidden(requireNonNull(name)));
         getNodeBuilder().setProperty(name, requireNonNull(value), requireNonNull(type));
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/TreeProviderService.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/tree/impl/TreeProviderService.java
@@ -16,14 +16,13 @@
  */
 package org.apache.jackrabbit.oak.plugins.tree.impl;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.tree.TreeProvider;
 import org.apache.jackrabbit.oak.plugins.tree.factories.TreeFactory;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 @Component(service = {TreeProvider.class})
 public class TreeProviderService implements TreeProvider {
@@ -43,7 +42,7 @@ public class TreeProviderService implements TreeProvider {
     @NotNull
     @Override
     public NodeState asNodeState(@NotNull Tree readOnlyTree) {
-        checkArgument(readOnlyTree instanceof AbstractTree);
+        Validate.isTrue(readOnlyTree instanceof AbstractTree);
         return ((AbstractTree) readOnlyTree).getNodeState();
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/ReadWriteVersionManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/ReadWriteVersionManager.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.jcr.RepositoryException;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -52,7 +53,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 import static org.apache.jackrabbit.JcrConstants.JCR_BASEVERSION;
@@ -380,7 +380,7 @@ public class ReadWriteVersionManager extends ReadOnlyVersionManager {
      */
     @NotNull
     private NodeBuilder resolve(NodeBuilder node, String relPath) {
-        checkArgument(!PathUtils.isAbsolute(relPath), "Not a relative path");
+        Validate.isTrue(!PathUtils.isAbsolute(relPath), "Not a relative path");
         for (String name : PathUtils.elements(relPath)) {
             node = node.getChildNode(name);
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AndImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AndImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.query.ast;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newLinkedHashSet;
@@ -36,7 +35,7 @@ import org.apache.jackrabbit.oak.spi.query.fulltext.FullTextExpression;
 import org.apache.jackrabbit.oak.query.QueryEngineSettings;
 import org.apache.jackrabbit.oak.query.QueryImpl;
 import org.apache.jackrabbit.oak.query.index.FilterImpl;
-
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 
 /**
@@ -47,7 +46,7 @@ public class AndImpl extends ConstraintImpl {
     private final List<ConstraintImpl> constraints;
 
     public AndImpl(List<ConstraintImpl> constraints) {
-        checkArgument(!constraints.isEmpty());
+        Validate.isTrue(!constraints.isEmpty());
         this.constraints = constraints;
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/OrImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/OrImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.query.ast;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Maps.newLinkedHashMap;
 import static org.apache.jackrabbit.guava.common.collect.Sets.newHashSet;
@@ -37,7 +36,7 @@ import java.util.Set;
 import org.apache.jackrabbit.oak.spi.query.fulltext.FullTextExpression;
 import org.apache.jackrabbit.oak.spi.query.fulltext.FullTextOr;
 import org.apache.jackrabbit.oak.query.index.FilterImpl;
-
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 
 /**
@@ -48,7 +47,7 @@ public class OrImpl extends ConstraintImpl {
     private final List<ConstraintImpl> constraints;
 
     public OrImpl(List<ConstraintImpl> constraints) {
-        checkArgument(!constraints.isEmpty());
+        Validate.isTrue(!constraints.isEmpty());
         this.constraints = constraints;
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserManagerImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserManagerImpl.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.security.user;
 
 import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.AuthorizableExistsException;
@@ -63,8 +64,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.util.Iterator;
 import java.util.Set;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 /**
  * UserManagerImpl...
@@ -293,7 +292,7 @@ public class UserManagerImpl implements UserManager {
     }
 
     void onCreate(@NotNull User systemUser) throws RepositoryException {
-        checkArgument(systemUser.isSystemUser());
+        Validate.isTrue(systemUser.isSystemUser());
         for (AuthorizableAction action : actionProvider.getAuthorizableActions(securityProvider)) {
             action.onCreate(systemUser, root, namePathMapper);
         }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/nodetype/write/NodeTypeRegistryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/nodetype/write/NodeTypeRegistryTest.java
@@ -18,7 +18,7 @@ package org.apache.jackrabbit.oak.plugins.nodetype.write;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
+
 import static org.apache.jackrabbit.guava.common.collect.ImmutableList.of;
 import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
@@ -54,7 +54,7 @@ import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.security.auth.login.LoginException;
 
 import org.apache.jackrabbit.guava.common.base.Strings;
-
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.commons.cnd.CompactNodeTypeDefReader;
 import org.apache.jackrabbit.commons.cnd.DefinitionBuilderFactory;
 import org.apache.jackrabbit.commons.cnd.TemplateBuilderFactory;
@@ -92,7 +92,7 @@ public class NodeTypeRegistryTest {
     private ContentSession session = null;
     
     static void registerNodeType(@NotNull Root root, @NotNull String resourceName) throws IOException {
-        checkArgument(!Strings.isNullOrEmpty(resourceName));
+        Validate.isTrue(!Strings.isNullOrEmpty(resourceName));
         requireNonNull(root);
 
         InputStream stream = null;

--- a/oak-store-document/pom.xml
+++ b/oak-store-document/pom.xml
@@ -147,6 +147,10 @@
     </dependency>
 
     <!-- General utility libraries -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+      </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/BatchCommit.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/BatchCommit.java
@@ -24,12 +24,11 @@ import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.util.concurrent.Futures;
 import org.apache.jackrabbit.guava.common.util.concurrent.SettableFuture;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
 
@@ -64,7 +63,7 @@ final class BatchCommit {
     }
 
     Callable<NodeDocument> enqueue(final UpdateOp op) {
-        checkArgument(op.getId().equals(id),
+        Validate.isTrue(op.getId().equals(id),
                 "Cannot add UpdateOp with id %s to BatchCommit with id %s",
                 op.getId(), id);
         Callable<NodeDocument> result;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Branch.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Branch.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.filter;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.transform;
@@ -32,6 +31,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Predicate;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 
@@ -77,7 +77,7 @@ class Branch {
            @NotNull RevisionVector base,
            @NotNull ReferenceQueue<Object> queue,
            @Nullable Object guard) {
-        checkArgument(!requireNonNull(base).isBranch(), "base is not a trunk revision: %s", base);
+        Validate.isTrue(!requireNonNull(base).isBranch(), "base is not a trunk revision: %s", base);
         this.base = base;
         this.commits = new ConcurrentSkipListMap<Revision, BranchCommit>(commits.comparator());
         for (Revision r : commits) {
@@ -126,10 +126,10 @@ class Branch {
      *                                  branch revision.
      */
     void rebase(@NotNull Revision head, @NotNull RevisionVector base) {
-        checkArgument(requireNonNull(head).isBranch(), "Not a branch revision: %s", head);
-        checkArgument(!requireNonNull(base).isBranch(), "Not a trunk revision: %s", base);
+        Validate.isTrue(requireNonNull(head).isBranch(), "Not a branch revision: %s", head);
+        Validate.isTrue(!requireNonNull(base).isBranch(), "Not a trunk revision: %s", base);
         Revision last = commits.lastKey();
-        checkArgument(head.compareRevisionTime(last) > 0);
+        Validate.isTrue(head.compareRevisionTime(last) > 0);
         commits.put(head, new RebaseCommit(base, head, commits));
     }
 
@@ -140,9 +140,9 @@ class Branch {
      * @throws IllegalArgumentException if r is not a branch revision.
      */
     void addCommit(@NotNull Revision r) {
-        checkArgument(requireNonNull(r).isBranch(), "Not a branch revision: %s", r);
+        Validate.isTrue(requireNonNull(r).isBranch(), "Not a branch revision: %s", r);
         Revision last = commits.lastKey();
-        checkArgument(commits.comparator().compare(r, last) > 0);
+        Validate.isTrue(commits.comparator().compare(r, last) > 0);
         commits.put(r, new BranchCommitImpl(commits.get(last).getBase(), r));
     }
 
@@ -201,7 +201,7 @@ class Branch {
      * @throws IllegalArgumentException if r is not a branch revision.
      */
     public void removeCommit(@NotNull Revision r) {
-        checkArgument(requireNonNull(r).isBranch(), "Not a branch revision: %s", r);
+        Validate.isTrue(requireNonNull(r).isBranch(), "Not a branch revision: %s", r);
         commits.remove(r);
     }
 
@@ -252,7 +252,7 @@ class Branch {
      *          {@code false} otherwise.
      */
     public boolean isHead(@NotNull Revision rev) {
-        checkArgument(requireNonNull(rev).isBranch(),
+        Validate.isTrue(requireNonNull(rev).isBranch(),
                 "Not a branch revision: %s", rev);
         return requireNonNull(rev).equals(commits.lastKey());
     }
@@ -266,7 +266,7 @@ class Branch {
      * @throws IllegalArgumentException if r is not a branch revision.
      */
     Iterable<Path> getModifiedPathsUntil(@NotNull final Revision r) {
-        checkArgument(requireNonNull(r).isBranch(),
+        Validate.isTrue(requireNonNull(r).isBranch(),
                 "Not a branch revision: %s", r);
         if (!commits.containsKey(r)) {
             return Collections.emptyList();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CommitQueue.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CommitQueue.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.HashSet;
@@ -31,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
@@ -83,7 +83,7 @@ final class CommitQueue {
 
     @NotNull
     SortedSet<Revision> createRevisions(int num) {
-        checkArgument(num > 0);
+        Validate.isTrue(num > 0);
         SortedSet<Revision> revs = new TreeSet<Revision>(StableRevisionComparator.INSTANCE);
         Revision rev = null;
         synchronized (this) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.partition;
@@ -128,10 +127,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.base.Strings;
-
 import org.apache.jackrabbit.guava.common.base.Suppliers;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
@@ -1010,7 +1008,7 @@ public final class DocumentNodeStore
     }
 
     void setRoot(@NotNull RevisionVector newHead) {
-        checkArgument(!newHead.isBranch());
+        Validate.isTrue(!newHead.isBranch());
         root = getRoot(newHead);
     }
 
@@ -3251,8 +3249,8 @@ public final class DocumentNodeStore
 
     private Commit newTrunkCommit(@NotNull Changes changes,
                                   @NotNull RevisionVector base) {
-        checkArgument(!requireNonNull(base).isBranch(),
-                "base must not be a branch revision: " + base);
+        Validate.isTrue(!requireNonNull(base).isBranch(),
+                "base must not be a branch revision: %s", base);
 
         // build commit before revision is created by the commit queue (OAK-7869)
         CommitBuilder commitBuilder = newCommitBuilder(base, null);
@@ -3278,8 +3276,8 @@ public final class DocumentNodeStore
     private Commit newBranchCommit(@NotNull Changes changes,
                                    @NotNull RevisionVector base,
                                    @Nullable DocumentNodeStoreBranch branch) {
-        checkArgument(requireNonNull(base).isBranch(),
-                "base must be a branch revision: " + base);
+        Validate.isTrue(requireNonNull(base).isBranch(),
+                "base must be a branch revision: %s", base);
 
         checkOpen();
         Revision commitRevision = newRevision();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -19,7 +19,7 @@ package org.apache.jackrabbit.oak.plugins.document;
 import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toUnmodifiableSet;
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
+
 import static org.apache.jackrabbit.guava.common.base.Suppliers.ofInstance;
 import static org.apache.jackrabbit.oak.plugins.document.CommitQueue.DEFAULT_SUSPEND_TIMEOUT;
 import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreService.DEFAULT_JOURNAL_GC_MAX_AGE_MILLIS;
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
 import org.apache.jackrabbit.guava.common.cache.RemovalCause;
@@ -557,11 +558,11 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
                                      int prevDocCachePercentage,
                                      int childrenCachePercentage,
                                      int diffCachePercentage) {
-        checkArgument(nodeCachePercentage >= 0);
-        checkArgument(prevDocCachePercentage >= 0);
-        checkArgument(childrenCachePercentage>= 0);
-        checkArgument(diffCachePercentage >= 0);
-        checkArgument(nodeCachePercentage + prevDocCachePercentage + childrenCachePercentage +
+        Validate.isTrue(nodeCachePercentage >= 0);
+        Validate.isTrue(prevDocCachePercentage >= 0);
+        Validate.isTrue(childrenCachePercentage>= 0);
+        Validate.isTrue(diffCachePercentage >= 0);
+        Validate.isTrue(nodeCachePercentage + prevDocCachePercentage + childrenCachePercentage +
                 diffCachePercentage < 100);
         this.nodeCachePercentage = nodeCachePercentage;
         this.prevDocCachePercentage = prevDocCachePercentage;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreMBeanImpl.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreMBeanImpl.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 
 import javax.management.openmbean.CompositeData;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.api.stats.RepositoryStatistics;
 import org.apache.jackrabbit.api.stats.TimeSeries;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -33,7 +34,6 @@ import org.apache.jackrabbit.stats.TimeSeriesStatsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.filter;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.toArray;
@@ -170,8 +170,8 @@ final class DocumentNodeStoreMBeanImpl extends AnnotatedStandardMBean implements
     @Override
     public int recover(String path, int clusterId) {
         requireNonNull(path, "path must not be null");
-        checkArgument(PathUtils.isAbsolute(path), "path must be absolute");
-        checkArgument(clusterId >= 0, "clusterId must not be a negative");
+        Validate.isTrue(PathUtils.isAbsolute(path), "path must be absolute");
+        Validate.isTrue(clusterId >= 0, "clusterId must not be a negative");
 
         DocumentStore docStore = nodeStore.getDocumentStore();
         boolean isActive = false;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalDiffLoader.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalDiffLoader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 
 import org.apache.jackrabbit.oak.cache.CacheStats;
@@ -31,7 +32,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 import static org.apache.jackrabbit.oak.plugins.document.JournalEntry.asId;
@@ -58,8 +58,8 @@ class JournalDiffLoader implements DiffCache.Loader {
         this.base = requireNonNull(base);
         this.node = requireNonNull(node);
         this.ns = requireNonNull(ns);
-        checkArgument(base.getPath().equals(node.getPath()),
-                "nodes must have matching paths: {} != {}",
+        Validate.isTrue(base.getPath().equals(node.getPath()),
+                "nodes must have matching paths: %s != %s",
                 base.getPath(), node.getPath());
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
@@ -44,7 +45,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.JOURNAL;
 
@@ -280,7 +280,7 @@ public final class JournalEntry extends Document {
                                    @Nullable JournalPropertyHandler journalPropertyHandler)
             throws IOException {
         requireNonNull(path);
-        checkArgument(requireNonNull(from).getClusterId() == requireNonNull(to).getClusterId());
+        Validate.isTrue(requireNonNull(from).getClusterId() == requireNonNull(to).getClusterId());
 
         if (from.compareRevisionTime(to) >= 0) {
             return 0;
@@ -700,7 +700,7 @@ public final class JournalEntry extends Document {
         }
 
         TreeNode(MapFactory mapFactory, TreeNode parent, String name) {
-            checkArgument(!name.contains("/"),
+            Validate.isTrue(!name.contains("/"),
                     "name must not contain '/': {}", name);
 
             this.mapFactory = mapFactory;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalPropertyHandler.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalPropertyHandler.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.document;
 
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.oak.plugins.document.spi.JournalProperty;
 import org.apache.jackrabbit.oak.plugins.document.spi.JournalPropertyBuilder;
@@ -29,8 +29,6 @@ import org.apache.jackrabbit.oak.plugins.document.spi.JournalPropertyService;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.commit.CommitContext;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 class JournalPropertyHandler {
     private final Map<String, JournalPropertyBuilder<JournalProperty>> builders = Maps.newHashMap();
@@ -93,8 +91,8 @@ class JournalPropertyHandler {
         if (o == null){
             return null;
         }
-        checkArgument(o instanceof JournalProperty, "CommitContext entry for name [%s] " +
-                "having value [%s] is not of type JournalEntry", name, o);
+        Validate.isTrue(o instanceof JournalProperty,
+                "CommitContext entry for name [%s] having value [%s] is not of type JournalEntry", name, o);
         return (JournalProperty) o;
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
@@ -18,7 +18,7 @@ package org.apache.jackrabbit.oak.plugins.document;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
+
 import static org.apache.jackrabbit.guava.common.collect.ImmutableList.copyOf;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.filter;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.mergeSorted;
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
@@ -736,7 +737,7 @@ public final class NodeDocument extends Document {
                                final Revision changeRev,
                                final Branch branch,
                                final Set<Revision> collisions) {
-        checkArgument(!baseRev.isBranch() || branch != null,
+        Validate.isTrue(!baseRev.isBranch() || branch != null,
                 "Branch must be non-null if baseRev is a branch revision");
         RevisionVector head = context.getHeadRevision();
         RevisionVector lower = branch != null ? branch.getBase() : baseRev;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Path.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Path.java
@@ -21,13 +21,13 @@ package org.apache.jackrabbit.oak.plugins.document;
 import java.util.Arrays;
 import java.util.Objects;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.elementsEqual;
 
@@ -67,7 +67,7 @@ public final class Path implements CacheValue, Comparable<Path> {
      */
     public Path(@NotNull Path parent, @NotNull String name) {
         this(requireNonNull(parent), requireNonNull(name), -1);
-        checkArgument(!name.isEmpty(), "name cannot be the empty String");
+        Validate.isTrue(!name.isEmpty(), "name cannot be the empty String");
     }
 
     /**
@@ -79,8 +79,8 @@ public final class Path implements CacheValue, Comparable<Path> {
      */
     public Path(@NotNull String name) {
         this(null, requireNonNull(name), -1);
-        checkArgument(!name.isEmpty(), "name cannot be the empty String");
-        checkArgument(name.indexOf('/') == -1, "name must not contain path separator: {}", name);
+        Validate.isTrue(!name.isEmpty(), "name cannot be the empty String");
+        Validate.isTrue(name.indexOf('/') == -1, "name must not contain path separator: %s", name);
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Range.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Range.java
@@ -16,9 +16,9 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -40,11 +40,11 @@ final class Range {
         this.high = requireNonNull(high);
         this.low = requireNonNull(low);
         this.height = height;
-        checkArgument(high.getClusterId() == low.getClusterId(),
+        Validate.isTrue(high.getClusterId() == low.getClusterId(),
                 "Revisions from have the same clusterId");
-        checkArgument(high.compareRevisionTime(low) >= 0,
+        Validate.isTrue(high.compareRevisionTime(low) >= 0,
                 "High Revision must be later than low Revision, high=%s low=%s" ,high, low);
-        checkArgument(height >= 0);
+        Validate.isTrue(height >= 0);
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/SplitDocumentCleanUp.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/SplitDocumentCleanUp.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
 import static org.apache.jackrabbit.oak.plugins.document.NodeDocument.SplitDocType.INTERMEDIATE;
 import static org.apache.jackrabbit.oak.plugins.document.NodeDocument.SplitDocType.NONE;
@@ -25,6 +24,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.commons.log.LogSilencer;
 import org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollector.VersionGCStats;
@@ -135,7 +135,7 @@ public class SplitDocumentCleanUp implements Closeable {
 
     private void disconnectFromIntermediate(NodeDocument splitDoc,
                                             Revision rev) {
-        checkArgument(splitDoc.getSplitDocType() == INTERMEDIATE,
+        Validate.isTrue(splitDoc.getSplitDocType() == INTERMEDIATE,
                 "Illegal type: %s", splitDoc.getSplitDocType());
 
         String splitDocId = splitDoc.getId();
@@ -168,7 +168,7 @@ public class SplitDocumentCleanUp implements Closeable {
     final void markStaleOnMain(NodeDocument main,
                                Revision rev,
                                int height) {
-        checkArgument(main.getSplitDocType() == NONE,
+        Validate.isTrue(main.getSplitDocType() == NONE,
                 "Illegal type: %s", main.getSplitDocType());
 
         UpdateOp update = new UpdateOp(main.getId(), false);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UnmergedBranches.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/UnmergedBranches.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.plugins.document.Branch.BranchCommit;
 import org.apache.jackrabbit.oak.plugins.document.Branch.BranchReference;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
@@ -32,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -121,9 +121,9 @@ class UnmergedBranches {
     Branch create(@NotNull RevisionVector base,
                   @NotNull Revision initial,
                   @Nullable Object guard) {
-        checkArgument(!requireNonNull(base).isBranch(),
+        Validate.isTrue(!requireNonNull(base).isBranch(),
                 "base is not a trunk revision: %s", base);
-        checkArgument(requireNonNull(initial).isBranch(),
+        Validate.isTrue(requireNonNull(initial).isBranch(),
                 "initial is not a branch revision: %s", initial);
         SortedSet<Revision> commits = new TreeSet<Revision>(StableRevisionComparator.INSTANCE);
         commits.add(initial);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/CompositeMatcher.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/CompositeMatcher.java
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.document.bundlor;
 
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Lists;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 class CompositeMatcher implements Matcher {
     private final List<Matcher> matchers;
@@ -45,7 +43,7 @@ class CompositeMatcher implements Matcher {
      */
     private CompositeMatcher(List<Matcher> matchers) {
         for (Matcher m : matchers){
-            checkArgument(m.isMatch(), "Non matching matcher found in [%s]", matchers);
+            Validate.isTrue(m.isMatch(), "Non matching matcher found in [%s]", matchers);
         }
         this.matchers = matchers;
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/DocumentBundlor.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/DocumentBundlor.java
@@ -22,6 +22,7 @@ package org.apache.jackrabbit.oak.plugins.document.bundlor;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -29,7 +30,6 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.oak.api.Type.STRINGS;
 import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProperty;
 
@@ -77,7 +77,7 @@ public class DocumentBundlor {
     private final List<Include> includes;
 
     public static DocumentBundlor from(NodeState nodeState){
-        checkArgument(nodeState.hasProperty(PROP_PATTERN), "NodeState [%s] does not have required " +
+        Validate.isTrue(nodeState.hasProperty(PROP_PATTERN), "NodeState [%s] does not have required " +
                 "property [%s]", nodeState, PROP_PATTERN);
        return DocumentBundlor.from(nodeState.getStrings(PROP_PATTERN));
     }
@@ -91,12 +91,12 @@ public class DocumentBundlor {
     }
 
     public static DocumentBundlor from(PropertyState prop){
-        checkArgument(META_PROP_PATTERN.equals(prop.getName()));
+        Validate.isTrue(META_PROP_PATTERN.equals(prop.getName()));
         return from(prop.getValue(Type.STRINGS));
     }
 
     private DocumentBundlor(List<Include> includes) {
-        checkArgument(!includes.isEmpty(), "Include list cannot be empty");
+        Validate.isTrue(!includes.isEmpty(), "Include list cannot be empty");
         this.includes = ImmutableList.copyOf(includes);
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/IncludeAllMatcher.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/bundlor/IncludeAllMatcher.java
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.document.bundlor;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.oak.commons.PathUtils.concat;
+
+import org.apache.commons.lang3.Validate;
 
 /**
  * Matcher which matches all child nodes
@@ -30,7 +30,7 @@ class IncludeAllMatcher implements Matcher {
     private final int depth;
 
     IncludeAllMatcher(String matchingPath, int depth) {
-        checkArgument(depth > 0);
+        Validate.isTrue(depth > 0);
         this.matchingPath = matchingPath;
         this.depth = depth;
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoUtils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoUtils.java
@@ -16,10 +16,9 @@
  */
 package org.apache.jackrabbit.oak.plugins.document.mongo;
 
-import java.util.Arrays;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoCommandException;
@@ -34,7 +33,6 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
-import com.mongodb.connection.ServerVersion;
 import com.mongodb.internal.connection.MongoWriteConcernWithResponseException;
 
 import org.apache.jackrabbit.oak.plugins.document.DocumentStoreException.Type;
@@ -43,8 +41,6 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 
 /**
  * Provides static utility methods for MongoDB.
@@ -92,7 +88,7 @@ class MongoUtils {
                             boolean unique,
                             boolean sparse)
             throws MongoException {
-        checkArgument(fields.length == ascending.length);
+        Validate.isTrue(fields.length == ascending.length);
         BasicDBObject index = new BasicDBObject();
         for (int i = 0; i < fields.length; i++) {
             index.put(fields[i], ascending[i] ? 1 : -1);
@@ -116,7 +112,7 @@ class MongoUtils {
                                    String[] fields,
                                    boolean[] ascending,
                                    String filter) throws MongoException {
-        checkArgument(fields.length == ascending.length);
+        Validate.isTrue(fields.length == ascending.length);
         BasicDBObject index = new BasicDBObject();
         for (int i = 0; i < fields.length; i++) {
             index.put(fields[i], ascending[i] ? 1 : -1);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/secondary/PathFilteringDiff.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/secondary/PathFilteringDiff.java
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.document.secondary;
 
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.plugins.document.AbstractDocumentNodeState;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
@@ -31,7 +31,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
 import static org.apache.jackrabbit.oak.plugins.document.secondary.DelegatingDocumentNodeState.PROP_LAST_REV;
 import static org.apache.jackrabbit.oak.plugins.document.secondary.DelegatingDocumentNodeState.PROP_REVISION;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
@@ -95,7 +94,7 @@ class PathFilteringDiff extends ApplyDiff {
     }
 
     private AbstractDocumentNodeState asDocumentState(NodeState state, String name){
-        checkArgument(state instanceof AbstractDocumentNodeState, "Node %s (%s) at [%s/%s] is not" +
+        Validate.isTrue(state instanceof AbstractDocumentNodeState, "Node %s (%s) at [%s/%s] is not" +
                 " of expected type i.e. AbstractDocumentNodeState. Parent %s (%s)",
                 state, state.getClass(), parent.getPath(), name, parent, parent.getClass());
         return (AbstractDocumentNodeState) state;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/TimeInterval.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/TimeInterval.java
@@ -18,7 +18,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document.util;
 
-import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
+import org.apache.commons.lang3.Validate;
 
 /**
  * A class representing a time interval, with utility methods to derive related
@@ -30,7 +30,7 @@ public class TimeInterval {
     public final long toMs;
 
     public TimeInterval(long fromMs, long toMs) {
-        checkArgument(fromMs <= toMs, "start must be <= end");
+        Validate.isTrue(fromMs <= toMs, "start must be <= end");
         this.fromMs = fromMs;
         this.toMs = toMs;
     }


### PR DESCRIPTION
Before proceeding with this, I'd love to get some feedback.

JDK lacks this feature. We can either use something identical from commons-lang (which we use anyway, and which I did here), or roll our own.

Opinions?

(note that I also took the freedom to fix "{}" in format strings, and to avoid string concatenation)