### PR TITLE
OAK-11089: Allow SegmentReferences/RecordNumbers to provide their memory estimates

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/ImmutableRecordNumbers.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/ImmutableRecordNumbers.java
@@ -59,6 +59,11 @@ class ImmutableRecordNumbers implements RecordNumbers {
         }
     }
 
+    @Override
+    public int estimateMemoryUsage() {
+        return offsets.length * RecordNumbers.MEMORY_USAGE_PER_NUMBER;
+    }
+
     @NotNull
     @Override
     public Iterator<Entry> iterator() {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MutableRecordNumbers.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MutableRecordNumbers.java
@@ -56,6 +56,11 @@ class MutableRecordNumbers implements RecordNumbers {
             : entries[index * 2];
     }
 
+    @Override
+    public int estimateMemoryUsage() {
+        return size / 2 * RecordNumbers.MEMORY_USAGE_PER_NUMBER;
+    }
+
     @NotNull
     @Override
     public synchronized Iterator<Entry> iterator() {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MutableSegmentReferences.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MutableSegmentReferences.java
@@ -92,6 +92,11 @@ class MutableSegmentReferences implements SegmentReferences {
         }
     }
 
+    @Override
+    public int estimateMemoryUsage() {
+        return SegmentReferences.MEMORY_USAGE_PER_REFERENCE * size();
+    }
+
     /**
      * Check if a reference exists for a provided segment ID.
      *

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordNumbers.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordNumbers.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
  * A table to translate record numbers to offsets.
  */
 public interface RecordNumbers extends Iterable<Entry> {
+    /** The memory usage, in bytes, per record number stored. */
+    int MEMORY_USAGE_PER_NUMBER = 5;
 
     /**
      * An always empty {@code RecordNumber} table.
@@ -82,6 +84,22 @@ public interface RecordNumbers extends Iterable<Entry> {
      * no offset is associated to the record number.
      */
     int getOffset(int recordNumber);
+
+
+    /**
+     * Estimates the memory usage, in bytes, of this table.
+     *
+     * <p>
+     * The default implementation iterates over all record numbers for backwards compatibility with all implementations,
+     * but implementations are encouraged to provide a more efficient implementation.
+     */
+    default int estimateMemoryUsage() {
+        int size = 0;
+        for (var number : this) {
+            size += MEMORY_USAGE_PER_NUMBER;
+        }
+        return size;
+    }
 
     /**
      * Represents an entry in the record table.

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/Segment.java
@@ -461,12 +461,8 @@ public class Segment {
         size += 56; // 7 refs x 8 bytes
 
         if (id.isDataSegmentId()) {
-            int recordNumberCount = getRecordNumberCount();
-            size += 5 * recordNumberCount;
-
-            int referencedSegmentIdCount = getReferencedSegmentIdCount();
-            size += 8 * referencedSegmentIdCount;
-
+            size += recordNumbers.estimateMemoryUsage();
+            size += segmentReferences.estimateMemoryUsage();
             size += StringUtils.estimateMemoryUsage(info);
         }
         size += data.estimateMemoryUsage();

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentReferences.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentReferences.java
@@ -30,6 +30,8 @@ import static org.apache.jackrabbit.guava.common.base.Preconditions.checkState;
  * Represents a list of segment IDs referenced from a segment.
  */
 public interface SegmentReferences extends Iterable<SegmentId> {
+    /** The memory usage, in bytes, per segment reference stored. */
+    int MEMORY_USAGE_PER_REFERENCE = 8;
 
     /** Builds a new instance of {@link SegmentReferences} from the provided {@link SegmentData}. */
     static @NotNull SegmentReferences fromSegmentData(@NotNull SegmentData data, @NotNull SegmentIdProvider idProvider) {
@@ -68,6 +70,11 @@ public interface SegmentReferences extends Iterable<SegmentId> {
                 return id;
             }
 
+            @Override
+            public int estimateMemoryUsage() {
+                return MEMORY_USAGE_PER_REFERENCE * referencedSegmentIdCount;
+            }
+
             @NotNull
             @Override
             public Iterator<SegmentId> iterator() {
@@ -96,4 +103,18 @@ public interface SegmentReferences extends Iterable<SegmentId> {
      */
     SegmentId getSegmentId(int reference);
 
+    /**
+     * Estimates the memory usage, in bytes, of this list.
+     *
+     * <p>
+     * The default implementation iterates over all references for backwards compatibility with all implementations,
+     * but implementations are encouraged to provide a more efficient implementation.
+     */
+    default int estimateMemoryUsage() {
+        int size = 0;
+        for (var number : this) {
+            size += MEMORY_USAGE_PER_REFERENCE;
+        }
+        return size;
+    }
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/ImmutableRecordNumbersTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/ImmutableRecordNumbersTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.jackrabbit.oak.segment.RecordNumbers.Entry;
+import org.apache.jackrabbit.oak.segment.memory.MemoryStore;
 import org.junit.Test;
 
 public class ImmutableRecordNumbersTest {
@@ -83,6 +84,12 @@ public class ImmutableRecordNumbersTest {
         }
 
         assertEquals(entries, iterated);
+    }
+
+    @Test
+    public void shouldEstimateMemoryUsage() throws Exception {
+        RecordNumbers recordNumbers = new ImmutableRecordNumbers(new int[3], new byte[3]);
+        assertEquals(5 * 3, recordNumbers.estimateMemoryUsage());
     }
 
     private Map<Integer, RecordEntry> recordEntries(Map<Integer, Integer> offsets) {

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/MutableSegmentReferencesTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/MutableSegmentReferencesTest.java
@@ -85,6 +85,19 @@ public class MutableSegmentReferencesTest {
     }
 
     @Test
+    public void shouldEstimateMemoryUsage() throws Exception {
+        MemoryStore store = new MemoryStore();
+        MutableSegmentReferences table = new MutableSegmentReferences();
+
+        for (int i = 0; i < 3; i++) {
+            SegmentId id = store.getSegmentIdProvider().newDataSegmentId();
+            table.addOrReference(id);
+        }
+
+        assertEquals(8 * 3, table.estimateMemoryUsage());
+    }
+
+    @Test
     public void shouldContainAddedSegment() throws Exception {
         MemoryStore store = new MemoryStore();
         SegmentId id = store.getSegmentIdProvider().newDataSegmentId();

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/RecordNumbersTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/RecordNumbersTest.java
@@ -19,9 +19,15 @@
 
 package org.apache.jackrabbit.oak.segment;
 
+import org.apache.jackrabbit.oak.segment.memory.MemoryStore;
+import org.jetbrains.annotations.NotNull;
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.segment.data.SegmentData;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Iterator;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,5 +50,28 @@ public class RecordNumbersTest {
         assertEquals(262088, recordNumbers.getOffset(2));
         assertEquals(262080, recordNumbers.getOffset(3));
         assertEquals(-1, recordNumbers.getOffset(4));
+    }
+
+    @Test
+    public void shouldEstimateMemoryUsageWithDefaultImplementation() throws Exception {
+        MemoryStore store = new MemoryStore();
+
+        RecordNumbers.Entry entry = Mockito.mock(RecordNumbers.Entry.class);
+        List<RecordNumbers.Entry> list = List.of(entry, entry, entry);
+
+        var customRecordNumbersImplementation = new RecordNumbers() {
+            @NotNull
+            @Override
+            public Iterator<Entry> iterator() {
+                return list.iterator();
+            }
+
+            @Override
+            public int getOffset(int recordNumber) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        assertEquals(list.size() * 5, customRecordNumbersImplementation.estimateMemoryUsage());
     }
 }


### PR DESCRIPTION
Closes OAK-11089:

> The `Segment#estimateMemoryUsage` currently takes into account the number of record numbers and referenced segment IDs in the segment in order to provide the total size estimate.
> This can be in issue when using implementations of `RecordNumbers`/`SegmentReferences` for which determining this total count is expensive. To improve this, we should allow `RecordNumbers`/`SegmentReferences` to provide themselves an estimate. By default, this estimation would be computed in the same way as we currently do, which makes this change backwards-compatible.

This PR also adds new unit tests for the new methods.