### PR TITLE
OAK-11121 - indexing-job: print thread CPU, GC and memory usage statistics periodically during indexing download

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -346,7 +346,7 @@ public class PipelinedStrategy extends IndexStoreSortStrategyBase {
     @Override
     public File createSortedStoreFile() throws IOException {
         int numberOfThreads = 1 + numberOfTransformThreads + 1 + 1; // dump, transform, sort threads, sorted files merge
-        final ThreadMonitor threadMonitor = new ThreadMonitor();
+        ThreadMonitor threadMonitor = new ThreadMonitor();
         var threadFactory = new ThreadMonitor.AutoRegisteringThreadFactory(threadMonitor, new ThreadFactoryBuilder().setDaemon(true).build());
         ExecutorService threadPool = Executors.newFixedThreadPool(numberOfThreads, threadFactory);
         // This executor can wait for several tasks at the same time. We use this below to wait at the same time for

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/ThreadMonitor.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/ThreadMonitor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+
+import org.apache.jackrabbit.guava.common.base.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.ThreadMXBean;
+import java.util.Comparator;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+public class ThreadMonitor {
+    private static final Logger LOG = LoggerFactory.getLogger(ThreadMonitor.class);
+    private final CopyOnWriteArraySet<Thread> threadIds = new CopyOnWriteArraySet<>();
+
+    private final Stopwatch stopwatch = Stopwatch.createUnstarted();
+
+    public void start() {
+        stopwatch.start();
+    }
+
+    public void registerThread(Thread thread) {
+        threadIds.add(thread);
+    }
+
+    public void printStatistics() {
+        long timeSinceStartMillis = stopwatch.elapsed().toMillis();
+
+        StringBuilder sb = new StringBuilder("MemoryMonitor report:\n");
+        for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            sb.append(String.format("  Collector: %s, collectionCount: %d, collectionTime: %d ms (%.2f%%)\n",
+                    gcBean.getName(), gcBean.getCollectionCount(), gcBean.getCollectionTime(), percentage(gcBean.getCollectionTime(), timeSinceStartMillis))
+            );
+        }
+        MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
+        sb.append(String.format("  Heap memory usage: %s, Non-heap memory usage: %s\n", memoryMxBean.getHeapMemoryUsage(), memoryMxBean.getNonHeapMemoryUsage()));
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        threadIds.stream().sorted(Comparator.comparing(Thread::getName)).forEach(thread -> {
+            long threadCpuTimeMillis = threadMXBean.getThreadCpuTime(thread.getId()) / 1_000_000;
+            long threadUserTimeMillis = threadMXBean.getThreadUserTime(thread.getId()) / 1_000_000;
+            double threadCpuTimePercentage = percentage(threadCpuTimeMillis, timeSinceStartMillis);
+            double threadUserTimePercentage = percentage(threadUserTimeMillis, timeSinceStartMillis);
+            sb.append(String.format("  Thread: %s, CPU time: %d (%.2f%%), User time: %d (%.2f%%)\n",
+                    thread.getName(), threadCpuTimeMillis, threadCpuTimePercentage, threadUserTimeMillis, threadUserTimePercentage)
+            );
+        });
+        // Remove the last newline
+        LOG.info(sb.substring(0, sb.length() - 1));
+    }
+
+    private static double percentage(long value, long total) {
+        return (double) value / total * 100;
+    }
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/ThreadMonitor.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/ThreadMonitor.java
@@ -19,6 +19,8 @@
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
+import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +30,33 @@ import java.lang.management.MemoryMXBean;
 import java.lang.management.ThreadMXBean;
 import java.util.Comparator;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
 
 public class ThreadMonitor {
+    static class AutoRegisteringThreadFactory implements ThreadFactory {
+        private final ThreadMonitor threadMonitor;
+        private final ThreadFactory delegate;
+
+        public AutoRegisteringThreadFactory(ThreadMonitor threadMonitor, ThreadFactory delegate) {
+            this.threadMonitor = threadMonitor;
+            this.delegate = delegate;
+        }
+
+        public AutoRegisteringThreadFactory(ThreadMonitor threadMonitor) {
+            this.threadMonitor = threadMonitor;
+            this.delegate = Executors.defaultThreadFactory();
+        }
+
+        @Override
+        public Thread newThread(@NotNull Runnable r) {
+            Thread t = delegate.newThread(r);
+            threadMonitor.registerThread(t);
+            return t;
+        }
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(ThreadMonitor.class);
     private final CopyOnWriteArraySet<Thread> threadIds = new CopyOnWriteArraySet<>();
 
@@ -43,32 +70,41 @@ public class ThreadMonitor {
         threadIds.add(thread);
     }
 
+    public void unregisterThread(Thread thread) {
+        threadIds.remove(thread);
+    }
+
     public void printStatistics() {
+        printStatistics("Thread/Memory report");
+    }
+
+    public void printStatistics(String heading) {
         long timeSinceStartMillis = stopwatch.elapsed().toMillis();
 
-        StringBuilder sb = new StringBuilder("MemoryMonitor report:\n");
+        StringBuilder sb = new StringBuilder(heading + ". Time elapsed: " + stopwatch + "\n");
+        MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
+        sb.append(String.format("  Heap memory usage: %s, Non-heap memory usage: %s\n",
+                memoryMxBean.getHeapMemoryUsage(), memoryMxBean.getNonHeapMemoryUsage()));
         for (GarbageCollectorMXBean gcBean : ManagementFactory.getGarbageCollectorMXBeans()) {
             sb.append(String.format("  Collector: %s, collectionCount: %d, collectionTime: %d ms (%.2f%%)\n",
-                    gcBean.getName(), gcBean.getCollectionCount(), gcBean.getCollectionTime(), percentage(gcBean.getCollectionTime(), timeSinceStartMillis))
+                    gcBean.getName(), gcBean.getCollectionCount(), gcBean.getCollectionTime(),
+                    FormattingUtils.safeComputePercentage(gcBean.getCollectionTime(), timeSinceStartMillis))
             );
         }
-        MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
-        sb.append(String.format("  Heap memory usage: %s, Non-heap memory usage: %s\n", memoryMxBean.getHeapMemoryUsage(), memoryMxBean.getNonHeapMemoryUsage()));
+
         ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-        threadIds.stream().sorted(Comparator.comparing(Thread::getName)).forEach(thread -> {
+        threadIds.stream().sorted(Comparator.comparing(Thread::getId)).forEach(thread -> {
             long threadCpuTimeMillis = threadMXBean.getThreadCpuTime(thread.getId()) / 1_000_000;
             long threadUserTimeMillis = threadMXBean.getThreadUserTime(thread.getId()) / 1_000_000;
-            double threadCpuTimePercentage = percentage(threadCpuTimeMillis, timeSinceStartMillis);
-            double threadUserTimePercentage = percentage(threadUserTimeMillis, timeSinceStartMillis);
-            sb.append(String.format("  Thread: %s, CPU time: %d (%.2f%%), User time: %d (%.2f%%)\n",
-                    thread.getName(), threadCpuTimeMillis, threadCpuTimePercentage, threadUserTimeMillis, threadUserTimePercentage)
+            double threadCpuTimePercentage = FormattingUtils.safeComputePercentage(threadCpuTimeMillis, timeSinceStartMillis);
+            double threadUserTimePercentage = FormattingUtils.safeComputePercentage(threadUserTimeMillis, timeSinceStartMillis);
+            sb.append(String.format("  Thread %d/%s - cpuTime: %d (%.2f%%), userTime: %d (%.2f%%)\n",
+                    thread.getId(), thread.getName(),
+                    threadCpuTimeMillis, threadCpuTimePercentage,
+                    threadUserTimeMillis, threadUserTimePercentage)
             );
         });
         // Remove the last newline
         LOG.info(sb.substring(0, sb.length() - 1));
-    }
-
-    private static double percentage(long value, long total) {
-        return (double) value / total * 100;
     }
 }


### PR DESCRIPTION
During the download phase of the indexing job, prints a periodic log message with statistics on memory, GC and CPU usage:
```
16:10:35.776 [main] INFO  o.a.j.o.i.i.d.f.p.ThreadMonitor - Thread/Memory report. Time since start of monitoring: 2.001 min
  Heap memory usage: init = 4294967296(4194304K) used = 3628072960(3543040K) committed = 4294967296(4194304K) max = 4294967296(4194304K), Non-heap memory usage: init = 7667712(7488K) used = 48238256(47107K) committed = 50397184(49216K) max = -1(-1K)
  Collector: G1 Young Generation, collectionCount: 7, collectionTime: 157 ms (0.13%)
  Collector: G1 Concurrent GC, collectionCount: 4, collectionTime: 5 ms (0.00%)
  Collector: G1 Old Generation, collectionCount: 0, collectionTime: 0 ms (0.00%)
  Thread mongo-dump/42             - cpuTime:     52 (0.04%), userTime:     48 (0.04%)
  Thread mongo-transform-0/43      - cpuTime:    902 (0.75%), userTime:    792 (0.66%)
  Thread mongo-transform-1/44      - cpuTime:    908 (0.76%), userTime:    791 (0.66%)
  Thread mongo-sort-batch/45       - cpuTime:      0 (0.00%), userTime:      0 (0.00%)
  Thread mongo-merge-sort-files/49 - cpuTime:      0 (0.00%), userTime:      0 (0.00%)
  Thread mongo-dump-ascending/50   - cpuTime:   1936 (1.61%), userTime:   1111 (0.93%)
  Thread mongo-dump-descending/51  - cpuTime:    214 (0.18%), userTime:    197 (0.16%)
```