### PR TITLE
OAK-11229: remove usage of newArrayList(Iterable/Iterator)

### DIFF
--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/DynamicGroupValidatorTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/DynamicGroupValidatorTest.java
@@ -18,7 +18,6 @@ package org.apache.jackrabbit.oak.spi.security.authentication.external.impl.prin
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -28,6 +27,7 @@ import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
@@ -269,7 +269,7 @@ public class DynamicGroupValidatorTest extends AbstractPrincipalTest {
 
         Tree groupTree = r.getTree(localGroup.getPath());
         Tree userTree = r.getTree(userManager.getAuthorizable(USER_ID).getPath());
-        List<String> members = Lists.newArrayList(groupTree.getProperty(REP_MEMBERS).getValue(Type.STRINGS));
+        List<String> members = CollectionUtils.toList(groupTree.getProperty(REP_MEMBERS).getValue(Type.STRINGS));
         members.add(userTree.getProperty(JCR_UUID).getValue(Type.STRING));
         groupTree.setProperty(REP_MEMBERS, members, Type.WEAKREFERENCES);
         r.commit();
@@ -301,7 +301,7 @@ public class DynamicGroupValidatorTest extends AbstractPrincipalTest {
         r.commit();
         
         Tree groupTree = r.getTree(localGroup.getPath());
-        List<String> members = Lists.newArrayList(groupTree.getProperty(REP_MEMBERS).getValue(Type.STRINGS));
+        List<String> members = CollectionUtils.toList(groupTree.getProperty(REP_MEMBERS).getValue(Type.STRINGS));
         members.remove(1);
         groupTree.setProperty(REP_MEMBERS, members, Type.WEAKREFERENCES);
         r.commit();
@@ -319,7 +319,7 @@ public class DynamicGroupValidatorTest extends AbstractPrincipalTest {
 
         Tree groupTree = r.getTree(localGroup.getPath());
         Tree userTree = r.getTree(userManager.getAuthorizable(USER_ID).getPath());
-        List<String> members = Lists.newArrayList(groupTree.getProperty(REP_MEMBERS).getValue(Type.STRINGS));
+        List<String> members = CollectionUtils.toList(groupTree.getProperty(REP_MEMBERS).getValue(Type.STRINGS));
         members.add(userTree.getProperty(JCR_UUID).getValue(Type.STRING));
         groupTree.setProperty(REP_MEMBERS, members, Type.WEAKREFERENCES);
         try {

--- a/oak-benchmarks-lucene/src/main/java/org/apache/jackrabbit/oak/benchmark/HybridIndexTest.java
+++ b/oak-benchmarks-lucene/src/main/java/org/apache/jackrabbit/oak/benchmark/HybridIndexTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.benchmark;
 
 import java.io.File;
@@ -45,12 +44,12 @@ import javax.jcr.query.QueryResult;
 
 import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.api.jmx.IndexStatsMBean;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.fixture.JcrCreator;
 import org.apache.jackrabbit.oak.fixture.OakRepositoryFixture;
 import org.apache.jackrabbit.oak.fixture.RepositoryFixture;
@@ -514,7 +513,7 @@ public class HybridIndexTest extends AbstractTest<HybridIndexTest.TestContext> {
             if (nodetype.exists()) {
                 List<String> nodetypes = new ArrayList<>();
                 if (nodetype.hasProperty(DECLARING_NODE_TYPES)){
-                    nodetypes = Lists.newArrayList(nodetype.getProperty(DECLARING_NODE_TYPES).getValue(Type.STRINGS));
+                    nodetypes = CollectionUtils.toList(nodetype.getProperty(DECLARING_NODE_TYPES).getValue(Type.STRINGS));
                 }
 
                 if (nodetypes.isEmpty()) {

--- a/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/FacetSearchTest.java
+++ b/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/FacetSearchTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.benchmark;
 
-
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
@@ -39,13 +38,14 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 import javax.jcr.security.Privilege;
+
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.commons.JcrUtils.getOrCreateByPath;
 import static org.apache.jackrabbit.oak.api.Type.BOOLEAN;
 import static org.apache.jackrabbit.oak.api.Type.LONG;
@@ -142,7 +142,7 @@ public class FacetSearchTest extends AbstractTest<FacetSearchTest.TestContext> {
     }
 
     protected String getQuery() {
-        List<String> samples = newArrayList(propVals);
+        List<String> samples = new ArrayList<>(propVals);
         return "SELECT [rep:facet(foo)], [rep:facet(bar)] FROM [nt:base] WHERE [cons] = '" + samples.get(rgen.nextInt(samples.size())) + "'";
     }
 

--- a/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/SearchTest.java
+++ b/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/SearchTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.benchmark;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 
 import java.io.File;
@@ -194,7 +193,7 @@ public class SearchTest extends AbstractTest<SearchTest.TestContext> {
     }
 
     private String[] getRandomWords() {
-        List<String> samples = newArrayList(sampleSet);
+        List<String> samples = new ArrayList<>(sampleSet);
         String[] words = new String[100];
         for (int i = 0; i < words.length; i++) {
             words[i] = samples.get(random.nextInt(samples.size()));

--- a/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/authorization/HasPermissionHasItemGetItemTest.java
+++ b/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/authorization/HasPermissionHasItemGetItemTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.benchmark.authorization;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.spi.security.authorization.permission.Permissions;
 import org.apache.jackrabbit.util.Text;
 import org.jetbrains.annotations.NotNull;
@@ -24,11 +23,13 @@ import org.jetbrains.annotations.NotNull;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlManager;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public class HasPermissionHasItemGetItemTest extends AbstractHasItemGetItemTest {
 
-    private static final List<String> PERMISSIONS = Lists.newArrayList(Permissions.PERMISSION_NAMES.values());
+    private static final List<String> PERMISSIONS = new ArrayList<>(Permissions.PERMISSION_NAMES.values());
 
     public HasPermissionHasItemGetItemTest(int itemsToRead, int numberOfACEs, int numberOfGroups, boolean doReport) {
         super(itemsToRead, numberOfACEs, numberOfGroups, doReport);

--- a/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
+++ b/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
@@ -48,6 +48,7 @@ import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStoreException;
 import org.apache.jackrabbit.core.data.util.NamedThreadFactory;
 import org.apache.jackrabbit.oak.commons.PropertiesUtil;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordDownloadOptions;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordUpload;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordUploadException;
@@ -95,7 +96,6 @@ import org.apache.jackrabbit.guava.common.base.Strings;
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
@@ -1099,7 +1099,7 @@ public class S3Backend extends AbstractSharedBackend {
                     return false;
                 }
 
-                List<S3ObjectSummary> listing = Lists.newArrayList(
+                List<S3ObjectSummary> listing = CollectionUtils.toList(
                     filter(prevObjectListing.getObjectSummaries(),
                             input -> !input.getKey().startsWith(META_KEY_PREFIX)));
 

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/BlobIdTracker.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/BlobIdTracker.java
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.core.data.DataRecord;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
 import org.apache.jackrabbit.oak.commons.io.BurnOnCloseFileIterator;
 import org.apache.jackrabbit.oak.commons.io.FileLineDifferenceIterator;
@@ -46,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.jackrabbit.guava.common.collect.Iterables.transform;
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.io.Files.move;
 import static org.apache.jackrabbit.guava.common.io.Files.newWriter;
 import static java.io.File.createTempFile;
@@ -267,7 +267,7 @@ public class BlobIdTracker implements Closeable, BlobTracker {
             Iterable<DataRecord> refRecords = datastore.getAllMetadataRecords(fileNamePrefix);
 
             // Download all the corresponding files for the records
-            List<File> refFiles = newArrayList(transform(refRecords, input -> {
+            List<File> refFiles = CollectionUtils.toList(transform(refRecords, input -> {
                     InputStream inputStream = null;
                     try {
                         inputStream = input.getStream();

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/ActiveDeletionTrackerStoreTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/ActiveDeletionTrackerStoreTest.java
@@ -118,7 +118,7 @@ public class ActiveDeletionTrackerStoreTest {
         File toFilter = create(range(7, 10), folder);
         Iterator<String> filtered = tracker.filter(toFilter);
 
-        assertTrue("More elements after filtering", Lists.newArrayList(filtered).isEmpty());
+        assertTrue("More elements after filtering", CollectionUtils.toList(filtered).isEmpty());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class ActiveDeletionTrackerStoreTest {
         File toFilterFile = create(toFilter, folder);
         Iterator<String> filtered = tracker.filter(toFilterFile);
 
-        assertEquals("Incorrect elements after filtering", range(0, 4), Lists.newArrayList(filtered));
+        assertEquals("Incorrect elements after filtering", range(0, 4), CollectionUtils.toList(filtered));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class ActiveDeletionTrackerStoreTest {
         Iterator<String> filtered = tracker.filter(toFilterFile);
 
         assertEquals("Incorrect elements after filtering",
-            range(0, 4), Lists.newArrayList(filtered));
+            range(0, 4), CollectionUtils.toList(filtered));
     }
 
     @Test

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStoreTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStoreTest.java
@@ -171,7 +171,7 @@ public class DataStoreBlobStoreTest extends AbstractBlobStoreTest {
         DataIdentifier d20 = new DataIdentifier("d-20");
         DataIdentifier d30 = new DataIdentifier("d-30");
         List<DataIdentifier> dis = ImmutableList.of(d10, d20, d30);
-        List<DataRecord> recs = Lists.newArrayList(
+        List<DataRecord> recs = CollectionUtils.toList(
             Iterables.transform(dis, input -> new TimeDataRecord(input)));
         OakFileDataStore mockedDS = mock(OakFileDataStore.class);
         when(mockedDS.getAllRecords()).thenReturn(recs.iterator());

--- a/oak-blob/src/test/java/org/apache/jackrabbit/oak/spi/blob/AbstractBlobStoreTest.java
+++ b/oak-blob/src/test/java/org/apache/jackrabbit/oak/spi/blob/AbstractBlobStoreTest.java
@@ -418,7 +418,7 @@ public abstract class AbstractBlobStoreTest {
     public void delete() throws Exception {
         Set<String> ids = createArtifacts();
 
-        store.deleteChunks(Lists.newArrayList(ids), 0);
+        store.deleteChunks(new ArrayList<>(ids), 0);
 
         Iterator<String> iter = store.getAllChunkIds(0);
         Set<String> ret = new HashSet<>();
@@ -433,7 +433,7 @@ public abstract class AbstractBlobStoreTest {
     public void deleteCount() throws Exception {
         Set<String> ids = createArtifacts();
 
-        long count = store.countDeleteChunks(Lists.newArrayList(ids), 0);
+        long count = store.countDeleteChunks(new ArrayList<>(ids), 0);
 
         Iterator<String> iter = store.getAllChunkIds(0);
         Set<String> ret = new HashSet<>();
@@ -463,7 +463,7 @@ public abstract class AbstractBlobStoreTest {
         while (iter.hasNext()) {
             chunks.add(iter.next());
         }
-        long count = store.countDeleteChunks(Lists.newArrayList(chunks), beforeUpdateTime);
+        long count = store.countDeleteChunks(new ArrayList<>(chunks), beforeUpdateTime);
         assertEquals("Deleted updated blobs", 0, count);
     }
 

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/collections/CollectionUtils.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/collections/CollectionUtils.java
@@ -59,7 +59,7 @@ public class CollectionUtils {
      * @param <T> the type of the elements
      */
     @NotNull
-    public static <T> List<T> toList(@NotNull final Iterable<T> iterable) {
+    public static <T> List<T> toList(@NotNull final Iterable<? extends T> iterable) {
         Objects.requireNonNull(iterable);
         List<T> result = new ArrayList<>();
         iterable.forEach(result::add);
@@ -87,7 +87,7 @@ public class CollectionUtils {
      * @param <T> the type of the elements
      */
     @NotNull
-    public static <T> List<T> toList(final Iterator<T> iterator) {
+    public static <T> List<T> toList(final Iterator<? extends T> iterator) {
         Objects.requireNonNull(iterator);
         List<T> result = new ArrayList<>();
         iterator.forEachRemaining(result::add);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/AnnotatingConflictHandler.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/commit/AnnotatingConflictHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.commit;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
@@ -36,6 +35,7 @@ import java.util.List;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants;
 import org.apache.jackrabbit.oak.spi.commit.ThreeWayConflictHandler;
 import org.apache.jackrabbit.oak.spi.state.ConflictType;
@@ -136,7 +136,7 @@ public class AnnotatingConflictHandler implements ThreeWayConflictHandler {
     }
 
     private static NodeBuilder addConflictMarker(@NotNull NodeBuilder parent) {
-        List<String> mixins = newArrayList(parent.getNames(JCR_MIXINTYPES));
+        List<String> mixins = CollectionUtils.toList(parent.getNames(JCR_MIXINTYPES));
         if (mixins.add(MIX_REP_MERGE_CONFLICT)) {
             parent.setProperty(JCR_MIXINTYPES, mixins, NAMES);
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/cow/BranchNodeStore.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/cow/BranchNodeStore.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -124,7 +125,7 @@ public class BranchNodeStore implements NodeStore, Observable {
     @NotNull
     @Override
     public Iterable<String> checkpoints() {
-        List<String> result = newArrayList(inheritedCheckpoints);
+        List<String> result = new ArrayList<>(inheritedCheckpoints);
         result.retainAll(newArrayList(nodeStore.checkpoints()));
 
         checkpointMapping.entrySet().stream()

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/cow/BranchNodeStore.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/cow/BranchNodeStore.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.plugins.cow;
 
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.spi.commit.CommitHook;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
@@ -57,7 +58,7 @@ public class BranchNodeStore implements NodeStore, Observable {
 
     public BranchNodeStore(NodeStore nodeStore) throws CommitFailedException {
         this.nodeStore = nodeStore;
-        this.inheritedCheckpoints = newArrayList(nodeStore.checkpoints());
+        this.inheritedCheckpoints = CollectionUtils.toList(nodeStore.checkpoints());
         this.checkpointMapping = new ConcurrentHashMap<>();
 
         String cp = nodeStore.checkpoint(CHECKPOINT_LIFETIME, singletonMap("type", "copy-on-write"));

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/itemsave/ItemSaveValidator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/itemsave/ItemSaveValidator.java
@@ -18,13 +18,13 @@
  */
 package org.apache.jackrabbit.oak.plugins.itemsave;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.commons.PathUtils.elements;
 
 import java.util.List;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.commit.FailingValidator;
 import org.apache.jackrabbit.oak.spi.commit.SubtreeExcludingValidator;
 import org.apache.jackrabbit.oak.spi.commit.Validator;
@@ -50,7 +50,7 @@ class ItemSaveValidator extends SubtreeExcludingValidator {
         this(new FailingValidator(CommitFailedException.UNSUPPORTED, 0,
                 "Failed to save subtree at " + path + ". There are " +
                         "transient modifications outside that subtree."),
-                newArrayList(elements(path)));
+                CollectionUtils.toList(elements(path)));
     }
 
     private ItemSaveValidator(Validator validator, List<String> path) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
@@ -468,7 +468,7 @@ public class TypeEditor extends DefaultEditor {
             constraintViolation(21, "Mandatory property '" + properties.iterator().next() + "' not found in a new node");
         }
 
-        List<String> names = Lists.newArrayList(after.getChildNodeNames());
+        List<String> names = CollectionUtils.toList(after.getChildNodeNames());
         for (String child : effective.getMandatoryChildNodes()) {
             if (!names.remove(child)) {
                 constraintViolation(25, "Mandatory child node '" + child + "' not found in a new node");

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
@@ -46,7 +46,6 @@ import javax.jcr.PropertyType;
 import javax.jcr.Value;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -442,9 +441,9 @@ public class TypeEditor extends DefaultEditor {
     }
 
     private static boolean mixinsChanged(NodeState before, Iterable<String> after) {
-        List<String> pre = Lists.newArrayList(before.getNames(JCR_MIXINTYPES));
+        List<String> pre = CollectionUtils.toList(before.getNames(JCR_MIXINTYPES));
         Collections.sort(pre);
-        List<String> post = Lists.newArrayList(after);
+        List<String> post = CollectionUtils.toList(after);
         Collections.sort(post);
         if (pre.isEmpty() && post.isEmpty()) {
             return false;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeRegistration.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeRegistration.java
@@ -19,7 +19,6 @@ package org.apache.jackrabbit.oak.plugins.nodetype;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.addAll;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.contains;
 import static org.apache.jackrabbit.guava.common.collect.Iterables.isEmpty;
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Sets.union;
 import static java.util.Collections.emptyList;
 import static org.apache.jackrabbit.JcrConstants.JCR_CHILDNODEDEFINITION;
@@ -77,7 +76,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 
 /**
  * This class is used by the {@link TypeEditorProvider} to check for,
@@ -387,7 +385,7 @@ class TypeRegistration extends DefaultNodeStateDiff {
 
     private void addNameToList(NodeBuilder type, String name, String value) {
         List<String> values;
-        values = newArrayList(getNames(type, name));
+        values = CollectionUtils.toList(getNames(type, name));
         if (!values.contains(value)) {
             values.add(value);
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeRegistration.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeRegistration.java
@@ -77,6 +77,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
+import org.apache.jackrabbit.guava.common.collect.Lists;
 
 /**
  * This class is used by the {@link TypeEditorProvider} to check for,

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/observation/EventGenerator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/observation/EventGenerator.java
@@ -25,6 +25,7 @@ import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORD
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.MISSING_NODE;
 import static org.apache.jackrabbit.oak.spi.state.MoveDetector.SOURCE_PATH;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/observation/EventGenerator.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/observation/EventGenerator.java
@@ -18,14 +18,12 @@
  */
 package org.apache.jackrabbit.oak.plugins.observation;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.api.Type.NAMES;
 import static org.apache.jackrabbit.oak.api.Type.STRING;
 import static org.apache.jackrabbit.oak.plugins.tree.TreeConstants.OAK_CHILD_ORDER;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.MISSING_NODE;
 import static org.apache.jackrabbit.oak.spi.state.MoveDetector.SOURCE_PATH;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -35,6 +33,7 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStateDiff;
 import org.apache.jackrabbit.oak.commons.PerfLogger;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 
@@ -195,9 +194,9 @@ public class EventGenerator {
                 if (OAK_CHILD_ORDER.equals(before.getName())) {
                     // list the child node names before and after the change
                     List<String> beforeNames =
-                            newArrayList(before.getValue(NAMES));
+                            CollectionUtils.toList(before.getValue(NAMES));
                     List<String> afterNames =
-                            newArrayList(after.getValue(NAMES));
+                            CollectionUtils.toList(after.getValue(NAMES));
 
                     // check only those names that weren't added or removed
                     beforeNames.retainAll(new HashSet<>(afterNames));

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionableState.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/version/VersionableState.java
@@ -55,12 +55,12 @@ import javax.jcr.Value;
 import javax.jcr.nodetype.PropertyDefinition;
 import javax.jcr.version.OnParentVersionAction;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.UUIDUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeBuilder;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
@@ -187,7 +187,7 @@ class VersionableState {
         frozen.setProperty(JCR_PRIMARYTYPE, NT_FROZENNODE, Type.NAME);
         List<String> mixinTypes;
         if (node.hasProperty(JCR_MIXINTYPES)) {
-            mixinTypes = Lists.newArrayList(node.getNames(JCR_MIXINTYPES));
+            mixinTypes = CollectionUtils.toList(node.getNames(JCR_MIXINTYPES));
         } else {
             mixinTypes = Collections.emptyList();
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/InImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/InImpl.java
@@ -66,7 +66,7 @@ public class InImpl extends ConstraintImpl {
             return new ComparisonImpl(
                     operand1, Operator.EQUAL, set.iterator().next());
         } else if (set.size() != operand2.size()) {
-            return new InImpl(operand1, newArrayList(set));
+            return new InImpl(operand1, new ArrayList<>(set));
         } else {
             return this;
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/OrImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/OrImpl.java
@@ -114,7 +114,7 @@ public class OrImpl extends ConstraintImpl {
                         entry.getKey(), EQUAL, values.iterator().next()));
             } else {
                 simplified.add(new InImpl(
-                        entry.getKey(), newArrayList(values)));
+                        entry.getKey(), new ArrayList<>(values)));
             }
         }
 
@@ -309,7 +309,7 @@ public class OrImpl extends ConstraintImpl {
             }
         }
 
-        InImpl in = new InImpl(operand, newArrayList(values));
+        InImpl in = new InImpl(operand, new ArrayList<>(values));
         in.setQuery(query);
         in.restrictPushDown(s);
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/ACL.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/ACL.java
@@ -30,8 +30,8 @@ import javax.jcr.security.AccessControlException;
 import javax.jcr.security.Privilege;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.ACE;
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AbstractAccessControlList;
@@ -164,7 +164,7 @@ abstract class ACL extends AbstractAccessControlList {
     private boolean internalAddEntry(@NotNull ACE entry) throws RepositoryException {
         final String principalName = entry.getPrincipal().getName();
         final Set<Restriction> restrictions = entry.getRestrictions();
-        List<ACE> subList = Lists.newArrayList(Iterables.filter(entries, ace ->
+        List<ACE> subList = CollectionUtils.toList(Iterables.filter(entries, ace ->
                 principalName.equals(requireNonNull(ace).getPrincipal().getName()) && restrictions.equals(ace.getRestrictions())));
 
         boolean addEntry = true;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlManagerImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/AccessControlManagerImpl.java
@@ -219,7 +219,7 @@ public class AccessControlManagerImpl extends AbstractAccessControlManager imple
         AccessControlPolicy[] plcs = getPolicies(principalAcl.principal);
         PrincipalACL existing = (plcs.length == 0) ? null : (PrincipalACL) plcs[0];
 
-        List<ACE> toAdd = Lists.newArrayList(principalAcl.getEntries());
+        List<ACE> toAdd = new ArrayList<>(principalAcl.getEntries());
         List<ACE> toRemove = Collections.emptyList();
         if (existing != null) {
             toAdd.removeAll(existing.getEntries());

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/internal/SecurityProviderRegistration.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/internal/SecurityProviderRegistration.java
@@ -76,6 +76,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.security.AccessControlManager;
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
@@ -599,7 +600,7 @@ public class SecurityProviderRegistration {
             protected List<RestrictionProvider> getServices() {
                 Collection<RestrictionProvider> values = restrictionProviders.values();
                 synchronized (restrictionProviders) {
-                    return newArrayList(values);
+                    return new ArrayList<>(values);
                 }
             }
 
@@ -613,7 +614,7 @@ public class SecurityProviderRegistration {
             protected List<AuthorizableActionProvider> getServices() {
                 Collection<AuthorizableActionProvider> values = authorizableActionProviders.values();
                 synchronized (authorizableActionProviders) {
-                    return newArrayList(values);
+                    return new ArrayList<>(values);
                 }
             }
 
@@ -627,7 +628,7 @@ public class SecurityProviderRegistration {
             protected List<AuthorizableNodeName> getServices() {
                 Collection<AuthorizableNodeName> values = authorizableNodeNames.values();
                 synchronized (authorizableNodeNames) {
-                    return newArrayList(values);
+                    return new ArrayList<>(values);
                 }
             }
 
@@ -641,7 +642,7 @@ public class SecurityProviderRegistration {
             protected List<UserAuthenticationFactory> getServices() {
                 Collection<UserAuthenticationFactory> values = userAuthenticationFactories.values();
                 synchronized (userAuthenticationFactories) {
-                    return newArrayList(values);
+                    return new ArrayList<>(values);
                 }
             }
 
@@ -651,7 +652,7 @@ public class SecurityProviderRegistration {
     private AggregationFilter createAggregationFilter() {
         List<AggregationFilter> filters;
         synchronized (aggregationFilters) {
-            filters = newArrayList(aggregationFilters.values());
+            filters = new ArrayList<>(aggregationFilters.values());
         }
         switch (filters.size()) {
             case 0: return AggregationFilter.DEFAULT;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/PasswordHistory.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/PasswordHistory.java
@@ -22,10 +22,10 @@ import javax.jcr.AccessDeniedException;
 import javax.jcr.nodetype.ConstraintViolationException;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.apache.jackrabbit.oak.spi.security.user.util.PasswordUtil;
@@ -86,7 +86,7 @@ final class PasswordHistory implements UserConstants {
             PropertyState historyProp = passwordTree.getProperty(UserConstants.REP_PWD_HISTORY);
 
             // insert the current (old) password at the beginning of the password history
-            List<String> historyEntries = (historyProp == null) ? new ArrayList<>() : Lists.newArrayList(historyProp.getValue(Type.STRINGS));
+            List<String> historyEntries = (historyProp == null) ? new ArrayList<>() : CollectionUtils.toList(historyProp.getValue(Type.STRINGS));
             historyEntries.add(0, currentPasswordHash);
 
             /* remove oldest history entries exceeding configured history max size (e.g. after

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexInfoServiceImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexInfoServiceImplTest.java
@@ -16,13 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index;
 
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.jackrabbit.guava.common.collect.Lists;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
@@ -113,7 +113,7 @@ public class IndexInfoServiceImplTest {
         service.bindInfoProviders(type_c);
         service.bindInfoProviders(type_d);
 
-        List<IndexInfo> infos = Lists.newArrayList(service.getAllIndexInfo());
+        List<IndexInfo> infos = CollectionUtils.toList(service.getAllIndexInfo());
 
         //Result would only have 2 entries. One throwing exception would be ignored
         assertEquals(2, infos.size());

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexPathServiceImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexPathServiceImplTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;
@@ -101,7 +100,7 @@ public class IndexPathServiceImplTest extends AbstractQueryTest {
 
         List<String> nodetypes = new ArrayList<>();
         if (nodetype.hasProperty(DECLARING_NODE_TYPES)){
-            nodetypes = Lists.newArrayList(nodetype.getProperty(DECLARING_NODE_TYPES).getValue(Type.STRINGS));
+            nodetypes = CollectionUtils.toList(nodetype.getProperty(DECLARING_NODE_TYPES).getValue(Type.STRINGS));
         }
 
         nodetypes.add(INDEX_DEFINITIONS_NODE_TYPE);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/aggregate/SimpleNodeAggregatorTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/aggregate/SimpleNodeAggregatorTest.java
@@ -29,6 +29,7 @@ import static org.apache.jackrabbit.oak.plugins.index.aggregate.SimpleNodeAggreg
 
 import java.util.List;
 
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -50,7 +51,7 @@ public class SimpleNodeAggregatorTest {
                 NT_FILE, newArrayList(JCR_CONTENT));
 
         String path = "/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertEquals(newArrayList("/file"), actual);
@@ -71,7 +72,7 @@ public class SimpleNodeAggregatorTest {
                 NT_FILE, newArrayList(JCR_CONTENT));
 
         String path = "/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertTrue(actual.isEmpty());
@@ -92,7 +93,7 @@ public class SimpleNodeAggregatorTest {
                 NT_FILE, newArrayList(INCLUDE_ALL));
 
         String path = "/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertEquals(newArrayList("/file"), actual);
@@ -113,7 +114,7 @@ public class SimpleNodeAggregatorTest {
                 NT_FILE, newArrayList("*", "*/*", "*/*/*", "*/*/*/*"));
 
         String path = "/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertEquals(newArrayList("/file"), actual);
@@ -134,7 +135,7 @@ public class SimpleNodeAggregatorTest {
                 NT_FILE, newArrayList(INCLUDE_ALL));
 
         String path = "/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertTrue(actual.isEmpty());
@@ -159,7 +160,7 @@ public class SimpleNodeAggregatorTest {
                 newArrayList(INCLUDE_ALL));
 
         String path = "/folder/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertEquals(newArrayList("/folder/file", "/folder"), actual);
@@ -184,7 +185,7 @@ public class SimpleNodeAggregatorTest {
                 newArrayList(JCR_CONTENT));
 
         String path = "/folder/file/jcr:content";
-        List<String> actual = newArrayList(agg.getParents(
+        List<String> actual = CollectionUtils.toList(agg.getParents(
                 builder.getNodeState(), path));
 
         assertEquals(newArrayList("/folder/file", "/folder"), actual);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/MultiPropertyOrTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/MultiPropertyOrTest.java
@@ -31,13 +31,13 @@ import java.util.Random;
 import javax.jcr.query.Query;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.api.PropertyValue;
 import org.apache.jackrabbit.oak.api.ResultRow;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexUtils;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.query.AbstractQueryTest;
@@ -186,7 +186,7 @@ public class MultiPropertyOrTest extends AbstractQueryTest {
     }
 
     private String measureWithLimit(String query, String lang, int limit) throws ParseException {
-        List<? extends ResultRow> result = Lists.newArrayList(
+        List<? extends ResultRow> result = CollectionUtils.toList(
             qe.executeQuery(query, lang, limit, 0, Maps.<String, PropertyValue>newHashMap(),
                 NO_MAPPINGS).getRows());
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/FilteringNodeStateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/migration/FilteringNodeStateTest.java
@@ -22,6 +22,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
@@ -146,7 +147,7 @@ public class FilteringNodeStateTest {
         { // access via getProperty()
             final PropertyState childOrder = decorated.getProperty(OAK_CHILD_ORDER);
             final Iterable<String> values = childOrder.getValue(Type.STRINGS);
-            assertEquals(newArrayList("football"), newArrayList(values));
+            assertEquals(newArrayList("football"), CollectionUtils.toList(values));
         }
 
         { // access via getProperties()
@@ -158,7 +159,7 @@ public class FilteringNodeStateTest {
             };
             final PropertyState childOrder = Iterables.find(decorated.getProperties(), isChildOrderProperty::test);
             final Iterable<String> values = childOrder.getValue(Type.STRINGS);
-            assertEquals(newArrayList("football"), newArrayList(values));
+            assertEquals(newArrayList("football"), CollectionUtils.toList(values));
         }
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/impl/ImmutableTreeTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/impl/ImmutableTreeTest.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.AbstractSecurityTest;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.apache.jackrabbit.oak.plugins.tree.TreeType;
 import org.apache.jackrabbit.oak.plugins.tree.TreeTypeProvider;
@@ -263,7 +264,7 @@ public class ImmutableTreeTest extends AbstractSecurityTest {
     }
 
     private static void assertSequence(Iterable<Tree> trees, String... names) {
-        List<String> actual = Lists.newArrayList(Iterables.transform(trees, input -> input.getName()));
+        List<String> actual = CollectionUtils.toList(Iterables.transform(trees, input -> input.getName()));
         assertEquals(Lists.newArrayList(names), actual);
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/OrQueryOrderLimitWithoutIndexTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/OrQueryOrderLimitWithoutIndexTest.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.api.QueryEngine;
 import org.apache.jackrabbit.oak.api.Result;
 import org.apache.jackrabbit.oak.api.ResultRow;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.security.OpenSecurityProvider;
 import org.junit.After;
 import org.junit.Assert;
@@ -84,7 +85,7 @@ public class OrQueryOrderLimitWithoutIndexTest extends AbstractQueryTest {
         Result result = qe.executeQuery(query, QueryEngineImpl.SQL2, limit, offset,
                 QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
 
-        List<ResultRow> rows = Lists.newArrayList(result.getRows());
+        List<ResultRow> rows = CollectionUtils.toList(result.getRows());
         Assert.assertEquals(expected.length, rows.size());
 
         int i = 0;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.ContentRepository;
@@ -34,6 +33,7 @@ import org.apache.jackrabbit.oak.api.Result;
 import org.apache.jackrabbit.oak.api.ResultRow;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.namepath.impl.GlobalNameMapper;
 import org.apache.jackrabbit.oak.namepath.impl.NamePathMapperImpl;
@@ -222,7 +222,7 @@ public class UnionQueryTest extends AbstractQueryTest {
         Result result = qe.executeQuery(union, QueryEngineImpl.SQL2, limit, offset,
                 QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
 
-        List<ResultRow> rows = Lists.newArrayList(result.getRows());
+        List<ResultRow> rows = CollectionUtils.toList(result.getRows());
         assertEquals(expected.length, rows.size());
 
         int i = 0;
@@ -247,7 +247,7 @@ public class UnionQueryTest extends AbstractQueryTest {
         Result result = qe.executeQuery(union, QueryEngineImpl.SQL2, Optional.empty(), Optional.empty(),
                 QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
 
-        List<ResultRow> rows = Lists.newArrayList(result.getRows());
+        List<ResultRow> rows = CollectionUtils.toList(result.getRows());
         assertEquals(expected.length, rows.size());
 
         int i = 0;
@@ -302,7 +302,7 @@ public class UnionQueryTest extends AbstractQueryTest {
         Result result = qe.executeQuery(explainedStatement, QueryEngineImpl.SQL2, limit, offset,
                 QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
 
-        List<ResultRow> rows = Lists.newArrayList(result.getRows());
+        List<ResultRow> rows = CollectionUtils.toList(result.getRows());
         assertEquals(expected.length, rows.size());
 
         int i = 0;
@@ -353,7 +353,7 @@ public class UnionQueryTest extends AbstractQueryTest {
         Result result = qe.executeQuery(explainedStatement, QueryEngineImpl.SQL2, limit, offset,
                 QueryEngine.NO_BINDINGS, QueryEngine.NO_MAPPINGS);
 
-        List<ResultRow> rows = Lists.newArrayList(result.getRows());
+        List<ResultRow> rows = CollectionUtils.toList(result.getRows());
         assertEquals(expected.length, rows.size());
 
         int i = 0;

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/composite/CompositeNodeStoreTest.java
@@ -19,7 +19,6 @@
 package org.apache.jackrabbit.oak.composite;
 
 import static org.apache.jackrabbit.guava.common.collect.Iterables.filter;
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexUtils.createIndexDefinition;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -52,6 +51,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreBuilder;
 import org.apache.jackrabbit.oak.plugins.document.rdb.RDBDataSourceFactory;
@@ -650,13 +650,13 @@ public class CompositeNodeStoreTest {
         deepMountBuilder.child("new").setProperty("store", "deepMounted", Type.STRING);
         deepMountedStore.merge(deepMountBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
 
-        List<ChildNodeEntry> children = newArrayList(filter(store.getRoot().getChildNodeEntries(),
+        List<ChildNodeEntry> children = CollectionUtils.toList(filter(store.getRoot().getChildNodeEntries(),
                 x -> Objects.equals(x == null ? null : x.getName(), "new")));
         assertEquals(1, children.size());
         assertEquals("global", children.get(0).getNodeState().getString("store"));
 
         NodeBuilder rootBuilder = store.getRoot().builder();
-        List<String> childNames = newArrayList(filter(rootBuilder.getChildNodeNames(),
+        List<String> childNames = CollectionUtils.toList(filter(rootBuilder.getChildNodeNames(),
                 x -> Objects.equals(x, "new")));
         assertEquals(1, childNames.size());
         assertEquals("global", rootBuilder.getChildNode("new").getString("store"));

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreTrackerGCTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreTrackerGCTest.java
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.api.Blob;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.blob.BlobTrackingStore;
 import org.apache.jackrabbit.oak.plugins.blob.MarkSweepGarbageCollector;
@@ -60,8 +61,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 
 import static org.apache.jackrabbit.guava.common.collect.Sets.union;
 import static java.lang.String.valueOf;
@@ -350,7 +349,7 @@ public class DataStoreTrackerGCTest {
             Iterator<String> idIter =
                 ((GarbageCollectableBlobStore) ds.getBlobStore())
                     .resolveChunks(b.toString());
-            List<String> ids = Lists.newArrayList(idIter);
+            List<String> ids = CollectionUtils.toList(idIter);
             if (toBeDeleted != i) {
                 set.addAll(ids);
             }

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreTrackerGCTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreTrackerGCTest.java
@@ -250,7 +250,7 @@ public class DataStoreTrackerGCTest {
         DataStoreState state = init(cluster.nodeStore, 0);
 
         // Directly delete from blobstore
-        ArrayList<String> blobs = Lists.newArrayList(state.blobsPresent);
+        ArrayList<String> blobs = new ArrayList<>(state.blobsPresent);
         String removedId = blobs.remove(0);
         ((DataStoreBlobStore) s).deleteChunks(Lists.newArrayList(removedId), 0);
         state.blobsPresent = new HashSet<>(blobs);

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/ObservationManagerImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/ObservationManagerImpl.java
@@ -139,7 +139,7 @@ public class ObservationManagerImpl implements JackrabbitObservationManager {
         List<ChangeProcessor> toBeStopped;
 
         synchronized (this) {
-            toBeStopped = newArrayList(processors.values());
+            toBeStopped = new ArrayList<>(processors.values());
             processors.clear();
         }
 

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ObservationTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ObservationTest.java
@@ -1371,7 +1371,7 @@ public class ObservationTest extends AbstractRepositoryTest {
         }
 
         public List<Event> getUnexpected() {
-            return Lists.newArrayList(unexpected);
+            return new ArrayList<>(unexpected);
         }
 
         @Override

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobCollectorFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobCollectorFactory.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.jackrabbit.guava.common.base.Joiner;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.io.Closeables;
 import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.commons.io.FileUtils;
@@ -48,6 +47,7 @@ import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.jackrabbit.core.data.DataStoreException;
 import org.apache.jackrabbit.oak.commons.FileIOUtils;
 import org.apache.jackrabbit.oak.commons.PerfLogger;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.blob.BlobTrackingStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.BlobTracker;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.BlobTracker.Options;
@@ -273,7 +273,7 @@ public class ActiveDeletedBlobCollectorFactory {
 
                                     lastDeletedBlobTimestamp = Math.max(lastDeletedBlobTimestamp, blobDeletionTimestamp);
 
-                                    List<String> chunkIds = Lists.newArrayList(blobStore.resolveChunks(deletedBlobId));
+                                    List<String> chunkIds = CollectionUtils.toList(blobStore.resolveChunks(deletedBlobId));
                                     if (chunkIds.size() > 0) {
                                         long deleted = blobStore.countDeleteChunks(chunkIds, 0);
                                         if (deleted < 1) {

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexRootDirectory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexRootDirectory.java
@@ -35,11 +35,11 @@ import org.apache.jackrabbit.guava.common.base.Joiner;
 import org.apache.jackrabbit.guava.common.collect.ArrayListMultimap;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.ListMultimap;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.hash.Hashing;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.plugins.index.lucene.hybrid.NRTIndex;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
@@ -191,7 +191,7 @@ public class IndexRootDirectory {
      * The resulting file name would be truncated to MAX_NAME_LENGTH
      */
     static String getIndexFolderBaseName(String indexPath) {
-        List<String> elements = Lists.newArrayList(PathUtils.elements(indexPath));
+        List<String> elements = CollectionUtils.toList(PathUtils.elements(indexPath));
         Collections.reverse(elements);
         List<String> result = new ArrayList<>(2);
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakBufferedIndexFile.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakBufferedIndexFile.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.StringUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.lucene.store.DataInput;
@@ -37,7 +38,6 @@ import org.jetbrains.annotations.NotNull;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkElementIndex;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.guava.common.base.Preconditions.checkPositionIndexes;
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.JcrConstants.JCR_DATA;
 import static org.apache.jackrabbit.JcrConstants.JCR_LASTMODIFIED;
 import static org.apache.jackrabbit.oak.api.Type.BINARIES;
@@ -128,7 +128,7 @@ class OakBufferedIndexFile implements OakIndexFile {
 
         PropertyState property = file.getProperty(JCR_DATA);
         if (property != null && property.getType() == BINARIES) {
-            this.data = newArrayList(property.getValue(BINARIES));
+            this.data = CollectionUtils.toList(property.getValue(BINARIES));
         } else {
             this.data = new ArrayList<>();
         }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakBufferedIndexFile.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakBufferedIndexFile.java
@@ -153,7 +153,7 @@ class OakBufferedIndexFile implements OakIndexFile {
 
         this.position = that.position;
         this.length = that.length;
-        this.data = newArrayList(that.data);
+        this.data = new ArrayList<>(that.data);
         this.dataModified = that.dataModified;
         this.blobFactory = that.blobFactory;
     }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexStatisticsTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexStatisticsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -157,7 +157,7 @@ public class IndexStatisticsTest {
     }
 
     private static Directory createSampleDirectory(long numOfDocs, Iterable<Document> moreDocs) throws IOException {
-        List<Document> docs = Lists.newArrayList(moreDocs);
+        List<Document> docs = CollectionUtils.toList(moreDocs);
         for (int i = 0; i < numOfDocs; i++) {
             Document doc = new Document();
             doc.add(new StringField("foo", "bar" + i, Field.Store.NO));

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LucenePropertyIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LucenePropertyIndexTest.java
@@ -60,6 +60,7 @@ import org.apache.jackrabbit.oak.api.Result;
 import org.apache.jackrabbit.oak.api.ResultRow;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexInfoService;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexInfoServiceImpl;
@@ -1274,7 +1275,7 @@ public class LucenePropertyIndexTest extends AbstractQueryTest {
 
         // Add the path of property added as timestamp string in the sorted list
         assertOrderedQuery("select [jcr:path] from [nt:base] where [bar] = 'baz' order by [foo]",
-                Lists.newArrayList(Iterables.concat(Lists.newArrayList("/test/n0"),
+                CollectionUtils.toList(Iterables.concat(Lists.newArrayList("/test/n0"),
                         getSortedPaths(tuples, OrderDirection.ASC))));
         // Append the path of property added as timestamp string to the sorted list
         assertOrderedQuery(
@@ -1508,7 +1509,7 @@ public class LucenePropertyIndexTest extends AbstractQueryTest {
     }
 
     private String measureWithLimit(String query, String lang, int limit) throws ParseException {
-        List<? extends ResultRow> result = Lists.newArrayList(
+        List<? extends ResultRow> result = CollectionUtils.toList(
             qe.executeQuery(query, lang, limit, 0, Maps.<String, PropertyValue>newHashMap(),
                 NO_MAPPINGS).getRows());
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobCollectorTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobCollectorTest.java
@@ -52,6 +52,7 @@ import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.core.data.DataStoreException;
 import org.apache.jackrabbit.oak.commons.CIHelper;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.ActiveDeletedBlobCollectorFactory.ActiveDeletedBlobCollector;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.ActiveDeletedBlobCollectorFactory.ActiveDeletedBlobCollectorImpl;
@@ -377,7 +378,7 @@ public class ActiveDeletedBlobCollectorTest {
         bdc.deleted("blobId3", Collections.singleton("/c"));
         bdc.commitProgress(COMMIT_SUCCEDED);
 
-        List<String> externallyDeletedChunks = Lists.newArrayList(blobStore.resolveChunks("blobId2"));
+        List<String> externallyDeletedChunks = CollectionUtils.toList(blobStore.resolveChunks("blobId2"));
         blobStore.countDeleteChunks(externallyDeletedChunks, 0);
 
         warnLogCustomizer.starting();
@@ -395,7 +396,7 @@ public class ActiveDeletedBlobCollectorTest {
         bdc.commitProgress(COMMIT_SUCCEDED);
 
         blobStore.resetLists();
-        blobStore.failWithDSEForChunkIds.addAll(Lists.newArrayList(blobStore.resolveChunks("blobId4")));
+        blobStore.failWithDSEForChunkIds.addAll(CollectionUtils.toList(blobStore.resolveChunks("blobId4")));
 
         warnLogCustomizer.starting();
         adbc.purgeBlobsDeleted(clock.getTimeIncreasing(), blobStore);
@@ -411,7 +412,7 @@ public class ActiveDeletedBlobCollectorTest {
         bdc.commitProgress(COMMIT_SUCCEDED);
 
         blobStore.resetLists();
-        blobStore.failWithExceptionForChunkIds.addAll(Lists.newArrayList(blobStore.resolveChunks("blobId6")));
+        blobStore.failWithExceptionForChunkIds.addAll(CollectionUtils.toList(blobStore.resolveChunks("blobId6")));
 
         warnLogCustomizer.starting();
         adbc.purgeBlobsDeleted(clock.getTimeIncreasing(), blobStore);
@@ -435,7 +436,7 @@ public class ActiveDeletedBlobCollectorTest {
         bdc.deleted("blobId3", Collections.singleton("/c"));
         bdc.commitProgress(COMMIT_SUCCEDED);
 
-        List<String> externallyDeletedChunks = Lists.newArrayList(blobStore.resolveChunks("blobId2"));
+        List<String> externallyDeletedChunks = CollectionUtils.toList(blobStore.resolveChunks("blobId2"));
         blobStore.countDeleteChunks(externallyDeletedChunks, 0);
 
         warnLogCustomizer.starting();
@@ -453,7 +454,7 @@ public class ActiveDeletedBlobCollectorTest {
         bdc.commitProgress(COMMIT_SUCCEDED);
 
         blobStore.resetLists();
-        blobStore.failWithDSEForChunkIds.addAll(Lists.newArrayList(blobStore.resolveChunks("blobId4")));
+        blobStore.failWithDSEForChunkIds.addAll(CollectionUtils.toList(blobStore.resolveChunks("blobId4")));
 
         warnLogCustomizer.starting();
         adbc.purgeBlobsDeleted(clock.getTimeIncreasing(), blobStore);
@@ -498,7 +499,7 @@ public class ActiveDeletedBlobCollectorTest {
     private void verifyBlobsDeleted(String ... blobIds) throws IOException {
         List<String> chunkIds = new ArrayList<>();
         for (String blobId : blobIds) {
-            chunkIds.addAll(Lists.newArrayList(blobStore.resolveChunks(blobId)));
+            chunkIds.addAll(CollectionUtils.toList(blobStore.resolveChunks(blobId)));
         }
 
         assertThat(blobStore.deletedChunkIds, containsInAnyOrder(chunkIds.toArray()));

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobSyncTrackerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ActiveDeletedBlobSyncTrackerTest.java
@@ -18,7 +18,6 @@ package org.apache.jackrabbit.oak.plugins.index.lucene.directory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -28,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.blob.BlobTrackingStore;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.BlobIdTracker;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreBlobStore;
@@ -51,7 +51,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.spi.cluster.ClusterRepositoryInfo.getOrCreateId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -142,9 +141,9 @@ public class ActiveDeletedBlobSyncTrackerTest extends AbstractActiveDeletedBlobT
     private static void assertTrackedDeleted(Iterator<String> afterDeletions,
         GarbageCollectableBlobStore blobStore) throws IOException {
 
-        List<String> afterDeletionIds = newArrayList(afterDeletions);
+        List<String> afterDeletionIds = CollectionUtils.toList(afterDeletions);
         // get the currently tracked ones
-        ArrayList<String> trackedIds = newArrayList(((BlobTrackingStore) blobStore).getTracker().get());
+        List<String> trackedIds = CollectionUtils.toList(((BlobTrackingStore) blobStore).getTracker().get());
         assertEquals("Tracked ids length different from current blob list",
             trackedIds.size(), afterDeletionIds.size());
         assertTrue("Tracked ids different from current blob list",

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ChunkedOakDirectoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ChunkedOakDirectoryTest.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.lucene.directory;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStore;
@@ -42,7 +42,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.api.Type.BINARIES;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.directory.OakDirectory.UNIQUE_KEY_SIZE;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -94,7 +93,7 @@ public class ChunkedOakDirectoryTest extends OakDirectoryTestBase {
 
     @Override
     void assertBlobSizeInWrite(PropertyState jcrData, int blobSize, int fileSize) {
-        List<Blob> blobs = newArrayList(jcrData.getValue(BINARIES));
+        List<Blob> blobs = CollectionUtils.toList(jcrData.getValue(BINARIES));
         assertEquals(blobSize + UNIQUE_KEY_SIZE, blobs.get(0).length());
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexConsistencyCheckerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexConsistencyCheckerTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.lucene.directory;
 
 import java.io.ByteArrayOutputStream;
@@ -30,6 +29,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.oak.InitialContentHelper;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.lucene.OakAnalyzer;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.IndexConsistencyChecker.Level;
@@ -172,7 +172,7 @@ public class IndexConsistencyCheckerTest {
         NodeBuilder builder = rootState.builder();
 
         NodeBuilder file = idx.getChildNode(":data").getChildNode("_0.cfe");
-        List<Blob> blobs = Lists.newArrayList(file.getProperty("jcr:data").getValue(Type.BINARIES));
+        List<Blob> blobs = CollectionUtils.toList(file.getProperty("jcr:data").getValue(Type.BINARIES));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         IOUtils.copy(blobs.get(0).getNewStream(), baos);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/util/TapeSamplingTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/util/TapeSamplingTest.java
@@ -20,13 +20,13 @@ package org.apache.jackrabbit.oak.plugins.index.lucene.util;
 
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -46,7 +46,7 @@ public class TapeSamplingTest {
         List<Integer> input = range(start, end);
         TapeSampling<Integer> res = new TapeSampling<>(r, input.iterator(), input.size(), k);
 
-        List<Integer> samples = newArrayList(res.getSamples());
+        List<Integer> samples = CollectionUtils.toList(res.getSamples());
         List<Integer> expected = range(end - k + 1, end);
 
         assertEquals(expected, samples);
@@ -67,7 +67,7 @@ public class TapeSamplingTest {
         List<Integer> input = range(start, end);
         TapeSampling<Integer> res = new TapeSampling<>(r, input.iterator(), input.size(), k);
 
-        List<Integer> samples = newArrayList(res.getSamples());
+        List<Integer> samples = CollectionUtils.toList(res.getSamples());
         List<Integer> expected = range(start, start + k - 1);
 
         assertEquals(expected, samples);
@@ -83,7 +83,7 @@ public class TapeSamplingTest {
         List<Integer> input = range(start, end);
         TapeSampling<Integer> res = new TapeSampling<>(r, input.iterator(), input.size(), k);
 
-        List<Integer> samples = newArrayList(res.getSamples());
+        List<Integer> samples = CollectionUtils.toList(res.getSamples());
         List<Integer> expected = input;
 
         assertEquals(expected, samples);
@@ -136,6 +136,6 @@ public class TapeSamplingTest {
             }
         };
 
-        return newArrayList(iter);
+        return CollectionUtils.toList(iter);
     }
 }

--- a/oak-pojosr/src/main/java/org/apache/jackrabbit/oak/run/osgi/OakOSGiRepositoryFactory.java
+++ b/oak-pojosr/src/main/java/org/apache/jackrabbit/oak/run/osgi/OakOSGiRepositoryFactory.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.run.osgi;
 
 import static java.util.Objects.requireNonNull;
@@ -25,6 +24,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -45,7 +45,6 @@ import javax.management.AttributeList;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.util.concurrent.SettableFuture;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.felix.connect.launch.BundleDescriptor;
@@ -347,8 +346,7 @@ public class OakOSGiRepositoryFactory implements RepositoryFactory {
             if (bundleFilter == null){
                 bundleFilter = REPOSITORY_BUNDLE_FILTER_DEFAULT;
             }
-            List<BundleDescriptor> descriptors = new ClasspathScanner().scanForBundles(bundleFilter);
-            descriptors = Lists.newArrayList(descriptors);
+            List<BundleDescriptor> descriptors = new ArrayList<>(new ClasspathScanner().scanForBundles(bundleFilter));
             if (PropertiesUtil.toBoolean(config.get(REPOSITORY_ENV_SPRING_BOOT), false)){
                 descriptors = SpringBootSupport.processDescriptors(descriptors);
             }

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/query/facet/FacetResult.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/query/facet/FacetResult.java
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.query.facet;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.oak.commons.json.JsopBuilder;
 import org.apache.jackrabbit.oak.commons.json.JsopReader;
@@ -41,6 +39,8 @@ import java.util.Set;
 
 import static java.util.Collections.reverseOrder;
 import static java.util.Comparator.comparingInt;
+
+import java.util.ArrayList;
 
 /**
  * A facet result is a wrapper for {@link javax.jcr.query.QueryResult} capable of returning information about facets
@@ -135,7 +135,7 @@ public class FacetResult {
                 label = null;
             }
         }
-        facets = Lists.newArrayList(facetsMap.values());
+        facets = new ArrayList<>(facetsMap.values());
         Collections.sort(facets, reverseOrder(comparingInt(Facet::getCount)));
         perDimFacets.put(dimension, facets);
     }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/OakHelpFormatter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/OakHelpFormatter.java
@@ -28,9 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.guava.common.primitives.Ints;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
+
 import joptsimple.BuiltinHelpFormatter;
 import joptsimple.HelpFormatter;
 import joptsimple.OptionDescriptor;
@@ -47,7 +48,7 @@ public class OakHelpFormatter implements HelpFormatter {
 
     public OakHelpFormatter(Iterable<OptionsBean> optionBeans, @Nullable String commandName,
                             @Nullable String summary,@Nullable String connectionString) {
-        this.optionBeans = Lists.newArrayList(optionBeans);
+        this.optionBeans = CollectionUtils.toList(optionBeans);
         this.commandName = commandName;
         this.summary = summary;
         this.connectionString = connectionString;

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AbstractSegmentTarExplorerBackend.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AbstractSegmentTarExplorerBackend.java
@@ -22,6 +22,7 @@ import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.segment.RecordId;
 import org.apache.jackrabbit.oak.segment.SegmentBlob;
 import org.apache.jackrabbit.oak.segment.SegmentId;
@@ -45,7 +46,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static java.util.Collections.reverseOrder;
 
 /**
@@ -85,7 +85,7 @@ public abstract class AbstractSegmentTarExplorerBackend implements ExplorerBacke
                     entry -> entry.getRevision());
 
             try {
-                revs = newArrayList(revisionIterator);
+                revs = CollectionUtils.toList(revisionIterator);
             } finally {
                 journalReader.close();
             }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/NodeStoreTree.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/NodeStoreTree.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.explorer;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.guava.common.collect.Sets.intersection;
 import static org.apache.jackrabbit.guava.common.escape.Escapers.builder;
 import static java.util.Collections.sort;
@@ -57,6 +56,7 @@ import javax.swing.tree.DefaultTreeModel;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
@@ -708,7 +708,7 @@ class NodeStoreTree extends JPanel implements TreeSelectionListener, Closeable {
         }
         Long[] s = {0L, 0L};
 
-        List<String> names = newArrayList(ns.getChildNodeNames());
+        List<String> names = CollectionUtils.toList(ns.getChildNodeNames());
 
         if (names.contains("root")) {
             List<String> temp = new ArrayList<>();

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/document/SweepHelper.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/document/SweepHelper.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +83,7 @@ public final class SweepHelper {
                 sweepRev.set(Utils.max(sweepRev.get(), jRev));
                 // now that journal entry is in place, perform the actual
                 // updates on the documents
-                store.createOrUpdate(NODES, newArrayList(updates.values()));
+                store.createOrUpdate(NODES, new ArrayList<>(updates.values()));
                 sweepUpdates.incrementAndGet();
                 trackStats(updates.values());
                 System.out.println("Sweeper updated " + updates.keySet());

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/IncrementalStoreTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/IncrementalStoreTest.java
@@ -91,7 +91,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDED_PATHS;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_CUSTOM_EXCLUDE_ENTRIES_REGEX;
 import static org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedMongoDownloadTask.OAK_INDEXER_PIPELINED_MONGO_REGEX_PATH_FILTERING;
@@ -281,7 +280,7 @@ public class IncrementalStoreTest {
         IndexDefinitionUpdater indexDefinitionUpdater = new IndexDefinitionUpdater(new File(referenceIndexFilePath));
 
 
-        ExtendedIndexHelper indexHelper = new ExtendedIndexHelper(store, blobStore, whiteboard, workDir, workDir, newArrayList(indexDefinitionUpdater.getIndexPaths()));
+        ExtendedIndexHelper indexHelper = new ExtendedIndexHelper(store, blobStore, whiteboard, workDir, workDir, new ArrayList<>(indexDefinitionUpdater.getIndexPaths()));
         IndexerSupport indexerSupport = new IndexerSupport(indexHelper, checkpoint);
         indexerSupport.setIndexDefinitions(new File(referenceIndexFilePath));
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/ReindexIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/ReindexIT.java
@@ -19,11 +19,11 @@
 package org.apache.jackrabbit.oak.index;
 
 import org.apache.jackrabbit.guava.common.collect.Iterators;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.json.JsopDiff;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.IndexPathService;
@@ -361,7 +361,7 @@ public class ReindexIT extends LuceneAbstractIndexCommandTest {
         assertThat(explain, containsString("/oak:index/barIndex"));
 
         IndexPathService idxPathService = new IndexPathServiceImpl(fixture2.getNodeStore());
-        List<String> indexPaths = Lists.newArrayList(idxPathService.getIndexPaths());
+        List<String> indexPaths = CollectionUtils.toList(idxPathService.getIndexPaths());
 
         assertThat(indexPaths, hasItem("/oak:index/nodetype"));
         assertThat(indexPaths, hasItem("/oak:index/barIndex"));

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/util/TapeSamplingTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/util/TapeSamplingTest.java
@@ -20,13 +20,13 @@ package org.apache.jackrabbit.oak.plugins.index.search.util;
 
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.Iterators;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -46,7 +46,7 @@ public class TapeSamplingTest {
         List<Integer> input = range(start, end);
         TapeSampling<Integer> res = new TapeSampling<>(r, input.iterator(), input.size(), k);
 
-        List<Integer> samples = newArrayList(res.getSamples());
+        List<Integer> samples = CollectionUtils.toList(res.getSamples());
         List<Integer> expected = range(end - k + 1, end);
 
         assertEquals(expected, samples);
@@ -67,7 +67,7 @@ public class TapeSamplingTest {
         List<Integer> input = range(start, end);
         TapeSampling<Integer> res = new TapeSampling<>(r, input.iterator(), input.size(), k);
 
-        List<Integer> samples = newArrayList(res.getSamples());
+        List<Integer> samples = CollectionUtils.toList(res.getSamples());
         List<Integer> expected = range(start, start + k - 1);
 
         assertEquals(expected, samples);
@@ -83,7 +83,7 @@ public class TapeSamplingTest {
         List<Integer> input = range(start, end);
         TapeSampling<Integer> res = new TapeSampling<>(r, input.iterator(), input.size(), k);
 
-        List<Integer> samples = newArrayList(res.getSamples());
+        List<Integer> samples = CollectionUtils.toList(res.getSamples());
         List<Integer> expected = input;
 
         assertEquals(expected, samples);
@@ -136,6 +136,6 @@ public class TapeSamplingTest {
             }
         };
 
-        return newArrayList(iter);
+        return CollectionUtils.toList(iter);
     }
 }

--- a/oak-segment-aws/src/test/java/org/apache/jackrabbit/oak/segment/aws/AwsArchiveManagerTest.java
+++ b/oak-segment-aws/src/test/java/org/apache/jackrabbit/oak/segment/aws/AwsArchiveManagerTest.java
@@ -93,7 +93,7 @@ public class AwsArchiveManagerTest {
 
         LinkedHashMap<UUID, byte[]> recovered = new LinkedHashMap<>();
         manager.recoverEntries("data00000a.tar", recovered);
-        assertEquals(uuids.subList(0, 5), newArrayList(recovered.keySet()));
+        assertEquals(uuids.subList(0, 5), new ArrayList<>(recovered.keySet()));
     }
 
     @Test

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/ToolUtils.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/ToolUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.segment.azure.tool;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.segment.azure.util.AzureConfigurationParserUtils.KEY_ACCOUNT_NAME;
 import static org.apache.jackrabbit.oak.segment.azure.util.AzureConfigurationParserUtils.KEY_DIR;
 import static org.apache.jackrabbit.oak.segment.azure.util.AzureConfigurationParserUtils.KEY_SHARED_ACCESS_SIGNATURE;
@@ -39,6 +38,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.segment.azure.AzurePersistence;
 import org.apache.jackrabbit.oak.segment.azure.AzureStorageCredentialManager;
 import org.apache.jackrabbit.oak.segment.azure.AzureUtilities;
@@ -197,7 +197,7 @@ public class ToolUtils {
                 try (JournalReader journalReader = new JournalReader(journal)) {
                     Iterator<String> revisionIterator = Iterators.transform(journalReader,
                          entry -> entry.getRevision());
-                    return newArrayList(revisionIterator);
+                    return CollectionUtils.toList(revisionIterator);
                 } catch (Exception e) {
                     log.error("Error while reading from journal file");
                     e.printStackTrace();

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/DefaultSegmentWriter.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/DefaultSegmentWriter.java
@@ -480,7 +480,7 @@ public class DefaultSegmentWriter implements SegmentWriter {
             int shift = 32 - (level + 1) * MapRecord.BITS_PER_LEVEL;
 
             List<List<MapEntry>> buckets =
-                    newArrayList(nCopies(MapRecord.BUCKETS_PER_LEVEL, (List<MapEntry>) null));
+                    new ArrayList<>(nCopies(MapRecord.BUCKETS_PER_LEVEL, (List<MapEntry>) null));
             for (MapEntry entry : entries) {
                 int index = (entry.getHash() >> shift) & mask;
                 List<MapEntry> bucket = buckets.get(index);

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentIdTable.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentIdTable.java
@@ -60,7 +60,7 @@ public class SegmentIdTable {
      * entries would be slower).
      */
     private final ArrayList<WeakReference<SegmentId>> references =
-            newArrayList(nCopies(1024, (WeakReference<SegmentId>) null));
+            new ArrayList<>(nCopies(1024, (WeakReference<SegmentId>) null));
 
     private static final Logger LOG = LoggerFactory.getLogger(SegmentIdTable.class);
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/FullSizeDeltaEstimationStrategy.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/FullSizeDeltaEstimationStrategy.java
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.file;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static org.apache.jackrabbit.oak.segment.file.PrintableBytes.newPrintableBytes;
 
@@ -90,7 +88,7 @@ class FullSizeDeltaEstimationStrategy implements EstimationStrategy {
     }
 
     private boolean previousIsTail(Context context) {
-        List<GCJournalEntry> entries = newArrayList(context.getGCJournal().readAll());
+        List<GCJournalEntry> entries = new ArrayList<>(context.getGCJournal().readAll());
         if (entries.isEmpty()) {
             // We should not get here but if we do the condition is vacuously true
             return true;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarReader.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarReader.java
@@ -18,13 +18,13 @@
  */
 package org.apache.jackrabbit.oak.segment.file.tar;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static java.util.Collections.singletonList;
 import static org.apache.jackrabbit.oak.segment.file.tar.GCGeneration.newGCGeneration;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,7 +86,7 @@ public class TarReader implements Closeable {
         SortedMap<Character, String> sorted = new TreeMap<>();
         sorted.putAll(files);
 
-        List<String> list = newArrayList(sorted.values());
+        List<String> list = new ArrayList<>(sorted.values());
         Collections.reverse(list);
 
         TarReader reader = openFirstFileWithValidIndex(list, archiveManager);

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/Utils.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/Utils.java
@@ -17,7 +17,6 @@
 package org.apache.jackrabbit.oak.segment.tool;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
 
 import java.io.File;
@@ -27,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.jackrabbit.guava.common.collect.Iterators;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.json.JsonObject;
 import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
 import org.apache.jackrabbit.oak.segment.SegmentId;
@@ -76,7 +76,7 @@ public final class Utils {
             try (JournalReader journalReader = new JournalReader(journal)) {
                 Iterator<String> revisionIterator = Iterators.transform(journalReader,
                         entry -> entry.getRevision());
-                return newArrayList(revisionIterator);
+                return CollectionUtils.toList(revisionIterator);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentBufferWriterTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentBufferWriterTest.java
@@ -14,10 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.jackrabbit.oak.segment;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.segment.DefaultSegmentWriterBuilder.defaultSegmentWriterBuilder;
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
 import static org.junit.Assert.assertEquals;
@@ -28,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
 import org.apache.jackrabbit.oak.segment.file.FileStore;
 import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
@@ -56,7 +55,7 @@ public class SegmentBufferWriterTest {
             // init
         }
         try (ReadOnlyFileStore store = openReadOnlyFileStore()) {
-            before = newArrayList(store.getSegmentIds());
+            before = CollectionUtils.toList(store.getSegmentIds());
         }
 
         try (FileStore store = openFileStore()) {
@@ -66,7 +65,7 @@ public class SegmentBufferWriterTest {
         List<SegmentId> after;
 
         try (ReadOnlyFileStore store = openReadOnlyFileStore()) {
-            after = newArrayList(store.getSegmentIds());
+            after = CollectionUtils.toList(store.getSegmentIds());
         }
 
         assertEquals(before, after);
@@ -80,7 +79,7 @@ public class SegmentBufferWriterTest {
             // init
         }
         try (ReadOnlyFileStore store = openReadOnlyFileStore()) {
-            before = newArrayList(store.getSegmentIds());
+            before = CollectionUtils.toList(store.getSegmentIds());
         }
 
         try (FileStore store = openFileStore()) {
@@ -92,7 +91,7 @@ public class SegmentBufferWriterTest {
         List<SegmentId> after;
 
         try (ReadOnlyFileStore store = openReadOnlyFileStore()) {
-            after = newArrayList(store.getSegmentIds());
+            after = CollectionUtils.toList(store.getSegmentIds());
         }
 
         assertNotEquals(before, after);

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentDataStoreBlobGCIT.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentDataStoreBlobGCIT.java
@@ -342,7 +342,7 @@ public class SegmentDataStoreBlobGCIT {
         
         // Simulate faulty state by deleting some blobs directly
         Random rand = new Random(87);
-        List<String> existing = Lists.newArrayList(state.blobsPresent);
+        List<String> existing = new ArrayList<>(state.blobsPresent);
         
         long count = blobStore.countDeleteChunks(ImmutableList.of(existing.get(rand.nextInt(existing.size()))), 0);
         

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/GcJournalTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/GcJournalTest.java
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.file;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.apache.jackrabbit.oak.segment.file.tar.GCGeneration.newGCGeneration;
 import static org.junit.Assert.assertEquals;
 
@@ -126,7 +124,7 @@ public class GcJournalTest {
         GCJournal gcJournal = new GCJournal(getPersistence().getGCJournalFile());
         gcJournal.persist(75, 300, newGCGeneration(3, 0, false), 125, "bar");
 
-        ArrayList<GCJournalEntry> entries = newArrayList(gcJournal.readAll());
+        List<GCJournalEntry> entries = new ArrayList<>(gcJournal.readAll());
         assertEquals(2, entries.size());
 
         GCJournalEntry entry = entries.get(0);

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/InitialContentMigrator.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/InitialContentMigrator.java
@@ -16,11 +16,11 @@
  */
 package org.apache.jackrabbit.oak.composite;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.migration.FilteringNodeState;
 import org.apache.jackrabbit.oak.plugins.migration.report.LoggingReporter;
 import org.apache.jackrabbit.oak.plugins.migration.report.ReportingNodeState;
@@ -179,7 +179,7 @@ public class InitialContentMigrator {
             if (temp == null) {
                 continue;
             }
-            List<String> tempValues = Lists.newArrayList(temp.getValue(Type.STRINGS));
+            List<String> tempValues = CollectionUtils.toList(temp.getValue(Type.STRINGS));
             for (Map.Entry<String, String> sToD : checkpointSegmentToDoc.entrySet()) {
                 if (tempValues.contains(sToD.getKey())) {
                     tempValues.set(tempValues.indexOf(sToD.getKey()), sToD.getValue());

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -2952,7 +2952,7 @@ public final class DocumentNodeStore
                     setRoot(newHead);
                     commitQueue.headRevisionChanged();
 
-                    store.createOrUpdate(NODES, Lists.newArrayList(updates.values()));
+                    store.createOrUpdate(NODES, new ArrayList<>(updates.values()));
                     numUpdates.addAndGet(updates.size());
                     LOG.debug("Background sweep2 updated {}", updates.keySet());
                 }
@@ -3074,7 +3074,7 @@ public final class DocumentNodeStore
                     setRoot(newHead);
                     commitQueue.headRevisionChanged();
 
-                    store.createOrUpdate(NODES, Lists.newArrayList(updates.values()));
+                    store.createOrUpdate(NODES, new ArrayList<>(updates.values()));
                     numUpdates.addAndGet(updates.size());
                     LOG.debug("Background sweep updated {}", updates.keySet());
                 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentStoreException.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentStoreException.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -171,7 +171,7 @@ public class DocumentStoreException extends RuntimeException {
                                                                   Iterable<String> ids) {
         String msg = message;
         if (ids.iterator().hasNext()) {
-            msg += " " + Lists.newArrayList(ids);
+            msg += " " + CollectionUtils.toList(ids);
         }
         if (t instanceof DocumentStoreException) {
             return (DocumentStoreException) t;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -316,7 +316,7 @@ public class LastRevRecoveryAgent {
                     sweepRev.set(Utils.max(sweepRev.get(), jRev));
                     // now that journal entry is in place, perform the actual
                     // updates on the documents
-                    store.createOrUpdate(NODES, newArrayList(updates.values()));
+                    store.createOrUpdate(NODES, new ArrayList<>(updates.values()));
                     log.info("Sweeper updated {}", updates.keySet());
                 }
             });

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
@@ -102,6 +102,7 @@ import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.json.JsopDiff;
 import org.apache.jackrabbit.oak.plugins.commit.AnnotatingConflictHandler;
 import org.apache.jackrabbit.oak.plugins.commit.ConflictHook;
@@ -1975,7 +1976,7 @@ public class DocumentNodeStoreTest {
 
         // on cluster node 2, remove of child-0 is not yet visible
         DocumentNodeState bar = asDocumentNodeState(ns2.getRoot().getChildNode("foo").getChildNode("bar"));
-        List<ChildNodeEntry> children = Lists.newArrayList(bar.getChildNodeEntries());
+        List<ChildNodeEntry> children = CollectionUtils.toList(bar.getChildNodeEntries());
         assertEquals(2, Iterables.size(children));
         RevisionVector invalidate = bar.getLastRevision();
         assertNotNull(invalidate);
@@ -1992,7 +1993,7 @@ public class DocumentNodeStoreTest {
         // forget cache entry for deleted node
         ns2.invalidateNodeCache("/foo/bar/child-0", invalidate);
 
-        children = Lists.newArrayList(ns2.getRoot().getChildNode("foo").getChildNode("bar").getChildNodeEntries());
+        children = CollectionUtils.toList(ns2.getRoot().getChildNode("foo").getChildNode("bar").getChildNodeEntries());
         assertEquals(1, Iterables.size(children));
     }
 
@@ -2034,13 +2035,13 @@ public class DocumentNodeStoreTest {
         merge(ns2, b2);
 
         // on cluster node 2, add of child-1 is not yet visible
-        List<ChildNodeEntry> children = Lists.newArrayList(ns2.getRoot().getChildNode("foo").getChildNodeEntries());
+        List<ChildNodeEntry> children = CollectionUtils.toList(ns2.getRoot().getChildNode("foo").getChildNodeEntries());
         assertEquals(1, Iterables.size(children));
 
         // this will make changes from cluster node 1 visible
         ns2.runBackgroundOperations();
 
-        children = Lists.newArrayList(ns2.getRoot().getChildNode("foo").getChildNodeEntries());
+        children = CollectionUtils.toList(ns2.getRoot().getChildNode("foo").getChildNodeEntries());
         assertEquals(2, Iterables.size(children));
     }
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreTest.java
@@ -3325,7 +3325,7 @@ public class DocumentNodeStoreTest {
         NodeDocument doc = store.find(NODES, Utils.getIdFromPath("/a/b"));
         assertNotNull(doc);
         long previousValue = -1;
-        List<String> values = Lists.newArrayList(doc.getLocalMap("p").values());
+        List<String> values = new ArrayList<>(doc.getLocalMap("p").values());
         for (String v : Lists.reverse(values)) {
             long currentValue = Long.parseLong(v);
             assertEquals(previousValue + 1, currentValue);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentSplitTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentSplitTest.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.guava.common.collect.Iterators;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Key;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp.Operation;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
@@ -48,7 +49,6 @@ import org.junit.Test;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Lists;
-import org.apache.jackrabbit.guava.common.collect.Sets;
 
 import static org.apache.jackrabbit.guava.common.collect.ImmutableList.copyOf;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
@@ -629,7 +629,7 @@ public class DocumentSplitTest extends BaseDocumentMKTest {
         Revision r = valueMap.keySet().iterator().next();
         assertTrue(doc.getLocalRevisions().containsKey(r));
         // but also the previous document must contain the revision
-        List<NodeDocument> prevDocs = Lists.newArrayList(doc.getAllPreviousDocs());
+        List<NodeDocument> prevDocs = CollectionUtils.toList(doc.getAllPreviousDocs());
         assertEquals(1, prevDocs.size());
         NodeDocument prev = prevDocs.get(0);
         assertTrue(prev.getLocalRevisions().containsKey(r));
@@ -663,7 +663,7 @@ public class DocumentSplitTest extends BaseDocumentMKTest {
         Revision r = valueMap.keySet().iterator().next();
         assertTrue(doc.getLocalCommitRoot().containsKey(r));
         // but also the previous document must contain the commitRoot entry
-        List<NodeDocument> prevDocs = Lists.newArrayList(doc.getAllPreviousDocs());
+        List<NodeDocument> prevDocs = CollectionUtils.toList(doc.getAllPreviousDocs());
         assertEquals(1, prevDocs.size());
         NodeDocument prev = prevDocs.get(0);
         assertTrue(prev.getLocalCommitRoot().containsKey(r));

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentSplitTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentSplitTest.java
@@ -48,7 +48,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 
 import static org.apache.jackrabbit.guava.common.collect.ImmutableList.copyOf;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
@@ -539,7 +538,7 @@ public class DocumentSplitTest extends BaseDocumentMKTest {
 
         doc = store.find(NODES, id);
         assertNotNull(doc);
-        List<UpdateOp> splitOps = Lists.newArrayList(doc.split(
+        List<UpdateOp> splitOps = CollectionUtils.toList(doc.split(
                 mk.getNodeStore(), mk.getNodeStore().getHeadRevision(),
                 NO_BINARY));
         assertEquals(2, splitOps.size());
@@ -596,7 +595,7 @@ public class DocumentSplitTest extends BaseDocumentMKTest {
 
         // must split document and create a previous document starting at
         // the second most recent revision
-        List<UpdateOp> splitOps = Lists.newArrayList(doc.split(
+        List<UpdateOp> splitOps = CollectionUtils.toList(doc.split(
                 mk.getNodeStore(), mk.getNodeStore().getHeadRevision(),
                 NO_BINARY));
         assertEquals(2, splitOps.size());

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryRandomizedIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryRandomizedIT.java
@@ -21,12 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
@@ -190,7 +190,7 @@ public class LastRevRecoveryRandomizedIT {
 
     private void addNode() {
         String p = choosePath();
-        List<String> elements = Lists.newArrayList(PathUtils.elements(p));
+        List<String> elements = CollectionUtils.toList(PathUtils.elements(p));
         if (elements.size() > 2) {
             elements = elements.subList(1, elements.size() - 1);
             elements = elements.subList(0, random.nextInt(elements.size() + 1));

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoBlobGCTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MongoBlobGCTest.java
@@ -315,7 +315,7 @@ public class MongoBlobGCTest extends AbstractMongoConnectionTest {
         
         // Simulate faulty state by deleting some blobs directly
         Random rand = new Random(87);
-        List<String> existing = Lists.newArrayList(state.blobsPresent);
+        List<String> existing = new ArrayList<>(state.blobsPresent);
 
         GarbageCollectableBlobStore store = (GarbageCollectableBlobStore)
                                                 mk.getNodeStore().getBlobStore();

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/NodeDocumentTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/NodeDocumentTest.java
@@ -40,6 +40,7 @@ import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollector.VersionGCStats;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
@@ -1012,7 +1013,7 @@ public class NodeDocumentTest {
         int numMoreChanges = 50;
         List<RevisionVector> moreRevs = Lists.reverse(
                 createTestData(nodeStores, random, numMoreChanges, numChanges));
-        headRevisions = Lists.newArrayList(Iterables.concat(moreRevs, headRevisions));
+        headRevisions = CollectionUtils.toList(Iterables.concat(moreRevs, headRevisions));
         numChanges += numMoreChanges;
 
         // now merge the branch and update 'q'. this will split
@@ -1026,7 +1027,7 @@ public class NodeDocumentTest {
         numMoreChanges = 50;
         moreRevs = Lists.reverse(
                 createTestData(nodeStores, random, numMoreChanges, numChanges));
-        headRevisions = Lists.newArrayList(Iterables.concat(moreRevs, headRevisions));
+        headRevisions = CollectionUtils.toList(Iterables.concat(moreRevs, headRevisions));
         numChanges += numMoreChanges;
 
         NodeDocument doc = getRootDocument(store);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/NodeStoreDiffTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/NodeStoreDiffTest.java
@@ -16,15 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.document;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -141,7 +140,7 @@ public class NodeStoreDiffTest {
                 //rebase was performed
 
                 // remember paths accessed so far
-                List<String> paths = Lists.newArrayList(tds.paths);
+                List<String> paths = new ArrayList<>(tds.paths);
 
                 //This is not to be done in actual cases as CommitHooks are invoked in critical sections
                 //and creating nodes from within CommitHooks would cause deadlock. This is done here to ensure

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/SharedBlobStoreGCTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/SharedBlobStoreGCTest.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.guava.common.collect.Sets;
 import org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors;
 import org.apache.jackrabbit.core.data.DataStore;
 import org.apache.jackrabbit.oak.api.Blob;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.blob.BlobGarbageCollector;
 import org.apache.jackrabbit.oak.plugins.blob.GarbageCollectionRepoStats;
 import org.apache.jackrabbit.oak.plugins.blob.MarkSweepGarbageCollector;
@@ -427,7 +428,7 @@ public class SharedBlobStoreGCTest {
                 Iterator<String> idIter =
                     ((GarbageCollectableBlobStore) ds.getBlobStore())
                         .resolveChunks(b.toString());
-                set.addAll(Lists.newArrayList(idIter));
+                set.addAll(CollectionUtils.toList(idIter));
             }
             ds.merge(a, EmptyHook.INSTANCE, CommitInfo.EMPTY);
             return set;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ValueMapTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/ValueMapTest.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.memory.MemoryDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
@@ -123,7 +124,7 @@ public class ValueMapTest {
 
         NodeDocument doc = store.find(NODES, rootId);
         assertNotNull(doc);
-        List<NodeDocument> prevDocs = Lists.newArrayList(
+        List<NodeDocument> prevDocs = CollectionUtils.toList(
                 doc.getPreviousDocs("p1", null));
         assertEquals(2, prevDocs.size());
         assertEquals(Utils.getPreviousIdFor(ROOT, r31, 0), prevDocs.get(0).getId());

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
@@ -113,6 +113,7 @@ import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStoreFixture.RDBFixture;
 import org.apache.jackrabbit.oak.plugins.document.FailingDocumentStore.FailedUpdateOpListener;
 import org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollector.FullGCMode;
@@ -3583,7 +3584,7 @@ public class VersionGarbageCollectorIT {
         assertNotNull(foo);
         Long modCount = foo.getModCount();
         assertNotNull(modCount);
-        List<String> prevIds = Lists.newArrayList(Iterators.transform(
+        List<String> prevIds = CollectionUtils.toList(Iterators.transform(
                 foo.getPreviousDocLeaves(), input -> input.getId()));
 
         // run gc on another document node store

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/AcquireRecoveryLockTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/AcquireRecoveryLockTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.mongodb.MongoClient;
 
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.AbstractMongoConnectionTest;
 import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo;
 import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfoDocument;
@@ -31,7 +32,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.apache.jackrabbit.guava.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -73,7 +73,7 @@ public class AcquireRecoveryLockTest extends AbstractMongoConnectionTest {
     @Test
     public void recoveryBy() throws Exception {
         MongoMissingLastRevSeeker seeker = new MongoMissingLastRevSeeker(store, getTestClock());
-        List<ClusterNodeInfoDocument> infoDocs = newArrayList(seeker.getAllClusters());
+        List<ClusterNodeInfoDocument> infoDocs = CollectionUtils.toList(seeker.getAllClusters());
         assertEquals(1, infoDocs.size());
         int clusterId = infoDocs.get(0).getClusterId();
         int otherClusterId = clusterId + 1;

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MemoryNodeStore.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MemoryNodeStore.java
@@ -25,6 +25,7 @@ import static org.apache.jackrabbit.oak.plugins.memory.ModifiedNodeState.squeeze
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.jackrabbit.guava.common.io.ByteStreams;
 
@@ -224,7 +224,7 @@ public class MemoryNodeStore implements NodeStore, Observable {
     @NotNull
     @Override
     public synchronized Iterable<String> checkpoints() {
-        return Lists.newArrayList(checkpoints.keySet());
+        return new ArrayList<>(checkpoints.keySet());
     }
 
     @Override @Nullable

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiLongPropertyState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiLongPropertyState.java
@@ -18,9 +18,9 @@
  */
 package org.apache.jackrabbit.oak.plugins.memory;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.value.Conversions;
 import org.apache.jackrabbit.oak.plugins.value.Conversions.Converter;
 
@@ -37,7 +37,7 @@ public class MultiLongPropertyState extends MultiPropertyState<Long> {
      * @return  The new property state of type {@link Type#LONGS}
      */
     public static PropertyState createLongProperty(String name, Iterable<Long> values) {
-        return new MultiLongPropertyState(name, Lists.newArrayList(values));
+        return new MultiLongPropertyState(name, CollectionUtils.toList(values));
     }
 
     @Override

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiPropertyState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiPropertyState.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.plugins.memory;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.PropertyType;

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiPropertyState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/MultiPropertyState.java
@@ -20,14 +20,13 @@ package org.apache.jackrabbit.oak.plugins.memory;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.jcr.PropertyType;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.plugins.value.Conversions.Converter;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +45,7 @@ abstract class MultiPropertyState<T> extends EmptyPropertyState {
      */
     protected MultiPropertyState(String name, Iterable<T> values) {
         super(name);
-        this.values = Lists.newArrayList(values);
+        this.values = CollectionUtils.toList(values);
     }
 
     /**

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/PropertyBuilder.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/PropertyBuilder.java
@@ -25,10 +25,10 @@ import java.util.List;
 import javax.jcr.PropertyType;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.jetbrains.annotations.NotNull;
 
@@ -263,7 +263,7 @@ public class PropertyBuilder<T> {
 
     @NotNull
     public PropertyBuilder<T> setValues(Iterable<T> values) {
-        this.values = Lists.newArrayList(values);
+        this.values = CollectionUtils.toList(values);
         return this;
     }
 

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/PropertyBuilder.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/PropertyBuilder.java
@@ -133,7 +133,7 @@ public class PropertyBuilder<T> {
 
     @NotNull
     public List<T> getValues() {
-        return Lists.newArrayList(values);
+        return new ArrayList<>(values);
     }
 
     public T getValue(int index) {

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/RepositorySidegrade.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/RepositorySidegrade.java
@@ -27,13 +27,13 @@ import java.util.Set;
 import javax.jcr.RepositoryException;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeState;
 import org.apache.jackrabbit.oak.plugins.migration.FilteringNodeState;
 import org.apache.jackrabbit.oak.plugins.migration.NodeStateCopier;
@@ -382,7 +382,7 @@ public class RepositorySidegrade {
             if (temp == null) {
                 continue;
             }
-            List<String> tempValues = Lists.newArrayList(temp.getValue(Type.STRINGS));
+            List<String> tempValues = CollectionUtils.toList(temp.getValue(Type.STRINGS));
             for (Map.Entry<String, String> sToD : checkpointSegmentToDoc.entrySet()) {
                 if (tempValues.contains(sToD.getKey())) {
                     tempValues.set(tempValues.indexOf(sToD.getKey()), sToD.getValue());

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/checkpoint/CheckpointRetriever.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/checkpoint/CheckpointRetriever.java
@@ -19,7 +19,7 @@
 package org.apache.jackrabbit.oak.upgrade.checkpoint;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.guava.common.collect.Lists;
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.plugins.document.DocumentCheckpointRetriever;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.segment.CheckpointAccessor;
@@ -86,7 +86,7 @@ public final class CheckpointRetriever {
     }
 
     private static List<Checkpoint> getCheckpoints(NodeState checkpointRoot) {
-        return Lists.newArrayList(Iterables.transform(checkpointRoot.getChildNodeEntries(),
+        return CollectionUtils.toList(Iterables.transform(checkpointRoot.getChildNodeEntries(),
                 input -> Checkpoint.createFromSegmentNode(input.getName(), input.getNodeState())));
     }
 }

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/OakUpgrade.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/OakUpgrade.java
@@ -22,10 +22,11 @@ import java.util.ServiceLoader;
 
 import javax.jcr.RepositoryException;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.jackrabbit.guava.common.io.Closer;
 
 import joptsimple.OptionSet;
+
+import org.apache.jackrabbit.oak.commons.collections.CollectionUtils;
 import org.apache.jackrabbit.oak.spi.lifecycle.CompositeInitializer;
 import org.apache.jackrabbit.oak.spi.lifecycle.RepositoryInitializer;
 import org.apache.jackrabbit.oak.upgrade.cli.parser.CliArgumentException;
@@ -94,7 +95,7 @@ public class OakUpgrade {
 
     private static RepositoryInitializer createCompositeInitializer() {
         ServiceLoader<RepositoryInitializer> loader = ServiceLoader.load(RepositoryInitializer.class);
-        List<RepositoryInitializer> initializers = Lists.newArrayList(loader.iterator());
+        List<RepositoryInitializer> initializers = CollectionUtils.toList(loader.iterator());
         return new CompositeInitializer(initializers);
     }
 


### PR DESCRIPTION
Note: the changes vary depending on whether the parameter already is a collection (in which case the ArrayList contructor can be used), or not (in which case we need CollectionUtils.toList()).