### PR TITLE
OAK-11169: MongoVersionGCSupport (oak-document-store) uses incorrect syntax for sort mongodb function

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -259,7 +259,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
                         and(gt(MODIFIED_IN_SECS, getModifiedInSecs(fromModified)), lt(MODIFIED_IN_SECS, getModifiedInSecs(toModified)))));
 
         // first sort by _modified and then by _id
-        final Bson sort = and(eq(MODIFIED_IN_SECS, 1), eq(ID, 1));
+        final Bson sort = ascending(MODIFIED_IN_SECS, ID);
 
         logQueryExplain("fullGC query explain details, hint : {} - explain : {}", query, modifiedIdHint);
 
@@ -345,7 +345,7 @@ public class MongoVersionGCSupport extends VersionGCSupport {
     public long getOldestDeletedOnceTimestamp(Clock clock, long precisionMs) {
         LOG.debug("getOldestDeletedOnceTimestamp() <- start");
         Bson query = Filters.eq(DELETED_ONCE, Boolean.TRUE);
-        Bson sort = Filters.eq(MODIFIED_IN_SECS, 1);
+        Bson sort = ascending(MODIFIED_IN_SECS);
         List<Long> result = new ArrayList<>(1);
         getNodeCollection().find(query).sort(sort).limit(1).forEach(
                 new Block<BasicDBObject>() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -23,6 +23,7 @@ import static com.mongodb.client.model.Filters.exists;
 import static com.mongodb.client.model.Filters.gt;
 import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Projections.include;
+import static com.mongodb.client.model.Sorts.ascending;
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.concat;
@@ -373,19 +374,19 @@ public class MongoVersionGCSupport extends VersionGCSupport {
      */
     @Override
     public Optional<NodeDocument> getOldestModifiedDoc(final Clock clock) {
-        final Bson sort = and(eq(MODIFIED_IN_SECS, 1), eq(ID, 1));
-
         // we need to add query condition to ignore `previous` documents which doesn't have this field
         final Bson query = exists(MODIFIED_IN_SECS);
+        // sort by MODIFIED_IN_SECS first, ID otherwise
+        final Bson sort = ascending(MODIFIED_IN_SECS, ID);
 
         FindIterable<BasicDBObject> limit = getNodeCollection().find(query).sort(sort).limit(1);
 
-        try(MongoCursor<BasicDBObject> cur = limit.iterator()) {
+        try (MongoCursor<BasicDBObject> cur = limit.iterator()) {
             return cur.hasNext() ? ofNullable(store.convertFromDBObject(NODES, cur.next())) : empty();
         } catch (Exception ex) {
             LOG.error("getOldestModifiedDoc() <- error while fetching data from Mongo", ex);
         }
-        LOG.info("No Modified Doc has been found, retuning empty");
+        LOG.info("No Modified Doc has been found, returning empty");
         return empty();
     }
 


### PR DESCRIPTION
The change in the test case is not really needed, but it would detect the case where sorting by ID does not happen (as opposed to be happening as default fallback).

@rgambelli - thanks for finding this.