### PR TITLE
 OAK-11431: Remove usage of Guava Files.createTempDir() 

### DIFF
--- a/oak-blob/src/test/java/org/apache/jackrabbit/oak/spi/blob/split/SplitBlobStoreTest.java
+++ b/oak-blob/src/test/java/org/apache/jackrabbit/oak/spi/blob/split/SplitBlobStoreTest.java
@@ -16,13 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.spi.blob.split;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -30,12 +30,9 @@ import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.blob.FileBlobStore;
-import org.apache.jackrabbit.oak.spi.blob.split.DefaultSplitBlobStore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.apache.jackrabbit.guava.common.io.Files;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -61,7 +58,7 @@ public class SplitBlobStoreTest {
 
     @Before
     public void setup() throws IOException {
-        repository = Files.createTempDir();
+        repository = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         oldBlobStore = new FileBlobStore(repository.getPath() + "/old");
         newBlobStore = new FileBlobStore(repository.getPath() + "/new");
         splitBlobStore = new DefaultSplitBlobStore(repository.getPath(), oldBlobStore, newBlobStore);

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/util/SuggestHelper.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/util/SuggestHelper.java
@@ -21,11 +21,11 @@ package org.apache.jackrabbit.oak.plugins.index.lucene.util;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.jackrabbit.guava.common.io.Closer;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.lucene.analysis.Analyzer;
@@ -67,7 +67,7 @@ public class SuggestHelper {
             //create a placeholder non-existing-sub-child which would mark the location when we want to return
             //our internal suggestion OakDirectory. After build is done, we'd delete the temp directory
             //thereby removing any temp stuff that suggester created in the interim.
-            tempDir = Files.createTempDir();
+            tempDir = Files.createTempDirectory(SuggestHelper.class.getSimpleName() + "-").toFile();
             File tempSubChild = new File(tempDir, "non-existing-sub-child");
 
             if (reader.getDocCount(FieldNames.SUGGEST) > 0) {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/BlobStoreFixtureProvider.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/BlobStoreFixtureProvider.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.jackrabbit.guava.common.io.Closer;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.felix.cm.file.ConfigurationHandler;
@@ -68,7 +68,7 @@ public class BlobStoreFixtureProvider {
             S3DataStore s3ds = new S3DataStore();
             Properties props = loadConfig(bsopts.getS3ConfigPath());
             s3ds.setProperties(props);
-            File homeDir =  Files.createTempDir();
+            File homeDir = Files.createTempDirectory(BlobStoreFixtureProvider.class.getSimpleName() + "-").toFile();
             closer.register(asCloseable(homeDir));
             populate(s3ds, asMap(props), false);
             s3ds.init(homeDir.getAbsolutePath());
@@ -78,7 +78,7 @@ public class BlobStoreFixtureProvider {
             String cfgPath = bsopts.getAzureConfigPath();
             Properties props = loadConfig(cfgPath);
             azureds.setProperties(props);
-            File homeDir =  Files.createTempDir();
+            File homeDir = Files.createTempDirectory(BlobStoreFixtureProvider.class.getSimpleName() + "-").toFile();
             populate(azureds, asMap(props), false);
             azureds.init(homeDir.getAbsolutePath());
             closer.register(asCloseable(homeDir));

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Utils.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/Utils.java
@@ -22,7 +22,6 @@ import static java.util.Objects.isNull;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.apache.jackrabbit.oak.commons.PropertiesUtil.populate;
-import static org.apache.jackrabbit.oak.plugins.document.LeaseCheckMode.DISABLED;
 import static org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentNodeStoreBuilder.newMongoDocumentNodeStoreBuilder;
 import static org.apache.jackrabbit.oak.plugins.document.rdb.RDBDocumentNodeStoreBuilder.newRDBDocumentNodeStoreBuilder;
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
@@ -32,6 +31,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -69,7 +69,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.jackrabbit.guava.common.io.Closer;
-import org.apache.jackrabbit.guava.common.io.Files;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoURI;
 
@@ -298,7 +297,7 @@ class Utils {
             String cfgPath = s3dsConfig.value(options);
             Properties props = loadAndTransformProps(cfgPath);
             s3ds.setProperties(props);
-            File homeDir =  Files.createTempDir();
+            File homeDir = Files.createTempDirectory(Utils.class.getSimpleName() + "-").toFile();
             closer.register(asCloseable(homeDir));
             s3ds.init(homeDir.getAbsolutePath());
             delegate = s3ds;
@@ -307,13 +306,13 @@ class Utils {
             String cfgPath = azureBlobDSConfig.value(options);
             Properties props = loadAndTransformProps(cfgPath);
             azureds.setProperties(props);
-            File homeDir =  Files.createTempDir();
+            File homeDir = Files.createTempDirectory(Utils.class.getSimpleName() + "-").toFile();
             azureds.init(homeDir.getAbsolutePath());
             closer.register(asCloseable(homeDir));
             delegate = azureds;
         } else if (options.has(nods)){
             delegate = new DummyDataStore();
-            File homeDir =  Files.createTempDir();
+            File homeDir = Files.createTempDirectory(Utils.class.getSimpleName() + "-").toFile();
             delegate.init(homeDir.getAbsolutePath());
             closer.register(asCloseable(homeDir));
         }

--- a/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/tool/AwsCompact.java
+++ b/oak-segment-aws/src/main/java/org/apache/jackrabbit/oak/segment/aws/tool/AwsCompact.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.aws.tool;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
@@ -26,11 +25,11 @@ import static org.apache.jackrabbit.oak.segment.aws.tool.AwsToolUtils.printableS
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
-import org.apache.jackrabbit.guava.common.io.Files;
 
 import org.apache.jackrabbit.oak.segment.SegmentCache;
 import org.apache.jackrabbit.oak.segment.aws.tool.AwsToolUtils.SegmentStoreType;
@@ -220,7 +219,8 @@ public class AwsCompact {
         printArchives(System.out, beforeArchives);
         System.out.printf("    -> compacting\n");
 
-        try (FileStore store = newFileStore(persistence, Files.createTempDir(), strictVersionCheck, segmentCacheSize,
+        try (FileStore store = newFileStore(persistence,
+                Files.createTempDirectory(getClass().getSimpleName() + "-").toFile(), strictVersionCheck, segmentCacheSize,
                 gcLogInterval, compactorType, concurrency)) {
             boolean success = false;
             switch (gcType) {

--- a/oak-segment-aws/src/test/java/org/apache/jackrabbit/oak/segment/aws/fixture/SegmentAwsFixture.java
+++ b/oak-segment-aws/src/test/java/org/apache/jackrabbit/oak/segment/aws/fixture/SegmentAwsFixture.java
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.aws.fixture;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
 import com.amazonaws.services.s3.AmazonS3;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStoreBuilders;
 import org.apache.jackrabbit.oak.segment.aws.AwsContext;
@@ -35,6 +33,7 @@ import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -89,7 +88,7 @@ public class SegmentAwsFixture extends NodeStoreFixture {
         }
 
         try {
-            FileStore fileStore = FileStoreBuilder.fileStoreBuilder(Files.createTempDir())
+            FileStore fileStore = FileStoreBuilder.fileStoreBuilder(Files.createTempDirectory(getClass().getSimpleName() + "-").toFile())
                     .withCustomPersistence(persistence).build();
             NodeStore nodeStore = SegmentNodeStoreBuilders.builder(fileStore).build();
             fileStoreMap.put(nodeStore, fileStore);

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/AzureCheck.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/AzureCheck.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.segment.azure.tool;
 
-import com.google.common.io.Files;
 import com.microsoft.azure.storage.blob.CloudBlobDirectory;
 import org.apache.jackrabbit.oak.segment.azure.AzurePersistence;
 import org.apache.jackrabbit.oak.segment.azure.AzureStorageCredentialManager;
@@ -29,7 +28,9 @@ import org.apache.jackrabbit.oak.segment.tool.Check;
 import org.apache.jackrabbit.oak.segment.tool.check.CheckHelper;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -388,7 +389,13 @@ public class AzureCheck {
             persistence = ToolUtils.decorateWithCache(persistence, persistentCachePath, persistentCacheSizeGb);
         }
 
-        FileStoreBuilder builder = fileStoreBuilder(Files.createTempDir()).withCustomPersistence(persistence);
+        FileStoreBuilder builder = null;
+        try {
+            builder = fileStoreBuilder(Files.createTempDirectory(getClass().getSimpleName() + "-").toFile()).withCustomPersistence(persistence);
+        } catch (IOException e) {
+            e.printStackTrace(err);
+            return 1;
+        }
 
         if (ioStatistics) {
             builder.withIOMonitor(ioMonitor);

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/AzureCompact.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/AzureCompact.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.azure.tool;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
@@ -27,7 +26,6 @@ import static org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.newSegmentN
 import static org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.printableStopwatch;
 
 import org.apache.jackrabbit.guava.common.base.Stopwatch;
-import org.apache.jackrabbit.guava.common.io.Files;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobListingDetails;
 import com.microsoft.azure.storage.blob.CloudBlob;
@@ -53,6 +51,7 @@ import org.apache.jackrabbit.oak.segment.tool.Compact;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -372,7 +371,9 @@ public class AzureCompact {
         GCGeneration gcGeneration = null;
         String root = null;
 
-        try (FileStore store = newFileStore(splitPersistence, Files.createTempDir(), strictVersionCheck, segmentCacheSize,
+        try (FileStore store =newFileStore(splitPersistence,
+                Files.createTempDirectory(getClass().getSimpleName() + "-").toFile(),
+                strictVersionCheck, segmentCacheSize,
                 gcLogInterval, compactorType, concurrency)) {
             if (garbageThresholdGb > 0 && garbageThresholdPercentage > 0) {
                 System.out.printf("    -> minimum garbage threshold set to %d GB or %d%%\n", garbageThresholdGb, garbageThresholdPercentage);

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/fixture/SegmentAzureFixture.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/fixture/SegmentAzureFixture.java
@@ -16,10 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.segment.azure.fixture;
 
-import org.apache.jackrabbit.guava.common.io.Files;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
@@ -34,6 +32,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.security.InvalidKeyException;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,7 +72,9 @@ public class SegmentAzureFixture extends NodeStoreFixture {
         }
 
         try {
-            FileStore fileStore = FileStoreBuilder.fileStoreBuilder(Files.createTempDir()).withCustomPersistence(persistence).build();
+            FileStore fileStore = FileStoreBuilder.fileStoreBuilder(
+                    Files.createTempDirectory(getClass().getSimpleName() + "-").toFile()).
+                    withCustomPersistence(persistence).build();
             NodeStore nodeStore = SegmentNodeStoreBuilders.builder(fileStore).build();
             fileStoreMap.put(nodeStore, fileStore);
             containerMap.put(nodeStore, container);

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/blob/AzureDataStoreFactory.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/blob/AzureDataStoreFactory.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,7 +43,6 @@ import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.stats.DefaultStatisticsProvider;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.apache.jackrabbit.guava.common.io.Closer;
-import org.apache.jackrabbit.guava.common.io.Files;
 
 public class AzureDataStoreFactory implements BlobStoreFactory {
 
@@ -68,7 +68,7 @@ public class AzureDataStoreFactory implements BlobStoreFactory {
         // Default directory
 
         this.directory = directory;
-        this.tempHomeDir = Files.createTempDir();
+        this.tempHomeDir = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         this.ignoreMissingBlobs = ignoreMissingBlobs;
     }
 

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/blob/S3DataStoreFactory.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/blob/S3DataStoreFactory.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,7 +40,6 @@ import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.DataStoreBlobStore;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.guava.common.io.Closer;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.stats.DefaultStatisticsProvider;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 
@@ -65,7 +65,7 @@ public class S3DataStoreFactory implements BlobStoreFactory {
         }
 
         this.directory = directory;
-        this.tempHomeDir = Files.createTempDir();
+        this.tempHomeDir = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         this.ignoreMissingBlobs = ignoreMissingBlobs;
     }
 

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/node/SegmentAzureFactory.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/cli/node/SegmentAzureFactory.java
@@ -22,7 +22,6 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobDirectory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.guava.common.io.Closer;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStoreBuilders;
 import org.apache.jackrabbit.oak.segment.azure.AzurePersistence;
 import org.apache.jackrabbit.oak.segment.azure.AzureStorageCredentialManager;
@@ -40,6 +39,7 @@ import org.apache.jackrabbit.oak.upgrade.cli.node.FileStoreUtils.NodeStoreWithFi
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.security.InvalidKeyException;
 
 import static org.apache.jackrabbit.oak.segment.SegmentCache.DEFAULT_SEGMENT_CACHE_MB;
@@ -125,7 +125,7 @@ public class SegmentAzureFactory implements NodeStoreFactory {
             throw new IllegalStateException(e);
         }
 
-        File tmpDir = Files.createTempDir();
+        File tmpDir = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         closer.register(() -> tmpDir.delete());
         FileStoreBuilder builder = FileStoreBuilder.fileStoreBuilder(tmpDir)
                 .withCustomPersistence(azPersistence).withMemoryMapping(false);
@@ -189,7 +189,7 @@ public class SegmentAzureFactory implements NodeStoreFactory {
             throw new IllegalStateException(e);
         }
 
-        File tmpDir = Files.createTempDir();
+        File tmpDir = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         FileStoreBuilder builder = FileStoreBuilder.fileStoreBuilder(tmpDir)
                 .withCustomPersistence(azPersistence).withMemoryMapping(false);
 

--- a/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/container/SegmentAzureNodeStoreContainer.java
+++ b/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/container/SegmentAzureNodeStoreContainer.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.upgrade.cli.container;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.security.InvalidKeyException;
 
 import org.apache.jackrabbit.oak.blob.cloud.azure.blobstorage.AzuriteDockerRule;
@@ -30,7 +31,6 @@ import org.apache.jackrabbit.oak.segment.file.FileStoreBuilder;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 
-import org.apache.jackrabbit.guava.common.io.Files;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 
@@ -83,7 +83,7 @@ public class SegmentAzureNodeStoreContainer implements NodeStoreContainer {
             throw new IllegalStateException(e);
         }
 
-        tmpDir = Files.createTempDir();
+        tmpDir = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         FileStoreBuilder builder = FileStoreBuilder.fileStoreBuilder(tmpDir)
                 .withCustomPersistence(azPersistence).withMemoryMapping(false);
 

--- a/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/container/SegmentAzureServicePrincipalNodeStoreContainer.java
+++ b/oak-upgrade/src/test/java/org/apache/jackrabbit/oak/upgrade/cli/container/SegmentAzureServicePrincipalNodeStoreContainer.java
@@ -17,7 +17,6 @@
 package org.apache.jackrabbit.oak.upgrade.cli.container;
 
 import com.microsoft.azure.storage.blob.CloudBlobDirectory;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStoreBuilders;
 import org.apache.jackrabbit.oak.segment.azure.AzurePersistence;
 import org.apache.jackrabbit.oak.segment.azure.AzureStorageCredentialManager;
@@ -33,6 +32,7 @@ import org.apache.jackrabbit.oak.upgrade.cli.node.FileStoreUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class SegmentAzureServicePrincipalNodeStoreContainer implements NodeStoreContainer {
     private static final Environment ENVIRONMENT = new Environment();
@@ -64,7 +64,7 @@ public class SegmentAzureServicePrincipalNodeStoreContainer implements NodeStore
             throw new IllegalStateException(e);
         }
 
-        tmpDir = Files.createTempDir();
+        tmpDir = Files.createTempDirectory(getClass().getSimpleName() + "-").toFile();
         FileStoreBuilder builder = FileStoreBuilder.fileStoreBuilder(tmpDir)
                 .withCustomPersistence(azurePersistence).withMemoryMapping(false);
         if (blobStore != null) {


### PR DESCRIPTION
(also assign prefixes to temp files to help debugging when they are left open)