### PR TITLE
OAK-11086 - Do not log stack traces of exceptions caused by reconnection attempts to Mongo

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
@@ -121,8 +121,8 @@ class FlatFileStoreIterator extends AbstractIterator<NodeStateEntry> implements 
     private NodeStateEntry computeNextEntry() {
         if (!buffer.isEmpty()) {
             if (buffer.size() > maxBufferSize || buffer.estimatedMemoryUsage() > maxBufferSizeBytes) {
-                maxBufferSize = buffer.size();
-                maxBufferSizeBytes = buffer.estimatedMemoryUsage();
+                maxBufferSize = Math.max(buffer.size(), maxBufferSize);
+                maxBufferSizeBytes = Math.max(buffer.estimatedMemoryUsage(), maxBufferSizeBytes);
                 LOG.info("Max buffer size changed {} (estimated memory usage: {} bytes) for path {}",
                         maxBufferSize, maxBufferSizeBytes, current.getPath());
             }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -692,7 +692,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                         if (failuresStartTimestamp == null) {
                             failuresStartTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
                         }
-                        LOG.warn("Connection error downloading from MongoDB.", e);
+                        LOG.info("Non-fatal connection error downloading from MongoDB: {}", e.toString());
                         long secondsSinceStartOfFailures = Duration.between(failuresStartTimestamp, Instant.now()).toSeconds();
                         if (parallelDump && parallelDumpSecondariesOnly && mongoServerSelector.atLeastOneConnectionActive()) {
                             // Special case, the cluster is up because one of the connections is active. This happens when

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -692,7 +692,7 @@ public class PipelinedMongoDownloadTask implements Callable<PipelinedMongoDownlo
                         if (failuresStartTimestamp == null) {
                             failuresStartTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS);
                         }
-                        LOG.info("Non-fatal connection error downloading from MongoDB: {}", e.toString());
+                        LOG.info("Non-fatal connection interruption downloading from MongoDB: {}", e.toString());
                         long secondsSinceStartOfFailures = Duration.between(failuresStartTimestamp, Instant.now()).toSeconds();
                         if (parallelDump && parallelDumpSecondariesOnly && mongoServerSelector.atLeastOneConnectionActive()) {
                             // Special case, the cluster is up because one of the connections is active. This happens when


### PR DESCRIPTION
Reduce level from WARN to INFO and change message to indicate that it is a non-fatal failure.