### PR TITLE
OAK-11156: VersionGarbageCollectorIT fails to dispose some DocumentStore instances

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
@@ -19,6 +19,7 @@
 package org.apache.jackrabbit.oak.plugins.document;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -287,8 +288,9 @@ public class VersionGarbageCollectorIT {
             }
         }
 
-        LOG.info("tearDown: DONE. fullGcMode = {}, test = {}, elapsed = {}ms", fullGcMode, name.getMethodName(),
-                System.currentTimeMillis() - startTime);
+        long elapsed = System.currentTimeMillis() - startTime;
+        LOG.info("tearDown: DONE. fullGcMode = {}, test = {}, elapsed = {}ms ({})", fullGcMode, name.getMethodName(), elapsed,
+                Duration.ofMillis(elapsed));
     }
 
     private final String internalRdbTablePrefix = "VGCIT" + Long.toHexString(startTime);


### PR DESCRIPTION
1. adds logging of mapping of testname to table prefix (RDB)
2. prefixes the prefix with "VCGIT" (RDB)
3. disposes DocumentStore instances previously not disposed
4. adds test method name (incl fixture) and elapsed time to tearDown log message