### PR TITLE
OAK-11412 - Indexing job: delay creation of index writers (Lucene and Elastic) until the start of the indexing phase

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinition.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinition.java
@@ -77,17 +77,17 @@ public class LuceneIndexDefinition extends IndexDefinition {
         this.codec = createCodec();
     }
 
-    public static Builder newBuilder(NodeState root, NodeState defn, String indexPath){
-        return (Builder)new Builder()
+    public static Builder newLuceneBuilder(NodeState root, NodeState defn, String indexPath){
+        return (Builder) new Builder()
                 .root(root)
                 .defn(defn)
                 .indexPath(indexPath);
     }
 
-    public static class Builder extends IndexDefinition.Builder {
+    public static class Builder extends IndexDefinition.Builder<LuceneIndexDefinition> {
         @Override
         public LuceneIndexDefinition build() {
-            return (LuceneIndexDefinition)super.build();
+            return super.build();
         }
 
         @Override
@@ -97,7 +97,7 @@ public class LuceneIndexDefinition extends IndexDefinition {
         }
 
         @Override
-        protected IndexDefinition createInstance(NodeState indexDefnStateToUse) {
+        protected LuceneIndexDefinition createInstance(NodeState indexDefnStateToUse) {
             return new LuceneIndexDefinition(root, indexDefnStateToUse, version, uid, indexPath);
         }
     }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditorProvider.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditorProvider.java
@@ -87,7 +87,6 @@ public class LuceneIndexEditorProvider implements IndexEditorProvider {
     private boolean nrtIndexingEnabled;
     private LuceneIndexWriterConfig writerConfig = new LuceneIndexWriterConfig();
 
-
     /**
      * Number of indexed Lucene document that can be held in memory
      * This ensures that for very large commit memory consumption
@@ -125,6 +124,7 @@ public class LuceneIndexEditorProvider implements IndexEditorProvider {
         this(indexCopier, indexTracker, extractedTextCache, augmentorFactory, mountInfoProvider,
                 ActiveDeletedBlobCollectorFactory.NOOP, null, null);
     }
+
     public LuceneIndexEditorProvider(@Nullable IndexCopier indexCopier,
                                      @Nullable IndexTracker indexTracker,
                                      ExtractedTextCache extractedTextCache,
@@ -203,7 +203,7 @@ public class LuceneIndexEditorProvider implements IndexEditorProvider {
 
                 if (indexDefinition == null) {
                     indexDefinition = LuceneIndexDefinition
-                            .newBuilder(root, definition.getNodeState(), indexPath)
+                            .newLuceneBuilder(root, definition.getNodeState(), indexPath)
                             .build();
                 }
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexInfoProvider.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexInfoProvider.java
@@ -116,7 +116,7 @@ public class LuceneIndexInfoProvider implements IndexInfoProvider {
     }
 
     private void computeSize(NodeState idxState, LuceneIndexInfo info) throws IOException {
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(nodeStore.getRoot(), idxState, info.indexPath).build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(nodeStore.getRoot(), idxState, info.indexPath).build();
         for (String dirName : idxState.getChildNodeNames()) {
             if (NodeStateUtils.isHidden(dirName)) {
                 // This is true for both read-write index data dir (:data) and the read-only mount (:oak-libs-mount-index-data)

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexConsistencyChecker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexConsistencyChecker.java
@@ -273,7 +273,7 @@ public class IndexConsistencyChecker {
 
     private void checkIndex(Result result, Closer closer) throws IOException {
         NodeState idx = NodeStateUtils.getNode(rootState, indexPath);
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, idx, indexPath).build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, idx, indexPath).build();
         workDir = createWorkDir(workDirRoot, PathUtils.getName(indexPath));
 
         for (String dirName : idx.getChildNodeNames()){

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/LuceneIndexDumper.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/LuceneIndexDumper.java
@@ -59,7 +59,7 @@ public class LuceneIndexDumper {
     public void dump() throws IOException {
         try (Closer closer = Closer.create()) {
             NodeState idx = NodeStateUtils.getNode(rootState, indexPath);
-            LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, idx, indexPath).build();
+            LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, idx, indexPath).build();
             indexDir = DirectoryUtils.createIndexDir(baseDir, indexPath);
             IndexMeta meta = new IndexMeta(indexPath);
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
@@ -175,7 +175,7 @@ class DefaultIndexWriter implements LuceneIndexWriter {
                     config.setMergePolicy(definition.getMergePolicy());
                     writer = localRefWriter = new IndexWriter(directory, config);
                     genAtStart = getLatestGeneration(directory);
-                    log.trace("IndexWriterConfig for index [{}] is {}", definition.getIndexPath(), config);
+                    log.info("Creating writer for index: {}. Config: {}", definition.getIndexPath(), config);
                     PERF_LOGGER.end(start, -1, "Created IndexWriter for directory {}", definition);
                 }
             }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerLargeStringPropertiesLogTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerLargeStringPropertiesLogTest.java
@@ -46,11 +46,11 @@ import static org.junit.Assert.assertTrue;
 public class LuceneDocumentMakerLargeStringPropertiesLogTest {
 
     ListAppender<ILoggingEvent> listAppender = null;
-    private final String nodeImplLogger = LuceneDocumentMaker.class.getName();
-    private final String warnMessage = "String length: {} for property: {} at Node: {} is greater than configured value {}";
-    private String customStringPropertyThresholdLimit = "9";
-    private String smallStringProperty = "1234567";
-    private String largeStringPropertyAsPerCustomThreshold = "1234567890";
+    private static final String nodeImplLogger = LuceneDocumentMaker.class.getName();
+    private static final String warnMessage = "String length: {} for property: {} at Node: {} is greater than configured value {}";
+    private static final String customStringPropertyThresholdLimit = "9";
+    private static final String smallStringProperty = "1234567";
+    private static final String largeStringPropertyAsPerCustomThreshold = "1234567890";
 
     @Rule
     public TemporarySystemProperty temporarySystemProperty = new TemporarySystemProperty();
@@ -81,7 +81,7 @@ public class LuceneDocumentMakerLargeStringPropertiesLogTest {
                 .analyzed()
                 .valueExcludedPrefixes("/jobs");
 
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(root, builder.build(), "/foo").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
         LuceneDocumentMaker docMaker = new LuceneDocumentMaker(defn,
                 defn.getApplicableIndexingRule("nt:base"), "/x");
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -25,15 +25,16 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.junit.Test;
 
-import static java.util.Arrays.asList;
+import java.util.List;
+
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class LuceneDocumentMakerTest {
-    private NodeState root = INITIAL_CONTENT;
-    private LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
+    private final NodeState root = INITIAL_CONTENT;
+    private final LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
 
     @Test
     public void excludeSingleProperty() throws Exception{
@@ -43,7 +44,7 @@ public class LuceneDocumentMakerTest {
                 .analyzed()
                 .valueExcludedPrefixes("/jobs");
 
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(root, builder.build(), "/foo").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
         LuceneDocumentMaker docMaker = new LuceneDocumentMaker(defn,
                 defn.getApplicableIndexingRule("nt:base"), "/x");
 
@@ -55,10 +56,10 @@ public class LuceneDocumentMakerTest {
         test.setProperty("foo", "/jobs/a");
         assertNull(docMaker.makeDocument(test.getNodeState()));
 
-        test.setProperty("foo", asList("/a", "/jobs/a"), Type.STRINGS);
+        test.setProperty("foo", List.of("/a", "/jobs/a"), Type.STRINGS);
         assertNotNull(docMaker.makeDocument(test.getNodeState()));
 
-        test.setProperty("foo", asList("/jobs/a"), Type.STRINGS);
+        test.setProperty("foo", List.of("/jobs/a"), Type.STRINGS);
         assertNull(docMaker.makeDocument(test.getNodeState()));
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/FSDirectoryFactoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/FSDirectoryFactoryTest.java
@@ -43,12 +43,12 @@ public class FSDirectoryFactoryTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder(new File("target"));
 
-    private NodeState root = INITIAL_CONTENT;
-    private NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
+    private final NodeState root = INITIAL_CONTENT;
+    private final NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
 
     @Test
     public void singleIndex() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(root, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, idx.getNodeState(), "/fooIndex").build();
         FSDirectoryFactory factory = new FSDirectoryFactory(temporaryFolder.getRoot());
 
         Directory dir = factory.newInstance(defn, idx, ":data", false);
@@ -64,8 +64,8 @@ public class FSDirectoryFactoryTest {
 
     @Test
     public void multiIndexWithSimilarPaths() throws Exception{
-        LuceneIndexDefinition defn1 = LuceneIndexDefinition.newBuilder(root, idx.getNodeState(), "/content/a/en_us/oak:index/fooIndex").build();
-        LuceneIndexDefinition defn2 = LuceneIndexDefinition.newBuilder(root, idx.getNodeState(), "/content/b/en_us/oak:index/fooIndex").build();
+        LuceneIndexDefinition defn1 = LuceneIndexDefinition.newLuceneBuilder(root, idx.getNodeState(), "/content/a/en_us/oak:index/fooIndex").build();
+        LuceneIndexDefinition defn2 = LuceneIndexDefinition.newLuceneBuilder(root, idx.getNodeState(), "/content/b/en_us/oak:index/fooIndex").build();
 
         FSDirectoryFactory factory = new FSDirectoryFactory(temporaryFolder.getRoot());
         factory.newInstance(defn1, idx, ":data", false).close();
@@ -81,7 +81,7 @@ public class FSDirectoryFactoryTest {
 
     @Test
     public void reuseExistingDir() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(root, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, idx.getNodeState(), "/fooIndex").build();
         FSDirectoryFactory factory = new FSDirectoryFactory(temporaryFolder.getRoot());
 
         Directory dir = factory.newInstance(defn, idx, ":data", false);
@@ -98,7 +98,7 @@ public class FSDirectoryFactoryTest {
 
     @Test
     public void directoryMapping() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(root, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, idx.getNodeState(), "/fooIndex").build();
         FSDirectoryFactory factory = new FSDirectoryFactory(temporaryFolder.getRoot());
 
         Directory dir1 = factory.newInstance(defn, idx, ":data", false);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexConsistencyCheckerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/IndexConsistencyCheckerTest.java
@@ -57,8 +57,8 @@ import static org.junit.Assert.assertTrue;
 
 public class IndexConsistencyCheckerTest {
 
-    private NodeState rootState = InitialContentHelper.INITIAL_CONTENT;
-    private NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
+    private final NodeState rootState = InitialContentHelper.INITIAL_CONTENT;
+    private final NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
 
 
     @Rule
@@ -117,7 +117,7 @@ public class IndexConsistencyCheckerTest {
 
     @Test
     public void validIndexTest() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
         Directory dir = new OakDirectory(idx, ":data", defn, false);
         createIndex(dir, 10);
 
@@ -142,7 +142,7 @@ public class IndexConsistencyCheckerTest {
 
     @Test
     public void missingFile() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
         Directory dir = new OakDirectory(idx, ":data", defn, false);
         createIndex(dir, 10);
 
@@ -164,7 +164,7 @@ public class IndexConsistencyCheckerTest {
 
     @Test
     public void badFile() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
         Directory dir = new OakDirectory(idx, ":data", defn, false);
         createIndex(dir, 10);
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/LuceneIndexDumperTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/LuceneIndexDumperTest.java
@@ -38,15 +38,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class LuceneIndexDumperTest {
-    private NodeState rootState = InitialContentHelper.INITIAL_CONTENT;
-    private NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
+    private final NodeState rootState = InitialContentHelper.INITIAL_CONTENT;
+    private final NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder(new File("target"));
 
     @Test
     public void directoryDump() throws Exception{
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, idx.getNodeState(), "/fooIndex").build();
 
         long size = 0;
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/LuceneIndexImporterTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/LuceneIndexImporterTest.java
@@ -45,8 +45,8 @@ import static org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.STA
 import static org.junit.Assert.*;
 
 public class LuceneIndexImporterTest {
-    private NodeState rootState = InitialContentHelper.INITIAL_CONTENT;
-    private NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
+    private final NodeState rootState = InitialContentHelper.INITIAL_CONTENT;
+    private final NodeBuilder idx = new LuceneIndexDefinitionBuilder().build().builder();
 
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder(new File("target"));
@@ -54,7 +54,7 @@ public class LuceneIndexImporterTest {
     @Test
     public void exportAndImport() throws Exception{
         NodeState baseIndexState = idx.getNodeState();
-        LuceneIndexDefinition defn = LuceneIndexDefinition.newBuilder(rootState, baseIndexState, "/oak:index/fooIndex").build();
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(rootState, baseIndexState, "/oak:index/fooIndex").build();
 
         LuceneIndexEditorContext.configureUniqueId(idx);
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -21,7 +21,6 @@ package org.apache.jackrabbit.oak.index.indexer.document;
 
 import com.codahale.metrics.MetricRegistry;
 import com.mongodb.MongoClientURI;
-import com.mongodb.client.MongoDatabase;
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
 import org.apache.jackrabbit.guava.common.io.Closer;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -371,7 +370,8 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
 
             Predicate<String> pathPredicate = path -> indexDefinitions.stream().anyMatch(indexer -> indexer.shouldInclude(path));
             List<IndexStore> indexStores = buildFlatFileStoreList(
-                    indexDefinitions, checkpointedState,
+                    indexDefinitions,
+                    checkpointedState,
                     pathPredicate,
                     null,
                     IndexerConfiguration.parallelIndexEnabled(),
@@ -487,10 +487,6 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
 
     private MongoClientURI getMongoClientURI() {
         return requireNonNull(indexHelper.getService(MongoClientURI.class));
-    }
-
-    private MongoDatabase getMongoDatabase() {
-        return requireNonNull(indexHelper.getService(MongoDatabase.class));
     }
 
     private void configureEstimators(IndexingProgressReporter progressReporter) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -69,6 +69,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -167,13 +168,20 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
         }
     }
 
+    private Set<String> getRelativeIndexedNodeNames(List<IndexDefinition> indexDefinitions) {
+        Set<String> result = new HashSet<>();
+        for (IndexDefinition indexer : indexDefinitions) {
+            result.addAll(indexer.getRelativeNodeNames());
+        }
+        return result;
+    }
+
     private List<IndexStore> buildFlatFileStoreList(NodeState checkpointedState,
-                                                       CompositeIndexer indexer,
-                                                       Predicate<String> pathPredicate,
-                                                       Set<String> preferredPathElements,
-                                                       boolean splitFlatFile,
-                                                       Set<IndexDefinition> indexDefinitions,
-                                                       IndexingReporter reporter) throws IOException {
+                                                    Predicate<String> pathPredicate,
+                                                    Set<String> preferredPathElements,
+                                                    boolean splitFlatFile,
+                                                    List<IndexDefinition> indexDefinitions,
+                                                    IndexingReporter reporter) throws IOException {
         List<IndexStore> storeList = new ArrayList<>();
 
         Stopwatch indexStoreWatch = Stopwatch.createStarted();
@@ -190,7 +198,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
             try {
                 builder = new FlatFileNodeStoreBuilder(indexHelper.getWorkDir())
                         .withBlobStore(indexHelper.getGCBlobStore())
-                        .withPreferredPathElements((preferredPathElements != null) ? preferredPathElements : indexer.getRelativeIndexedNodeNames())
+                        .withPreferredPathElements((preferredPathElements != null) ? preferredPathElements : getRelativeIndexedNodeNames(indexDefinitions))
                         .addExistingDataDumpDir(indexerSupport.getExistingDataDumpDir())
                         .withPathPredicate(pathPredicate)
                         .withIndexDefinitions(indexDefinitions)
@@ -210,10 +218,10 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
                     builder.addExistingDataDumpDir(dir);
                 }
                 if (splitFlatFile) {
-                    storeList = builder.buildList(indexHelper, indexerSupport, indexDefinitions);
+                    storeList = builder.buildList(indexHelper, indexerSupport, Set.copyOf(indexDefinitions));
                 } else {
                     log.info("Building index store");
-                    IndexStore store = builder.build(indexHelper, indexer);
+                    IndexStore store = builder.build(indexHelper, indexDefinitions);
                     int threads = IndexerConfiguration.indexThreadPoolSize();
                     if (store instanceof ParallelIndexStore && threads > 1) {
                         log.info("Indexing with {} threads", threads);
@@ -272,7 +280,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
     public IndexStore buildStore(String initialCheckpoint, String finalCheckpoint, long maxDurationSeconds) throws IOException, CommitFailedException {
         IncrementalStoreBuilder builder;
         IndexStore incrementalStore;
-        Set<IndexDefinition> indexDefinitions = indexerSupport.getIndexDefinitions();
+        List<IndexDefinition> indexDefinitions = indexerSupport.getIndexDefinitions();
         Set<String> preferredPathElements = indexerSupport.getPreferredPathElements(indexDefinitions);
         Stopwatch incrementalStoreWatch = Stopwatch.createStarted();
         Predicate<String> predicate = indexerSupport.getFilterPredicate(indexDefinitions, Function.identity());
@@ -333,10 +341,10 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
     @Deprecated
     public IndexStore buildFlatFileStore() throws IOException, CommitFailedException {
         NodeState checkpointedState = indexerSupport.retrieveNodeStateForCheckpoint();
-        Set<IndexDefinition> indexDefinitions = indexerSupport.getIndexDefinitions();
+        List<IndexDefinition> indexDefinitions = indexerSupport.getIndexDefinitions();
         Set<String> preferredPathElements = indexerSupport.getPreferredPathElements(indexDefinitions);
         Predicate<String> predicate = indexerSupport.getFilterPredicate(indexDefinitions, Function.identity());
-        IndexStore indexStore = buildFlatFileStoreList(checkpointedState, null, predicate,
+        IndexStore indexStore = buildFlatFileStoreList(checkpointedState, predicate,
                 preferredPathElements, IndexerConfiguration.parallelIndexEnabled(), indexDefinitions, indexingReporter).get(0);
         log.info("Store built. To use this store in a reindex step, set the system property {} to {}",
                 OAK_INDEXER_SORTED_FILE_PATH, indexStore.getStorePath());
@@ -345,7 +353,8 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
 
     public void reindex() throws CommitFailedException, IOException {
         INDEXING_PHASE_LOGGER.info("[TASK:FULL_INDEX_CREATION:START] Starting indexing job");
-        List<String> indexNames = indexerSupport.getIndexDefinitions().stream().map(IndexDefinition::getIndexName).collect(Collectors.toList());
+        List<IndexDefinition> indexDefinitions = indexerSupport.getIndexDefinitions();
+        List<String> indexNames = indexDefinitions.stream().map(IndexDefinition::getIndexName).collect(Collectors.toList());
         indexingReporter.setIndexNames(indexNames);
         Stopwatch indexJobWatch = Stopwatch.createStarted();
         try {
@@ -356,42 +365,41 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
             NodeState checkpointedState = indexerSupport.retrieveNodeStateForCheckpoint();
             NodeStore copyOnWriteStore = new MemoryNodeStore(checkpointedState);
             indexerSupport.switchIndexLanesAndReindexFlag(copyOnWriteStore);
-            NodeBuilder builder = copyOnWriteStore.getRoot().builder();
-            CompositeIndexer indexer = prepareIndexers(copyOnWriteStore, builder, progressReporter);
-            if (indexer.isEmpty()) {
+            if (indexDefinitions.isEmpty()) {
                 return;
             }
 
-            closer.register(indexer);
-
+            Predicate<String> pathPredicate = path -> indexDefinitions.stream().anyMatch(indexer -> indexer.shouldInclude(path));
             List<IndexStore> indexStores = buildFlatFileStoreList(
                     checkpointedState,
-                    indexer,
-                    indexer::shouldInclude,
+                    pathPredicate,
                     null,
                     IndexerConfiguration.parallelIndexEnabled(),
-                    indexerSupport.getIndexDefinitions(),
+                    indexDefinitions,
                     indexingReporter);
 
             progressReporter.reset();
 
             progressReporter.reindexingTraversalStart("/");
 
-            preIndexOperations(indexer.getIndexers());
+            NodeBuilder builder = copyOnWriteStore.getRoot().builder();
+            CompositeIndexer compositeIndexer = prepareIndexers(copyOnWriteStore, builder, progressReporter);
+            closer.register(compositeIndexer);
+            preIndexOperations(compositeIndexer.getIndexers());
 
             INDEXING_PHASE_LOGGER.info("[TASK:INDEXING:START] Starting indexing");
             Stopwatch indexerWatch = Stopwatch.createStarted();
             try {
                 if (indexStores.size() > 1) {
-                    indexParallel(indexStores, indexer, progressReporter);
+                    indexParallel(indexStores, compositeIndexer, progressReporter);
                 } else if (indexStores.size() == 1) {
                     IndexStore indexStore = indexStores.get(0);
                     TopKSlowestPaths slowestTopKElements = new TopKSlowestPaths(TOP_SLOWEST_PATHS_TO_LOG);
-                    indexer.onIndexingStarting();
+                    compositeIndexer.onIndexingStarting();
                     long entryStart = System.nanoTime();
                     for (NodeStateEntry entry : indexStore) {
                         reportDocumentRead(entry.getPath(), progressReporter);
-                        indexer.index(entry);
+                        compositeIndexer.index(entry);
                         // Avoid calling System.nanoTime() twice per each entry, by reusing the timestamp taken at the end
                         // of indexing an entry as the start time of the following entry. This is less accurate, because
                         // the measured times will also include the bookkeeping at the end of indexing each entry, but

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -176,11 +176,11 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
         return result;
     }
 
-    private List<IndexStore> buildFlatFileStoreList(NodeState checkpointedState,
+    private List<IndexStore> buildFlatFileStoreList(List<IndexDefinition> indexDefinitions,
+                                                    NodeState checkpointedState,
                                                     Predicate<String> pathPredicate,
                                                     Set<String> preferredPathElements,
                                                     boolean splitFlatFile,
-                                                    List<IndexDefinition> indexDefinitions,
                                                     IndexingReporter reporter) throws IOException {
         List<IndexStore> storeList = new ArrayList<>();
 
@@ -218,7 +218,7 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
                     builder.addExistingDataDumpDir(dir);
                 }
                 if (splitFlatFile) {
-                    storeList = builder.buildList(indexHelper, indexerSupport, Set.copyOf(indexDefinitions));
+                    storeList = builder.buildList(indexHelper, indexerSupport, indexDefinitions);
                 } else {
                     log.info("Building index store");
                     IndexStore store = builder.build(indexHelper, indexDefinitions);
@@ -344,8 +344,8 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
         List<IndexDefinition> indexDefinitions = indexerSupport.getIndexDefinitions();
         Set<String> preferredPathElements = indexerSupport.getPreferredPathElements(indexDefinitions);
         Predicate<String> predicate = indexerSupport.getFilterPredicate(indexDefinitions, Function.identity());
-        IndexStore indexStore = buildFlatFileStoreList(checkpointedState, predicate,
-                preferredPathElements, IndexerConfiguration.parallelIndexEnabled(), indexDefinitions, indexingReporter).get(0);
+        IndexStore indexStore = buildFlatFileStoreList(indexDefinitions, checkpointedState, predicate,
+                preferredPathElements, IndexerConfiguration.parallelIndexEnabled(), indexingReporter).get(0);
         log.info("Store built. To use this store in a reindex step, set the system property {} to {}",
                 OAK_INDEXER_SORTED_FILE_PATH, indexStore.getStorePath());
         return indexStore;
@@ -371,11 +371,10 @@ public abstract class DocumentStoreIndexerBase implements Closeable {
 
             Predicate<String> pathPredicate = path -> indexDefinitions.stream().anyMatch(indexer -> indexer.shouldInclude(path));
             List<IndexStore> indexStores = buildFlatFileStoreList(
-                    checkpointedState,
+                    indexDefinitions, checkpointedState,
                     pathPredicate,
                     null,
                     IndexerConfiguration.parallelIndexEnabled(),
-                    indexDefinitions,
                     indexingReporter);
 
             progressReporter.reset();

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -27,7 +27,6 @@ import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.index.IndexHelper;
 import org.apache.jackrabbit.oak.index.IndexerSupport;
 import org.apache.jackrabbit.oak.index.indexer.document.CompositeException;
-import org.apache.jackrabbit.oak.index.indexer.document.CompositeIndexer;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntryTraverserFactory;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.ConfigHelper;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy;
@@ -106,7 +105,7 @@ public class FlatFileNodeStoreBuilder {
     private RevisionVector rootRevision = null;
     private DocumentNodeStore nodeStore = null;
     private MongoDocumentStore mongoDocumentStore = null;
-    private Set<IndexDefinition> indexDefinitions = null;
+    private List<IndexDefinition> indexDefinitions = null;
     private String checkpoint;
     private long minModified;
     private StatisticsProvider statisticsProvider = StatisticsProvider.NOOP;
@@ -164,7 +163,7 @@ public class FlatFileNodeStoreBuilder {
         return this;
     }
 
-    public FlatFileNodeStoreBuilder withIndexDefinitions(Set<IndexDefinition> indexDefinitions) {
+    public FlatFileNodeStoreBuilder withIndexDefinitions(List<IndexDefinition> indexDefinitions) {
         this.indexDefinitions = indexDefinitions;
         return this;
     }
@@ -233,7 +232,7 @@ public class FlatFileNodeStoreBuilder {
         return build(null, null);
     }
 
-    public IndexStore build(IndexHelper indexHelper, CompositeIndexer indexer) throws IOException, CompositeException {
+    public IndexStore build(IndexHelper indexHelper, List<IndexDefinition> indexDefinitions) throws IOException, CompositeException {
         logFlags();
         entryWriter = new NodeStateEntryWriter(blobStore);
         IndexStoreFiles indexStoreFiles = createdSortedStoreFiles();
@@ -250,12 +249,12 @@ public class FlatFileNodeStoreBuilder {
         if (entryCount > 0) {
             store.setEntryCount(entryCount);
         }
-        if (indexer == null || indexHelper == null) {
+        if (indexDefinitions == null || indexHelper == null) {
             return store;
         }
         if (withAheadOfTimeBlobDownloading && store instanceof FlatFileStore) {
             FlatFileStore ffs = (FlatFileStore) store;
-            return AheadOfTimeBlobDownloadingFlatFileStore.wrap(ffs, indexer, indexHelper);
+            return AheadOfTimeBlobDownloadingFlatFileStore.wrap(ffs, indexDefinitions, indexHelper.getGCBlobStore());
         }
         return store;
     }
@@ -264,14 +263,14 @@ public class FlatFileNodeStoreBuilder {
         TreeStore indexingTreeStore = new TreeStore(
                 "indexing", file,
                 new NodeStateEntryReader(blobStore), 10);
-        indexingTreeStore.setIndexDefinitions(indexDefinitions);
+        indexingTreeStore.setIndexDefinitions(Set.copyOf(indexDefinitions));
 
         // use a separate tree store (with a smaller cache)
         // for prefetching, to avoid cache evictions
         TreeStore prefetchTreeStore = new TreeStore(
                 "prefetch", file,
                 new NodeStateEntryReader(blobStore), 3);
-        prefetchTreeStore.setIndexDefinitions(indexDefinitions);
+        prefetchTreeStore.setIndexDefinitions(Set.copyOf(indexDefinitions));
         String blobPrefetchEnableForIndexes = ConfigHelper.getSystemPropertyAsString(
                 AheadOfTimeBlobDownloadingFlatFileStore.BLOB_PREFETCH_ENABLE_FOR_INDEXES_PREFIXES, "");
         Prefetcher prefetcher = new Prefetcher(prefetchTreeStore, indexingTreeStore);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -287,7 +287,7 @@ public class FlatFileNodeStoreBuilder {
     }
 
     public List<IndexStore> buildList(IndexHelper indexHelper, IndexerSupport indexerSupport,
-                                         Set<IndexDefinition> indexDefinitions) throws IOException, CompositeException {
+                                         List<IndexDefinition> indexDefinitions) throws IOException, CompositeException {
         logFlags();
         entryWriter = new NodeStateEntryWriter(blobStore);
 

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileSplitter.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileSplitter.java
@@ -69,13 +69,13 @@ public class FlatFileSplitter {
     private final File flatFile;
     private final NodeStateEntryReader entryReader;
     private final Compression algorithm;
-    private final Set<IndexDefinition> indexDefinitions;
+    private final List<IndexDefinition> indexDefinitions;
     private Set<String> splitNodeTypeNames;
 
     static Predicate<File> IS_SPLIT = path -> path.getParent().endsWith(SPLIT_DIR_NAME);
     
     public FlatFileSplitter(File flatFile, File workdir, NodeTypeInfoProvider infoProvider, NodeStateEntryReader entryReader,
-            Set<IndexDefinition> indexDefinitions) {
+            List<IndexDefinition> indexDefinitions) {
         this.flatFile = flatFile;
         this.indexDefinitions = indexDefinitions;
         this.workDir = new File(workdir, SPLIT_DIR_NAME);

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/AheadOfTimeBlobDownloadingFlatFileStoreTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/AheadOfTimeBlobDownloadingFlatFileStoreTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexer;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.junit.Test;
 
 import java.util.List;
@@ -82,17 +82,17 @@ public class AheadOfTimeBlobDownloadingFlatFileStoreTest {
     }
 
     private void doFilterEnabledIndexesTest(List<String> expectedIndexes, List<String> enabledForIndexes, List<String> indexNames) {
-        List<TestNodeStateIndexer> indexers = createIndexersWithName(indexNames);
-        List<TestNodeStateIndexer> enabledIndexers = filterEnabledIndexes(enabledForIndexes, indexers);
+        List<IndexDefinition> indexers = createIndexersWithName(indexNames);
+        List<IndexDefinition> enabledIndexers = filterEnabledIndexes(enabledForIndexes, indexers);
         assertEquals(
                 Set.copyOf(expectedIndexes),
-                enabledIndexers.stream().map(NodeStateIndexer::getIndexName).collect(Collectors.toSet())
+                enabledIndexers.stream().map(IndexDefinition::getIndexName).collect(Collectors.toSet())
         );
     }
 
-    private List<TestNodeStateIndexer> createIndexersWithName(List<String> indexNames) {
+    private List<IndexDefinition> createIndexersWithName(List<String> indexNames) {
         return indexNames.stream()
-                .map(name -> new TestNodeStateIndexer(name, List.of()))
+                .map(name -> new TestIndexDefinition(name, List.of()))
                 .collect(Collectors.toList());
     }
 }

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloaderTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/DefaultAheadOfTimeBlobDownloaderTest.java
@@ -20,7 +20,7 @@ package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
 
 import org.apache.jackrabbit.oak.commons.Compression;
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexer;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.spi.blob.MemoryBlobStore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,39 +66,39 @@ public class DefaultAheadOfTimeBlobDownloaderTest {
 
     @Test
     public void testSingleIndexIncludeAllPaths() throws IOException {
-        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/"))), BINARY_BLOB_SUFFIX, 3);
+        doTestSingleIndexIncludeAllPaths(List.of(new TestIndexDefinition(List.of("/"))), BINARY_BLOB_SUFFIX, 3);
     }
 
     @Test
     public void testSingleIndexIncludeOnePath() throws IOException {
-        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/include1"))), BINARY_BLOB_SUFFIX, 1);
+        doTestSingleIndexIncludeAllPaths(List.of(new TestIndexDefinition(List.of("/include1"))), BINARY_BLOB_SUFFIX, 1);
     }
 
     @Test
     public void testSingleIndexIncludePathDoesNotExist() throws IOException {
-        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/doesnotexist"))), BINARY_BLOB_SUFFIX, 0);
+        doTestSingleIndexIncludeAllPaths(List.of(new TestIndexDefinition(List.of("/doesnotexist"))), BINARY_BLOB_SUFFIX, 0);
     }
 
     @Test
     public void testSingleIndexPathDoesNotContainMatches() throws IOException {
-        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/var"))), BINARY_BLOB_SUFFIX, 0);
+        doTestSingleIndexIncludeAllPaths(List.of(new TestIndexDefinition(List.of("/var"))), BINARY_BLOB_SUFFIX, 0);
     }
 
     @Test
     public void testMultipleIndexes() throws IOException {
         doTestSingleIndexIncludeAllPaths(List.of(
-                        new TestNodeStateIndexer(List.of("/include2")),
-                        new TestNodeStateIndexer(List.of("/include1"))),
+                        new TestIndexDefinition(List.of("/include2")),
+                        new TestIndexDefinition(List.of("/include1"))),
                 BINARY_BLOB_SUFFIX, 2);
     }
 
     @Test
     public void testMultipleIncludePaths() throws IOException {
-        doTestSingleIndexIncludeAllPaths(List.of(new TestNodeStateIndexer(List.of("/include2", "/include1"))),
+        doTestSingleIndexIncludeAllPaths(List.of(new TestIndexDefinition("test-index", List.of("/include2", "/include1"))),
                 BINARY_BLOB_SUFFIX, 2);
     }
 
-    private void doTestSingleIndexIncludeAllPaths(List<NodeStateIndexer> indexers, String prefetchBinaryBlobSuffix, int expectedBlobsDownloaded) throws IOException {
+    private void doTestSingleIndexIncludeAllPaths(List<IndexDefinition> indexers, String prefetchBinaryBlobSuffix, int expectedBlobsDownloaded) throws IOException {
         Path ffsPath = folder.newFile("ffs.json").toPath();
         try (MemoryBlobStore blobStore = new MemoryBlobStore()) {
             generateTestFFS(ffsPath, FFS_PATHS, blobStore);

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilderTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilderTest.java
@@ -83,7 +83,7 @@ public class FlatFileNodeStoreBuilderTest {
         when(mongoDocumentStore.isReadOnly()).thenReturn(true);
         FlatFileNodeStoreBuilder builder = new FlatFileNodeStoreBuilder(folder.getRoot())
                 .withNodeStateEntryTraverserFactory(nodeStateEntryTraverserFactory)
-                .withIndexDefinitions(Set.of())
+                .withIndexDefinitions(List.of())
                 .withMongoDocumentStore(mongoDocumentStore);
         SortStrategy sortStrategy = builder.createSortStrategy(builder.createStoreDir());
         assertTrue(sortStrategy instanceof PipelinedStrategy);

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilderTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilderTest.java
@@ -22,9 +22,8 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.oak.InitialContent;
@@ -213,13 +212,13 @@ public class FlatFileNodeStoreBuilderTest {
         }
     }
 
-    private static Set<IndexDefinition> mockIndexDefns() {
+    private static List<IndexDefinition> mockIndexDefns() {
         NodeStore store = new MemoryNodeStore();
         EditorHook hook = new EditorHook(
                 new CompositeEditorProvider(new NamespaceEditorProvider(), new TypeEditorProvider()));
         OakInitializer.initialize(store, new InitialContent(), hook);
 
-        Set<IndexDefinition> defns = new HashSet<>();
+        List<IndexDefinition> defns = new ArrayList<>();
         IndexDefinitionBuilder defnBuilder = new IndexDefinitionBuilder();
         defnBuilder.indexRule("dam:Asset");
         defnBuilder.aggregateRule("dam:Asset");

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileSplitterTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileSplitterTest.java
@@ -339,13 +339,13 @@ public class FlatFileSplitterTest {
     }
 
     @Test
-    public void getSplitNodeTypeNames() throws IllegalAccessException {
+    public void getSplitNodeTypeNames() {
         NodeStore store = new MemoryNodeStore();
         EditorHook hook = new EditorHook(
                 new CompositeEditorProvider(new NamespaceEditorProvider(), new TypeEditorProvider()));
         OakInitializer.initialize(store, new InitialContent(), hook);
 
-        Set<IndexDefinition> defns = new HashSet<>();
+        List<IndexDefinition> defns = new ArrayList<>();
 
         IndexDefinitionBuilder defnb1 = new IndexDefinitionBuilder();
         defnb1.indexRule("testIndexRule1");

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestIndexDefinition.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/TestIndexDefinition.java
@@ -18,31 +18,25 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile;
 
-import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
-import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexer;
-import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
+import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
+import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
-class TestNodeStateIndexer implements NodeStateIndexer {
+class TestIndexDefinition extends IndexDefinition {
 
-    private final String name;
+    private final String indexName;
     private final List<String> includedPaths;
 
-    public TestNodeStateIndexer(List<String> includedPaths) {
-        this("test-index", includedPaths);
-    }
-
-    public TestNodeStateIndexer(String name, List<String> includedPaths) {
-        this.name = name;
+    public TestIndexDefinition(String indexName, List<String> includedPaths) {
+        super(EmptyNodeState.EMPTY_NODE, EmptyNodeState.EMPTY_NODE, "");
+        this.indexName = indexName;
         this.includedPaths = includedPaths;
     }
 
-    @Override
-    public void close() {
+    public TestIndexDefinition(List<@NotNull String> includedPaths) {
+        this("test-index", includedPaths);
     }
 
     @Override
@@ -51,27 +45,8 @@ class TestNodeStateIndexer implements NodeStateIndexer {
     }
 
     @Override
-    public boolean shouldInclude(NodeDocument doc) {
-        return false;
-    }
-
-    @Override
-    public boolean index(NodeStateEntry entry) throws IOException, CommitFailedException {
-        return false;
-    }
-
-    @Override
-    public boolean indexesRelativeNodes() {
-        return false;
-    }
-
-    @Override
-    public Set<String> getRelativeIndexedNodeNames() {
-        return null;
-    }
-
-    @Override
     public String getIndexName() {
-        return name;
+        return indexName;
     }
+
 }

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
@@ -76,7 +76,7 @@ public class ElasticIndexer implements NodeStateIndexer {
 
     @Override
     public boolean shouldInclude(String path) {
-        return getFilterResult(path) != PathFilter.Result.EXCLUDE;
+        return definition.getFilterResult(path) != PathFilter.Result.EXCLUDE;
     }
 
     @Override
@@ -94,7 +94,7 @@ public class ElasticIndexer implements NodeStateIndexer {
     @Override
     public boolean index(NodeStateEntry entry) throws IOException, CommitFailedException {
 
-        if (getFilterResult(entry.getPath()) != PathFilter.Result.INCLUDE) {
+        if (definition.getFilterResult(entry.getPath()) != PathFilter.Result.INCLUDE) {
             return false;
         }
         IndexDefinition.IndexingRule indexingRule = definition.getApplicableIndexingRule(entry.getNodeState());
@@ -136,10 +136,6 @@ public class ElasticIndexer implements NodeStateIndexer {
         LOG.info("Statistics: {}", indexerStatisticsTracker.formatStats());
         binaryTextExtractor.logStats();
         indexWriter.close(System.currentTimeMillis());
-    }
-
-    private PathFilter.Result getFilterResult(String path) {
-        return definition.getPathFilter().filter(path);
     }
 
     private void writeToIndex(ElasticDocument doc, String path) throws IOException {

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexer.java
@@ -76,7 +76,7 @@ public class ElasticIndexer implements NodeStateIndexer {
 
     @Override
     public boolean shouldInclude(String path) {
-        return definition.getFilterResult(path) != PathFilter.Result.EXCLUDE;
+        return definition.shouldInclude(path);
     }
 
     @Override

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexerProvider.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexerProvider.java
@@ -57,13 +57,12 @@ public class ElasticIndexerProvider implements NodeStateIndexerProvider {
         this.connection = connection;
     }
 
-
     @Override
     public @Nullable NodeStateIndexer getIndexer(@NotNull String type, @NotNull String indexPath, @NotNull NodeBuilder definition, @NotNull NodeState root, IndexingProgressReporter progressReporter) {
         if (!ElasticIndexDefinition.TYPE_ELASTICSEARCH.equals(definition.getString(TYPE_PROPERTY_NAME))) {
             return null;
         }
-        ElasticIndexDefinition idxDefinition = (ElasticIndexDefinition) new ElasticIndexDefinition.Builder(connection.getIndexPrefix()).
+        ElasticIndexDefinition idxDefinition = new ElasticIndexDefinition.Builder(connection.getIndexPrefix()).
                 root(root).indexPath(indexPath).defn(definition.getNodeState()).reindex().build();
 
         FulltextIndexWriter<ElasticDocument> indexWriter = indexWriterFactory.newInstance(idxDefinition, definition, CommitInfo.EMPTY, true);

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexer.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexer.java
@@ -68,7 +68,8 @@ public class LuceneIndexer implements NodeStateIndexer, FacetsConfigProvider {
 
     @Override
     public boolean shouldInclude(String path) {
-        return getFilterResult(path) != PathFilter.Result.EXCLUDE;
+        return definition.shouldInclude(path);
+
     }
 
     @Override
@@ -79,7 +80,7 @@ public class LuceneIndexer implements NodeStateIndexer, FacetsConfigProvider {
 
     @Override
     public boolean index(NodeStateEntry entry) throws IOException, CommitFailedException {
-        if (getFilterResult(entry.getPath()) != PathFilter.Result.INCLUDE) {
+        if (definition.getFilterResult(entry.getPath()) != PathFilter.Result.INCLUDE) {
             return false;
         }
 
@@ -124,10 +125,6 @@ public class LuceneIndexer implements NodeStateIndexer, FacetsConfigProvider {
         LOG.info("[{}] Statistics: {}", definition.getIndexName(), indexerStatisticsTracker.formatStats());
         binaryTextExtractor.logStats();
         indexWriter.close(System.currentTimeMillis());
-    }
-
-    private PathFilter.Result getFilterResult(String path) {
-        return definition.getPathFilter().filter(path);
     }
 
     private void writeToIndex(Document doc, String path) throws IOException {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
@@ -26,7 +26,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.index.ExtendedIndexHelper;
 import org.apache.jackrabbit.oak.index.IndexerSupport;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
-import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexWriterFactory;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.DirectoryFactory;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.FSDirectoryFactory;
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.DefaultIndexWriterFactory;
@@ -37,21 +36,27 @@ import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.FulltextBinaryT
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstants.TYPE_LUCENE;
 
 public class LuceneIndexerProvider implements NodeStateIndexerProvider {
+    private final static Logger LOG = LoggerFactory.getLogger(LuceneIndexerProvider.class);
+
     private final ExtractedTextCache textCache =
             new ExtractedTextCache(FileUtils.ONE_MB * 5, TimeUnit.HOURS.toSeconds(5));
-    private final ExtendedIndexHelper extendedIndexHelper;
-    private final LuceneIndexWriterFactory indexWriterFactory;
+    private final DefaultIndexWriterFactory indexWriterFactory;
 
     public LuceneIndexerProvider(ExtendedIndexHelper extendedIndexHelper, IndexerSupport indexerSupport) throws IOException {
-        this.extendedIndexHelper = extendedIndexHelper;
         DirectoryFactory dirFactory = new FSDirectoryFactory(indexerSupport.getLocalIndexDir());
         this.indexWriterFactory = new DefaultIndexWriterFactory(extendedIndexHelper.getMountInfoProvider(),
                 dirFactory, extendedIndexHelper.getLuceneIndexHelper().getWriterConfigForReindex());
+    }
+
+    private void init() {
+
     }
 
     @Override
@@ -62,7 +67,8 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
             return null;
         }
 
-        LuceneIndexDefinition idxDefinition = LuceneIndexDefinition.newBuilder(root, definition.getNodeState(), indexPath).reindex().build();
+        LOG.info("Creating LuceneIndexer for {}", indexPath);
+        LuceneIndexDefinition idxDefinition = LuceneIndexDefinition.newLuceneBuilder(root, definition.getNodeState(), indexPath).reindex().build();
 
         LuceneIndexWriter indexWriter = indexWriterFactory.newInstance(idxDefinition, definition, null, true);
         FulltextBinaryTextExtractor textExtractor = new FulltextBinaryTextExtractor(textCache, idxDefinition, true);
@@ -82,6 +88,7 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
 
     @Override
     public void close() throws IOException {
-
+        LOG.info("Closing LuceneIndexerProvider");
+        indexWriterFactory.close();
     }
 }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
@@ -79,6 +79,6 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
 
     @Override
     public void close() throws IOException {
-        indexWriterFactory.close();
+
     }
 }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/LuceneIndexerProvider.java
@@ -36,15 +36,11 @@ import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.FulltextBinaryT
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexConstants.TYPE_LUCENE;
 
 public class LuceneIndexerProvider implements NodeStateIndexerProvider {
-    private final static Logger LOG = LoggerFactory.getLogger(LuceneIndexerProvider.class);
-
     private final ExtractedTextCache textCache =
             new ExtractedTextCache(FileUtils.ONE_MB * 5, TimeUnit.HOURS.toSeconds(5));
     private final DefaultIndexWriterFactory indexWriterFactory;
@@ -55,10 +51,6 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
                 dirFactory, extendedIndexHelper.getLuceneIndexHelper().getWriterConfigForReindex());
     }
 
-    private void init() {
-
-    }
-
     @Override
     public NodeStateIndexer getIndexer(@NotNull String type, @NotNull String indexPath,
                                        @NotNull NodeBuilder definition, @NotNull NodeState root,
@@ -67,7 +59,6 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
             return null;
         }
 
-        LOG.info("Creating LuceneIndexer for {}", indexPath);
         LuceneIndexDefinition idxDefinition = LuceneIndexDefinition.newLuceneBuilder(root, definition.getNodeState(), indexPath).reindex().build();
 
         LuceneIndexWriter indexWriter = indexWriterFactory.newInstance(idxDefinition, definition, null, true);
@@ -88,7 +79,6 @@ public class LuceneIndexerProvider implements NodeStateIndexerProvider {
 
     @Override
     public void close() throws IOException {
-        LOG.info("Closing LuceneIndexerProvider");
         indexWriterFactory.close();
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -383,7 +383,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
      * Class to help with {@link ElasticIndexDefinition} creation.
      * The built object represents the index definition only without the node structure.
      */
-    public static class Builder extends IndexDefinition.Builder {
+    public static class Builder extends IndexDefinition.Builder<ElasticIndexDefinition> {
 
         private final String indexPrefix;
 
@@ -393,7 +393,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
 
         @Override
         public ElasticIndexDefinition build() {
-            return (ElasticIndexDefinition) super.build();
+            return super.build();
         }
 
         @Override
@@ -403,7 +403,7 @@ public class ElasticIndexDefinition extends IndexDefinition {
         }
 
         @Override
-        protected IndexDefinition createInstance(NodeState indexDefnStateToUse) {
+        protected ElasticIndexDefinition createInstance(NodeState indexDefnStateToUse) {
             return new ElasticIndexDefinition(root, indexDefnStateToUse, indexPath, indexPrefix);
         }
     }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMakerLargeStringPropertiesLogTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMakerLargeStringPropertiesLogTest.java
@@ -22,7 +22,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.junit.TemporarySystemProperty;
-import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextDocumentMaker;
@@ -49,10 +48,10 @@ public class ElasticDocumentMakerLargeStringPropertiesLogTest {
 
     ListAppender<ILoggingEvent> listAppender = null;
     private final String nodeImplLogger = ElasticDocumentMaker.class.getName();
-    private final String warnMessage = "String length: {} for property: {} at Node: {} is greater than configured value {}";
-    private String customStringPropertyThresholdLimit = "9";
-    private String smallStringProperty = "1234567";
-    private String largeStringPropertyAsPerCustomThreshold = "1234567890";
+    private static final String warnMessage = "String length: {} for property: {} at Node: {} is greater than configured value {}";
+    private static final String customStringPropertyThresholdLimit = "9";
+    private static final String smallStringProperty = "1234567";
+    private static final String largeStringPropertyAsPerCustomThreshold = "1234567890";
 
     @Rule
     public TemporarySystemProperty temporarySystemProperty = new TemporarySystemProperty();
@@ -74,7 +73,7 @@ public class ElasticDocumentMakerLargeStringPropertiesLogTest {
         System.setProperty(FulltextDocumentMaker.WARN_LOG_STRING_SIZE_THRESHOLD_KEY, threshold);
     }
 
-    private ElasticDocumentMaker addPropertyAccordingToType(NodeBuilder test, Type type, String... str) throws IOException {
+    private ElasticDocumentMaker addPropertyAccordingToType(NodeBuilder test, Type type, String... str) {
         NodeState root = INITIAL_CONTENT;
         ElasticIndexDefinitionBuilder builder = new ElasticIndexDefinitionBuilder();
         builder.indexRule("nt:base")
@@ -83,7 +82,7 @@ public class ElasticDocumentMakerLargeStringPropertiesLogTest {
                 .analyzed()
                 .valueExcludedPrefixes("/jobs");
 
-        IndexDefinition defn = ElasticIndexDefinition.newBuilder(root, builder.build(), "/foo").build();
+        IndexDefinition defn = IndexDefinition.newBuilder(root, builder.build(), "/foo").build();
         ElasticDocumentMaker docMaker = new ElasticDocumentMaker(null, defn,
                 defn.getApplicableIndexingRule("nt:base"), "/x");
 


### PR DESCRIPTION
Postpone creation of Lucene index writers until the indexing phase of the indexing job.

Replace uses of Set<IndexDefinition> by List<IndexDefinition>, as this class does not define equals() and hashCode(), so storing them on a set does will not ensure that duplicate index definitions are not kept (HashSet will use reference equality in this case).

Change the IndexDefinitionBuilder class hierarchy to be parametrized with the specific type of index definition, to improve readability and type safety.

The changeset is large, but most changes are mechanical. The main logic changes are in the class `DocumentStoreIndexerBase`, where the creation of the indexer instances is moved for after the download and construction of the FFS. All the logic that is used to build the FFS, like the ahead of time downloader, now has a dependency only on the IndexDefinitions, instead of depending on the Indexers. The dependency on the Indexers was a false coupling, because these classes only need the index definition.