### PR TITLE
OAK-11090: Move creation of RecordNumbers/SegmentReferences from segment data

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordNumbers.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordNumbers.java
@@ -17,10 +17,13 @@
 
 package org.apache.jackrabbit.oak.segment;
 
+import static java.util.Arrays.fill;
+
 import java.util.Collections;
 import java.util.Iterator;
 
 import org.apache.jackrabbit.oak.segment.RecordNumbers.Entry;
+import org.apache.jackrabbit.oak.segment.data.SegmentData;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -43,6 +46,33 @@ interface RecordNumbers extends Iterable<Entry> {
             return Collections.emptyIterator();
         }
     };
+
+    /**
+     * Read the serialized table mapping record numbers to offsets.
+     *
+     * @return An instance of {@link RecordNumbers}
+     */
+    static @NotNull RecordNumbers fromSegmentData(@NotNull SegmentData data) {
+        int recordNumberCount = data.getRecordReferencesCount();
+
+        if (recordNumberCount == 0) {
+            return EMPTY_RECORD_NUMBERS;
+        }
+
+        int maxIndex = data.getRecordReferenceNumber(recordNumberCount - 1);
+
+        byte[] types = new byte[maxIndex + 1];
+        int[] offsets = new int[maxIndex + 1];
+        fill(offsets, -1);
+
+        for (int i = 0; i < recordNumberCount; i++) {
+            int recordNumber = data.getRecordReferenceNumber(i);
+            types[recordNumber] = data.getRecordReferenceType(i);
+            offsets[recordNumber] = data.getRecordReferenceOffset(i);
+        }
+
+        return new ImmutableRecordNumbers(offsets, types);
+    }
 
     /**
      * Translate a record number to an offset.

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentReferences.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentReferences.java
@@ -17,10 +17,75 @@
 
 package org.apache.jackrabbit.oak.segment;
 
+import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
+import org.apache.jackrabbit.oak.segment.data.SegmentData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+
+import static org.apache.jackrabbit.guava.common.base.Preconditions.checkArgument;
+import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
+
 /**
  * Represents a list of segment IDs referenced from a segment.
  */
 interface SegmentReferences extends Iterable<SegmentId> {
+
+    /** Builds a new instance of {@link SegmentReferences} from the provided {@link SegmentData}. */
+    static @NotNull SegmentReferences fromSegmentData(@NotNull SegmentData data, @NotNull SegmentIdProvider idProvider) {
+        final int referencedSegmentIdCount = data.getSegmentReferencesCount();
+
+        checkState(referencedSegmentIdCount + 1 < 0xffff, "Segment cannot have more than 0xffff references");
+
+        // We need to keep SegmentId references (as opposed to e.g. UUIDs)
+        // here as frequently resolving the segment ids via the segment id
+        // tables is prohibitively expensive.
+        // These SegmentId references are not a problem wrt. heap usage as
+        // their individual memoised references to their underlying segment
+        // is managed via the SegmentCache. It is the size of that cache that
+        // keeps overall heap usage by Segment instances bounded.
+        // See OAK-6106.
+
+        final SegmentId[] refIds = new SegmentId[referencedSegmentIdCount];
+
+        return new SegmentReferences() {
+
+            @Override
+            public SegmentId getSegmentId(int reference) {
+                checkArgument(reference <= referencedSegmentIdCount, "Segment reference out of bounds");
+                SegmentId id = refIds[reference - 1];
+                if (id == null) {
+                    synchronized (refIds) {
+                        id = refIds[reference - 1];
+                        if (id == null) {
+                            long msb = data.getSegmentReferenceMsb(reference - 1);
+                            long lsb = data.getSegmentReferenceLsb(reference - 1);
+                            id = idProvider.newSegmentId(msb, lsb);
+                            refIds[reference - 1] = id;
+                        }
+                    }
+                }
+                return id;
+            }
+
+            @NotNull
+            @Override
+            public Iterator<SegmentId> iterator() {
+                return new AbstractIterator<>() {
+                    private int reference = 1;
+
+                    @Override
+                    protected SegmentId computeNext() {
+                        if (reference <= referencedSegmentIdCount) {
+                            return getSegmentId(reference++);
+                        } else {
+                            return endOfData();
+                        }
+                    }
+                };
+            }
+        };
+    }
 
     /**
      * Fetch the referenced segment ID associated to the provided reference.

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/RecordNumbersTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/RecordNumbersTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.jackrabbit.oak.segment;
+
+import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.data.SegmentData;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RecordNumbersTest {
+    @Test
+    public void shouldReadRecordNumbersFromSegmentData() {
+        SegmentData sampleSegmentData = SegmentData.newSegmentData(Buffer.wrap(new byte[] {
+                48, 97, 75, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                -116, -71, -35, -50, 87, -7, 64, 125, -96, -24, -82, 112, 44, -36, 63, 67, 0, 0, 0, 0, 4, 0, 3, -1, -40,
+                0, 0, 0, 1, 5, 0, 3, -1, -48, 0, 0, 0, 2, 4, 0, 3, -1, -56, 0, 0, 0, 3, 5, 0, 3, -1, -64, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 10, -48, -66, -83, 11, -22, -48,
+                -66, 37, 123, 34, 119, 105, 100, 34, 58, 34, 116, 34, 44, 34, 115, 110, 111, 34, 58, 50, 44, 34, 116,
+                34, 58, 49, 55, 50, 51, 55, 49, 51, 51, 53, 57, 54, 54, 54, 125, 0, 0
+        }).asReadOnlyBuffer());
+
+        RecordNumbers recordNumbers = RecordNumbers.fromSegmentData(sampleSegmentData);
+
+        assertEquals(262104, recordNumbers.getOffset(0));
+        assertEquals(262096, recordNumbers.getOffset(1));
+        assertEquals(262088, recordNumbers.getOffset(2));
+        assertEquals(262080, recordNumbers.getOffset(3));
+        assertEquals(-1, recordNumbers.getOffset(4));
+    }
+}

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentReferencesTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentReferencesTest.java
@@ -22,10 +22,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
+import org.apache.jackrabbit.oak.segment.data.SegmentData;
 import org.apache.jackrabbit.oak.segment.file.FileStore;
 import org.apache.jackrabbit.oak.segment.file.FileStoreBuilder;
+import org.apache.jackrabbit.oak.segment.memory.MemoryStore;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.junit.Rule;
 import org.junit.Test;
@@ -92,4 +96,21 @@ public class SegmentReferencesTest {
         }
     }
 
+    @Test
+    public void shouldReadSegmentReferencesFromSegmentData() throws IOException {
+        SegmentData sampleSegmentData = SegmentData.newSegmentData(Buffer.wrap(new byte[] {
+                48, 97, 75, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                -116, -71, -35, -50, 87, -7, 64, 125, -96, -24, -82, 112, 44, -36, 63, 67, 0, 0, 0, 0, 4, 0, 3, -1, -40,
+                0, 0, 0, 1, 5, 0, 3, -1, -48, 0, 0, 0, 2, 4, 0, 3, -1, -56, 0, 0, 0, 3, 5, 0, 3, -1, -64, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 10, -48, -66, -83, 11, -22, -48,
+                -66, 37, 123, 34, 119, 105, 100, 34, 58, 34, 116, 34, 44, 34, 115, 110, 111, 34, 58, 50, 44, 34, 116,
+                34, 58, 49, 55, 50, 51, 55, 49, 51, 51, 53, 57, 54, 54, 54, 125, 0, 0
+        }).asReadOnlyBuffer());
+
+        SegmentReferences segmentReferences = SegmentReferences.fromSegmentData(sampleSegmentData, new MemoryStore().getSegmentIdProvider());
+
+        SegmentId segmentId = segmentReferences.getSegmentId(1);
+        assertEquals(segmentId.getMostSignificantBits(), -8306364159399214979L);
+        assertEquals(segmentId.getLeastSignificantBits(), -6852035036232007869L);
+    }
 }


### PR DESCRIPTION
When initializing a Segment instance, we create RecordNumbers/SegmentReferences instances with the data contained in SegmentData. This operation is currently done from two private methods, Segment#readRecordNumberOffsets and Segment#readReferencedSegments. By moving this code somewhere else (e.g. in static methods of RecordNumbers/SegmentReferences), it makes it easier to reuse it and add unit tests for these methods.

This commit also add unit tests to verify these methods.

Closes OAK-11090