### PR TITLE
OAK-11062: document-store: refine skipping of MongoDB tests

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/AbstractDocumentStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/AbstractDocumentStoreTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
-import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -44,8 +43,6 @@ public abstract class AbstractDocumentStoreTest {
     protected List<String> removeMeClusterNodes = new ArrayList<String>();
 
     static final Logger LOG = LoggerFactory.getLogger(AbstractDocumentStoreTest.class);
-
-    private static final boolean SKIP_MONGO = SystemPropertySupplier.create("oak.skipMongo", false).loggingTo(LOG).get();
 
     public AbstractDocumentStoreTest(DocumentStoreFixture dsf) {
         this.dsf = dsf;
@@ -88,9 +85,7 @@ public abstract class AbstractDocumentStoreTest {
                 DocumentStoreFixture.RDB_MSSQL };
 
         for (DocumentStoreFixture dsf : candidates) {
-            if (SKIP_MONGO && dsf instanceof DocumentStoreFixture.MongoFixture) {
-                LOG.info("Mongo fixture '{}' skipped.", dsf.getName());
-            } else if (dsf.isAvailable()) {
+            if (dsf.isAvailable()) {
                 if (!multi || dsf.hasSinglePersistence()) {
                     result.add(new DocumentStoreFixture[] { dsf });
                     names.add(dsf.getName());

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentStoreFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentStoreFixture.java
@@ -23,6 +23,7 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import org.apache.jackrabbit.oak.commons.FixturesHelper;
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.rdb.RDBDataSourceFactory;
@@ -236,6 +237,9 @@ public abstract class DocumentStoreFixture {
     }
 
     public static class MongoFixture extends DocumentStoreFixture {
+
+        private static final boolean SKIP_MONGO = SystemPropertySupplier.create("oak.skipMongo", false).loggingTo(LOG).get();
+
         protected List<MongoConnection> connections = Lists.newArrayList();
 
         @Override
@@ -257,7 +261,7 @@ public abstract class DocumentStoreFixture {
 
         @Override
         public boolean isAvailable() {
-            return MongoUtils.isAvailable();
+            return !SKIP_MONGO && MongoUtils.isAvailable();
         }
 
         @Override

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentStoreFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentStoreFixture.java
@@ -238,7 +238,7 @@ public abstract class DocumentStoreFixture {
 
     public static class MongoFixture extends DocumentStoreFixture {
 
-        private static final boolean SKIP_MONGO = SystemPropertySupplier.create("oak.skipMongo", false).loggingTo(LOG).get();
+        public static final boolean SKIP_MONGO = SystemPropertySupplier.create("oak.skipMongo", false).loggingTo(LOG).get();
 
         protected List<MongoConnection> connections = Lists.newArrayList();
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoConnectionFactory.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoConnectionFactory.java
@@ -51,6 +51,9 @@ public class MongoConnectionFactory extends ExternalResource {
 
     @Nullable
     public MongoConnection getConnection(String dbName) {
+        if (DocumentStoreFixture.MongoFixture.SKIP_MONGO) {
+            return null;
+        }
         // first try MongoDB running on configured host and port
         MongoConnection c = MongoUtils.getConnection(dbName);
         if (c == null && MongoDockerRule.isDockerAvailable()) {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoUtils.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoUtils.java
@@ -62,28 +62,30 @@ public class MongoUtils {
         if (mongoUrl == null || mongoUrl.isEmpty()) {
             mongoUrl = "mongodb://" + HOST + ":" + PORT + "/" + DB + "?" + OPTIONS;
         }
-        // check if we can connect
-        MongoConnection c = getConnectionByURL(mongoUrl);
-        if (c != null) {
-            c.close();
-            return mongoUrl;
-        }
-        // fallback to docker based MongoDB if available
-        MongoDockerRule dockerRule = new MongoDockerRule();
-        if (MongoDockerRule.isDockerAvailable()) {
-            AtomicReference<String> host = new AtomicReference<>();
-            AtomicInteger port = new AtomicInteger();
-            try {
-                dockerRule.apply(new Statement() {
-                    @Override
-                    public void evaluate() {
-                        host.set(dockerRule.getHost());
-                        port.set(dockerRule.getPort());
-                    }
-                }, Description.EMPTY).evaluate();
-                mongoUrl = "mongodb://" + host + ":" + port.get() + "/" + DB + "?" + OPTIONS;
-            } catch (Throwable t) {
-                LOG.warn("Unable to get MongoDB port from Docker", t);
+        if (!DocumentStoreFixture.MongoFixture.SKIP_MONGO) {
+            // check if we can connect
+            MongoConnection c = getConnectionByURL(mongoUrl);
+            if (c != null) {
+                c.close();
+                return mongoUrl;
+            }
+            // fallback to docker based MongoDB if available
+            MongoDockerRule dockerRule = new MongoDockerRule();
+            if (MongoDockerRule.isDockerAvailable()) {
+                AtomicReference<String> host = new AtomicReference<>();
+                AtomicInteger port = new AtomicInteger();
+                try {
+                    dockerRule.apply(new Statement() {
+                        @Override
+                        public void evaluate() {
+                            host.set(dockerRule.getHost());
+                            port.set(dockerRule.getPort());
+                        }
+                    }, Description.EMPTY).evaluate();
+                    mongoUrl = "mongodb://" + host + ":" + port.get() + "/" + DB + "?" + OPTIONS;
+                } catch (Throwable t) {
+                    LOG.warn("Unable to get MongoDB port from Docker", t);
+                }
             }
         }
         return mongoUrl;
@@ -210,7 +212,7 @@ public class MongoUtils {
      * @return the connection or null
      */
     private static MongoConnection getConnectionByURL(String url) {
-        if (exceptions.get(url) != null) {
+        if (DocumentStoreFixture.MongoFixture.SKIP_MONGO || exceptions.get(url) != null) {
             return null;
         }
         MongoConnection mongoConnection;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDockerRule.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDockerRule.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document.mongo;
 
+import org.apache.jackrabbit.oak.plugins.document.DocumentStoreFixture;
 import org.junit.Assume;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
@@ -112,9 +113,12 @@ public class MongoDockerRule extends ExternalResource {
     }
 
     private static boolean checkImageAvailability() throws TimeoutException {
-        RemoteDockerImage remoteDockerImage = new RemoteDockerImage(DOCKER_IMAGE_NAME);
-        remoteDockerImage.get(1, TimeUnit.MINUTES);
-        return true;
+        RemoteDockerImage remoteDockerImage = null;
+        if (!DocumentStoreFixture.MongoFixture.SKIP_MONGO) {
+            remoteDockerImage = new RemoteDockerImage(DOCKER_IMAGE_NAME);
+            remoteDockerImage.get(1, TimeUnit.MINUTES);
+        }
+        return remoteDockerImage != null;
     }
 
     private static boolean checkDockerAvailability() {

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/prefetch/CacheWarmingTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/prefetch/CacheWarmingTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -107,7 +108,7 @@ public class CacheWarmingTest {
 
     private DocumentStore newMongoDocumentStore() throws InterruptedException {
         mongoConnection = connectionFactory.getConnection();
-        assertNotNull(mongoConnection);
+        assumeNotNull(mongoConnection);
         db = new CountingMongoDatabase(mongoConnection.getDatabase());
         MongoUtils.dropCollections(db);
         DocumentMK.Builder builder = new DocumentMK.Builder()

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/prefetch/CacheWarmingTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/prefetch/CacheWarmingTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -108,7 +107,7 @@ public class CacheWarmingTest {
 
     private DocumentStore newMongoDocumentStore() throws InterruptedException {
         mongoConnection = connectionFactory.getConnection();
-        assumeNotNull(mongoConnection);
+        assertNotNull(mongoConnection);
         db = new CountingMongoDatabase(mongoConnection.getDatabase());
         MongoUtils.dropCollections(db);
         DocumentMK.Builder builder = new DocumentMK.Builder()


### PR DESCRIPTION
All tests against MongoDB will now be skipped if the system property oak.skipMongo is true.