### PR TITLE
OAK-11291 Tree store: speed up merging, and concurrent indexing

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
@@ -145,12 +145,7 @@ class DefaultIndexWriter implements LuceneIndexWriter {
                 PERF_LOGGER.end(start, -1, "Completed suggester for directory {}", definition);
             }
 
-            if (reindex && writerConfig.getThreadCount() > 1) {
-                // merges could be disabled, so it could in theory wait forever
-                writer.close(false);
-            } else {
-                writer.close();
-            }
+            writer.close();
             PERF_LOGGER.end(start, -1, "Closed writer for directory {}", definition);
 
             if (!indexUpdated){
@@ -175,12 +170,6 @@ class DefaultIndexWriter implements LuceneIndexWriter {
                     final long start = PERF_LOGGER.start();
                     directory = directoryFactory.newInstance(definition, definitionBuilder, dirName, reindex);
                     boolean serialScheduler = directoryFactory.remoteDirectory();
-                    if (writerConfig.getThreadCount() > 1) {
-                        // for multi-threaded indexing (using oak-run), use the serial scheduler,
-                        // to avoid concurrency issues with the concurrent merge policy
-                        log.info("Using the serial scheduler for parallel indexing");
-                        serialScheduler = true;
-                    }
                     IndexWriterConfig config = getIndexWriterConfig(definition, serialScheduler, writerConfig);
                     config.setMergePolicy(definition.getMergePolicy());
                     writer = localRefWriter = new IndexWriter(directory, config);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTreeStoreTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTreeStoreTask.java
@@ -52,7 +52,7 @@ public class PipelinedTreeStoreTask implements Callable<PipelinedSortBatchTask.R
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedTreeStoreTask.class);
     private static final String THREAD_NAME = "tree-store-task";
 
-    private static final int MERGE_BATCH = 10;
+    private static final int MERGE_BATCH = 25;
     private static final boolean SKIP_FINAL_MERGE = false;
 
     private final TreeStore treeStore;


### PR DESCRIPTION
The serial merge scheduler was used because there were errors when merging... but recently I found that the errors were because of missing synchronization in MultiplexingIndexWriter, which was fixed in https://github.com/apache/jackrabbit-oak/pull/1873/files .

So then, I I tested again and found that the default concurrent merge scheduler is faster than the serial one.