### PR TITLE
OAK-11409: Allow multiple cache expiration properties

### DIFF
--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProvider.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProvider.java
@@ -436,7 +436,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
 
     /**
      * Special handling for the case where dynamic groups have been added to local groups
-     * @return set of inherited group principals
+     * @return set of inherited group principals 
      */
     private Set<Principal> getInheritedPrincipals(@NotNull Set<Principal> externalGroupPrincipals, @NotNull String idpName) {
         if (idpNamesWithDynamicGroups.contains(idpName)) {

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProvider.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProvider.java
@@ -68,6 +68,7 @@ import org.apache.jackrabbit.oak.spi.security.principal.PrincipalProvider;
 import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
 import org.apache.jackrabbit.oak.spi.security.user.DynamicMembershipProvider;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
 import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
 import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
 import org.jetbrains.annotations.NotNull;
@@ -102,6 +103,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
 
     private static final Logger log = LoggerFactory.getLogger(ExternalGroupPrincipalProvider.class);
     static final String CACHE_PRINCIPAL_NAMES = "rep:externalLocalPrincipalNames";
+    static final String CACHE_EXP_PROPERTY_NAME = CacheConstants.REP_EXPIRATION + "ExternalLocalPrincipalNames";
 
     private static final String BINDING_PRINCIPAL_NAMES = "principalNames";
 
@@ -145,14 +147,12 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
         autoMembershipPrincipals = new AutoMembershipPrincipals(userManager, syncConfigTracker.getAutoMembership(), syncConfigTracker.getAutoMembershipConfig());
         groupAutoMembershipPrincipals = (idpNamesWithDynamicGroups.isEmpty()) ? null : new AutoMembershipPrincipals(userManager, syncConfigTracker.getGroupAutoMembership(), syncConfigTracker.getAutoMembershipConfig());
 
-        cacheReaderFactory = (String idpName) -> userConfiguration.getCachedMembershipReader(root,
-                (principalName) -> new CachedGroupPrincipal(principalName, userManager),
-                CACHE_PRINCIPAL_NAMES);
+        cacheReaderFactory = (String idpName) -> userConfiguration.getCachedMembershipReader(root, (principalName) -> new CachedGroupPrincipal(principalName, userManager), CACHE_PRINCIPAL_NAMES, CACHE_EXP_PROPERTY_NAME);
     }
 
     // Tests only
     ExternalGroupPrincipalProvider(@NotNull Root root, @NotNull UserConfiguration userConfiguration,
-                                   @NotNull NamePathMapper namePathMapper, 
+                                   @NotNull NamePathMapper namePathMapper,
                                    @NotNull String idpName,
                                    @NotNull DefaultSyncConfig syncConfig,
                                    @NotNull Set<String> idpNamesWithDynamicGroups, boolean hasOnlyDynamicGroups) {
@@ -163,11 +163,11 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
         this.idpNamesWithDynamicGroups = idpNamesWithDynamicGroups;
         this.hasOnlyDynamicGroups = hasOnlyDynamicGroups;
 
-        autoMembershipPrincipals = new AutoMembershipPrincipals(userManager, 
+        autoMembershipPrincipals = new AutoMembershipPrincipals(userManager,
                 Collections.singletonMap(idpName, Iterables.toArray(Iterables.concat(syncConfig.user().getAutoMembership(),syncConfig.group().getAutoMembership()), String.class)),
                 Collections.singletonMap(idpName, syncConfig.user().getAutoMembershipConfig()));
-        groupAutoMembershipPrincipals = (idpNamesWithDynamicGroups.isEmpty()) ? null : 
-                new AutoMembershipPrincipals(userManager, 
+        groupAutoMembershipPrincipals = (idpNamesWithDynamicGroups.isEmpty()) ? null :
+                new AutoMembershipPrincipals(userManager,
                 Collections.singletonMap(idpName, syncConfig.group().getAutoMembership().toArray(new String[0])),
                 Collections.singletonMap(idpName, syncConfig.group().getAutoMembershipConfig()));
     }
@@ -348,8 +348,8 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
     /**
      * Verify that the dynamic external group belongs to the same IDP as the member for which groups are being retrieved.
      * Note that {@code DynamicSyncContext#syncMembership} also asserts there are no collisions between external principal names.
-     * 
-     * @param group The authorizable matching an entry in the {@code REP_EXTERNAL_PRINCIPAL_NAMES} property of the 
+     *
+     * @param group The authorizable matching an entry in the {@code REP_EXTERNAL_PRINCIPAL_NAMES} property of the
      *              target member.
      * @param member The target member
      * @return {@code true} if the given authorizable is a valid external group that belongs to the same IDP; {@code false} otherwise.
@@ -436,7 +436,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
 
     /**
      * Special handling for the case where dynamic groups have been added to local groups
-     * @return set of inherited group principals 
+     * @return set of inherited group principals
      */
     private Set<Principal> getInheritedPrincipals(@NotNull Set<Principal> externalGroupPrincipals, @NotNull String idpName) {
         if (idpNamesWithDynamicGroups.contains(idpName)) {
@@ -453,7 +453,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
     private Set<Principal> getAutomembershipPrincipals(@NotNull String idpName, @NotNull Authorizable authorizable) {
         if (authorizable.isGroup()) {
             // no need to check for 'groupAutoMembershipPrincipals' being null as it is created if 'idpNamesWithDynamicGroups' is not empty
-            return (idpNamesWithDynamicGroups.contains(idpName)) ? 
+            return (idpNamesWithDynamicGroups.contains(idpName)) ?
                     groupAutoMembershipPrincipals.getAutoMembership(idpName, authorizable, true).keySet() :
                     Collections.emptySet();
         } else {
@@ -547,8 +547,8 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
     }
 
     /**
-     * Implementation of the {@link org.apache.jackrabbit.api.security.principal.GroupPrincipal} interface representing 
-     * external group identities that are represented as authorizable group in the repository's user management i.e.   
+     * Implementation of the {@link org.apache.jackrabbit.api.security.principal.GroupPrincipal} interface representing
+     * external group identities that are represented as authorizable group in the repository's user management i.e.
      * the {@code SyncHandler} configured for the IDP with the given name has dynamic-group option enabled.
      */
     private final class ExternalGroupPrincipalItemBased extends ExternalGroupPrincipal implements ItemBasedPrincipal {
@@ -703,7 +703,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
      * exact name of the external group principal.
      *
      * @see ExternalGroupPrincipal#members()
-     * @see ExternalGroupPrincipalProvider#getMembers(Group, boolean) 
+     * @see ExternalGroupPrincipalProvider#getMembers(Group, boolean)
      */
     private abstract class MemberIterator<T> extends AbstractLazyIterator<T> {
 

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProvider.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProvider.java
@@ -152,7 +152,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
 
     // Tests only
     ExternalGroupPrincipalProvider(@NotNull Root root, @NotNull UserConfiguration userConfiguration,
-                                   @NotNull NamePathMapper namePathMapper,
+                                   @NotNull NamePathMapper namePathMapper, 
                                    @NotNull String idpName,
                                    @NotNull DefaultSyncConfig syncConfig,
                                    @NotNull Set<String> idpNamesWithDynamicGroups, boolean hasOnlyDynamicGroups) {
@@ -163,11 +163,11 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
         this.idpNamesWithDynamicGroups = idpNamesWithDynamicGroups;
         this.hasOnlyDynamicGroups = hasOnlyDynamicGroups;
 
-        autoMembershipPrincipals = new AutoMembershipPrincipals(userManager,
+        autoMembershipPrincipals = new AutoMembershipPrincipals(userManager, 
                 Collections.singletonMap(idpName, Iterables.toArray(Iterables.concat(syncConfig.user().getAutoMembership(),syncConfig.group().getAutoMembership()), String.class)),
                 Collections.singletonMap(idpName, syncConfig.user().getAutoMembershipConfig()));
-        groupAutoMembershipPrincipals = (idpNamesWithDynamicGroups.isEmpty()) ? null :
-                new AutoMembershipPrincipals(userManager,
+        groupAutoMembershipPrincipals = (idpNamesWithDynamicGroups.isEmpty()) ? null : 
+                new AutoMembershipPrincipals(userManager, 
                 Collections.singletonMap(idpName, syncConfig.group().getAutoMembership().toArray(new String[0])),
                 Collections.singletonMap(idpName, syncConfig.group().getAutoMembershipConfig()));
     }
@@ -348,8 +348,8 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
     /**
      * Verify that the dynamic external group belongs to the same IDP as the member for which groups are being retrieved.
      * Note that {@code DynamicSyncContext#syncMembership} also asserts there are no collisions between external principal names.
-     *
-     * @param group The authorizable matching an entry in the {@code REP_EXTERNAL_PRINCIPAL_NAMES} property of the
+     * 
+     * @param group The authorizable matching an entry in the {@code REP_EXTERNAL_PRINCIPAL_NAMES} property of the 
      *              target member.
      * @param member The target member
      * @return {@code true} if the given authorizable is a valid external group that belongs to the same IDP; {@code false} otherwise.
@@ -453,7 +453,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
     private Set<Principal> getAutomembershipPrincipals(@NotNull String idpName, @NotNull Authorizable authorizable) {
         if (authorizable.isGroup()) {
             // no need to check for 'groupAutoMembershipPrincipals' being null as it is created if 'idpNamesWithDynamicGroups' is not empty
-            return (idpNamesWithDynamicGroups.contains(idpName)) ?
+            return (idpNamesWithDynamicGroups.contains(idpName)) ? 
                     groupAutoMembershipPrincipals.getAutoMembership(idpName, authorizable, true).keySet() :
                     Collections.emptySet();
         } else {
@@ -547,8 +547,8 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
     }
 
     /**
-     * Implementation of the {@link org.apache.jackrabbit.api.security.principal.GroupPrincipal} interface representing
-     * external group identities that are represented as authorizable group in the repository's user management i.e.
+     * Implementation of the {@link org.apache.jackrabbit.api.security.principal.GroupPrincipal} interface representing 
+     * external group identities that are represented as authorizable group in the repository's user management i.e.   
      * the {@code SyncHandler} configured for the IDP with the given name has dynamic-group option enabled.
      */
     private final class ExternalGroupPrincipalItemBased extends ExternalGroupPrincipal implements ItemBasedPrincipal {
@@ -703,7 +703,7 @@ class ExternalGroupPrincipalProvider implements PrincipalProvider, ExternalIdent
      * exact name of the external group principal.
      *
      * @see ExternalGroupPrincipal#members()
-     * @see ExternalGroupPrincipalProvider#getMembers(Group, boolean)
+     * @see ExternalGroupPrincipalProvider#getMembers(Group, boolean) 
      */
     private abstract class MemberIterator<T> extends AbstractLazyIterator<T> {
 

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProviderWithCacheTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/ExternalGroupPrincipalProviderWithCacheTest.java
@@ -153,7 +153,6 @@ public class ExternalGroupPrincipalProviderWithCacheTest extends AbstractPrincip
         Authorizable user = getUserManager(root).getAuthorizable(USER_ID);
         assertNotNull(user);
 
-        // same as in test before even if the principal is not a tree-based-principal
         Set<Principal> expected = getExternalGroupPrincipals(USER_ID);
         expected.add(testGroup.getPrincipal());
         Set<? extends Principal> principals = principalProvider.getMembershipPrincipals(user.getPrincipal());
@@ -169,42 +168,4 @@ public class ExternalGroupPrincipalProviderWithCacheTest extends AbstractPrincip
         Set<Principal> readFromCache = principalProvider.getMembershipPrincipals(user.getPrincipal());
         assertEquals(expected, readFromCache);
     }
-
-//    @Test
-//    public void testCachedGroupPrincipalIsMember() throws Exception {
-//        Authorizable user = getUserManager(root).getAuthorizable(USER_ID);
-//        assertNotNull(user);
-//        Set<? extends Principal> principals = principalProvider.getMembershipPrincipals(user.getPrincipal());
-//        assertTrue(principals.contains(testGroup.getPrincipal()));
-//
-//        root.refresh(); //Refreshing root to make sure changes in cache are reflected
-//        Tree cacheTree = root.getTree(user.getPath()).getChild(REP_CACHE);
-//        assertNotNull(cacheTree);
-//        assertTrue(cacheTree.hasProperty(CACHE_PRINCIPAL_NAMES));
-//        assertFalse(cacheTree.getProperty(CACHE_PRINCIPAL_NAMES).getValue(Type.STRING).isEmpty());
-//
-//        Set<Principal> externalPrincipals = getExternalGroupPrincipals(USER_ID);
-//        Set<Principal> cachedPrincipals = principalProvider.getMembershipPrincipals(user.getPrincipal());
-//        cachedPrincipals.forEach(principal -> {
-//            try {
-//                assertTrue(principal instanceof ItemBasedPrincipal);
-//                assertTrue(principal instanceof GroupPrincipal);
-//                GroupPrincipal groupPrincipal = (GroupPrincipal) principal;
-//                ItemBasedPrincipal itemBasedPrincipal = (ItemBasedPrincipal) principal;
-//                assertNotNull(itemBasedPrincipal.getPath());
-//                if (principal.getName().equals(testGroup.getPrincipal().getName())) {
-//                    //Check if external group is a member of the cached group
-//                    externalPrincipals.forEach(externalPrincipal -> {
-//                        assertTrue(groupPrincipal.isMember(externalPrincipal));
-//                    });
-//
-//                    var members = groupPrincipal.members();
-//                    assertTrue(members.hasMoreElements());
-//
-//                }
-//            } catch (RepositoryException e) {
-//                throw new RuntimeException(e);
-//            }
-//        });
-//    }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CacheConfiguration.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CacheConfiguration.java
@@ -81,7 +81,7 @@ final class CacheConfiguration {
             throw new IllegalArgumentException("Invalid property name: " + propertyName);
         }
 
-        if (StringUtils.isBlank(expirationPropertyName)  || !expirationPropertyName.startsWith(CacheConstants.REP_EXPIRATION)) {
+        if (StringUtils.isBlank(expirationPropertyName) || !expirationPropertyName.startsWith(CacheConstants.REP_EXPIRATION)) {
             throw new IllegalArgumentException("Invalid expiration property name: " + expirationPropertyName);
         }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CacheConfiguration.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CacheConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.security.user;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -39,23 +40,29 @@ final class CacheConfiguration {
     private final long maxStale;
     private final String propertyName;
     private final int membershipThreshold;
+    private final String expirationPropertyName;
 
-    private CacheConfiguration(UserConfiguration userConfig, long expiration, long maxStale, @NotNull String propertyName) {
+    private CacheConfiguration(UserConfiguration userConfig, long expiration, long maxStale,
+           @NotNull String propertyName,
+           @NotNull String expirationPropertyName) {
         this.userConfig = userConfig;
         this.expiration = expiration;
         this.maxStale = maxStale;
         this.propertyName = propertyName;
+        this.expirationPropertyName = expirationPropertyName;
         this.membershipThreshold = 0;
     }
 
     // Only for testing
     CacheConfiguration(UserConfiguration userConfig, long expiration, long maxStale,
             @NotNull String propertyName,
+            @NotNull String expirationPropertyName,
             int membershipThreshold) {
         this.userConfig = userConfig;
         this.expiration = expiration;
         this.maxStale = maxStale;
         this.propertyName = propertyName;
+        this.expirationPropertyName = expirationPropertyName;
         this.membershipThreshold = Math.max(membershipThreshold, MEMBERSHIP_THRESHOLD);
     }
 
@@ -66,15 +73,33 @@ final class CacheConfiguration {
      * @param propertyName Property name used to store the cached principal names
      * @return CacheConfiguration based on the user configuration
      */
-    public static CacheConfiguration fromUserConfiguration(@NotNull UserConfiguration config, @NotNull String propertyName) {
+    public static CacheConfiguration fromUserConfiguration(@NotNull UserConfiguration config,
+            @NotNull String propertyName,
+            @NotNull String expirationPropertyName) {
 
-        if (StringUtils.isEmpty(propertyName) || propertyName.trim().isEmpty()) {
+        if (StringUtils.isBlank(propertyName)) {
             throw new IllegalArgumentException("Invalid property name: " + propertyName);
+        }
+
+        if (StringUtils.isBlank(expirationPropertyName)  || !expirationPropertyName.startsWith(CacheConstants.REP_EXPIRATION)) {
+            throw new IllegalArgumentException("Invalid expiration property name: " + expirationPropertyName);
         }
 
         long maxStale = config.getParameters().getConfigValue(PARAM_CACHE_MAX_STALE, NO_STALE_CACHE);
         long expiration  = config.getParameters().getConfigValue(PARAM_CACHE_EXPIRATION, EXPIRATION_NO_CACHE);
-        return new CacheConfiguration(config, expiration, maxStale, propertyName);
+
+        return new CacheConfiguration(config, expiration, maxStale, propertyName, expirationPropertyName);
+    }
+
+    /**
+     * Default visibility builder method that uses REP_EXPIRATION as the default expiration property name.
+     * @param config UserConfiguration to create the cache configuration from
+     * @param propertyName Property name used to store the cached principal names
+     * @return CacheConfiguration based on the user configuration
+     */
+    static CacheConfiguration fromUserConfiguration(@NotNull UserConfiguration config,
+            @NotNull String propertyName) {
+        return fromUserConfiguration(config, propertyName, CacheConstants.REP_EXPIRATION);
     }
 
     public boolean isCacheEnabled() {
@@ -91,6 +116,10 @@ final class CacheConfiguration {
 
     String getPropertyName() {
         return propertyName;
+    }
+
+    String getExpirationPropertyName() {
+        return expirationPropertyName;
     }
 
     UserConfiguration getUserConfiguration() {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CacheConflictHandler.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CacheConflictHandler.java
@@ -51,15 +51,14 @@ class CacheConflictHandler extends DefaultThreeWayConflictHandler {
 
     protected CacheConflictHandler() {
         super(Resolution.IGNORED);
-
     }
 
     private Resolution resolveRepExpirationConflict(@NotNull NodeBuilder parent, @NotNull PropertyState ours, @NotNull PropertyState theirs,
                                          PropertyState base) {
-        if (CacheConstants.REP_EXPIRATION.equals(ours.getName()) && CacheConstants.REP_EXPIRATION.equals(theirs.getName())){
+        if (ours.getName() != null && ours.getName().equals(theirs.getName()) && ours.getName().startsWith(CacheConstants.REP_EXPIRATION)) {
 
             PropertyBuilder<Long> merged = PropertyBuilder.scalar(Type.LONG);
-            merged.setName(CacheConstants.REP_EXPIRATION);
+            merged.setName(ours.getName());
 
             //if base is bigger than ours and theirs, then use base. This should never happens
             if (base.getValue(Type.LONG) > ours.getValue(Type.LONG)  &&
@@ -77,7 +76,7 @@ class CacheConflictHandler extends DefaultThreeWayConflictHandler {
                 merged.setValue(theirs.getValue(Type.LONG));
             }
             parent.setProperty(merged.getPropertyState());
-            LOG.debug("Resolved conflict for property {} our value: {}, their value {}, merged value: {}", CacheConstants.REP_EXPIRATION, ours.getValue(Type.LONG), theirs.getValue(Type.LONG), merged.getValue(0));
+            LOG.debug("Resolved conflict for property {} our value: {}, their value {}, merged value: {}", ours.getName(), ours.getValue(Type.LONG), theirs.getValue(Type.LONG), merged.getValue(0));
             return Resolution.MERGED;
         }
         return Resolution.IGNORED;
@@ -88,9 +87,6 @@ class CacheConflictHandler extends DefaultThreeWayConflictHandler {
     @NotNull
     public Resolution changeChangedProperty(@NotNull NodeBuilder parent, @NotNull PropertyState ours, @NotNull PropertyState theirs,
                                             @NotNull PropertyState base) {
-
         return resolveRepExpirationConflict(parent, ours, theirs, base);
     }
-
-
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CachedPrincipalMembershipReader.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CachedPrincipalMembershipReader.java
@@ -16,8 +16,27 @@
  */
 package org.apache.jackrabbit.oak.security.user;
 
-import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.EXPIRATION_NO_CACHE;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.guava.common.collect.Iterables;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Root;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.LongUtils;
+import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
+import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheLoader;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CachePrincipalFactory;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
+import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
+import org.apache.jackrabbit.util.Text;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.jcr.AccessDeniedException;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,28 +44,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.jcr.AccessDeniedException;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jackrabbit.guava.common.base.Strings;
-import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.api.Root;
-import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.commons.LongUtils;
-import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CacheLoader;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CachePrincipalFactory;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
-import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
-import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
-import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
-import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
-import org.apache.jackrabbit.util.Text;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.EXPIRATION_NO_CACHE;
 
 /**
  * Extension of {@code PrincipalMembershipReader} that caches the membership of a given user principal. The cache
@@ -80,12 +79,14 @@ class CachedPrincipalMembershipReader implements CachedMembershipReader {
     private final long maxStale;
     private final String propertyName;
     private final int membershipThreshold;
+    private final String expirationPropertyName;
 
     CachedPrincipalMembershipReader(@NotNull CacheConfiguration cacheConfiguration, @NotNull Root root,
             @NotNull CachePrincipalFactory principalFactory) {
         this.expiration = cacheConfiguration.getExpiration();
         this.maxStale = cacheConfiguration.getMaxStale();
         this.propertyName = cacheConfiguration.getPropertyName();
+        this.expirationPropertyName = cacheConfiguration.getExpirationPropertyName();
         this.config = cacheConfiguration.getUserConfiguration();
         this.membershipThreshold = cacheConfiguration.getMembershipThreshold();
         this.root = root;
@@ -161,11 +162,11 @@ class CachedPrincipalMembershipReader implements CachedMembershipReader {
         return groups;
     }
 
-    private static long readExpirationTime(@NotNull Tree principalCache) {
-        if (!principalCache.exists()) {
+    private long readExpirationTime(@NotNull Tree principalCache) {
+        if (!principalCache.exists() || !principalCache.hasProperty(expirationPropertyName)) {
             return EXPIRATION_NO_CACHE;
         }
-        return TreeUtil.getLong(principalCache, CacheConstants.REP_EXPIRATION, EXPIRATION_NO_CACHE);
+        return TreeUtil.getLong(principalCache, expirationPropertyName, EXPIRATION_NO_CACHE);
     }
 
     private static boolean isValidCache(long expirationTime, long now) {
@@ -226,7 +227,7 @@ class CachedPrincipalMembershipReader implements CachedMembershipReader {
                             CacheConstants.NT_REP_CACHE);
                 }
             }
-            cache.setProperty(CacheConstants.REP_EXPIRATION, LongUtils.calculateExpirationTime(expiration));
+            cache.setProperty(this.expirationPropertyName, LongUtils.calculateExpirationTime(expiration));
             String value = (groupPrincipals.isEmpty()) ? "" : String.join(",", Iterables.transform(groupPrincipals, input -> Text.escape(input.getName())));
             cache.setProperty(this.propertyName, value);
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CachedPrincipalMembershipReader.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/CachedPrincipalMembershipReader.java
@@ -16,27 +16,8 @@
  */
 package org.apache.jackrabbit.oak.security.user;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jackrabbit.guava.common.collect.Iterables;
-import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.api.Root;
-import org.apache.jackrabbit.oak.api.Tree;
-import org.apache.jackrabbit.oak.commons.LongUtils;
-import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
-import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
-import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
-import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CacheLoader;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CachePrincipalFactory;
-import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
-import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
-import org.apache.jackrabbit.util.Text;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.EXPIRATION_NO_CACHE;
 
-import javax.jcr.AccessDeniedException;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.HashSet;
@@ -44,8 +25,27 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.jcr.AccessDeniedException;
 
-import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.EXPIRATION_NO_CACHE;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.guava.common.collect.Iterables;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Root;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.LongUtils;
+import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheLoader;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CachePrincipalFactory;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.security.user.AuthorizableType;
+import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
+import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
+import org.apache.jackrabbit.util.Text;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Extension of {@code PrincipalMembershipReader} that caches the membership of a given user principal. The cache

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserConfigurationImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserConfigurationImpl.java
@@ -321,8 +321,10 @@ public class UserConfigurationImpl extends ConfigurationBase implements UserConf
 
     @Override
     public CachedMembershipReader getCachedMembershipReader(@NotNull Root root,
-            @NotNull CachePrincipalFactory cachePrincipalFactory, @NotNull String propName) {
-        CacheConfiguration cacheConfig = CacheConfiguration.fromUserConfiguration(this, propName);
+            @NotNull CachePrincipalFactory cachePrincipalFactory,
+            @NotNull String propName,
+            @NotNull String expirationPropName) {
+        CacheConfiguration cacheConfig = CacheConfiguration.fromUserConfiguration(this, propName, expirationPropName);
         if (cacheConfig.isCacheEnabled()) {
             return new CachedPrincipalMembershipReader(cacheConfig, root, cachePrincipalFactory);
         } else {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/CacheConfigurationTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/CacheConfigurationTest.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.AbstractSecurityTest;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationBase;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
 import org.junit.Test;
 
 public class CacheConfigurationTest extends AbstractSecurityTest {
@@ -61,6 +62,10 @@ public class CacheConfigurationTest extends AbstractSecurityTest {
         assertThrows(IllegalArgumentException.class, () -> CacheConfiguration.fromUserConfiguration(getUserConfiguration(), null));
         assertThrows(IllegalArgumentException.class, () -> CacheConfiguration.fromUserConfiguration(getUserConfiguration(), ""));
         assertThrows(IllegalArgumentException.class, () -> CacheConfiguration.fromUserConfiguration(getUserConfiguration(), " "));
+        assertThrows(IllegalArgumentException.class, () -> CacheConfiguration.fromUserConfiguration(getUserConfiguration(), "property", null));
+        assertThrows(IllegalArgumentException.class, () -> CacheConfiguration.fromUserConfiguration(getUserConfiguration(), "property", " "));
+        assertThrows(IllegalArgumentException.class, () -> CacheConfiguration.fromUserConfiguration(getUserConfiguration(), "property", "wrongExpiration"));
+
     }
 
     @Test
@@ -94,7 +99,7 @@ public class CacheConfigurationTest extends AbstractSecurityTest {
 
     @Test
     public void testConfigurationWithMembershipThreshold() {
-        CacheConfiguration cacheConfiguration = new CacheConfiguration(getUserConfiguration(), 10000, 100, UserPrincipalProvider.REP_GROUP_PRINCIPAL_NAMES, 10);
+        CacheConfiguration cacheConfiguration = new CacheConfiguration(getUserConfiguration(), 10000, 100, UserPrincipalProvider.REP_GROUP_PRINCIPAL_NAMES, CacheConstants.REP_EXPIRATION, 10);
 
         assertNotNull(cacheConfiguration);
         assertTrue(cacheConfiguration.isCacheEnabled());

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/CachedPrincipalMembershipReaderTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/CachedPrincipalMembershipReaderTest.java
@@ -22,8 +22,10 @@ import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.NO_STAL
 import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.PARAM_CACHE_EXPIRATION;
 import static org.apache.jackrabbit.oak.security.user.CacheConfiguration.PARAM_CACHE_MAX_STALE;
 import static org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants.REP_CACHE;
+import static org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants.REP_EXPIRATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -213,8 +215,7 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
     public void testWritingCacheFailsWithException() throws Exception {
         CachedMembershipReader cachedGroupMembershipReader = createCacheMembershipReader(root);
 
-        Set<Principal> groupPrincipals = new HashSet<>();
-        groupPrincipals.addAll(cachedGroupMembershipReader.readMembership(root.getTree(userPath), cacheLoader));
+        Set<Principal> groupPrincipals = new HashSet<>(cachedGroupMembershipReader.readMembership(root.getTree(userPath), cacheLoader));
 
         Set<Principal> expected = Collections.singleton(getUserManager(root).getAuthorizable(groupId).getPrincipal());
         assertEquals(expected, groupPrincipals);
@@ -232,9 +233,8 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
     public void testReadMembershipForNonUser() throws Exception {
         CachedMembershipReader cachedGroupMembershipReader = spy(createCacheMembershipReader(root));
 
-        Set<Principal> groupPrincipals = new HashSet<>();
         Tree groupTree = getTree(groupId2, root);
-        groupPrincipals.addAll(cachedGroupMembershipReader.readMembership(groupTree, cacheLoader));
+        Set<Principal> groupPrincipals = new HashSet<>(cachedGroupMembershipReader.readMembership(groupTree, cacheLoader));
 
         Set<Principal> expected = Collections.singleton(getUserManager(root).getAuthorizable(groupId).getPrincipal());
         assertEquals(expected, groupPrincipals);
@@ -252,8 +252,7 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
         Root systemRoot = spy(getSystemRoot());
         CachedMembershipReader cachedGroupMembershipReader = createCacheMembershipReader(systemRoot);
 
-        Set<Principal> groupPrincipal = new HashSet<>();
-        groupPrincipal.addAll(cachedGroupMembershipReader.readMembership(systemRoot.getTree(userPath), cacheLoader));
+        Set<Principal> groupPrincipal = new HashSet<>(cachedGroupMembershipReader.readMembership(systemRoot.getTree(userPath), cacheLoader));
 
         //Assert that the first time the cache was created
         assertEquals(2, logCustomizer.getLogs().size());
@@ -289,7 +288,7 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
             getMembershipThreads[i] = new Thread(() -> {
                 CachedMembershipReader membershipReader = createMockedPrincipalMembershipReader(mockedGroupPrincipalFactory, getUserConfiguration(), mockedRoot);
                 Set<Principal> groupPrincipals = new HashSet<>(membershipReader.readMembership(mockedUser, (tree) -> Set.of(principal)));
-                assertEquals(groupPrincipals.size(), 1);
+                assertEquals(1, groupPrincipals.size());
             });
             getMembershipThreads[i].start();
         }
@@ -330,8 +329,8 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
 
         PropertyState propertyStateExpiration = mock(PropertyState.class);
         when(propertyStateExpiration.getValue(Type.LONG)).thenReturn(System.currentTimeMillis());
-        when(mockedPrincipalCache.getProperty(CacheConstants.REP_EXPIRATION)).thenReturn(
-                propertyStateExpiration);
+        when(mockedPrincipalCache.getProperty(CacheConstants.REP_EXPIRATION)).thenReturn(propertyStateExpiration);
+        when(mockedPrincipalCache.hasProperty(CacheConstants.REP_EXPIRATION)).thenReturn(true);
 
         PropertyState propertyStatePrincipalNames = mock(PropertyState.class);
         when(propertyStatePrincipalNames.getValue(Type.STRING)).thenReturn("groupPrincipal");
@@ -541,7 +540,7 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
         //Create cache configuration but targeting different property name
         String newCachePropertyName = "anotherCache";
         CacheConfiguration anotherCacheConfiguration =
-                new CacheConfiguration(getUserConfiguration(), 5000, cacheMaxStale, newCachePropertyName, 2);
+                new CacheConfiguration(getUserConfiguration(), 5000, cacheMaxStale, newCachePropertyName, CacheConstants.REP_EXPIRATION, 2);
         CachedMembershipReader anotherCacheReader = new CachedPrincipalMembershipReader(anotherCacheConfiguration,
                 systemRoot, name -> getPrincipalByName(systemRoot, name));
 
@@ -562,6 +561,44 @@ public class CachedPrincipalMembershipReaderTest extends AbstractSecurityTest {
         assertFalse(cacheNode.hasProperty(newCachePropertyName));
     }
 
+    @Test
+    public void testMultipleCacheProviderWithDifferentExpirationProperties() throws Exception {
+        Root systemRoot = getSystemRoot();
+        CachedMembershipReader defaultCacheReader = createCacheMembershipReader(systemRoot);
+
+        //Create cache configuration but targeting different property name
+        String newCachePropertyName = "anotherCache";
+        String newExpirationCacheName = REP_EXPIRATION + "AnotherCache";
+        CacheConfiguration anotherCacheConfiguration = CacheConfiguration.fromUserConfiguration(getUserConfiguration(),
+                newCachePropertyName, newExpirationCacheName);
+        CachedMembershipReader anotherCacheReader = new CachedPrincipalMembershipReader(anotherCacheConfiguration,
+                systemRoot, name -> getPrincipalByName(systemRoot, name));
+
+        Set<Principal> groupPrincipal = new HashSet<>();
+        groupPrincipal.addAll(defaultCacheReader.readMembership(systemRoot.getTree(userPath), cacheLoader));
+
+        //Assert that the first time the cache was created
+        assertEquals(2, logCustomizer.getLogs().size());
+        assertEquals("Attempting to create new membership cache at " + userPath, logCustomizer.getLogs().get(0));
+        assertEquals(1, groupPrincipal.size());
+
+        groupPrincipal.addAll(anotherCacheReader.readMembership(systemRoot.getTree(userPath), cacheLoader));
+        assertEquals(3, logCustomizer.getLogs().size());
+        //Assert that the cache was used
+        assertEquals("Cached membership property '" + newCachePropertyName + "' at " + userPath, logCustomizer.getLogs().get(2));
+        assertEquals(1, groupPrincipal.size());
+
+        assertTrue(systemRoot.getTree(userPath).hasChild(REP_CACHE));
+        Tree cacheNode = systemRoot.getTree(userPath).getChild(REP_CACHE);
+        assertTrue(cacheNode.hasProperty(UserPrincipalProvider.REP_GROUP_PRINCIPAL_NAMES));
+        assertTrue(cacheNode.hasProperty(newCachePropertyName));
+        assertTrue(cacheNode.hasProperty(newExpirationCacheName));
+        assertTrue(cacheNode.hasProperty(REP_EXPIRATION));
+        assertNotEquals(cacheNode.getProperty(REP_EXPIRATION), cacheNode.getProperty(newExpirationCacheName));
+        assertEquals(cacheNode.getProperty(UserPrincipalProvider.REP_GROUP_PRINCIPAL_NAMES).getValue(Type.STRINGS),
+                cacheNode.getProperty(newCachePropertyName).getValue(Type.STRINGS));
+
+    }
 
     // -------------------------- Helper methods --------------------------------
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/UserConfigurationImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/UserConfigurationImplTest.java
@@ -17,12 +17,15 @@
 package org.apache.jackrabbit.oak.security.user;
 
 import org.apache.jackrabbit.oak.AbstractSecurityTest;
+import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.spi.commit.MoveTracker;
 import org.apache.jackrabbit.oak.spi.commit.ThreeWayConflictHandler;
 import org.apache.jackrabbit.oak.spi.commit.ValidatorProvider;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
 import org.apache.jackrabbit.oak.spi.security.user.util.PasswordUtil;
 import org.apache.jackrabbit.oak.spi.xml.ImportBehavior;
 import org.apache.jackrabbit.oak.spi.xml.ProtectedItemImporter;
@@ -37,7 +40,10 @@ import java.util.List;
 
 import static org.apache.jackrabbit.oak.spi.security.user.UserConstants.PARAM_DEFAULT_DEPTH;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class UserConfigurationImplTest extends AbstractSecurityTest {
 
@@ -56,7 +62,7 @@ public class UserConfigurationImplTest extends AbstractSecurityTest {
 
     @Override
     protected ConfigurationParameters getSecurityConfigParameters() {
-        return ConfigurationParameters.of(UserConfiguration.NAME, getParams());
+        return ConfigurationParameters.of(UserConfiguration.NAME, getParams(false));
     }
 
     @Test
@@ -65,7 +71,7 @@ public class UserConfigurationImplTest extends AbstractSecurityTest {
         configuration.setRootProvider(getRootProvider());
         configuration.setTreeProvider(getTreeProvider());
 
-        List<? extends ValidatorProvider> validators = configuration.getValidators(adminSession.getWorkspaceName(), Collections.<Principal>emptySet(), new MoveTracker());
+        List<? extends ValidatorProvider> validators = configuration.getValidators(adminSession.getWorkspaceName(), Collections.emptySet(), new MoveTracker());
         assertEquals(2, validators.size());
 
         List<String> clNames = new ArrayList<>(Arrays.asList(
@@ -106,10 +112,26 @@ public class UserConfigurationImplTest extends AbstractSecurityTest {
     @Test
     public void testUserConfigurationWithSetParameters() {
         UserConfigurationImpl userConfiguration = new UserConfigurationImpl();
-        userConfiguration.setParameters(getParams());
+        userConfiguration.setParameters(getParams(false));
         testConfigurationParameters(userConfiguration.getParameters());
     }
-    
+
+    @Test
+    public void testUserConfigurationCacheDisabled() {
+        UserConfigurationImpl userConfiguration = new UserConfigurationImpl(getSecurityProvider());
+        userConfiguration.setParameters(getParams(false));
+        CachedMembershipReader cachedMembershipReader = userConfiguration.getCachedMembershipReader(mock(Root.class), (name) -> mock(Principal.class), "propName", CacheConstants.REP_EXPIRATION);
+        assertNull(cachedMembershipReader);
+    }
+
+    @Test
+    public void testUserConfigurationCacheEnabled() {
+        UserConfigurationImpl userConfiguration = new UserConfigurationImpl(getSecurityProvider());
+        userConfiguration.setParameters(getParams(true));
+        CachedMembershipReader cachedMembershipReader = userConfiguration.getCachedMembershipReader(mock(Root.class), (name) -> mock(Principal.class), "propName", CacheConstants.REP_EXPIRATION);
+        assertNotNull(cachedMembershipReader);
+    }
+
     private void testConfigurationParameters(ConfigurationParameters parameters) {
         assertEquals(USER_PATH, parameters.getConfigValue(UserConstants.PARAM_USER_PATH, UserConstants.DEFAULT_USER_PATH));
         assertEquals(GROUP_PATH, parameters.getConfigValue(UserConstants.PARAM_GROUP_PATH, UserConstants.DEFAULT_GROUP_PATH));
@@ -125,8 +147,8 @@ public class UserConfigurationImplTest extends AbstractSecurityTest {
         assertEquals(ENABLE_RFC7613_USERCASE_MAPPED_PROFILE, parameters.getConfigValue(UserConstants.PARAM_ENABLE_RFC7613_USERCASE_MAPPED_PROFILE, UserConstants.DEFAULT_ENABLE_RFC7613_USERCASE_MAPPED_PROFILE));
     }
 
-    private ConfigurationParameters getParams() {
-        ConfigurationParameters params = ConfigurationParameters.of(new HashMap<String, Object>() {{
+    private ConfigurationParameters getParams(boolean cacheEnabled) {
+        return ConfigurationParameters.of(new HashMap<String, Object>() {{
             put(UserConstants.PARAM_USER_PATH, USER_PATH);
             put(UserConstants.PARAM_GROUP_PATH, GROUP_PATH);
             put(PARAM_DEFAULT_DEPTH, DEFAULT_DEPTH);
@@ -139,7 +161,7 @@ public class UserConfigurationImplTest extends AbstractSecurityTest {
             put(UserConstants.PARAM_PASSWORD_INITIAL_CHANGE, INITIAL_PASSWORD_CHANGE);
             put(UserConstants.PARAM_PASSWORD_HISTORY_SIZE, PASSWORD_HISTORY_SIZE);
             put(UserConstants.PARAM_ENABLE_RFC7613_USERCASE_MAPPED_PROFILE, ENABLE_RFC7613_USERCASE_MAPPED_PROFILE);
+            put(CacheConstants.PARAM_CACHE_EXPIRATION, cacheEnabled ? 10L : 0L);
         }});
-        return params;
     }
 }

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/user/UserConfiguration.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/user/UserConfiguration.java
@@ -21,6 +21,7 @@ import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.spi.security.SecurityConfiguration;
 import org.apache.jackrabbit.oak.spi.security.principal.PrincipalProvider;
+import org.apache.jackrabbit.oak.spi.security.user.cache.CacheConstants;
 import org.apache.jackrabbit.oak.spi.security.user.cache.CachePrincipalFactory;
 import org.apache.jackrabbit.oak.spi.security.user.cache.CachedMembershipReader;
 import org.jetbrains.annotations.NotNull;
@@ -66,6 +67,26 @@ public interface UserConfiguration extends SecurityConfiguration {
     @Nullable
     PrincipalProvider getUserPrincipalProvider(@NotNull Root root, @NotNull NamePathMapper namePathMapper);
 
+
+    /**
+     * Optional method that allows a given user management implementation to
+     * provide a specific and optimized implementation of the {@link CachedMembershipReader}
+     * interface for the principals represented by the user/groups known to
+     * this implementation.
+     *
+     * If this method returns {@code null} the security setup won't, by default, use
+     * a cached membership reader.
+     *
+     * @param root The root used to read the principal information from.
+     * @param cachePrincipalFactory The factory to create the principal from the cache.
+     * @param propName The name of the property that contains the cache.
+     * @return An implementation of {@code CachedMembershipReader} or {@code null} if the UserConfiguration implementation
+     * does not provide a cached membership reader.
+     */
+    @Nullable
+    default CachedMembershipReader getCachedMembershipReader(@NotNull Root root, @NotNull CachePrincipalFactory cachePrincipalFactory, @NotNull String propName) {
+        return getCachedMembershipReader(root, cachePrincipalFactory, propName, CacheConstants.REP_EXPIRATION);
+    }
 
     /**
      * Optional method that allows a given user management implementation to

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/user/UserConfiguration.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/user/UserConfiguration.java
@@ -79,11 +79,12 @@ public interface UserConfiguration extends SecurityConfiguration {
      * @param root The root used to read the principal information from.
      * @param cachePrincipalFactory The factory to create the principal from the cache.
      * @param propName The name of the property that contains the cache.
+     * @param expirationPropName The name of the property that contains cache expiration time.
      * @return An implementation of {@code CachedMembershipReader} or {@code null} if the UserConfiguration implementation
      * does not provide a cached membership reader.
      */
     @Nullable
-    default CachedMembershipReader getCachedMembershipReader(@NotNull Root root, @NotNull CachePrincipalFactory cachePrincipalFactory, @NotNull String propName) {
+    default CachedMembershipReader getCachedMembershipReader(@NotNull Root root, @NotNull CachePrincipalFactory cachePrincipalFactory, @NotNull String propName, @NotNull String expirationPropName) {
         return null;
     }
 }

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/user/package-info.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/user/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("2.8.0")
+@Version("2.9.0")
 package org.apache.jackrabbit.oak.spi.security.user;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Changed CachePrincipalMembershipReader to allow to define an alternative cache expiration property. 
