### PR TITLE
OAK-11204: Incorrect order with more than 2^16 segments in remote archive

### DIFF
--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/AbstractRemoteSegmentArchiveWriter.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/AbstractRemoteSegmentArchiveWriter.java
@@ -157,6 +157,11 @@ public abstract class AbstractRemoteSegmentArchiveWriter implements SegmentArchi
         return true;
     }
 
+    @Override
+    public int getMaxEntryCount() {
+        return RemoteUtilities.MAX_ENTRY_COUNT;
+    }
+
     /**
      * Writes a segment to the remote storage.
      * @param indexEntry, the archive index entry to write

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilities.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilities.java
@@ -18,7 +18,6 @@ package org.apache.jackrabbit.oak.segment.remote;
 
 import static java.lang.Boolean.getBoolean;
 
-import org.apache.jackrabbit.oak.segment.remote.RemoteSegmentArchiveEntry;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilities.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilities.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 public final class RemoteUtilities {
     public static final boolean OFF_HEAP = getBoolean("access.off.heap");
     public static final String SEGMENT_FILE_NAME_PATTERN = "^([0-9a-f]{4})\\.([0-9a-f-]+)$";
+    public static final int MAX_ENTRY_COUNT = 0x10000;
 
     private static final Pattern PATTERN = Pattern.compile(SEGMENT_FILE_NAME_PATTERN);
 
@@ -40,7 +41,7 @@ public final class RemoteUtilities {
     }
 
     public static String getSegmentFileName(long offset, long msb, long lsb) {
-        return String.format("%04x.%s", offset, new UUID(msb, lsb).toString());
+        return String.format("%04x.%s", offset, new UUID(msb, lsb));
     }
 
     public static UUID getSegmentUUID(@NotNull String segmentFileName) {

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/package-info.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("1.2.0")
+@Version("1.3.0")
 package org.apache.jackrabbit.oak.segment.remote;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilitiesTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilitiesTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jackrabbit.oak.segment.remote;
 
 import org.junit.Test;

--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilitiesTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/RemoteUtilitiesTest.java
@@ -1,0 +1,32 @@
+package org.apache.jackrabbit.oak.segment.remote;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class RemoteUtilitiesTest {
+    @Test
+    public void testValidEntryIndex() {
+        UUID uuid = UUID.randomUUID();
+        String name = RemoteUtilities.getSegmentFileName(
+                RemoteUtilities.MAX_ENTRY_COUNT - 1,
+                uuid.getMostSignificantBits(),
+                uuid.getLeastSignificantBits()
+        );
+        assertEquals(uuid, RemoteUtilities.getSegmentUUID(name));
+    }
+
+  @Test
+  public void testInvalidEntryIndex() {
+    UUID uuid = UUID.randomUUID();
+    String name = RemoteUtilities.getSegmentFileName(
+            RemoteUtilities.MAX_ENTRY_COUNT,
+            uuid.getMostSignificantBits(),
+            uuid.getLeastSignificantBits()
+    );
+    assertNotEquals(uuid, RemoteUtilities.getSegmentUUID(name));
+  }
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/SegmentTarWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/SegmentTarWriter.java
@@ -43,7 +43,6 @@ import org.apache.jackrabbit.oak.segment.file.tar.index.SimpleIndexEntry;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +93,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public void writeSegment(long msb, long lsb, byte @NotNull [] data, int offset, int size, int generation, int fullGeneration, boolean compacted) throws IOException {
+    public void writeSegment(long msb, long lsb, byte[] data, int offset, int size, int generation, int fullGeneration, boolean compacted) throws IOException {
         UUID uuid = new UUID(msb, lsb);
         CRC32 checksum = new CRC32();
         checksum.update(data, offset, size);
@@ -154,7 +153,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public void writeGraph(byte @NotNull [] data) throws IOException {
+    public void writeGraph(byte[] data) throws IOException {
         int paddingSize = getPaddingSize(data.length);
         byte[] header = newEntryHeader(file.getName() + ".gph", data.length + paddingSize);
         access.write(header);
@@ -168,7 +167,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public void writeBinaryReferences(byte @NotNull [] data) throws IOException {
+    public void writeBinaryReferences(byte[] data) throws IOException {
         int paddingSize = getPaddingSize(data.length);
         byte[] header = newEntryHeader(file.getName() + ".brf", data.length + paddingSize);
         access.write(header);
@@ -238,7 +237,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public @NotNull String getName() {
+    public String getName() {
         return file.getName();
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/SegmentTarWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/SegmentTarWriter.java
@@ -43,6 +43,7 @@ import org.apache.jackrabbit.oak.segment.file.tar.index.SimpleIndexEntry;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +94,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public void writeSegment(long msb, long lsb, byte[] data, int offset, int size, int generation, int fullGeneration, boolean compacted) throws IOException {
+    public void writeSegment(long msb, long lsb, byte @NotNull [] data, int offset, int size, int generation, int fullGeneration, boolean compacted) throws IOException {
         UUID uuid = new UUID(msb, lsb);
         CRC32 checksum = new CRC32();
         checksum.update(data, offset, size);
@@ -153,7 +154,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public void writeGraph(byte[] data) throws IOException {
+    public void writeGraph(byte @NotNull [] data) throws IOException {
         int paddingSize = getPaddingSize(data.length);
         byte[] header = newEntryHeader(file.getName() + ".gph", data.length + paddingSize);
         access.write(header);
@@ -167,7 +168,7 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public void writeBinaryReferences(byte[] data) throws IOException {
+    public void writeBinaryReferences(byte @NotNull [] data) throws IOException {
         int paddingSize = getPaddingSize(data.length);
         byte[] header = newEntryHeader(file.getName() + ".brf", data.length + paddingSize);
         access.write(header);
@@ -237,13 +238,18 @@ public class SegmentTarWriter implements SegmentArchiveWriter {
     }
 
     @Override
-    public String getName() {
+    public @NotNull String getName() {
         return file.getName();
     }
 
     @Override
     public boolean isRemote() {
         return false;
+    }
+
+    @Override
+    public int getMaxEntryCount() {
+        return Integer.MAX_VALUE;
     }
 
     private static byte[] newEntryHeader(String name, int size) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarFiles.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarFiles.java
@@ -645,7 +645,8 @@ public class TarFiles implements Closeable {
                     writer.addBinaryReference(generation, id, reference);
                 }
             }
-            if (size >= maxFileSize) {
+            int entryCount = writer.getEntryCount();
+            if (size >= maxFileSize || entryCount >= writer.getMaxEntryCount()) {
                 internalNewWriter();
             }
         } finally {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriter.java
@@ -121,6 +121,13 @@ class TarWriter implements Closeable {
     }
 
     /**
+     * @return the maximum number of entries supported by this writer
+     */
+    int getMaxEntryCount() {
+        return archive.getMaxEntryCount();
+    }
+
+    /**
      * If the given segment is in this file, get the byte buffer that allows
      * reading it.
      * 
@@ -145,8 +152,10 @@ class TarWriter implements Closeable {
             archive.writeSegment(msb, lsb, data, offset, size, generation.getGeneration(), generation.getFullGeneration(), generation.isCompacted());
             segmentCount.inc();
             long currentLength = archive.getLength();
+            int currentEntryCount = archive.getEntryCount();
 
             checkState(currentLength <= Integer.MAX_VALUE);
+            checkState(currentEntryCount <= archive.getMaxEntryCount());
 
             return currentLength;
         }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/SegmentArchiveWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/SegmentArchiveWriter.java
@@ -63,7 +63,8 @@ public interface SegmentArchiveWriter {
      * @param isCompacted the segment compaction property, see {@link SegmentArchiveEntry#isCompacted()}
      * @throws IOException error writing segment
      */
-    void writeSegment(long msb, long lsb, byte @NotNull [] data, int offset, int size, int generation, int fullGeneration, boolean isCompacted) throws IOException;
+    @NotNull
+    void writeSegment(long msb, long lsb, @NotNull byte[] data, int offset, int size, int generation, int fullGeneration, boolean isCompacted) throws IOException;
 
     /**
      * Read the segment.
@@ -89,14 +90,14 @@ public interface SegmentArchiveWriter {
      *
      * @param data serialized segment graph data
      */
-    void writeGraph(byte @NotNull [] data) throws IOException;
+    void writeGraph(@NotNull byte[] data) throws IOException;
 
     /**
      * Write the binary references data.
      *
      * @param data serialized binary references data
      */
-    void writeBinaryReferences(byte @NotNull [] data) throws IOException;
+    void writeBinaryReferences(@NotNull byte[] data) throws IOException;
 
     /**
      * Get the current length of the archive.

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/SegmentArchiveWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/SegmentArchiveWriter.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.Nullable;
  * any time. They <b>should be thread safe</b>.
  */
 public interface SegmentArchiveWriter {
-
     /**
      * Write the new segment to the archive.
      *
@@ -62,10 +61,9 @@ public interface SegmentArchiveWriter {
      * @param generation the segment generation, see {@link SegmentArchiveEntry#getGeneration()}
      * @param fullGeneration the segment full generation, see {@link SegmentArchiveEntry#getFullGeneration()}
      * @param isCompacted the segment compaction property, see {@link SegmentArchiveEntry#isCompacted()}
-     * @throws IOException
+     * @throws IOException error writing segment
      */
-    @NotNull
-    void writeSegment(long msb, long lsb, @NotNull byte[] data, int offset, int size, int generation, int fullGeneration, boolean isCompacted) throws IOException;
+    void writeSegment(long msb, long lsb, byte @NotNull [] data, int offset, int size, int generation, int fullGeneration, boolean isCompacted) throws IOException;
 
     /**
      * Read the segment.
@@ -91,14 +89,14 @@ public interface SegmentArchiveWriter {
      *
      * @param data serialized segment graph data
      */
-    void writeGraph(@NotNull byte[] data) throws IOException;
+    void writeGraph(byte @NotNull [] data) throws IOException;
 
     /**
      * Write the binary references data.
      *
      * @param data serialized binary references data
      */
-    void writeBinaryReferences(@NotNull byte[] data) throws IOException;
+    void writeBinaryReferences(byte @NotNull [] data) throws IOException;
 
     /**
      * Get the current length of the archive.
@@ -142,12 +140,20 @@ public interface SegmentArchiveWriter {
     String getName();
 
     /**
-     * This method returns {@code true} if the storage is accessed via a network protocol, not tight to the traditional storage technology,
+     * This method returns {@code true} if the storage is accessed via a network protocol, not tied to the traditional storage technology,
      * for example, HTTP. Based on that info, for instance, calling classes can decide to update archive metadata (graph, binary references, index) more frequently,
      * and not only when the archive is being closed. With that multiple Oak processes can access the storage simultaneously, with one process in read-write mode and
      * one or more processes in read-only mode.
      *
-     * @return
+     * @return true if the storage is accessed via a network protocol, false otherwise
      */
     boolean isRemote();
+
+    /**
+     * This method returns the maximum number of segments that can be supported by the underlying persistence
+     * implementation of the archive writer.
+     *
+     * @return maximum number of segments supported by the writer implementation
+     */
+    int getMaxEntryCount();
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/FileStoreTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/FileStoreTest.java
@@ -236,7 +236,7 @@ public class FileStoreTest {
                     public SegmentArchiveWriter create(String archiveName) {
                         return new SegmentTarWriter(new File(directory, archiveName), fileStoreMonitor, ioMonitor) {
                             @Override
-                            public void writeGraph(byte @NotNull [] data) throws IOException {
+                            public void writeGraph(byte[] data) throws IOException {
                                 throw new IOException(FAILED_TO_WRITE_ON_CLOSE);
                             }
                         };

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/FileStoreTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/FileStoreTest.java
@@ -236,7 +236,7 @@ public class FileStoreTest {
                     public SegmentArchiveWriter create(String archiveName) {
                         return new SegmentTarWriter(new File(directory, archiveName), fileStoreMonitor, ioMonitor) {
                             @Override
-                            public void writeGraph(byte[] data) throws IOException {
+                            public void writeGraph(byte @NotNull [] data) throws IOException {
                                 throw new IOException(FAILED_TO_WRITE_ON_CLOSE);
                             }
                         };

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarFilesTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarFilesTest.java
@@ -42,9 +42,16 @@ import java.util.UUID;
 import org.apache.jackrabbit.oak.api.IllegalRepositoryStateException;
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.segment.file.tar.TarFiles.CleanupResult;
+import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitor;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RemoteStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveManager;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -415,10 +422,9 @@ public class TarFilesTest {
         assertEquals(0, tarFiles.readerCount());
         assertEquals(0, tarFiles.segmentCount());
         assertEquals(0, tarFiles.size());
-        assertFalse(tarFiles.containsSegment(0l, 0l));
-        assertNull(tarFiles.readSegment(0l, 0l));
+        assertFalse(tarFiles.containsSegment(0L, 0L));
+        assertNull(tarFiles.readSegment(0L, 0L));
 
-        tarFiles.toString();
         assertThrows(IllegalRepositoryStateException.class, () -> tarFiles.flush());
         assertThrows(IllegalRepositoryStateException.class, () -> writeSegment(randomUUID()));
         assertThrows(IllegalRepositoryStateException.class, () -> tarFiles.cleanup(new CleanupContext() {
@@ -444,5 +450,55 @@ public class TarFilesTest {
         assertTrue(tarFiles.getGraph("").isEmpty());
 
         assertThrows(IllegalRepositoryStateException.class, () -> tarFiles.createFileReaper());
+    }
+
+    @Test
+    public void testWriterRolloverOnExcessiveEntryCount() throws IOException {
+        // TOTAL_ENTRIES > WRITER_ENTRY_LIMIT;
+        final int WRITER_ENTRY_LIMIT = 8;
+        final int TOTAL_ENTRIES = 42;
+
+        IOMonitorAdapter ioMonitor = new IOMonitorAdapter();
+        FileStoreMonitor fsMonitor = new FileStoreMonitorAdapter();
+        RemoteStoreMonitor remoteStoreMonitor = new RemoteStoreMonitorAdapter();
+        File rootDirectory = folder.getRoot();
+        File segmentStoreDir = folder.newFolder();
+
+        // create persistence
+        SegmentNodeStorePersistence persistence = new TarPersistence(rootDirectory) {
+            @Override
+            public SegmentArchiveManager createArchiveManager(
+                    boolean memoryMapping, boolean offHeapAccess, IOMonitor ioMonitor,
+                    FileStoreMonitor fileStoreMonitor, RemoteStoreMonitor remoteStoreMonitor
+            ) {
+                return new SegmentTarManager(
+                        segmentStoreDir, fsMonitor, ioMonitor, false, false
+                ) {
+                    @Override
+                    public @NotNull SegmentArchiveWriter create(String archiveName) {
+                        return new SegmentTarWriter(new File(segmentStoreDir, archiveName), fsMonitor, ioMonitor) {
+                            @Override
+                            public int getMaxEntryCount() {
+                                return WRITER_ENTRY_LIMIT;
+                            }
+                        };
+                    }
+                };
+            }
+        };
+        tarFiles = TarFiles.builder()
+                .withDirectory(rootDirectory)
+                .withTarRecovery((id, data, recovery) -> {})
+                .withIOMonitor(ioMonitor)
+                .withFileStoreMonitor(fsMonitor)
+                .withMaxFileSize(MAX_FILE_SIZE)
+                .withRemoteStoreMonitor(remoteStoreMonitor)
+                .withPersistence(persistence)
+                .build();
+
+        // write more entries than fit into a single tar file
+        for (int i = 0; i < TOTAL_ENTRIES; i++) {
+            writeSegment(randomUUID());
+        }
     }
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarFilesTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarFilesTest.java
@@ -500,5 +500,7 @@ public class TarFilesTest {
         for (int i = 0; i < TOTAL_ENTRIES; i++) {
             writeSegment(randomUUID());
         }
+
+        assertEquals(TOTAL_ENTRIES / WRITER_ENTRY_LIMIT, tarFiles.readerCount());
     }
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriterTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriterTest.java
@@ -101,7 +101,7 @@ public class TarWriterTest {
             public @NotNull SegmentArchiveWriter create(String archiveName) {
                 return new SegmentTarWriter(new File(segmentstoreDir, archiveName), monitor, ioMonitor) {
                     @Override
-                    public void writeGraph(byte @NotNull [] data) throws IOException {
+                    public void writeGraph(byte[] data) throws IOException {
                         throw new IOException("test");
                     }
                 };

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriterTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/tar/TarWriterTest.java
@@ -101,7 +101,7 @@ public class TarWriterTest {
             public @NotNull SegmentArchiveWriter create(String archiveName) {
                 return new SegmentTarWriter(new File(segmentstoreDir, archiveName), monitor, ioMonitor) {
                     @Override
-                    public void writeGraph(byte[] data) throws IOException {
+                    public void writeGraph(byte @NotNull [] data) throws IOException {
                         throw new IOException("test");
                     }
                 };
@@ -132,4 +132,30 @@ public class TarWriterTest {
         }
     }
 
+    @Test
+    public void testTarWriterFailOnExcessiveEntryCount() throws Exception {
+        final int ENTRY_LIMIT = 8;
+        IOMonitorAdapter ioMonitor = new IOMonitorAdapter();
+        File segmentstoreDir = folder.newFolder();
+        SegmentArchiveManager archiveManager = new SegmentTarManager(
+                segmentstoreDir, monitor, ioMonitor, false, false
+        ) {
+            @Override
+            public @NotNull SegmentArchiveWriter create(String archiveName) {
+                return new SegmentTarWriter(new File(segmentstoreDir, archiveName), monitor, ioMonitor) {
+                    @Override
+                    public int getMaxEntryCount() {
+                        return ENTRY_LIMIT;
+                    }
+                };
+            }
+        };
+
+        TarWriter tarWriter = new TarWriter(archiveManager, 0, NoopStats.INSTANCE);
+        for (int i = 0; i < ENTRY_LIMIT; i++) {
+            writeEntry(tarWriter);
+        }
+        assertThrows(IllegalStateException.class, () -> writeEntry(tarWriter));
+        tarWriter.close();
+    }
 }


### PR DESCRIPTION
Adds the ability for `SegmentArchiveWriter` implementations to communicate a limitation in segment count support number. This is used by `TarFiles` to roll over to a new writer if needed.