### PR TITLE
OAK-11132 - AOT blob downloader: may download a blob for a node that has already been indexed

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloader.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloader.java
@@ -91,7 +91,7 @@ public class DefaultAheadOfTimeBlobDownloader implements AheadOfTimeBlobDownload
     // Set with the ids of blobs that were already enqueued for download. Avoids creating a large number of download
     // requests for the blobs that are referenced by many nodes. Although this is a HashMap it is used as a set. The
     // value is just a placeholder, we use Boolean.TRUE for no particular reason.
-    private static final int DOWNLOADED_BLOB_IDS_CACHE_SIZE = 4096;
+    private static final int DOWNLOADED_BLOB_IDS_CACHE_SIZE = 1024;
     private final LinkedHashMap<String, Boolean> downloadedBlobs = new LinkedHashMap<>(DOWNLOADED_BLOB_IDS_CACHE_SIZE, 0.75f, true) {
         // Avoid resizing operations
         private final static int MAX_ENTRIES = (int) (DOWNLOADED_BLOB_IDS_CACHE_SIZE * 0.70);
@@ -300,7 +300,10 @@ public class DefaultAheadOfTimeBlobDownloader implements AheadOfTimeBlobDownload
                     LOG.debug("[{}] Blob already downloaded or enqueued for download: {}", linesScanned, blob.getContentIdentity());
                     continue;
                 }
-                throttler.reserveSpaceForBlob(linesScanned, blob.length());
+                if (!throttler.reserveSpaceForBlob(linesScanned, blob.length())) {
+                    skippedLinesDueToLaggingIndexing++;
+                    continue;
+                }
                 downloadedBlobs.put(blob.getContentIdentity(), Boolean.TRUE);
                 queue.put(blob);
                 blobsEnqueuedForDownload++;


### PR DESCRIPTION
Do not enqueue a blob to download if the space reservation throttler indicates that the indexer has already advanced past this blob.

Additional change:
- Reduce size of downloaded blobs ids cache from 4096 to 1024.