### PR TITLE
OAK-11082 - indexing-job: improve interning of strings for sort phase

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PathElementComparator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PathElementComparator.java
@@ -26,9 +26,10 @@ public class PathElementComparator implements Comparator<String[]> {
     private final Set<String> preferred;
 
     public PathElementComparator(Set<String> preferredPathElements) {
-        // Many of the lookups in this set will be for Strings that are interned, so interning the elements in the set
-        // will make it more likely that the elements in the set and the values looked up will be the same object,
-        // which should speed up lookups, as String::equals first tries reference equality before comparing the contents
+        // Many of the lookups in this set will be for interned Strings, so interning the elements will speed-up lookups
+        // for Strings that are present in the set, because the call to String::equals done by the Set implementation
+        // will likely be comparing the same String object, so it can return after the reference equality check, avoiding
+        // having to do a comparison of the contents.
         this.preferred = preferredPathElements.stream().map(String::intern).collect(Collectors.toUnmodifiableSet());
     }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PathElementComparator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PathElementComparator.java
@@ -20,12 +20,16 @@ package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import java.util.Comparator;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PathElementComparator implements Comparator<String[]> {
     private final Set<String> preferred;
 
     public PathElementComparator(Set<String> preferredPathElements) {
-        this.preferred = Set.copyOf(preferredPathElements);
+        // Many of the lookups in this set will be for Strings that are interned, so interning the elements in the set
+        // will make it more likely that the elements in the set and the values looked up will be the same object,
+        // which should speed up lookups, as String::equals first tries reference equality before comparing the contents
+        this.preferred = preferredPathElements.stream().map(String::intern).collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/SortKey.java
@@ -59,9 +59,10 @@ public final class SortKey {
             // Interning these strings should provide a big reduction in memory usage.
             // It is not worth to intern all levels because at lower levels the names are more likely to be less diverse,
             // often even unique, so interning them would fill up the interned string hashtable with useless entries.
-            if ((i < 3 || part.length() == 1 || part.startsWith("jcr:") || COMMON_PATH_WORDS.contains(part)) &&
-                    INTERN_CACHE.size() < MAX_INTERN_CACHE && part.length() < MAX_INTERNED_STRING_LENGTH) {
-                pathElements[i] = INTERN_CACHE.computeIfAbsent(part, String::intern);
+            if ((i < 3 || part.length() == 1 || part.startsWith("jcr:") || COMMON_PATH_WORDS.contains(part)) && part.length() < MAX_INTERNED_STRING_LENGTH) {
+                pathElements[i] = INTERN_CACHE.size() < MAX_INTERN_CACHE ?
+                        INTERN_CACHE.computeIfAbsent(part, String::intern) :
+                        INTERN_CACHE.getOrDefault(part, part);
             } else {
                 pathElements[i] = part;
             }


### PR DESCRIPTION
Fix: when full, intern cache was no longer being used to lookup for already interned strings.