### PR TITLE
OAK-11154: Read partial segments from SegmentWriter

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/DefaultSegmentWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/DefaultSegmentWriter.java
@@ -69,6 +69,7 @@ import org.apache.jackrabbit.oak.plugins.blob.BlobStoreBlob;
 import org.apache.jackrabbit.oak.plugins.memory.ModifiedNodeState;
 import org.apache.jackrabbit.oak.segment.RecordWriters.RecordWriter;
 import org.apache.jackrabbit.oak.segment.WriteOperationHandler.WriteOperation;
+import org.apache.jackrabbit.oak.segment.data.PartialSegmentState;
 import org.apache.jackrabbit.oak.segment.file.tar.GCGeneration;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.DefaultNodeStateDiff;
@@ -154,6 +155,11 @@ public class DefaultSegmentWriter implements SegmentWriter {
     @Override
     public void flush() throws IOException {
         writeOperationHandler.flush(store);
+    }
+
+    @Override
+    public @Nullable PartialSegmentState readPartialSegmentState(@NotNull SegmentId sid) {
+        return writeOperationHandler.readPartialSegmentState(sid);
     }
 
     @NotNull

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentWriter.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.data.PartialSegmentState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,6 +33,19 @@ import org.jetbrains.annotations.Nullable;
 public interface SegmentWriter {
 
     void flush() throws IOException;
+
+    /**
+     * Get the {@link PartialSegmentState partial state} of a segment
+     * that has started being written to but hasn’t been flushed yet.
+     *
+     * @param sid The ID of the segment
+     * @return The partial state or {@code null} if no partial state was found for the given segment ID.
+     * @throws UnsupportedOperationException if reading partial segment states is not supported.
+     */
+    @Nullable
+    default PartialSegmentState readPartialSegmentState(@NotNull SegmentId sid) {
+        throw new UnsupportedOperationException("Trying to read partial segment state from a SegmentWriter that doesn’t support it.");
+    }
 
     /**
      * Write a blob (as list of block records)

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperationHandler.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriteOperationHandler.java
@@ -21,9 +21,11 @@ package org.apache.jackrabbit.oak.segment;
 
 import java.io.IOException;
 
+import org.apache.jackrabbit.oak.segment.data.PartialSegmentState;
 import org.jetbrains.annotations.NotNull;
 
 import org.apache.jackrabbit.oak.segment.file.tar.GCGeneration;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A {@code WriteOperationHandler} executes {@link WriteOperation
@@ -73,4 +75,10 @@ interface WriteOperationHandler {
      * @throws IOException
      */
     void flush(@NotNull SegmentStore store) throws IOException;
+
+    /** @see SegmentWriter#readPartialSegmentState(SegmentId) */
+    @Nullable
+    default PartialSegmentState readPartialSegmentState(@NotNull SegmentId sid) {
+        throw new UnsupportedOperationException("Trying to read partial segment state from a WriteOperationHandler that doesn’t support it.");
+    }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/PartialSegmentState.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/data/PartialSegmentState.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.segment.data;
+
+import org.apache.jackrabbit.oak.segment.RecordType;
+import org.apache.jackrabbit.oak.segment.SegmentWriter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Contains the state of a partial segment, i.e. a segment that is currently being written to by {@link SegmentWriter}
+ * and has not been flushed yet.
+ *
+ * <p>
+ * The data contained in the partial segment is permanent, i.e. instances of {@code PartialSegmentState} will never
+ * return data which is incoherent with earlier instances of {@code PartialSegmentState} for the same segment.
+ * For instance, {@link #version()} will always return the same value for the same segment and will never be changed.
+ * However, the data may be incomplete. For instance, the segment may not contain all the records that will be written
+ * to it before it is flushed.
+ *
+ * <p>
+ * Instances of this class are <em>immutable</em> and thus <em>thread-safe</em>.
+ *
+ * @link <a href="https://jackrabbit.apache.org/oak/docs/nodestore/segment/records.html">Documentation of the segment structure</a>
+ */
+public final class PartialSegmentState {
+    private final byte version;
+    private final int generation;
+    private final int fullGeneration;
+    private final boolean isCompacted;
+    private final @NotNull List<@NotNull SegmentReference> segmentReferences;
+    private final @NotNull List<@NotNull Record> records;
+
+    public PartialSegmentState(byte version, int generation, int fullGeneration, boolean isCompacted, @NotNull List<@NotNull SegmentReference> segmentReferences, @NotNull List<@NotNull Record> records) {
+        this.version = version;
+        this.generation = generation;
+        this.fullGeneration = fullGeneration;
+        this.isCompacted = isCompacted;
+        this.segmentReferences = List.copyOf(segmentReferences);
+        this.records = List.copyOf(records);
+    }
+
+    public byte version() {
+        return version;
+    }
+
+    public int generation() {
+        return generation;
+    }
+
+    public int fullGeneration() {
+        return fullGeneration;
+    }
+
+    public boolean isCompacted() {
+        return isCompacted;
+    }
+
+    /**
+     * The references to other segments, in the order of their appearance in the segment header
+     * (segment number = index of a reference in {@code segmentReferences} + 1).
+     *
+     * <p>
+     * New elements might be added to this list before the segment is flushed in newer instances of
+     * {@code PartialSegmentState} for the same segment, but the elements that are already present will never be changed.
+     */
+    public @NotNull List<@NotNull SegmentReference> segmentReferences() {
+        return segmentReferences;
+    }
+
+    /**
+     * The records in the segment, sorted by offset in descending order (highest offset first, which is the order of
+     * record numbers in the segment header).
+     *
+     * <p>
+     * This list may be incomplete if new records are added before the segment is flushed.
+     * Also, existing records may themselves be incomplete (see {@link Record}).
+     */
+    public @NotNull List<@NotNull Record> records() {
+        return records;
+    }
+
+    public static final class SegmentReference {
+        private final long msb;
+        private final long lsb;
+
+        public SegmentReference(long msb, long lsb) {
+            this.msb = msb;
+            this.lsb = lsb;
+        }
+
+        public long msb() {
+            return msb;
+        }
+
+        public long lsb() {
+            return lsb;
+        }
+    }
+
+    public static final class Record {
+        /** The reference number of the record (= record number) */
+        private final int refNumber;
+
+        /** The type of the record */
+        private final RecordType recordType;
+
+        /**
+         * The offset of the record in the segment (smaller than {@link Segment#MAX_SEGMENT_SIZE}).
+         *
+         * <p>
+         * This offset is relative to a
+         * <a href="https://jackrabbit.apache.org/oak/docs/nodestore/segment/records.html#record-numbers-and-offsets">theoretical 256-KiB segment</a>.
+         */
+        private final int offset;
+
+        /**
+         * The known contents of the segment starting at its {@link #offset}.
+         *
+         * <p>
+         * This array can be smaller than the actual size of the record if the contents of this record are only
+         * partially known.
+         */
+        private final byte @NotNull [] contents;
+
+        public Record(int refNumber, @NotNull RecordType recordType, int offset, byte @NotNull [] contents) {
+            this.refNumber = refNumber;
+            this.recordType = requireNonNull(recordType);
+            this.offset = offset;
+            this.contents = requireNonNull(contents);
+        }
+
+        /** @see #refNumber */
+        public int refNumber() {
+            return refNumber;
+        }
+
+        /** @see #recordType */
+        public @NotNull RecordType recordType() {
+            return recordType;
+        }
+
+        /** @see #offset */
+        public int offset() {
+            return offset;
+        }
+
+        /** @see #contents */
+        public byte @NotNull [] contents() {
+            return contents;
+        }
+    }
+}


### PR DESCRIPTION
This pull request modifies the `SegmentWriter` interface in oak-segment-tar to add the possibility of reading the state of a segment currently being written to, as described in OAK-11154. 

Closes OAK-11154

## Why?
oak-segment-tar writes new segments using an implementation of `SegmentWriter`.

Since segments are immutable, the state of a segment that hasn’t been flushed yet isn’t visible outside of the `SegmentWriter` instance. However, in some cases, code using `SegmentWriter` might want to access the partial segment data.

Currently, the only possible way to do it is to call `flush`, which will force the segment to be flushed right away, and then get the full segment from the underlying segment store. This is bad for performance, because we need to do more flushes that necessary, and because there’s a risk of creating a lot of segments that have a size much smaller than `MAX_SEGMENT_SIZE`.

To avoid this, I suggest that we add a `readPartialSegmentState` method to `SegmentWriter`, which takes the segment ID of an unflushed segment and returns it if possible.

## Backwards-compatibility
This change is backwards-compatible with existing users of `SegmentWriter` (because they’re not using the new method). The new method comes with a default implementation which throws an `UnsupportedOperationException`.

## Concurrency
Previously, the class was marked as *not thread-safe*, which made sense since it was only expected that a single writer thread uses it at the same time (concurrent calls wouldn’t have made sense since the order in which `prepare` and `writeXYZ` methods are called matters).

One major change with `SegmentBufferWriter` is that its `readPartialSegmentState` method can now be called concurrently with the other methods in the same class. To support this, we now use `synchronized` on the methods that are accessible publicly. This shouldn’t cause a drop in performance, because most calls to the class are on the writer thread (so not concurrent between themselves), and it is expected from `readPartialSegmentState` to be called rarely (compared to the other methods).

I could confirm that there is no noticeable drop in performance by running the write benchmarks without and with the change, and observed no difference:

**Without `synchronized`**
``` 
# ConcurrentWriteReadTest          C     min     10%     50%     90%     max     N       mean
Oak-Segment-Tar                    1       1       5      11      61    258    2535      24
# ConcurrentWriteTest              C     min     10%     50%     90%     max     N       mean
Oak-Segment-Tar                    1      29      31      36      58    622    1373      44
# BasicWriteTest                   C     min     10%     50%     90%     max     N       mean
Oak-Segment-Tar                    1      14      15      16      19    320    3448      17
```

**With `synchronized`**
```
# ConcurrentWriteReadTest          C     min     10%     50%     90%     max     N       mean
Oak-Segment-Tar                    1       1       4      12      58    553    2531      24
# ConcurrentWriteTest              C     min     10%     50%     90%     max     N       mean
Oak-Segment-Tar                    1      29      31      35      65    461    1319      46
# BasicWriteTest                   C     min     10%     50%     90%     max     N       mean
Oak-Segment-Tar                    1      14      15      16      19     96    3444      17
```

## Testing
The PR adds a new test, `readPartialSegmentState`, which covers the implementation of the method in `SegmentBufferWriter`.
