### PR TITLE
OAK-11197: improve statistical facets by introducing pre-computed random values

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -100,6 +100,11 @@ public class ElasticIndexDefinition extends IndexDefinition {
     public static final String DYNAMIC_BOOST_FULLTEXT = ":dynamic-boost-ft";
 
     /**
+     * Precomputed random value based on the path of the document
+     */
+    public static final String PATH_RANDOM_VALUE = ":path-random-value";
+
+    /**
      * Dynamic properties are fields that are not explicitly defined in the index mapping and are added on the fly when a document is indexed.
      * Examples: aggregations with relative nodes, regex properties (to be supported), etc.
      */

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
@@ -19,7 +19,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.jackrabbit.guava.common.hash.Hashing;
+import org.apache.commons.codec.digest.MurmurHash3;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
@@ -61,8 +61,13 @@ public class ElasticDocument {
     private final List<Map<String, Object>> dynamicProperties;
 
     ElasticDocument(String path) {
+        this(path, 0);
+    }
+
+    ElasticDocument(String path, int seed) {
         this.path = path;
-        this.pathRandomValue = Hashing.murmur3_32_fixed(300).hashString(path, StandardCharsets.UTF_8).asInt();
+        byte[] pathBytes = path.getBytes(StandardCharsets.UTF_8);
+        this.pathRandomValue = MurmurHash3.hash32x86(pathBytes, 0, pathBytes.length, seed);
         this.fulltext = new LinkedHashSet<>();
         this.suggest = new LinkedHashSet<>();
         this.spellcheck = new LinkedHashSet<>();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
@@ -42,7 +42,7 @@ public class ElasticDocument {
     @JsonProperty(FieldNames.PATH)
     public final String path;
     @JsonProperty(ElasticIndexDefinition.PATH_RANDOM_VALUE)
-    public final float pathRandomValue;
+    public final short pathRandomValue;
     @JsonProperty(FieldNames.FULLTEXT)
     public final Set<String> fulltext;
     @JsonProperty(FieldNames.SUGGEST)
@@ -61,7 +61,7 @@ public class ElasticDocument {
 
     ElasticDocument(String path) {
         this.path = path;
-        this.pathRandomValue = ElasticIndexUtils.getRandomLongFromString(path);
+        this.pathRandomValue = ElasticIndexUtils.getRandomShortFromString(path);
         this.fulltext = new LinkedHashSet<>();
         this.suggest = new LinkedHashSet<>();
         this.spellcheck = new LinkedHashSet<>();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.BlobByteSource;
 
@@ -40,6 +41,8 @@ public class ElasticDocument {
 
     @JsonProperty(FieldNames.PATH)
     public final String path;
+    @JsonProperty(ElasticIndexDefinition.PATH_RANDOM_VALUE)
+    public final float pathRandomValue;
     @JsonProperty(FieldNames.FULLTEXT)
     public final Set<String> fulltext;
     @JsonProperty(FieldNames.SUGGEST)
@@ -58,6 +61,7 @@ public class ElasticDocument {
 
     ElasticDocument(String path) {
         this.path = path;
+        this.pathRandomValue = ElasticIndexUtils.getRandomLongFromString(path);
         this.fulltext = new LinkedHashSet<>();
         this.suggest = new LinkedHashSet<>();
         this.spellcheck = new LinkedHashSet<>();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
@@ -19,14 +19,15 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.jackrabbit.guava.common.hash.Hashing;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
-import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.BlobByteSource;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class ElasticDocument {
     @JsonProperty(FieldNames.PATH)
     public final String path;
     @JsonProperty(ElasticIndexDefinition.PATH_RANDOM_VALUE)
-    public final short pathRandomValue;
+    public final int pathRandomValue;
     @JsonProperty(FieldNames.FULLTEXT)
     public final Set<String> fulltext;
     @JsonProperty(FieldNames.SUGGEST)
@@ -61,7 +62,7 @@ public class ElasticDocument {
 
     ElasticDocument(String path) {
         this.path = path;
-        this.pathRandomValue = ElasticIndexUtils.getRandomShortFromString(path);
+        this.pathRandomValue = Hashing.murmur3_32_fixed(300).hashString(path, StandardCharsets.UTF_8).asInt();
         this.fulltext = new LinkedHashSet<>();
         this.suggest = new LinkedHashSet<>();
         this.spellcheck = new LinkedHashSet<>();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
@@ -21,6 +21,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.Aggregate;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
@@ -48,7 +49,7 @@ public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument>
 
     @Override
     protected ElasticDocument initDoc() {
-        return new ElasticDocument(path);
+        return new ElasticDocument(path, (int) definition.getDefinitionNodeState().getLong(ElasticIndexDefinition.PROP_INDEX_NAME_SEED));
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -94,8 +94,9 @@ class ElasticIndexHelper {
     }
 
     private static void mapInternalProperties(@NotNull TypeMapping.Builder builder) {
-        builder.properties(FieldNames.PATH,
-                        b1 -> b1.keyword(builder3 -> builder3))
+        builder.properties(FieldNames.PATH, b1 -> b1.keyword(builder3 -> builder3))
+                .properties(ElasticIndexDefinition.PATH_RANDOM_VALUE,
+                        b1 -> b1.float_(b2 -> b2.docValues(true)))
                 .properties(FieldNames.ANCESTORS,
                         b1 -> b1.text(
                                 b2 -> b2.analyzer("ancestor_analyzer")

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -96,7 +96,7 @@ class ElasticIndexHelper {
     private static void mapInternalProperties(@NotNull TypeMapping.Builder builder) {
         builder.properties(FieldNames.PATH, b1 -> b1.keyword(builder3 -> builder3))
                 .properties(ElasticIndexDefinition.PATH_RANDOM_VALUE,
-                        b1 -> b1.float_(b2 -> b2.docValues(true)))
+                        b1 -> b1.short_(b2 -> b2.docValues(true).index(false)))
                 .properties(FieldNames.ANCESTORS,
                         b1 -> b1.text(
                                 b2 -> b2.analyzer("ancestor_analyzer")

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -94,7 +94,8 @@ class ElasticIndexHelper {
     }
 
     private static void mapInternalProperties(@NotNull TypeMapping.Builder builder) {
-        builder.properties(FieldNames.PATH, b1 -> b1.keyword(builder3 -> builder3))
+        builder.properties(FieldNames.PATH,
+                        b1 -> b1.keyword(builder3 -> builder3))
                 .properties(ElasticIndexDefinition.PATH_RANDOM_VALUE,
                         b1 -> b1.short_(b2 -> b2.docValues(true).index(false)))
                 .properties(FieldNames.ANCESTORS,

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -97,7 +97,7 @@ class ElasticIndexHelper {
         builder.properties(FieldNames.PATH,
                         b1 -> b1.keyword(builder3 -> builder3))
                 .properties(ElasticIndexDefinition.PATH_RANDOM_VALUE,
-                        b1 -> b1.short_(b2 -> b2.docValues(true).index(false)))
+                        b1 -> b1.integer(b2 -> b2.docValues(true).index(false)))
                 .properties(FieldNames.ANCESTORS,
                         b1 -> b1.text(
                                 b2 -> b2.analyzer("ancestor_analyzer")

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
@@ -84,7 +84,7 @@ public class ElasticStatisticalFacetAsyncProvider implements ElasticFacetProvide
                         s.field(fs -> fs.field(
                                 ElasticIndexDefinition.PATH_RANDOM_VALUE)
                                 // this will handle the case when the field is not present in the index
-                                .unmappedType(FieldType.Short)
+                                .unmappedType(FieldType.Integer)
                         )
                 )
         );

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
@@ -18,7 +18,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.query.async.facets;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
-import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.mapping.FieldType;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -74,17 +74,19 @@ public class ElasticStatisticalFacetAsyncProvider implements ElasticFacetProvide
         this.isAccessible = isAccessible;
         this.facetFields = elasticRequestHandler.facetFields().collect(Collectors.toSet());
 
-        BoolQuery.Builder builder = elasticRequestHandler.baseQueryBuilder();
-        builder.should(sb -> sb.functionScore(fsb ->
-                fsb.functions(f -> f.randomScore(rsb -> rsb.seed("" + randomSeed).field(FieldNames.PATH)))
-        ));
-
         SearchRequest searchRequest = SearchRequest.of(srb -> srb.index(indexDefinition.getIndexAlias())
                 .trackTotalHits(thb -> thb.enabled(true))
                 .source(SourceConfig.of(scf -> scf.filter(ff -> ff.includes(FieldNames.PATH).includes(new ArrayList<>(facetFields)))))
-                .query(Query.of(qb -> qb.bool(builder.build())))
+                .query(Query.of(qb -> qb.bool(elasticRequestHandler.baseQueryBuilder().build())))
                 .aggregations(elasticRequestHandler.aggregations())
                 .size(sampleSize)
+                .sort(s ->
+                        s.field(fs -> fs.field(
+                                ElasticIndexDefinition.PATH_RANDOM_VALUE)
+                                // this will handle the case when the field is not present in the index
+                                .unmappedType(FieldType.Float)
+                        )
+                )
         );
 
         LOG.trace("Kicking search query with random sampling {}", searchRequest);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
@@ -84,7 +84,7 @@ public class ElasticStatisticalFacetAsyncProvider implements ElasticFacetProvide
                         s.field(fs -> fs.field(
                                 ElasticIndexDefinition.PATH_RANDOM_VALUE)
                                 // this will handle the case when the field is not present in the index
-                                .unmappedType(FieldType.Float)
+                                .unmappedType(FieldType.Short)
                         )
                 )
         );

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.util;
 
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -51,31 +50,6 @@ public class ElasticIndexUtils {
             }
         }
         return path;
-    }
-
-    /**
-     * Generates a consistent short value based on a given string using the SHA-256 algorithm.
-     * The generated value  is a 16-bit integer ranging from -32,768 to 32,767.
-     *
-     * @param input the input string to be hashed
-     * @return a short value from the input string
-     * @throws IllegalStateException if the SHA-256 algorithm is not available
-     */
-    public static short getRandomShortFromString(String input) {
-        try {
-            // Get a SHA-256 MessageDigest instance
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-
-            // Compute the hash of the input string
-            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
-
-            // Convert the first 2 bytes of the hash to an integer value
-            int hashValue = (hash[0] & 0xFF) << 8 | (hash[1] & 0xFF);
-
-            return (short) hashValue;
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     /**

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
@@ -54,14 +54,14 @@ public class ElasticIndexUtils {
     }
 
     /**
-     * Generates a consistent float value based on a given string using the SHA-256 algorithm.
-     * The generated float value will be between 0 and 1.
+     * Generates a consistent short value based on a given string using the SHA-256 algorithm.
+     * The generated value  is a 16-bit integer ranging from -32,768 to 32,767.
      *
      * @param input the input string to be hashed
-     * @return a float value between 0 and 1 derived from the input string
+     * @return a short value from the input string
      * @throws IllegalStateException if the SHA-256 algorithm is not available
      */
-    public static float getRandomLongFromString(String input) {
+    public static short getRandomShortFromString(String input) {
         try {
             // Get a SHA-256 MessageDigest instance
             MessageDigest md = MessageDigest.getInstance("SHA-256");
@@ -69,12 +69,10 @@ public class ElasticIndexUtils {
             // Compute the hash of the input string
             byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
 
-            // Convert the first 8 bytes of the hash to a long value
-            BigInteger bigInt = new BigInteger(1, hash);
+            // Convert the first 2 bytes of the hash to an integer value
+            int hashValue = (hash[0] & 0xFF) << 8 | (hash[1] & 0xFF);
 
-            // Normalize the long value to a float between 0 and 1
-            // We use Long.MAX_VALUE to map the long into the 0 to 1 range
-            return (bigInt.longValue() & 0x7FFFFFFFFFFFFFFFL) / (float) Long.MAX_VALUE;
+            return (short) hashValue;
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.util;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -50,6 +51,33 @@ public class ElasticIndexUtils {
             }
         }
         return path;
+    }
+
+    /**
+     * Generates a consistent float value based on a given string using the SHA-256 algorithm.
+     * The generated float value will be between 0 and 1.
+     *
+     * @param input the input string to be hashed
+     * @return a float value between 0 and 1 derived from the input string
+     * @throws IllegalStateException if the SHA-256 algorithm is not available
+     */
+    public static float getRandomLongFromString(String input) {
+        try {
+            // Get a SHA-256 MessageDigest instance
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+
+            // Compute the hash of the input string
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+
+            // Convert the first 8 bytes of the hash to a long value
+            BigInteger bigInt = new BigInteger(1, hash);
+
+            // Normalize the long value to a float between 0 and 1
+            // We use Long.MAX_VALUE to map the long into the 0 to 1 range
+            return (bigInt.longValue() & 0x7FFFFFFFFFFFFFFFL) / (float) Long.MAX_VALUE;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     /**

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -443,6 +443,6 @@ public interface FulltextIndexConstants {
      * needed from an outside process that does not have visibility to the specific index module.
      */
     Map<String, String> INDEX_VERSION_BY_TYPE = Map.of(
-            "elasticsearch", "1.1.0"
+            "elasticsearch", "1.2.0"
     );
 }


### PR DESCRIPTION
In #1217, we improved statistical facets by introducing a random score script to retrieve a random sample of results from an index without iterating over a large number of entries. By using a seed, we ensured that tests produce consistent results across different executions.

This approach worked well compared to the previous solution. However, for very large result sets (over 1 million entries), the strategy could become inefficient, leading to timeouts when the query doesn't return within 15 seconds.

To address this, the current PR precomputes consistent random values based on the `path` field and stores them in a dedicated index field of type `integer`, reducing disk usage and improving query performance (see [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html#_which_type_should_i_use)). As a result, queries now execute in milliseconds, regardless of the size of the result set.