### PR TITLE
OAK-11459 - Code cleanups on indexing related packages

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/ConfigHelper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/ConfigHelper.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+package org.apache.jackrabbit.oak.plugins.index;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
@@ -91,7 +91,7 @@ public class IndexingProgressReporter implements NodeTraversalCallback {
     }
 
     public void traversedNode(PathSource pathSource) throws CommitFailedException {
-        if (++traversalCount % 100_000 == 0) {
+        if (++traversalCount % 10_000 == 0) {
             double rate = traversalRateEstimator.getNodesTraversedPerSecond();
             String formattedRate = String.format("%1.2f nodes/s, %1.2f nodes/hr", rate, rate * 3600);
             String estimate = estimatePendingTraversal(rate);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/progress/IndexingProgressReporter.java
@@ -91,7 +91,7 @@ public class IndexingProgressReporter implements NodeTraversalCallback {
     }
 
     public void traversedNode(PathSource pathSource) throws CommitFailedException {
-        if (++traversalCount % 10000 == 0) {
+        if (++traversalCount % 100_000 == 0) {
             double rate = traversalRateEstimator.getNodesTraversedPerSecond();
             String formattedRate = String.format("%1.2f nodes/s, %1.2f nodes/hr", rate, rate * 3600);
             String estimate = estimatePendingTraversal(rate);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/ConfigHelperTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/ConfigHelperTest.java
@@ -16,21 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
+package org.apache.jackrabbit.oak.plugins.index;
 
-import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class ConfigHelperTest {
-
-    @Rule
-    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Test
     public void getSystemPropertyAsStringList() {

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/DefaultIndexWriter.java
@@ -216,6 +216,7 @@ class DefaultIndexWriter implements LuceneIndexWriter {
      * Checks if last suggestion build time was done sufficiently in the past AND that there were non-zero indexedNodes
      * stored in the last run. Note, if index is updated only to rebuild suggestions, even then we update indexedNodes,
      * which would be zero in case it was a forced update of suggestions.
+     *
      * @return is suggest dict should be updated
      */
     private boolean shouldUpdateSuggestions(Calendar currentTime) {
@@ -295,5 +296,12 @@ class DefaultIndexWriter implements LuceneIndexWriter {
             sb.append(", ");
         }
         log.trace("Directory overall size: {}, files: {}", IOUtils.humanReadableByteCount(overallSize), sb);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultIndexWriter{" +
+                "index=" + definition.getIndexName() +
+                '}';
     }
 }

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/LuceneIndexWriterConfig.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/LuceneIndexWriterConfig.java
@@ -19,9 +19,13 @@
 
 package org.apache.jackrabbit.oak.plugins.index.lucene.writer;
 
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LuceneIndexWriterConfig {
+    private final static Logger LOG = LoggerFactory.getLogger(LuceneIndexWriterConfig.class);
     /**
      * This property will be used to set Lucene's IndexWriter.maxBufferedDeleteTerms
      * IndexWriter.maxBufferedDeleteTerms is used to flush buffered data to lucene index.
@@ -34,11 +38,14 @@ public class LuceneIndexWriterConfig {
      */
     public final static String RAM_PER_THREAD_HARD_LIMIT_MB_KEY = "oak.index.lucene.ramPerThreadHardLimitMB";
 
+    private final int maxBufferedDeleteTerms = SystemPropertySupplier.create(
+                    MAX_BUFFERED_DELETE_TERMS_KEY, IndexWriterConfig.DISABLE_AUTO_FLUSH)
+            .loggingTo(LOG).get();
+    private final int ramPerThreadHardLimitMB = SystemPropertySupplier.create(
+                    RAM_PER_THREAD_HARD_LIMIT_MB_KEY, IndexWriterConfig.DEFAULT_RAM_PER_THREAD_HARD_LIMIT_MB)
+            .loggingTo(LOG).get();
+
     private final double ramBufferSizeMB;
-    private final int maxBufferedDeleteTerms = Integer.getInteger(MAX_BUFFERED_DELETE_TERMS_KEY,
-            IndexWriterConfig.DISABLE_AUTO_FLUSH);
-    private final int ramPerThreadHardLimitMB = Integer.getInteger(RAM_PER_THREAD_HARD_LIMIT_MB_KEY,
-            IndexWriterConfig.DEFAULT_RAM_PER_THREAD_HARD_LIMIT_MB);
     private final int threadCount;
 
     public LuceneIndexWriterConfig() {

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/MultiplexingIndexWriter.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/writer/MultiplexingIndexWriter.java
@@ -82,9 +82,9 @@ class MultiplexingIndexWriter implements LuceneIndexWriter {
         // This essentially ensures we respect DefaultIndexWriters#close's intent to
         // create empty index even if nothing has been written during re-index.
         StreamSupport.stream(concat(singleton(mountInfoProvider.getDefaultMount()), mountInfoProvider.getNonDefaultMounts())
-                .spliterator(), false)
-                .filter(m ->  reindex && !m.isReadOnly()) // only needed when re-indexing for read-write mounts.
-                                                         // reindex for ro-mount doesn't make sense in this case anyway.
+                        .spliterator(), false)
+                .filter(m -> reindex && !m.isReadOnly()) // only needed when re-indexing for read-write mounts.
+                // reindex for ro-mount doesn't make sense in this case anyway.
                 .forEach(this::getWriter); // open default writers for mounts that passed all our tests
 
         boolean indexUpdated = false;
@@ -100,15 +100,20 @@ class MultiplexingIndexWriter implements LuceneIndexWriter {
     }
 
     private DefaultIndexWriter getWriter(Mount mount) {
-        DefaultIndexWriter writer = writers.computeIfAbsent(mount, w -> createWriter(mount));
-        return writer;
+        return writers.computeIfAbsent(mount, w -> createWriter(mount));
     }
 
     private DefaultIndexWriter createWriter(Mount m) {
         String dirName = MultiplexersLucene.getIndexDirName(m);
         String suggestDirName = MultiplexersLucene.getSuggestDirName(m);
         return new DefaultIndexWriter(definition, definitionBuilder, directoryFactory, dirName,
-            suggestDirName, reindex, writerConfig);
+                suggestDirName, reindex, writerConfig);
     }
 
+    @Override
+    public String toString() {
+        return "MultiplexingIndexWriter{" +
+                "writers=" + writers.values() +
+                '}';
+    }
 }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/DocumentStoreIndexerBase.java
@@ -30,7 +30,7 @@ import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
 import org.apache.jackrabbit.oak.index.IndexHelper;
 import org.apache.jackrabbit.oak.index.IndexerSupport;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.FlatFileNodeStoreBuilder;
-import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.ConfigHelper;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.index.indexer.document.incrementalstore.IncrementalStoreBuilder;
 import org.apache.jackrabbit.oak.index.indexer.document.indexstore.IndexStore;
 import org.apache.jackrabbit.oak.index.indexer.document.tree.ParallelIndexStore;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/AheadOfTimeBlobDownloadingFlatFileStore.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/AheadOfTimeBlobDownloadingFlatFileStore.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntry;
-import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.ConfigHelper;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.index.indexer.document.indexstore.IndexStore;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.spi.blob.GarbageCollectableBlobStore;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileNodeStoreBuilder.java
@@ -28,7 +28,7 @@ import org.apache.jackrabbit.oak.index.IndexHelper;
 import org.apache.jackrabbit.oak.index.IndexerSupport;
 import org.apache.jackrabbit.oak.index.indexer.document.CompositeException;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateEntryTraverserFactory;
-import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.ConfigHelper;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedStrategy;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.PipelinedTreeStoreStrategy;
 import org.apache.jackrabbit.oak.index.indexer.document.indexstore.IndexStore;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/FlatFileStoreIterator.java
@@ -26,7 +26,7 @@ import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.Flat
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.NodeStateEntryList;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.PersistedLinkedList;
 import org.apache.jackrabbit.oak.index.indexer.document.flatfile.linkedList.PersistedLinkedListV2;
-import org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined.ConfigHelper;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.slf4j.Logger;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMergeSortTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMergeSortTask.java
@@ -25,6 +25,7 @@ import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.commons.sort.ExternalSortByteArray;
 import org.apache.jackrabbit.oak.index.indexer.document.indexstore.IndexStoreUtils;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;
 import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedMongoDownloadTask.java
@@ -43,6 +43,7 @@ import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.NodeDocument;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStoreHelper;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;
 import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedStrategy.java
@@ -33,6 +33,7 @@ import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;
 import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTreeStoreStrategy.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/PipelinedTreeStoreStrategy.java
@@ -34,6 +34,7 @@ import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.RevisionVector;
 import org.apache.jackrabbit.oak.plugins.document.mongo.MongoDocumentStore;
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.MetricsFormatter;
 import org.apache.jackrabbit.oak.plugins.index.IndexingReporter;

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/ConfigHelperTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/pipelined/ConfigHelperTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.jackrabbit.oak.index.indexer.document.flatfile.pipelined;
 
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/OutOfBandIndexer.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/OutOfBandIndexer.java
@@ -42,13 +42,13 @@ public class OutOfBandIndexer extends OutOfBandIndexerBase {
     }
 
     protected IndexEditorProvider createIndexEditorProvider() throws IOException {
-        IndexEditorProvider lucene = createLuceneEditorProvider();
-        IndexEditorProvider property = createPropertyEditorProvider();
+        LuceneIndexEditorProvider lucene = createLuceneEditorProvider();
+        SegmentPropertyIndexEditorProvider property = createPropertyEditorProvider();
 
         return CompositeIndexEditorProvider.compose(List.of(lucene, property));
     }
 
-    private IndexEditorProvider createPropertyEditorProvider() throws IOException {
+    private SegmentPropertyIndexEditorProvider createPropertyEditorProvider() throws IOException {
         SegmentPropertyIndexEditorProvider provider =
                 new SegmentPropertyIndexEditorProvider(new File(getLocalIndexDir(), "propertyIndexStore"));
         provider.with(extendedIndexHelper.getMountInfoProvider());
@@ -56,7 +56,7 @@ public class OutOfBandIndexer extends OutOfBandIndexerBase {
         return provider;
     }
 
-    private IndexEditorProvider createLuceneEditorProvider() throws IOException {
+    private LuceneIndexEditorProvider createLuceneEditorProvider() throws IOException {
         LuceneIndexHelper luceneIndexHelper = extendedIndexHelper.getLuceneIndexHelper();
         DirectoryFactory dirFactory = new FSDirectoryFactory(getLocalIndexDir());
         luceneIndexHelper.setDirectoryFactory(dirFactory);


### PR DESCRIPTION
Move ConfigHelper from oak-run-commons to oak-core
Minor refactorings and code cleanups to indexing modules.

Mostly cosmetic PR to reduce the changeset of OAK-11438.