### PR TITLE
OAK-11445: Remove usage of Guava Files.toString()

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/datastore/DataStoreTextWriter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/datastore/DataStoreTextWriter.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.plugins.index.datastore;
 
 import java.io.BufferedWriter;
@@ -26,11 +25,11 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
@@ -110,7 +109,7 @@ public class DataStoreTextWriter implements TextWriter, Closeable, PreExtractedT
         } else {
             File textFile = getFile(blobId);
             if (textFile.exists()) {
-                String text = Files.toString(textFile, StandardCharsets.UTF_8);
+                String text = new String(Files.readAllBytes(textFile.toPath()), StandardCharsets.UTF_8);
                 result = new ExtractedText(ExtractionResult.SUCCESS, text);
             }
         }
@@ -131,7 +130,7 @@ public class DataStoreTextWriter implements TextWriter, Closeable, PreExtractedT
         File textFile = getFile(stripLength(blobId));
         ensureParentExists(textFile);
         //TODO should we compress
-        Files.write(text, textFile, StandardCharsets.UTF_8);
+        org.apache.jackrabbit.guava.common.io.Files.write(text, textFile, StandardCharsets.UTF_8);
     }
 
     @Override
@@ -233,7 +232,7 @@ public class DataStoreTextWriter implements TextWriter, Closeable, PreExtractedT
     private Set<String> loadFromFile(File file) throws IOException {
         Set<String> result = new HashSet<>();
         if (file.exists()) {
-            result.addAll(Files.readLines(file, StandardCharsets.UTF_8));
+            result.addAll(org.apache.jackrabbit.guava.common.io.Files.readLines(file, StandardCharsets.UTF_8));
         }
         return result;
     }

--- a/oak-pojosr/src/main/java/org/apache/jackrabbit/oak/run/osgi/ConfigTracker.java
+++ b/oak-pojosr/src/main/java/org/apache/jackrabbit/oak/run/osgi/ConfigTracker.java
@@ -21,13 +21,13 @@ package org.apache.jackrabbit.oak.run.osgi;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.jackrabbit.guava.common.base.Splitter;
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -112,7 +112,7 @@ class ConfigTracker extends ServiceTracker<ConfigurationAdmin, ConfigurationAdmi
                 continue;
             }
 
-            String content = Files.toString(jsonFile, StandardCharsets.UTF_8);
+            String content = new String(Files.readAllBytes(jsonFile.toPath()), StandardCharsets.UTF_8);
             JSONObject json = (JSONObject) JSONValue.parse(content);
             configs.putAll(json);
         }

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/exporter/NodeStateSerializer.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/exporter/NodeStateSerializer.java
@@ -27,8 +27,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
-import org.apache.jackrabbit.guava.common.io.Files;
 import com.google.gson.stream.JsonWriter;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.commons.json.JsopWriter;
@@ -127,7 +127,9 @@ public class NodeStateSerializer {
     }
 
     private String getFilter() throws IOException {
-        return filterFile != null ? Files.toString(filterFile, StandardCharsets.UTF_8) : filter;
+        return filterFile != null
+                ? new String(Files.readAllBytes(filterFile.toPath()), StandardCharsets.UTF_8)
+                : filter;
     }
 
     public String getFileName() {

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/exporter/NodeStateSerializerTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/exporter/NodeStateSerializerTest.java
@@ -16,14 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.exporter;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.json.BlobDeserializer;
 import org.apache.jackrabbit.oak.json.JsonDeserializer;
@@ -66,7 +65,7 @@ public class NodeStateSerializerTest {
         File json = new File(folder.getRoot(), serializer.getFileName());
         assertTrue(json.exists());
 
-        String text = Files.toString(json, StandardCharsets.UTF_8);
+        String text = new String(Files.readAllBytes(json.toPath()), StandardCharsets.UTF_8);
         NodeState nodeState2 = deserialize(text);
         assertTrue(EqualsDiff.equals(builder.getNodeState(), nodeState2));
     }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/index/LuceneIndexCommandIT.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/index/LuceneIndexCommandIT.java
@@ -16,20 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.jackrabbit.oak.index;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
-
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.nio.charset.Charset.defaultCharset;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -65,8 +62,9 @@ public class LuceneIndexCommandIT extends LuceneAbstractIndexCommandTest {
         assertTrue(info.exists());
         assertTrue(defns.exists());
 
-        assertThat(Files.toString(info, defaultCharset()), containsString("/oak:index/uuid"));
-        assertThat(Files.toString(info, defaultCharset()), containsString("/oak:index/fooIndex"));
+        String s =  new String(Files.readAllBytes(info.toPath()), StandardCharsets.UTF_8);
+        assertThat(s, containsString("/oak:index/uuid"));
+        assertThat(s, containsString("/oak:index/fooIndex"));
     }
 
     @Test
@@ -93,8 +91,9 @@ public class LuceneIndexCommandIT extends LuceneAbstractIndexCommandTest {
 
         assertTrue(info.exists());
 
-        assertThat(Files.toString(info, defaultCharset()), not(containsString("/oak:index/uuid")));
-        assertThat(Files.toString(info, defaultCharset()), containsString("/oak:index/fooIndex"));
+        String s =  new String(Files.readAllBytes(info.toPath()), StandardCharsets.UTF_8);
+        assertThat(s, not(containsString("/oak:index/uuid")));
+        assertThat(s, containsString("/oak:index/fooIndex"));
     }
 
     @Test
@@ -122,7 +121,8 @@ public class LuceneIndexCommandIT extends LuceneAbstractIndexCommandTest {
         assertFalse(new File(outDir, IndexCommand.INDEX_DEFINITIONS_JSON).exists());
         assertTrue(report.exists());
 
-        assertThat(Files.toString(report, defaultCharset()), containsString("/oak:index/fooIndex"));
+        String s =  new String(Files.readAllBytes(report.toPath()), StandardCharsets.UTF_8);
+        assertThat(s, containsString("/oak:index/fooIndex"));
     }
 
     @Test


### PR DESCRIPTION
See

 https://github.com/greenbytes/guavaVsJDKTests/blob/main/src/test/java/org/greenbytes/java/src/test/java/guavaVsJDKTests/io/FilesTest.java
 
 for why this replacement variant was used.