### PR TITLE
OAK.11196: oak-auth-ldap: update mina dependency to 2.1.8

### DIFF
--- a/oak-auth-ldap/pom.xml
+++ b/oak-auth-ldap/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
Done.