### PR TITLE
OAK-11292: Remove usage of Guava ImmutableMap.copyOf()

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/mount/SimpleMountInfoProvider.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/spi/mount/SimpleMountInfoProvider.java
@@ -20,11 +20,10 @@ package org.apache.jackrabbit.oak.spi.mount;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 
 /**
  * A simple and inefficient implementation to manage mount points
@@ -103,7 +102,7 @@ final class SimpleMountInfoProvider implements MountInfoProvider {
         for (Mount mi : mountInfos) {
             mounts.put(mi.getName(), mi);
         }
-        return ImmutableMap.copyOf(mounts);
+        return Collections.unmodifiableMap(mounts);
     }
 
     private static Mount defaultMount(Map<String, Mount> mounts) {

--- a/oak-exercise/src/main/java/org/apache/jackrabbit/oak/exercise/security/authentication/CustomCredentials.java
+++ b/oak-exercise/src/main/java/org/apache/jackrabbit/oak/exercise/security/authentication/CustomCredentials.java
@@ -19,8 +19,6 @@ package org.apache.jackrabbit.oak.exercise.security.authentication;
 import java.util.Map;
 import javax.jcr.Credentials;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
-
 class CustomCredentials implements Credentials {
 
     private final String loginID;
@@ -30,7 +28,7 @@ class CustomCredentials implements Credentials {
     CustomCredentials(String loginID, String password, Map<String,String> attributes) {
         this.loginID = loginID;
         this.password = password;
-        this.attributes = ImmutableMap.copyOf(attributes);
+        this.attributes = Map.copyOf(attributes);
     }
 
     String getLoginID() {

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/WorkspaceDelegate.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/WorkspaceDelegate.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.jcr.delegate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,6 @@ import javax.jcr.ItemExistsException;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -126,7 +126,7 @@ public class WorkspaceDelegate {
                     String sourceBaseVersionId = source.getProperty(JcrConstants.JCR_BASEVERSION).getValue(Type.STRING);
                     copyInfo.put(VersionConstants.JCR_COPIED_FROM, sourceBaseVersionId);
                 }
-                root.commit(ImmutableMap.copyOf(copyInfo));
+                root.commit(Collections.unmodifiableMap(copyInfo));
             } catch (CommitFailedException e) {
                 throw e.asRepositoryException();
             }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexAugmentorFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexAugmentorFactory.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.guava.common.collect.LinkedListMultimap;
 import org.apache.jackrabbit.guava.common.collect.ListMultimap;
 import org.apache.felix.scr.annotations.Component;
@@ -133,7 +132,7 @@ public class IndexAugmentorFactory {
             providerMap.put(nodeType, compositeIndexFieldProvider);
         }
 
-        indexFieldProviderMap = ImmutableMap.copyOf(providerMap);
+        indexFieldProviderMap = Collections.unmodifiableMap(providerMap);
     }
 
     private void refreshFulltextQueryTermsProviders() {
@@ -154,7 +153,7 @@ public class IndexAugmentorFactory {
             providerMap.put(nodeType, compositeFulltextQueryTermsProvider);
         }
 
-        fulltextQueryTermsProviderMap = ImmutableMap.copyOf(providerMap);
+        fulltextQueryTermsProviderMap = Collections.unmodifiableMap(providerMap);
     }
 
     private void resetState() {

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinition.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinition.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.CompressingCodec;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.TokenizerChain;
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.CommitMitigatingTieredMergePolicy;
@@ -170,7 +169,7 @@ public class LuceneIndexDefinition extends IndexDefinition {
             analyzerMap.put(ANL_DEFAULT, new OakAnalyzer(VERSION, true));
         }
 
-        return ImmutableMap.copyOf(analyzerMap);
+        return Collections.unmodifiableMap(analyzerMap);
     }
 
 

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authorization/restriction/AbstractRestrictionProvider.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authorization/restriction/AbstractRestrictionProvider.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,7 +52,9 @@ public abstract class AbstractRestrictionProvider implements RestrictionProvider
     private CompositeRestrictionProvider composite = null;
 
     public AbstractRestrictionProvider(@NotNull Map<String, ? extends RestrictionDefinition> definitions) {
-        this.supported = Map.copyOf(definitions);
+        Map<String, RestrictionDefinition> builder = new LinkedHashMap<>();
+        builder.putAll(definitions);
+        this.supported = Collections.unmodifiableMap(builder);
     }
 
     //---------------------------------------------------< AggregationAware >---

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authorization/restriction/AbstractRestrictionProvider.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/authorization/restriction/AbstractRestrictionProvider.java
@@ -30,7 +30,6 @@ import javax.jcr.Value;
 import javax.jcr.security.AccessControlException;
 
 import org.apache.jackrabbit.guava.common.collect.ImmutableList;
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.guava.common.collect.ImmutableSet;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
@@ -52,7 +51,7 @@ public abstract class AbstractRestrictionProvider implements RestrictionProvider
     private CompositeRestrictionProvider composite = null;
 
     public AbstractRestrictionProvider(@NotNull Map<String, ? extends RestrictionDefinition> definitions) {
-        this.supported = ImmutableMap.copyOf(definitions);
+        this.supported = Map.copyOf(definitions);
     }
 
     //---------------------------------------------------< AggregationAware >---

--- a/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/CompositeNodeStore.java
+++ b/oak-store-composite/src/main/java/org/apache/jackrabbit/oak/composite/CompositeNodeStore.java
@@ -56,10 +56,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.guava.common.collect.ImmutableMap.copyOf;
 
 import static org.apache.jackrabbit.guava.common.collect.Iterables.filter;
-import static org.apache.jackrabbit.guava.common.collect.Maps.filterKeys;
 
 import static java.lang.System.currentTimeMillis;
 import static org.apache.jackrabbit.oak.composite.ModifiedPathDiff.getModifiedPaths;
@@ -243,8 +241,9 @@ public class CompositeNodeStore implements NodeStore, PrefetchNodeStore, Observa
             LOG.debug("Checkpoint {} doesn't exist. Debug info:\n{}", checkpoint, checkpointDebugInfo(), new Exception("call stack"));
             return Collections.emptyMap();
         }
-        return copyOf(filterKeys(ctx.getGlobalStore().getNodeStore().checkpointInfo(checkpoint),
-                input -> !input.startsWith(CHECKPOINT_METADATA)));
+        return ctx.getGlobalStore().getNodeStore().checkpointInfo(checkpoint).entrySet().stream().
+                filter(e -> !e.getKey().startsWith(CHECKPOINT_METADATA)).
+                collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     Map<String, String> allCheckpointInfo(String checkpoint) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeState.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeState.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
 import org.apache.jackrabbit.guava.common.collect.TreeTraverser;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.cache.CacheValue;
@@ -789,7 +788,7 @@ public class DocumentNodeState extends AbstractDocumentNodeState implements Cach
         public BundlingContext(Matcher matcher, Map<String, PropertyState> rootProperties,
                                boolean hasBundledChildren, boolean hasNonBundledChildren) {
             this.matcher = matcher;
-            this.rootProperties = ImmutableMap.copyOf(rootProperties);
+            this.rootProperties = Map.copyOf(rootProperties);
             this.hasBundledChildren = hasBundledChildren;
             this.hasNonBundledChildren = hasNonBundledChildren;
         }


### PR DESCRIPTION
Note most uses have been replaced my "Map.of()" (when the deep copy mattered) or "Collections.unmodifiableMap()". There's a single more complicated case.