### PR TITLE
OAK-11165 - Cache the Path field in the NodeDocument class.

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
@@ -364,6 +364,8 @@ public final class NodeDocument extends Document {
 
     private final long creationTime;
 
+    private Path path = null;
+
     NodeDocument(@NotNull DocumentStore store) {
         this(store, Revision.getCurrentTimestamp());
     }
@@ -2279,7 +2281,10 @@ public final class NodeDocument extends Document {
 
     @NotNull
     public Path getPath() {
-        return Path.fromString(getPathString());
+        if (path == null) {
+            path = Path.fromString(getPathString());
+        }
+        return path;
     }
 
     @NotNull


### PR DESCRIPTION
Creating a Path instance from a NodeDocument is an expensive operation, so it is worth to cache it. The performance improvements are noticeable in the indexing job, which calls `#getPath` twice in each NodeDocument that it processes. 

Similar idea as what is done here:
https://github.com/apache/jackrabbit-oak/blob/35950bec988fffe34708f635f29f7d268d54cb85/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Path.java#L297-L306