### PR TITLE
OAK-11094: Allow creating Segment with a provided SegmentData

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordNumbers.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordNumbers.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * A table to translate record numbers to offsets.
  */
-interface RecordNumbers extends Iterable<Entry> {
+public interface RecordNumbers extends Iterable<Entry> {
 
     /**
      * An always empty {@code RecordNumber} table.

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
@@ -217,6 +217,21 @@ public class Segment {
         }
     }
 
+    public Segment(
+            @NotNull SegmentReader reader,
+            @NotNull SegmentId id,
+            @NotNull SegmentData data,
+            @NotNull RecordNumbers recordNumbers,
+            @NotNull SegmentReferences segmentReferences
+    ) {
+        this.reader = requireNonNull(reader);
+        this.id = requireNonNull(id);
+        this.data = requireNonNull(data);
+        this.recordNumbers = requireNonNull(recordNumbers);
+        this.segmentReferences = requireNonNull(segmentReferences);
+        this.version = LATEST_VERSION;
+    }
+
     private static String toHex(byte[] bytes) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
@@ -229,7 +229,7 @@ public class Segment {
         this.data = requireNonNull(data);
         this.recordNumbers = requireNonNull(recordNumbers);
         this.segmentReferences = requireNonNull(segmentReferences);
-        this.version = LATEST_VERSION;
+        this.version = SegmentVersion.fromByte(data.getVersion());
     }
 
     private static String toHex(byte[] bytes) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentReferences.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentReferences.java
@@ -20,7 +20,7 @@ package org.apache.jackrabbit.oak.segment;
 /**
  * Represents a list of segment IDs referenced from a segment.
  */
-interface SegmentReferences extends Iterable<SegmentId> {
+public interface SegmentReferences extends Iterable<SegmentId> {
 
     /**
      * Fetch the referenced segment ID associated to the provided reference.

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentTest.java
@@ -38,7 +38,7 @@ public class SegmentTest {
 
         var segment = new Segment(segmentReader, segmentId, segmentData, recordNumbers, segmentReferences);
 
-        assertEquals(segment.getSegmentVersion(), SegmentVersion.V_12);
+        assertEquals(SegmentVersion.V_12, segment.getSegmentVersion());
     }
 
     @Test

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.segment;
+
+import org.apache.jackrabbit.oak.segment.data.SegmentData;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SegmentTest {
+    @Test
+    public void createsSegmentFromCustomSegmentData() {
+        var segmentReader = mock(SegmentReader.class);
+        var segmentId = mock(SegmentId.class);
+        var segmentData = mock(SegmentData.class);
+        when(segmentData.getVersion()).thenReturn((byte) 12);
+        var recordNumbers = mock(RecordNumbers.class);
+        var segmentReferences = mock(SegmentReferences.class);
+
+        var segment = new Segment(segmentReader, segmentId, segmentData, recordNumbers, segmentReferences);
+
+        assertEquals(segment.getSegmentVersion(), SegmentVersion.V_12);
+    }
+
+    @Test
+    public void creatingSegmentWithInvalidVersionNumberThrows() {
+        var segmentReader = mock(SegmentReader.class);
+        var segmentId = mock(SegmentId.class);
+        var segmentData = mock(SegmentData.class);
+        when(segmentData.getVersion()).thenReturn((byte) 42);
+        var recordNumbers = mock(RecordNumbers.class);
+        var segmentReferences = mock(SegmentReferences.class);
+
+        assertThrows(IllegalArgumentException.class, () -> new Segment(segmentReader, segmentId, segmentData, recordNumbers, segmentReferences));
+    }
+}


### PR DESCRIPTION
All currently existing constructors of `Segment` instantiate a `SegmentData` instance from the provided data buffer (either `byte[]` or `org.apache.jackrabbit.oak.commons.Buffer`)

In some cases where we would like to use a custom implementation of `SegmentData`, it could be helpful to have a constructor that takes a `SegmentData` instance instead.

This PR also makes `SegmentReferences` and `RecordNumber` public so that the constructor I’m adding can also be public.

Closes OAK-11094