### PR TITLE
OAK-11085: Use a single definition of MAX_SEGMENT_SIZE in Segment

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
@@ -96,7 +96,7 @@ public class Segment {
     /**
      * Maximum segment size
      */
-    static final int MAX_SEGMENT_SIZE = 1 << 18; // 256kB
+    public static final int MAX_SEGMENT_SIZE = 1 << 18; // 256kB
 
     /**
      * The size limit for small values. The variable length of small values

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/SegmentDataUtils.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/SegmentDataUtils.java
@@ -24,14 +24,14 @@ import java.nio.channels.WritableByteChannel;
 
 import org.apache.commons.io.HexDump;
 import org.apache.jackrabbit.oak.commons.Buffer;
+import static org.apache.jackrabbit.oak.segment.Segment.MAX_SEGMENT_SIZE;
+
 
 class SegmentDataUtils {
 
     private SegmentDataUtils() {
         // Prevent instantiation
     }
-
-    private static final int MAX_SEGMENT_SIZE = 1 << 18;
 
     static void hexDump(Buffer buffer, OutputStream stream) throws IOException {
         byte[] data = new byte[buffer.remaining()];


### PR DESCRIPTION
### Description
This PR addresses an issue where `MAX_SEGMENT_SIZE` was defined in both `Segment` and `SegmentDataUtils` with the same value, leading to redundancy. To resolve this:

- `MAX_SEGMENT_SIZE` in `Segment.java` has been made `public`.
- In `SegmentDataUtils.java`, the static import `import static org.apache.jackrabbit.oak.segment.Segment.MAX_SEGMENT_SIZE;` was added to utilize the constant defined in `Segment.java`.
- The redundant definition of `MAX_SEGMENT_SIZE` in `SegmentDataUtils` has been removed.

### Motivation
Having the constant defined in two places created potential maintenance issues and inconsistency risks. By consolidating the definition in `Segment.java`, the code becomes cleaner, more maintainable, and reduces the possibility of errors in future updates.

### Impact
- No functionality change, purely a refactor.
- This change should not impact existing functionality but reduces code duplication.

Please review and merge this PR to streamline the constant usage in both classes.
