### PR TITLE
OAK-11284: Greedy Reuse of cluster IDs may lead to synchronous LastRe…

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -80,7 +80,7 @@ public class LastRevRecoveryAgent {
 
     private final Consumer<Integer> afterRecovery;
 
-    private static final SystemPropertySupplier<Long> SYNC_RECEVERY_TIMEOUT = SystemPropertySupplier.create("oak.syncRecoveryTimeout", Long.MAX_VALUE);
+    private static final SystemPropertySupplier<Long> SYNC_RECEVERY_TIMEOUT_MILLIS = SystemPropertySupplier.create("oak.syncRecoveryTimeoutMillis", Long.MAX_VALUE);
 
     private static final long LOGINTERVALMS = TimeUnit.MINUTES.toMillis(1);
 
@@ -272,8 +272,8 @@ public class LastRevRecoveryAgent {
                 deadline = nodeInfo.getLeaseEndTime() - ClusterNodeInfo.DEFAULT_LEASE_FAILURE_MARGIN_MILLIS;
             }
             long now = System.currentTimeMillis();
-            if (Long.MAX_VALUE - SYNC_RECEVERY_TIMEOUT.get() > now) {
-                deadline = Math.min(deadline, now + SYNC_RECEVERY_TIMEOUT.get());
+            if (Long.MAX_VALUE - SYNC_RECEVERY_TIMEOUT_MILLIS.get() > now) {
+                deadline = Math.min(deadline, now + SYNC_RECEVERY_TIMEOUT_MILLIS.get());
             }
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -29,9 +29,11 @@ import static org.apache.jackrabbit.oak.plugins.document.util.Utils.PROPERTY_OR_
 import static org.apache.jackrabbit.oak.plugins.document.util.Utils.isCommitted;
 import static org.apache.jackrabbit.oak.plugins.document.util.Utils.resolveCommitRevision;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -274,6 +276,7 @@ public class LastRevRecoveryAgent {
             long now = System.currentTimeMillis();
             if (Long.MAX_VALUE - SYNC_RECOVERY_TIMEOUT_MILLIS.get() > now) {
                 deadline = Math.min(deadline, now + SYNC_RECOVERY_TIMEOUT_MILLIS.get());
+                log.info("Adjusted deadline for synchronous recovery. New deadline is {}", SimpleDateFormat.getDateTimeInstance().format(new Date(deadline)));
             }
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -34,7 +34,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -29,7 +29,8 @@ import static org.apache.jackrabbit.oak.plugins.document.util.Utils.PROPERTY_OR_
 import static org.apache.jackrabbit.oak.plugins.document.util.Utils.isCommitted;
 import static org.apache.jackrabbit.oak.plugins.document.util.Utils.resolveCommitRevision;
 
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -82,7 +83,10 @@ public class LastRevRecoveryAgent {
 
     private final Consumer<Integer> afterRecovery;
 
-    private static final SystemPropertySupplier<Long> SYNC_RECOVERY_TIMEOUT_MILLIS = SystemPropertySupplier.create("oak.syncRecoveryTimeoutMillis", Long.MAX_VALUE);
+    private static final long SYNC_RECOVERY_TIMEOUT_MILLIS =
+            SystemPropertySupplier
+                    .create("oak.documentMK.syncRecoveryTimeoutMillis", Long.MAX_VALUE)
+                    .validateWith(value -> value >= 0).get();
 
     private static final long LOGINTERVALMS = TimeUnit.MINUTES.toMillis(1);
 
@@ -271,12 +275,13 @@ public class LastRevRecoveryAgent {
         if (clusterId == revisionContext.getClusterId()) {
             ClusterNodeInfoDocument nodeInfo = missingLastRevUtil.getClusterNodeInfo(clusterId);
             if (nodeInfo != null && nodeInfo.isActive()) {
-                deadline = nodeInfo.getLeaseEndTime() - ClusterNodeInfo.DEFAULT_LEASE_FAILURE_MARGIN_MILLIS;
-            }
-            long now = System.currentTimeMillis();
-            if (Long.MAX_VALUE - SYNC_RECOVERY_TIMEOUT_MILLIS.get() > now) {
-                deadline = Math.min(deadline, now + SYNC_RECOVERY_TIMEOUT_MILLIS.get());
-                log.info("Adjusted deadline for synchronous recovery. New deadline is {}", SimpleDateFormat.getDateTimeInstance().format(new Date(deadline)));
+                long defaultDeadline = nodeInfo.getLeaseEndTime() - ClusterNodeInfo.DEFAULT_LEASE_FAILURE_MARGIN_MILLIS;
+                deadline = Math.min(defaultDeadline, revisionContext.getClock().millis() + SYNC_RECOVERY_TIMEOUT_MILLIS);
+                if (deadline != defaultDeadline) {
+                    log.info("Adjusted deadline for synchronous recovery from {} to {}.",
+                            LocalDateTime.ofEpochSecond(defaultDeadline / 1000, 0, ZoneOffset.UTC),
+                            LocalDateTime.ofEpochSecond(deadline / 1000, 0, ZoneOffset.UTC));
+                }
             }
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -45,6 +45,7 @@ import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.guava.common.collect.Sets;
 
 import org.apache.jackrabbit.oak.commons.TimeDurationFormatter;
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.plugins.document.bundlor.DocumentBundlor;
 import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
 import org.apache.jackrabbit.oak.plugins.document.util.MapFactory;
@@ -78,6 +79,8 @@ public class LastRevRecoveryAgent {
     private final MissingLastRevSeeker missingLastRevUtil;
 
     private final Consumer<Integer> afterRecovery;
+
+    private static final SystemPropertySupplier<Long> SYNC_RECEVERY_TIMEOUT = SystemPropertySupplier.create("oak.syncRecoveryTimeout", Long.MAX_VALUE);
 
     private static final long LOGINTERVALMS = TimeUnit.MINUTES.toMillis(1);
 
@@ -267,6 +270,10 @@ public class LastRevRecoveryAgent {
             ClusterNodeInfoDocument nodeInfo = missingLastRevUtil.getClusterNodeInfo(clusterId);
             if (nodeInfo != null && nodeInfo.isActive()) {
                 deadline = nodeInfo.getLeaseEndTime() - ClusterNodeInfo.DEFAULT_LEASE_FAILURE_MARGIN_MILLIS;
+            }
+            long now = System.currentTimeMillis();
+            if (Long.MAX_VALUE - SYNC_RECEVERY_TIMEOUT.get() > now) {
+                deadline = Math.min(deadline, now + SYNC_RECEVERY_TIMEOUT.get());
             }
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -80,7 +80,7 @@ public class LastRevRecoveryAgent {
 
     private final Consumer<Integer> afterRecovery;
 
-    private static final SystemPropertySupplier<Long> SYNC_RECEVERY_TIMEOUT_MILLIS = SystemPropertySupplier.create("oak.syncRecoveryTimeoutMillis", Long.MAX_VALUE);
+    private static final SystemPropertySupplier<Long> SYNC_RECOVERY_TIMEOUT_MILLIS = SystemPropertySupplier.create("oak.syncRecoveryTimeoutMillis", Long.MAX_VALUE);
 
     private static final long LOGINTERVALMS = TimeUnit.MINUTES.toMillis(1);
 
@@ -272,8 +272,8 @@ public class LastRevRecoveryAgent {
                 deadline = nodeInfo.getLeaseEndTime() - ClusterNodeInfo.DEFAULT_LEASE_FAILURE_MARGIN_MILLIS;
             }
             long now = System.currentTimeMillis();
-            if (Long.MAX_VALUE - SYNC_RECEVERY_TIMEOUT_MILLIS.get() > now) {
-                deadline = Math.min(deadline, now + SYNC_RECEVERY_TIMEOUT_MILLIS.get());
+            if (Long.MAX_VALUE - SYNC_RECOVERY_TIMEOUT_MILLIS.get() > now) {
+                deadline = Math.min(deadline, now + SYNC_RECOVERY_TIMEOUT_MILLIS.get());
             }
         }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LastRevRecoveryAgent.java
@@ -84,8 +84,8 @@ public class LastRevRecoveryAgent {
 
     private static final long SYNC_RECOVERY_TIMEOUT_MILLIS =
             SystemPropertySupplier
-                    .create("oak.documentMK.syncRecoveryTimeoutMillis", Long.MAX_VALUE)
-                    .validateWith(value -> value >= 0).get();
+                    .create("oak.documentMK.syncRecoveryTimeoutMillis", -1)
+                    .get();
 
     private static final long LOGINTERVALMS = TimeUnit.MINUTES.toMillis(1);
 
@@ -275,7 +275,7 @@ public class LastRevRecoveryAgent {
             ClusterNodeInfoDocument nodeInfo = missingLastRevUtil.getClusterNodeInfo(clusterId);
             if (nodeInfo != null && nodeInfo.isActive()) {
                 long defaultDeadline = nodeInfo.getLeaseEndTime() - ClusterNodeInfo.DEFAULT_LEASE_FAILURE_MARGIN_MILLIS;
-                deadline = Math.min(defaultDeadline, revisionContext.getClock().millis() + SYNC_RECOVERY_TIMEOUT_MILLIS);
+                deadline = SYNC_RECOVERY_TIMEOUT_MILLIS < 0 ? defaultDeadline : Math.min(defaultDeadline, revisionContext.getClock().millis() + SYNC_RECOVERY_TIMEOUT_MILLIS);
                 if (deadline != defaultDeadline) {
                     log.info("Adjusted deadline for synchronous recovery from {} to {}.",
                             LocalDateTime.ofEpochSecond(defaultDeadline / 1000, 0, ZoneOffset.UTC),


### PR DESCRIPTION
…vRecovery executions slowing down startup

Introduced the system variable oak.syncRecoveryTimeout to limit the duration of a self recovery at startup.