### PR TITLE
OAK-11088: Use default implementations for SegmentData#readLength/String/RecordId

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/SegmentDataV12.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/SegmentDataV12.java
@@ -62,10 +62,6 @@ class SegmentDataV12 implements SegmentData {
 
     // Relative to a record reference - END
 
-    private static final int MAX_SMALL_LENGTH_VALUE = 1 << 7;
-
-    private static final int MAX_MEDIUM_LENGTH_VALUE = (1 << 14) + MAX_SMALL_LENGTH_VALUE;
-
     final Buffer buffer;
 
     SegmentDataV12(Buffer buffer) {
@@ -148,68 +144,6 @@ class SegmentDataV12 implements SegmentData {
 
     private int index(int recordReferenceOffset) {
         return SegmentDataUtils.index(buffer, recordReferenceOffset);
-    }
-
-    @Override
-    public long readLength(int recordReferenceOffset) {
-        return internalReadLength(index(recordReferenceOffset));
-    }
-
-    private long internalReadLength(int index) {
-        int head = buffer.get(index) & 0xff;
-
-        if ((head & 0x80) == 0) {
-            return head;
-        }
-
-        if ((head & 0x40) == 0) {
-            return MAX_SMALL_LENGTH_VALUE + (buffer.getShort(index) & 0x3fff);
-        }
-
-        return MAX_MEDIUM_LENGTH_VALUE + (buffer.getLong(index) & 0x3fffffffffffffffL);
-    }
-
-    @Override
-    public StringData readString(int recordReferenceOffset) {
-        return internalReadString(index(recordReferenceOffset));
-    }
-
-    private StringData internalReadString(int index) {
-        long length = internalReadLength(index);
-
-        if (length < MAX_SMALL_LENGTH_VALUE) {
-            return internalReadString(index + Byte.BYTES, (int) length);
-        }
-
-        if (length < MAX_MEDIUM_LENGTH_VALUE) {
-            return internalReadString(index + Short.BYTES, (int) length);
-        }
-
-        if (length < Integer.MAX_VALUE) {
-            return new StringData(internalReadRecordId(index + Long.BYTES), (int) length);
-        }
-
-        throw new IllegalStateException("String is too long: " + length + "; possibly trying to read a "
-                + "BLOB using getString; can not convert BLOB to String");
-    }
-
-    private StringData internalReadString(int index, int length) {
-        Buffer duplicate = buffer.duplicate();
-        duplicate.position(index);
-        duplicate.limit(index + length);
-        String string = duplicate.decode(StandardCharsets.UTF_8).toString();
-        return new StringData(string, length);
-    }
-
-    @Override
-    public RecordIdData readRecordId(int recordReferenceOffset) {
-        return internalReadRecordId(index(recordReferenceOffset));
-    }
-
-    private RecordIdData internalReadRecordId(int index) {
-        int segmentReference = buffer.getShort(index) & 0xffff;
-        int recordNumber = buffer.getInt(index + Short.BYTES);
-        return new RecordIdData(segmentReference, recordNumber);
     }
 
     @Override

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/data/SegmentDataTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/data/SegmentDataTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.segment.data;
+
+import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.Segment;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SegmentDataTest {
+    @Test
+    public void readSmallLength() {
+        Buffer buffer = Buffer.wrap(new byte[]{0b1111111});
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        long length = segmentData.readLength(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+        assertEquals(127, length);
+    }
+
+    @Test
+    public void readMediumLength() {
+        //                                Medium prefix --
+        //                                    Arbitrary    ------          --------
+        Buffer buffer = Buffer.wrap(new byte[]{(byte) 0b10_000111, (byte)0b10101010});
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        long length = segmentData.readLength(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+
+        //                               ------ --------
+        assertEquals((1 << 7) + 0b000111_10101010, length);
+    }
+
+    @Test
+    public void readLongLength() {
+        //   Long prefix --
+        //     Arbitrary    ------    --------    --------    --------    --------    --------    --------    --------
+        Buffer buffer = Buffer.wrap(new byte[]{
+                (byte) 0b11_111000, 0b00001111, 0b00101010, 0b00001010, 0b01010101, 0b00010001, 0b01111110, 0b00000000
+        });
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        long length = segmentData.readLength(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+
+        //                                           ------ -------- -------- -------- -------- -------- -------- --------
+        assertEquals((1 << 14) + (1 << 7) + 0b111000_00001111_00101010_00001010_01010101_00010001_01111110_00000000L, length);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void readStringWithLengthLargerThanIntegerMaxValueThrows() {
+        Buffer buffer = Buffer.wrap(new byte[]{
+                (byte)0b111111111,
+                (byte)0b111111111,
+                (byte)0b111111111,
+                (byte)0b111111111,
+                (byte)0b111111111,
+                (byte)0b111111111,
+                (byte)0b111111111,
+                (byte)0b111111111,
+        });
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        segmentData.readString(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+    }
+
+    @Test
+    public void readStringWithSmallLength() {
+        Buffer buffer = Buffer.wrap(new byte[]{5, (byte)'H', (byte)'e', (byte)'l', (byte)'l', (byte)'o'});
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        StringData str = segmentData.readString(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+        assertEquals("Hello", str.getString());
+        assertEquals(5, str.getLength());
+        assertNull(str.getRecordId());
+    }
+
+    @Test
+    public void readStringWithMediumLength() {
+        int stringLength = (1 << 7) + 42;
+        Buffer buffer = Buffer.wrap(padRight(
+                //                   --                  Medium prefix
+                //                      ------        -- 42
+                new byte[] {(byte) 0b10_000000, (byte)42},
+                stringLength + 2,
+                (byte)'x' // 'x' × stringLength
+        ));
+        SegmentData segmentData = new SegmentDataV12(buffer);
+
+        StringData str = segmentData.readString(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+        assertEquals("x".repeat(stringLength), str.getString());
+        assertEquals(stringLength, str.getLength());
+        assertNull(str.getRecordId());
+    }
+
+    @Test
+    public void readStringStoredInExternalRecord() {
+        int stringLength = (1 << 14) + (1 << 7) + 42;
+
+        //   Long prefix --
+        //            42    ------    --------    --------    --------    --------    --------    --------    --------
+        Buffer buffer = Buffer.wrap(new byte[]{
+                (byte) 0b11_000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00000000, 0b00101010,
+
+                // seg ref       record number
+                // -------  ----------------------
+                0x11, 0x22, 0x33, 0x44, 0x55, 0x66
+        });
+
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        StringData str = segmentData.readString(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+        assertNull(str.getString());
+        assertEquals(0x1122, str.getRecordId().getSegmentReference());
+        assertEquals(0x33445566, str.getRecordId().getRecordNumber());
+    }
+
+    @Test
+    public void readRecordId() {
+        //                                      seg. ref.       record number
+        //                                     ----------  ----------------------
+        Buffer buffer = Buffer.wrap(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06});
+        SegmentData segmentData = new SegmentDataV12(buffer);
+        var recordId = segmentData.readRecordId(Segment.MAX_SEGMENT_SIZE - buffer.limit());
+        assertEquals(0x01_02, recordId.getSegmentReference());
+        assertEquals(0x03_04_05_06, recordId.getRecordNumber());
+    }
+
+    private byte[] padRight(byte[] bytes, int length, byte padding) {
+        byte[] padded = new byte[length];
+        System.arraycopy(bytes, 0, padded, 0, bytes.length);
+        for (int i = bytes.length; i < length; i++) {
+            padded[i] = padding;
+        }
+        return padded;
+    }
+}


### PR DESCRIPTION
This moves the implementations of `SegmentData#readLength`, `SegmentData#readString`, and `SegmentData#readRecordId` so that they are included as default methods in `SegmentData`, instead of being implemented in `SegmentDataV12`. These implementations use the appropriate abstract methods of `SegmentData` (`readInt`, `readShort`, `readLong`…). This move is useful when creating new implementations of SegmentData.

The PR also adds some tests that verify with 100% coverage the methods involved.

This change is backwards-compatible for external users of the classes involved.

Closes OAK-11088