### PR TITLE
OAK-11386: oak-auth-ldap: update o.a.d.api-api-all dependency to 2.1.…

### DIFF
--- a/oak-auth-ldap/pom.xml
+++ b/oak-auth-ldap/pom.xml
@@ -52,13 +52,10 @@
                             !org.xmlpull.v1,
                             !sun.net.util,
                             !net.sf.cglib.proxy,
-                            !antlr,
-                            !antlr.collections.impl,
-                            !org.apache.mina.*,
                             *
                         </Import-Package>
                         <Embed-Dependency>
-                            api-all,commons-pool2,mina-core,org.apache.servicemix.bundles.antlr
+                            api-all
                         </Embed-Dependency>
                     </instructions>
                 </configuration>
@@ -80,7 +77,7 @@
         <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-all</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -92,9 +89,29 @@
             <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.13.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.1.10</version>
+            <version>2.2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>2.36.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.48.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
…7 and mina dependency to 2.2.4

Updated dependencies and removed unnecessary embeddings.