### PR TITLE
OAK-11084 - Improve error handling and logging in mongo downloader

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
@@ -121,6 +121,16 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
     private NodeStateEntry computeNextEntry() {
         if (!buffer.isEmpty()) {
             if (buffer.size() > maxBufferSize || buffer.estimatedMemoryUsage() > maxBufferSizeBytes) {
+                // We need to take the max of the current max and of the current value, because the two metrics above
+                // can and will increase and decrease independently. For instance, consider the following
+                //buffer.size() = 10, buffer.estimatedMemoryUsage() = 1000
+                //10 elements of size 1000 in total.
+                //
+                //And then
+                //buffer.size() = 1, buffer.estimatedMemoryUsage() = 2000
+                //1 element of size 2000.
+                //
+                //So in this case, we want to update the max memory estimate but leave the max size at 10.
                 maxBufferSize = Math.max(buffer.size(), maxBufferSize);
                 maxBufferSizeBytes = Math.max(buffer.estimatedMemoryUsage(), maxBufferSizeBytes);
                 LOG.info("Max buffer size changed {} (estimated memory usage: {} bytes) for path {}",

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
@@ -123,14 +123,11 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
             if (buffer.size() > maxBufferSize || buffer.estimatedMemoryUsage() > maxBufferSizeBytes) {
                 // We need to take the max of the current max and of the current value, because the two metrics above
                 // can and will increase and decrease independently. For instance, consider the following
-                //buffer.size() = 10, buffer.estimatedMemoryUsage() = 1000
-                //10 elements of size 1000 in total.
                 //
-                //And then
-                //buffer.size() = 1, buffer.estimatedMemoryUsage() = 2000
-                //1 element of size 2000.
+                // buffer.size() = 10, buffer.estimatedMemoryUsage() = 1000  - 10 elements using 1000 bytes of memory.
+                // buffer.size() = 1, buffer.estimatedMemoryUsage() = 2000   - 1 element using 2000 bytes of memory.
                 //
-                //So in this case, we want to update the max memory estimate but leave the max size at 10.
+                // So in this case, we want to update the max memory estimate but leave the max size at 10.
                 maxBufferSize = Math.max(buffer.size(), maxBufferSize);
                 maxBufferSizeBytes = Math.max(buffer.estimatedMemoryUsage(), maxBufferSizeBytes);
                 LOG.info("Max buffer size changed {} (estimated memory usage: {} bytes) for path {}",

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
@@ -121,8 +121,8 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
     private NodeStateEntry computeNextEntry() {
         if (!buffer.isEmpty()) {
             if (buffer.size() > maxBufferSize || buffer.estimatedMemoryUsage() > maxBufferSizeBytes) {
-                maxBufferSize = buffer.size();
-                maxBufferSizeBytes = buffer.estimatedMemoryUsage();
+                maxBufferSize = Math.max(buffer.size(), maxBufferSize);
+                maxBufferSizeBytes = Math.max(buffer.estimatedMemoryUsage(), maxBufferSizeBytes);
                 LOG.info("Max buffer size changed {} (estimated memory usage: {} bytes) for path {}",
                         maxBufferSize, maxBufferSizeBytes, current.getPath());
             }


### PR DESCRIPTION
When one of the mongo download threads finishes and cancels the other one, in many cases the other thread would log an ERROR level log message. This is wrong because in this case the cancellation is a normal process, so it should not generate ERROR or even WARN log messages. Changes the logic to only log an INFO level message when the download thread is cancelled. 

Additional change: fix tracking of maximum size of Persisted Linked list buffers. With the previous logic, the maximum values could go be set to lower values.