### PR TITLE
OAK-11241 - Document mechanism for registering MBeans

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/whiteboard/WhiteboardUtils.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/whiteboard/WhiteboardUtils.java
@@ -108,6 +108,8 @@ public class WhiteboardUtils {
             table.put("type", JmxUtil.quoteValueIfRequired(type));
             table.put("name", JmxUtil.quoteValueIfRequired(name));
 
+            // ensure the MBean is tracked by the Aries JMX Whiteboard
+            // https://aries.apache.org/documentation/modules/jmx.html#_whiteboard_support
             ImmutableMap.Builder properties = ImmutableMap.builder();
             properties.put("jmx.objectname", new ObjectName(JMX_OAK_DOMAIN, table));
             properties.putAll(attrs);


### PR DESCRIPTION
It is not immediately obvious how the registerMBean method works so add a link to the Aries JMX whiteboard documentation.