### PR TITLE
OAK-11234 - Use virtual clock on Pipelined IT tests.

### DIFF
--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelineITUtil.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.MongoConnectionFactory;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
+import org.apache.jackrabbit.oak.plugins.document.TestUtils;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;
@@ -36,6 +37,7 @@ import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.stats.Clock;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -55,6 +57,12 @@ public class PipelineITUtil {
 
     private static final int LONG_PATH_TEST_LEVELS = 30;
     private static final String LONG_PATH_LEVEL_STRING = "Z12345678901234567890-Level_";
+
+    private final static Clock.Virtual clock = new Clock.Virtual();
+    static {
+        TestUtils.setRevisionClock(clock);
+    }
+
 
     static final List<String> EXPECTED_FFS = new ArrayList<>(List.of(
             "/|{}",
@@ -174,6 +182,7 @@ public class PipelineITUtil {
             builder.setReadOnlyMode();
         }
         builder.setAsyncDelay(1);
+        builder.clock(clock);
         DocumentNodeStore documentNodeStore = builder.getNodeStore();
         return new MongoTestBackend(c.getMongoURI(), (MongoDocumentStore) builder.getDocumentStore(), documentNodeStore, c.getDatabase());
     }
@@ -186,6 +195,7 @@ public class PipelineITUtil {
             builder.setReadOnlyMode();
         }
         builder.setAsyncDelay(1);
+        builder.clock(clock);
         DocumentNodeStore documentNodeStore = builder.getNodeStore();
         MongoDocumentStore mongoDocumentStore = (MongoDocumentStore) builder.getDocumentStore();
         // TODO: Resource not released

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTreeStoreIT.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTreeStoreIT.java
@@ -68,6 +68,7 @@ import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.filter.PathFilter;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.stats.Clock;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -364,11 +365,12 @@ public class PipelinedTreeStoreIT {
             contentDamBuilder.child("old.png");
             contentDamBuilder.child("change.png").setProperty("test", 0);
             rwNodeStore.merge(rootBuilder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
-            long oldMod = NodeDocument.getModifiedInSecs(System.currentTimeMillis());
+            Clock clock = rwNodeStore.getClock();
+            long oldMod = NodeDocument.getModifiedInSecs(clock.getTime());
             // wait until the modified time changes
             do {
-                Thread.sleep(10);
-                minModified = NodeDocument.getModifiedInSecs(System.currentTimeMillis());
+                clock.waitUntil(clock.getTime() + 1000);
+                minModified = NodeDocument.getModifiedInSecs(clock.getTime());
             } while (oldMod == minModified);
             rootBuilder = rwNodeStore.getRoot().builder();
             contentDamBuilder = rootBuilder.child("content").child("dam");


### PR DESCRIPTION
This is required to better test recovery from failures in the download phase of the Pipeline strategy. The tests should verify that the download does not miss any field, regardless of the `_modified` value. Without a virtual clock, it is not practical to create test content with different `_modified` values, as that would require waiting for more than 5 seconds between updates, as this is the granularity of the field. With a virtual clock, we can advance the clock by arbitrary amounts.