### PR TITLE
OAK-11423: Jdbc driver dependencies need to have scope compile in ord…

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -1090,6 +1090,8 @@
           <groupId>org.apache.derby</groupId>
           <artifactId>derby</artifactId>
           <version>${derby.version}</version>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1100,6 +1102,8 @@
           <groupId>mysql</groupId>
           <artifactId>mysql-connector-java</artifactId>
           <version>8.0.19</version>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1110,6 +1114,8 @@
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
           <version>42.7.4</version>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1120,6 +1126,8 @@
           <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>
           <version>${h2.version}</version>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1130,6 +1138,8 @@
           <groupId>com.microsoft.sqlserver</groupId>
           <artifactId>mssql-jdbc</artifactId>
           <version>8.2.2.jre8</version>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1146,6 +1156,8 @@
           <groupId>com.oracle.jdbc</groupId>
           <artifactId>ojdbc8</artifactId>
           <version>12.2.0.1</version>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>
@@ -1156,7 +1168,8 @@
           <groupId>com.ibm.db2</groupId>
           <artifactId>jcc</artifactId>
           <version>11.5.9.0</version>
-          <scope>test</scope>
+          <!-- OAK-11423: Jdbc driver dependencies need to have scope compile in order to be included in oak-run. -->
+          <scope>compile</scope>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
…er to be included in oak-run.

Fixed.