### PR TITLE
OAK-11085: Constant MAX_SEGMENT_SIZE is duplicated in Segment/SegmentDataUtils

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
@@ -94,9 +94,9 @@ public class Segment {
     static final int RECORD_ALIGN_BITS = 2; // align at the four-byte boundary
 
     /**
-     * Maximum segment size
+     * Maximum segment size (in bytes)
      */
-    static final int MAX_SEGMENT_SIZE = 1 << 18; // 256kB
+    public static final int MAX_SEGMENT_SIZE = 1 << 18; // 256 KiB
 
     /**
      * The size limit for small values. The variable length of small values

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/SegmentDataUtils.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/SegmentDataUtils.java
@@ -25,13 +25,13 @@ import java.nio.channels.WritableByteChannel;
 import org.apache.commons.io.HexDump;
 import org.apache.jackrabbit.oak.commons.Buffer;
 
+import static org.apache.jackrabbit.oak.segment.Segment.MAX_SEGMENT_SIZE;
+
 class SegmentDataUtils {
 
     private SegmentDataUtils() {
         // Prevent instantiation
     }
-
-    private static final int MAX_SEGMENT_SIZE = 1 << 18;
 
     static void hexDump(Buffer buffer, OutputStream stream) throws IOException {
         byte[] data = new byte[buffer.remaining()];


### PR DESCRIPTION
Closes OAK-11085