### PR TITLE
OAK-11277 Tree store: fix memory usage and support concurrent indexing

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexMeta.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexMeta.java
@@ -34,8 +34,6 @@ import org.apache.jackrabbit.guava.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.Nullable;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * Represents the index metadata file content as present in index-details.txt
  */
@@ -62,8 +60,9 @@ final class IndexMeta implements Comparable<IndexMeta> {
 
     public IndexMeta(File file) throws IOException {
         Properties p = loadFromFile(file);
-        this.indexPath = requireNonNull(p.getProperty("indexPath"));
-        this.creationTime = Long.valueOf(requireNonNull(p.getProperty("creationTime")));
+        // the file might be empty - in which case we ignore it
+        this.indexPath = p.getProperty("indexPath", "");
+        this.creationTime = Long.valueOf(p.getProperty("creationTime", "0"));
         this.properties = new HashMap<>(Maps.fromProperties(p));
     }
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakDirectory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/OakDirectory.java
@@ -206,11 +206,13 @@ public class OakDirectory extends Directory {
 
         // OAK-6562: Learn from FSDirectory and delete existing file
         // on creating output
-        if (directoryBuilder.hasChildNode(name)) {
-            directoryBuilder.getChildNode(name).remove();
+        // synchronize on the builder to support concurrent creation
+        synchronized (directoryBuilder) {
+            if (directoryBuilder.hasChildNode(name)) {
+                directoryBuilder.getChildNode(name).remove();
+            }
+            file = directoryBuilder.child(name);
         }
-
-        file = directoryBuilder.child(name);
         byte[] uniqueKey = new byte[UNIQUE_KEY_SIZE];
         secureRandom.nextBytes(uniqueKey);
         String key = StringUtils.convertBytesToHex(uniqueKey);

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
@@ -145,7 +145,12 @@ class DefaultIndexWriter implements LuceneIndexWriter {
                 PERF_LOGGER.end(start, -1, "Completed suggester for directory {}", definition);
             }
 
-            writer.close();
+            if (reindex && writerConfig.getThreadCount() > 1) {
+                // merges could be disabled, so it could in theory wait forever
+                writer.close(false);
+            } else {
+                writer.close();
+            }
             PERF_LOGGER.end(start, -1, "Closed writer for directory {}", definition);
 
             if (!indexUpdated){

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/ConcurrentMultiplexingIndexWriterTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/ConcurrentMultiplexingIndexWriterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.lucene.writer;
+
+import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
+import static org.apache.jackrabbit.oak.plugins.index.lucene.TestUtil.newDoc;
+import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexWriterFactory;
+import org.apache.jackrabbit.oak.plugins.index.lucene.directory.DefaultDirectoryFactory;
+import org.apache.jackrabbit.oak.plugins.index.lucene.directory.DirectoryFactory;
+import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
+import org.apache.jackrabbit.oak.spi.mount.Mounts;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ConcurrentMultiplexingIndexWriterTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder(new File("target"));
+
+    private NodeState root = INITIAL_CONTENT;
+    private NodeBuilder builder = EMPTY_NODE.builder();
+    private LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
+    private MountInfoProvider mip = Mounts.newBuilder()
+            .mount("foo", "/libs", "/apps")
+            .readOnlyMount("ro", "/ro-tree")
+            .build();
+    private LuceneIndexWriterConfig writerConfig = new LuceneIndexWriterConfig();
+
+    @Test
+    public void concurrentWrite() throws Exception{
+        LuceneIndexWriterFactory factory = newDirectoryFactory();
+        final LuceneIndexWriter writer = factory.newInstance(defn, builder, null, true);
+        
+        int THREAD_COUNT = 100;
+        final int LOOP_COUNT = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(THREAD_COUNT);
+        Exception[] firstException = new Exception[1];
+        
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            executorService.submit(() -> {
+                try {
+                    // wait for the signal
+                    startLatch.await(); 
+                    for (int j = 0; j < LOOP_COUNT; j++) {
+                        writer.updateDocument("/libs/config", newDoc("/libs/config"));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (Exception e) {
+                    firstException[0] = e;
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+        // signal
+        startLatch.countDown();
+        doneLatch.await();
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+        if (firstException[0] != null) {
+            throw firstException[0];
+        }
+        writer.close(0);
+    }    
+
+    private LuceneIndexWriterFactory newDirectoryFactory(){
+        return newDirectoryFactory(mip);
+    }
+
+    private LuceneIndexWriterFactory newDirectoryFactory(MountInfoProvider mountInfoProvider){
+        DirectoryFactory directoryFactory = new DefaultDirectoryFactory(null, null);
+        return new DefaultIndexWriterFactory(mountInfoProvider, directoryFactory, writerConfig);
+    }
+
+}

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/tree/TreeStore.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/tree/TreeStore.java
@@ -98,7 +98,7 @@ public class TreeStore implements ParallelIndexStore {
         long cacheSizeNodeMB = cacheSizeFactor * CACHE_SIZE_NODE_MB;
         long cacheSizeTreeStoreMB = cacheSizeFactor * CACHE_SIZE_TREE_STORE_MB;
         this.cacheSizeTreeStoreMB = cacheSizeTreeStoreMB;
-        nodeStateCache = new SieveCache<>(cacheSizeFactor * cacheSizeNodeMB * MB);
+        nodeStateCache = new SieveCache<>(cacheSizeNodeMB * MB);
         String storeConfig;
         if (FilePacker.isPackFile(fileOrDirectory)) {
             readOnly = true;

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/binary/FulltextBinaryTextExtractor.java
@@ -240,9 +240,14 @@ public class FulltextBinaryTextExtractor {
         return parser;
     }
 
-    private boolean isSupportedMediaType(String type) {
+    boolean isSupportedMediaType(String type) {
+        // we need to initialize the fields separately
+        // to prevent null pointer exceptions if the method
+        // is called concurrently from multiple threads
         if (supportedMediaTypes == null) {
             supportedMediaTypes = getParser().getSupportedTypes(new ParseContext());
+        }
+        if (nonIndexedMediaType == null) {
             nonIndexedMediaType = getNonIndexedMediaTypes();
         }
         MediaType mediaType = MediaType.parse(type);


### PR DESCRIPTION
The PR fixes a bunch of issues:

* IndexMeta: when re-indexing multiple indexes, each writer that tries to open a writer first reads _all_ metadata files (including those of concurrently added files). The thread is only interested in the current index, and all other indexes are then ignored - and on this index we synchronized. However, the problem is: another thread might concurrently create _another_ index, whose metadata file could be empty when this thread reads it. So protection against that is needed.
* The OakDirectory uses a ConcurrentHashSet, however it doesn't properly synchronize on the node builder.
* The MultiplexingIndexWriter doesn't support concurrent access (unlike the default index writer). This was not detected so far because multi-threaded indexing was usually only used for one single index. I tries reindexing all indexes with many threads, which uncovered this issue. (First, it is using a regular HashMap instead of a concurrent one... but more importantly, it could concurrently create two writers).
* The PipelinedTreeStoreStrategy doesn't support filtering yet, unlike the regular pipelined strategy.
* TreeStore memory usage: the cache size calculation was wrong: it multiplied by the size factor twice. This could result in out-of-memory.
* The FulltextBinaryTextExtractor didn't properly support concurrent initialization, leading to a NullPointerException.

For the concurrency issues, I added tests. They are pretty fast, because the corruption happens in memory and not on disk.