### PR TITLE
OAK-11092: Make the constructors of RecordIdData/StringData public

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/RecordIdData.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/RecordIdData.java
@@ -25,7 +25,7 @@ public class RecordIdData {
 
     private final int recordNumber;
 
-    RecordIdData(int segmentReference, int recordNumber) {
+    public RecordIdData(int segmentReference, int recordNumber) {
         this.segmentReference = segmentReference;
         this.recordNumber = recordNumber;
     }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/StringData.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/StringData.java
@@ -25,13 +25,13 @@ public class StringData {
 
     private final int length;
 
-    StringData(String string, int length) {
+    public StringData(String string, int length) {
         this.string = string;
         this.length = length;
         this.recordId = null;
     }
 
-    StringData(RecordIdData recordId, int length) {
+    public StringData(RecordIdData recordId, int length) {
         this.recordId = recordId;
         this.length = length;
         this.string = null;


### PR DESCRIPTION
Closes OAK-11092