### PR TITLE
OAK-11285 - Check if paths used in included/excluded Paths are absolute and fail if they are not

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/secondary/SecondaryStoreObserverTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/secondary/SecondaryStoreObserverTest.java
@@ -95,7 +95,7 @@ public class SecondaryStoreObserverTest {
 
     @Test
     public void childNodeChangedAndExclude() throws Exception{
-        PathFilter pathFilter = new PathFilter(of("/a"), of("a/b"));
+        PathFilter pathFilter = new PathFilter(of("/a"), of("/a/b"));
         SecondaryStoreObserver observer = createBuilder(pathFilter).buildObserver();
         primary.addObserver(observer);
 

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
@@ -122,7 +122,9 @@ public class PathFilter {
      * @param includes list of paths which should be included
      * @param excludes list of paths which should not be included
      */
-    public PathFilter(Iterable<String> includes, Iterable<String> excludes) {
+    public PathFilter(@NotNull Iterable<String> includes, @NotNull Iterable<String> excludes) {
+        checkPathsAreAbsolute(includes, "included");
+        checkPathsAreAbsolute(excludes, "excluded");
         Set<String> includeCopy = CollectionUtils.toSet(includes);
         Set<String> excludeCopy = CollectionUtils.toSet(excludes);
         PathUtils.unifyInExcludes(includeCopy, excludeCopy);
@@ -194,5 +196,13 @@ public class PathFilter {
             }
         }
         return false;
+    }
+
+    private static void checkPathsAreAbsolute(Iterable<String> paths, String pathType) {
+        for (String path : paths) {
+            if (!PathUtils.isAbsolute(path)) {
+                throw new IllegalStateException("Invalid path in " + pathType + "Paths: " + path + ". Paths must be absolute.");
+            }
+        }
     }
 }

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
@@ -201,7 +201,7 @@ public class PathFilter {
     private static void checkPathsAreAbsolute(Iterable<String> paths, String pathType) {
         for (String path : paths) {
             if (!PathUtils.isAbsolute(path)) {
-                throw new IllegalStateException("Invalid path in " + pathType + "Paths: " + path + ". Paths must be absolute.");
+                throw new IllegalStateException("Invalid path in " + pathType + " paths list: " + path + ". Paths must be absolute.");
             }
         }
     }

--- a/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
+++ b/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
@@ -129,6 +130,31 @@ public class PathFilterTest {
         } catch (IllegalStateException ignore) {
             // expected
         }
+    }
+
+    @Test
+    public void checkPathsAreAbsoluteOk() {
+        new PathFilter(List.of("/a", "/b", "/c"), List.of());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidIncludedStartsWithEmpty() {
+        new PathFilter(List.of( "/a", " /b"), List.of());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidExcludedStartsWithEmpty() {
+        new PathFilter(List.of(), List.of( "/a", " /b"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidIncludedDoesNotStartWithSlash() {
+        new PathFilter(List.of("a"), List.of());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void invalidExcludedDoesNotStartWithSlash() {
+        new PathFilter(List.of(), List.of("a"));
     }
 
     @Test


### PR DESCRIPTION
The `includedPaths` and `excludedPaths` in an index definition must be absolute. If they are not or if they start with a space, then the indexing job may fail or hang. This PR adds a check to the `PathFilter` constructor to check that all paths are absolute and fail immediately if they are not.