### PR TITLE
OAK-11131 - indexing-job: AOT Blob downloader may download blobs that are not needed for the indexes

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/CompositeIndexer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/CompositeIndexer.java
@@ -30,6 +30,10 @@ import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Many methods in this class call themselves recursively, and are susceptible to infinite recursion if a composite
+ * indexer contains itself, directly or indirectly. In this case, the methods will throw a StackOverflowException.
+ */
 public class CompositeIndexer implements NodeStateIndexer {
 
     private final List<NodeStateIndexer> indexers;
@@ -89,8 +93,6 @@ public class CompositeIndexer implements NodeStateIndexer {
 
     @Override
     public String getIndexName() {
-        // This is susceptible to infinite recursion if a composite indexer contains itself, directly or indirectly.
-        // The same is true for several other methods in this class.
         return indexers.stream().map(NodeStateIndexer::getIndexName).collect(Collectors.joining(",", "CompositeIndexer[", "]"));
     }
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/CompositeIndexer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/CompositeIndexer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
@@ -84,6 +85,13 @@ public class CompositeIndexer implements NodeStateIndexer {
             result.addAll(indexer.getRelativeIndexedNodeNames());
         }
         return result;
+    }
+
+    @Override
+    public String getIndexName() {
+        // This is susceptible to infinite recursion if a composite indexer contains itself, directly or indirectly.
+        // The same is true for several other methods in this class.
+        return indexers.stream().map(NodeStateIndexer::getIndexName).collect(Collectors.joining(",", "CompositeIndexer[", "]"));
     }
 
     @Override

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -31,12 +31,12 @@ public final class IndexerStatisticsTracker {
     // Timestamp of when indexing started.
     private long startIndexingNanos = 0;
     // Time spent indexing entries. Should be almost the same as totalMakeDocumentTimeNanos+totalWriteTimeNanos
-    private final AtomicLong totalIndexingTimeNanos = new AtomicLong();
+    private AtomicLong totalIndexingTimeNanos = new AtomicLong();
     // Time generating the Lucene document.
-    private final AtomicLong totalMakeDocumentTimeNanos = new AtomicLong();
+    private AtomicLong totalMakeDocumentTimeNanos = new AtomicLong();
     // Time writing the Lucene document to disk.
-    private final AtomicLong totalWriteTimeNanos = new AtomicLong();
-    private final AtomicLong nodesIndexed = new AtomicLong();
+    private AtomicLong totalWriteTimeNanos = new AtomicLong();
+    private AtomicLong nodesIndexed = new AtomicLong();
 
     public IndexerStatisticsTracker(Logger logger) {
         this.logger = logger;
@@ -50,10 +50,10 @@ public final class IndexerStatisticsTracker {
      * Mark that an entry completed indexing. If indexing the entry was slow, then a
      * message is logged.
      *
-     * @param entryPath the path
+     * @param path the path
      * @param startEntryNanos timestamp of when the current entry started being
      *                        indexed
-     * @param endEntryMakeDocumentNanos timestamp of when the current entry finished
+     * @oaran endEntryMakeDocumentNanos timestamp of when the current entry finished
      *        the makeDocument phase.
      */
     public void onEntryEnd(String entryPath, long startEntryNanos, long endEntryMakeDocumentNanos) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/IndexerStatisticsTracker.java
@@ -31,12 +31,12 @@ public final class IndexerStatisticsTracker {
     // Timestamp of when indexing started.
     private long startIndexingNanos = 0;
     // Time spent indexing entries. Should be almost the same as totalMakeDocumentTimeNanos+totalWriteTimeNanos
-    private AtomicLong totalIndexingTimeNanos = new AtomicLong();
+    private final AtomicLong totalIndexingTimeNanos = new AtomicLong();
     // Time generating the Lucene document.
-    private AtomicLong totalMakeDocumentTimeNanos = new AtomicLong();
+    private final AtomicLong totalMakeDocumentTimeNanos = new AtomicLong();
     // Time writing the Lucene document to disk.
-    private AtomicLong totalWriteTimeNanos = new AtomicLong();
-    private AtomicLong nodesIndexed = new AtomicLong();
+    private final AtomicLong totalWriteTimeNanos = new AtomicLong();
+    private final AtomicLong nodesIndexed = new AtomicLong();
 
     public IndexerStatisticsTracker(Logger logger) {
         this.logger = logger;
@@ -50,10 +50,10 @@ public final class IndexerStatisticsTracker {
      * Mark that an entry completed indexing. If indexing the entry was slow, then a
      * message is logged.
      *
-     * @param path the path
+     * @param entryPath the path
      * @param startEntryNanos timestamp of when the current entry started being
      *                        indexed
-     * @oaran endEntryMakeDocumentNanos timestamp of when the current entry finished
+     * @param endEntryMakeDocumentNanos timestamp of when the current entry finished
      *        the makeDocument phase.
      */
     public void onEntryEnd(String entryPath, long startEntryNanos, long endEntryMakeDocumentNanos) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateIndexer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateIndexer.java
@@ -26,9 +26,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Set;
 
-public interface NodeStateIndexer extends Closeable{
+public interface NodeStateIndexer extends Closeable {
 
-    default void onIndexingStarting() {}
+    default void onIndexingStarting() {
+    }
 
     default String getIndexName() {
         return "";

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateIndexer.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/NodeStateIndexer.java
@@ -19,16 +19,20 @@
 
 package org.apache.jackrabbit.oak.index.indexer.document;
 
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Set;
 
-import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
-
 public interface NodeStateIndexer extends Closeable{
 
     default void onIndexingStarting() {}
+
+    default String getIndexName() {
+        return "";
+    }
 
     boolean shouldInclude(String path);
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloader.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloader.java
@@ -108,7 +108,7 @@ public class DefaultAheadOfTimeBlobDownloader implements AheadOfTimeBlobDownload
     private final File ffsPath;
     private final Compression algorithm;
     private final GarbageCollectableBlobStore blobStore;
-    private final @NotNull List<NodeStateIndexer> indexers;
+    private final List<NodeStateIndexer> indexers;
 
     // Statistics
     private final LongAdder totalBytesDownloaded = new LongAdder();
@@ -132,7 +132,7 @@ public class DefaultAheadOfTimeBlobDownloader implements AheadOfTimeBlobDownload
      * @param algorithm             Compression algorithm of the flat file store.
      * @param blobStore             The blob store. This should be the same blob store used by the indexer and its cache should be
      *                              large enough to hold <code>maxPrefetchWindowMB</code> of data.
-     * @param indexers              The indexer, needed to check if a given path should be indexed.
+     * @param indexers              The indexeres for which AOT blob download is enabled.
      * @param nDownloadThreads      Number of download threads.
      * @param maxPrefetchWindowMB   Size of the prefetch window, that is, how much data the downlaoder will retrieve ahead of the indexer.
      */

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -271,8 +271,9 @@ public class FlatFileNodeStoreBuilder {
                 AheadOfTimeBlobDownloadingFlatFileStore.BLOB_PREFETCH_ENABLE_FOR_INDEXES_PREFIXES, "");
         Prefetcher prefetcher = new Prefetcher(prefetchTreeStore, indexingTreeStore);
         String blobSuffix = "";
-        if (AheadOfTimeBlobDownloadingFlatFileStore.isEnabledForIndexes(
-                blobPrefetchEnableForIndexes, indexHelper.getIndexPaths())) {
+        List<String> enabledIndexesPrefix = AheadOfTimeBlobDownloadingFlatFileStore.splitAndTrim(blobPrefetchEnableForIndexes);
+        if (AheadOfTimeBlobDownloadingFlatFileStore.isEnabledForAnyOfIndexes(
+                enabledIndexesPrefix, indexHelper.getIndexPaths())) {
             blobSuffix = ConfigHelper.getSystemPropertyAsString(
                     AheadOfTimeBlobDownloadingFlatFileStore.BLOB_PREFETCH_BINARY_NODES_SUFFIX, "");
         }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloaderTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
+
+
+import org.apache.jackrabbit.oak.commons.Compression;
+import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexer;
+import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultAheadOfTimeBlobDownloaderTest {
+    public final static String BINARY_BLOB_SUFFIX = "metadata/jcr:content";
+
+    private static final List<String> FFS_PATHS = List.of(
+            "/include1/asset1.pdf/metadata/jcr:content",
+            "/include1/asset1.pdf/jcr:content",
+            "/include2/asset2.pdf/metadata/jcr:content",
+            "/include2/asset2.pdf/jcr:content",
+            "/tmp/asset3.pdf/jcr:content/metadata",
+            "/tmp/asset3.pdf/jcr:content/metadata/jcr:content",
+            "/var/a/b"
+    );
+
+    private static void generateTestFFS(Path ffs, List<String> pathNames, MemoryBlobStore memoryBlobStore) throws IOException {
+        try (var bw = Files.newBufferedWriter(ffs, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+            for (String pathName : pathNames) {
+                String blobContent = "This is the blob for path " + pathName;
+                String id = memoryBlobStore.writeBlob(new ByteArrayInputStream(blobContent.getBytes()));
+                bw.write(pathName);
+                bw.write("|{\"jcr:primaryType\":\"nam:oak:Resource\",\"jcr:data\":\":blobId:");
+                bw.write(id);
+                bw.write("\"}\n");
+            }
+        }
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testSingleIndexIncludeAllPaths() throws IOException {
+        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/"))), BINARY_BLOB_SUFFIX, 3);
+    }
+
+    @Test
+    public void testSingleIndexIncludeOnePath() throws IOException {
+        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/include1"))), BINARY_BLOB_SUFFIX, 1);
+    }
+
+    @Test
+    public void testSingleIndexIncludePathDoesNotExist() throws IOException {
+        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/doesnotexist"))), BINARY_BLOB_SUFFIX, 0);
+    }
+
+    @Test
+    public void testSingleIndexPathDoesNotContainMatches() throws IOException {
+        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/var"))), BINARY_BLOB_SUFFIX, 0);
+    }
+
+    @Test
+    public void testMultipleIndexes() throws IOException {
+        doTestSingleIndexIncludeAllPaths(List.of(
+                        new TestNodeStateIndexer(List.of("/include2")),
+                        new TestNodeStateIndexer(List.of("/include1"))),
+                BINARY_BLOB_SUFFIX, 2);
+    }
+
+    @Test
+    public void testMultipleIncludePaths() throws IOException {
+        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/include2", "/include1"))),
+                BINARY_BLOB_SUFFIX, 2);
+    }
+
+    private void doTestSingleIndexIncludeAllPaths(List<NodeStateIndexer> indexers, String prefetchBinaryBlobSuffix, int expectedBlobsDownloaded) throws IOException {
+        Path ffsPath = folder.newFile("ffs.json").toPath();
+        try (MemoryBlobStore blobStore = new MemoryBlobStore()) {
+            generateTestFFS(ffsPath, FFS_PATHS, blobStore);
+
+            DefaultAheadOfTimeBlobDownloader defaultAheadOfTimeBlobDownloader = new DefaultAheadOfTimeBlobDownloader(
+                    prefetchBinaryBlobSuffix, ffsPath.toFile(), Compression.NONE,
+                    blobStore, indexers,
+                    2, 128, 1);
+
+            defaultAheadOfTimeBlobDownloader.start();
+            defaultAheadOfTimeBlobDownloader.join();
+
+            assertEquals(FFS_PATHS.size(), defaultAheadOfTimeBlobDownloader.getLinesScanned());
+            assertEquals(expectedBlobsDownloaded, defaultAheadOfTimeBlobDownloader.getBlobsEnqueuedForDownload());
+            assertEquals(expectedBlobsDownloaded, defaultAheadOfTimeBlobDownloader.getTotalBlobsDownloaded());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestNodeStateIndexer.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestNodeStateIndexer.java
@@ -1,0 +1,59 @@
+package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
+
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
+import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexer;
+import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+class TestNodeStateIndexer implements NodeStateIndexer {
+
+    private final String name;
+    private final List<String> includedPaths;
+
+    public TestNodeStateIndexer(List<String> includedPaths) {
+        this("test-index", includedPaths);
+    }
+
+    public TestNodeStateIndexer(String name, List<String> includedPaths) {
+        this.name = name;
+        this.includedPaths = includedPaths;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean shouldInclude(String path) {
+        return includedPaths.stream().anyMatch(path::startsWith);
+    }
+
+    @Override
+    public boolean shouldInclude(NodeDocument doc) {
+        return false;
+    }
+
+    @Override
+    public boolean index(NodeStateEntry entry) throws IOException, CommitFailedException {
+        return false;
+    }
+
+    @Override
+    public boolean indexesRelativeNodes() {
+        return false;
+    }
+
+    @Override
+    public Set<String> getRelativeIndexedNodeNames() {
+        return null;
+    }
+
+    @Override
+    public String getIndexName() {
+        return name;
+    }
+}

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestNodeStateIndexer.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestNodeStateIndexer.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
@@ -127,6 +127,11 @@ public class ElasticIndexer implements NodeStateIndexer {
     }
 
     @Override
+    public String getIndexName() {
+        return definition.getIndexName();
+    }
+
+    @Override
     public void close() throws IOException {
         LOG.info("Statistics: {}", indexerStatisticsTracker.formatStats());
         binaryTextExtractor.logStats();

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexer.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexer.java
@@ -115,6 +115,11 @@ public class LuceneIndexer implements NodeStateIndexer, FacetsConfigProvider {
     }
 
     @Override
+    public String getIndexName() {
+        return definition.getIndexName();
+    }
+
+    @Override
     public void close() throws IOException {
         LOG.info("[{}] Statistics: {}", definition.getIndexName(), indexerStatisticsTracker.formatStats());
         binaryTextExtractor.logStats();


### PR DESCRIPTION
The AOT Blob downloader makes several checks on each line/node in the FFS before downloading an non-inlined blob. One of these checks is if the line/node is needed by the **indexers for which the feature is enabled**. The current implementation is **checking if any of the indexers requires the line**. This is incorrect, because it may download blobs for lines that are not required by the indexers with AOT blob download enabled. In the worst case, this will slow down significantly the downloader, which may make it fall behind the indexer, thereby preventing it from downloading the blobs for the lines that are actually needed by the indexers.

This PR changes the logic so that the AOT blob downloader to only check against the indexes for which AOT blob download is enabled when deciding if a line/node is to be considered for blob download or not.

This PR also adds additional tests for the AOT blob downloader.