### PR TITLE
OAK-11133: lucene type filter does not get correctly converted into the elastic counterpart

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
@@ -191,10 +191,9 @@ public class ElasticCustomAnalyzer {
                         .map(Map.Entry::getValue)
                         .collect(Collectors.toList());
             } catch (Exception e) {
-                LOG.warn("Unable to introspect lucene internal factories to perform transformations. " +
-                        "If you are using an elasticsearch specific factory, " +
-                        "please consider using the lucene compatible one for backward compatibility reasons. " +
-                        "Current configuration will be used. Error: {}" , e.getMessage());
+                LOG.warn("Unable to introspect Lucene internal factories for transformations. " +
+                        "If using an Elasticsearch-specific factory, consider using a Lucene-compatible one for backward compatibility. " +
+                        "Current configuration will be used. Error: {}", e.getMessage());
                 LOG.debug("Error details: ", e);
                 name = normalize(t.getName());
                 transformers = List.of();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
@@ -191,8 +191,11 @@ public class ElasticCustomAnalyzer {
                         .map(Map.Entry::getValue)
                         .collect(Collectors.toList());
             } catch (Exception e) {
-                LOG.warn("Unable introspect lucene internal factories to perform transformations. " +
-                        "Current configuration will be used", e);
+                LOG.warn("Unable to introspect lucene internal factories to perform transformations. " +
+                        "If you are using an elasticsearch specific factory, " +
+                        "please consider using the lucene compatible one for backward compatibility reasons. " +
+                        "Current configuration will be used. Error: {}" , e.getMessage());
+                LOG.debug("Error details: ", e);
                 name = normalize(t.getName());
                 transformers = List.of();
             }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
@@ -22,6 +22,7 @@ import org.apache.lucene.analysis.charfilter.MappingCharFilterFactory;
 import org.apache.lucene.analysis.cjk.CJKBigramFilterFactory;
 import org.apache.lucene.analysis.commongrams.CommonGramsFilterFactory;
 import org.apache.lucene.analysis.compound.DictionaryCompoundWordTokenFilterFactory;
+import org.apache.lucene.analysis.core.TypeTokenFilterFactory;
 import org.apache.lucene.analysis.en.AbstractWordsFileFilterFactory;
 import org.apache.lucene.analysis.miscellaneous.KeepWordFilterFactory;
 import org.apache.lucene.analysis.miscellaneous.KeywordMarkerFilterFactory;
@@ -129,6 +130,17 @@ public class ElasticCustomAnalyzerMappings {
             ));
         });
 
+        LUCENE_ELASTIC_TRANSFORMERS.put(TypeTokenFilterFactory.class, luceneParams -> {
+            Object useWhitelist = luceneParams.remove("useWhitelist");
+            if (useWhitelist != null && Boolean.parseBoolean(useWhitelist.toString())) {
+                luceneParams.put("mode", "include");
+            } else {
+                luceneParams.put("mode", "exclude");
+            }
+
+            return luceneParams;
+        });
+
         LUCENE_ELASTIC_TRANSFORMERS.put(PatternCaptureGroupFilterFactory.class, luceneParams ->
                 reKey.apply(luceneParams, Map.of("pattern", "patterns"))
         );
@@ -234,6 +246,7 @@ public class ElasticCustomAnalyzerMappings {
             Map.entry("pattern_capture_group", "pattern_capture"),
             Map.entry("reverse_string", "reverse"),
             Map.entry("snowball_porter", "snowball"),
-            Map.entry("dictionary_compound_word", "dictionary_decompounder")
+            Map.entry("dictionary_compound_word", "dictionary_decompounder"),
+            Map.entry("type", "keep_types")
     );
 }


### PR DESCRIPTION
Lucene type filter: 
https://lucene.apache.org/core/8_0_0/analyzers-common/org/apache/lucene/analysis/core/TypeTokenFilter.html

translates to Elastic keep types token filter:
https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-keep-types-tokenfilter.html