### PR TITLE
OAK-11461 : DocumentNodeStoreService -  disable discovery 

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -398,6 +398,6 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreServic
 
     @AttributeDefinition(
             name = "Invisible for discovery",
-            description = "Boolean value indicating that the instance should not be discoverable for the cluster. The default value is " + DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY)
+            description = ""Boolean value indicating whether the instance should be discoverable by the cluster. The default value is " + DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY)
     boolean invisibleForDiscovery() default DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY;
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -395,4 +395,9 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreServic
             description = "Integer value indicating the number of documents to check for garbage in each Full GC cycle." +
                     "The default value is " + DocumentNodeStoreService.DEFAULT_FGC_PROGRESS_SIZE)
     int fullGCProgressSize() default DocumentNodeStoreService.DEFAULT_FGC_PROGRESS_SIZE;
+
+    @AttributeDefinition(
+            name = "Invisible for discovery",
+            description = "Boolean value indicating that the instance should not be discoverable for the cluster. The default value is " + DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY)
+    boolean invisibleForDiscovery() default DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY;
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Configuration.java
@@ -398,6 +398,6 @@ import static org.apache.jackrabbit.oak.plugins.document.DocumentNodeStoreServic
 
     @AttributeDefinition(
             name = "Invisible for discovery",
-            description = ""Boolean value indicating whether the instance should be discoverable by the cluster. The default value is " + DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY)
+            description = "Boolean value indicating whether the instance should be discoverable by the cluster. The default value is " + DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY)
     boolean invisibleForDiscovery() default DocumentNodeStoreService.DEFAULT_INVISIBLE_FOR_DISCOVERY;
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -130,6 +130,7 @@ import org.slf4j.LoggerFactory;
         configurationPid = {Configuration.PID})
 public class DocumentNodeStoreService {
 
+    public static final boolean DEFAULT_INVISIBLE_FOR_DISCOVERY = false;
     private static final long MB = 1024 * 1024;
     static final String DEFAULT_URI = "mongodb://localhost:27017/oak";
     static final int DEFAULT_CACHE = (int) (DEFAULT_MEMORY_CACHE_SIZE / MB);
@@ -510,6 +511,7 @@ public class DocumentNodeStoreService {
                         config.childrenCachePercentage(),
                         config.diffCachePercentage(),
                         config.prevNoPropCachePercentage()).
+                setClusterInvisible(config.invisibleForDiscovery()).
                 setCacheSegmentCount(config.cacheSegmentCount()).
                 setCacheStackMoveDistance(config.cacheStackMoveDistance()).
                 setBundlingDisabled(config.bundlingDisabled()).

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceConfigurationTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class DocumentNodeStoreServiceConfigurationTest {
 
@@ -167,6 +168,28 @@ public class DocumentNodeStoreServiceConfigurationTest {
         addConfigurationEntry(preset, "fullGCBatchSize", batchSize);
         Configuration config = createConfiguration();
         assertEquals(batchSize, config.fullGCBatchSize());
+    }
+
+    @Test
+    public void invisibleForDiscoveryFalse() throws Exception {
+        boolean batchSize = false;
+        addConfigurationEntry(preset, "invisibleForDiscovery", batchSize);
+        Configuration config = createConfiguration();
+        assertFalse(config.invisibleForDiscovery());
+    }
+
+    @Test
+    public void invisibleForDiscoveryTrue() throws Exception {
+        boolean batchSize = true;
+        addConfigurationEntry(preset, "invisibleForDiscovery", batchSize);
+        Configuration config = createConfiguration();
+        assertTrue(config.invisibleForDiscovery());
+    }
+
+    @Test
+    public void invisibleForDiscoveryFalseByDefault() throws Exception {
+        Configuration config = createConfiguration();
+        assertFalse(config.invisibleForDiscovery());
     }
 
     @Test

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreServiceTest.java
@@ -257,6 +257,29 @@ public class DocumentNodeStoreServiceTest {
     }
 
     @Test
+    public void invisibleForDiscoveryTrueFalse() {
+        Map<String, Object> config = newConfig(repoHome);
+        MockOsgi.setConfigForPid(context.bundleContext(), PID, config);
+        MockOsgi.activate(service, context.bundleContext());
+
+        DocumentNodeStore dns = context.getService(DocumentNodeStore.class);
+        // false is the default
+        assertFalse(dns.getClusterInfo().isInvisible());
+    }
+
+    @Test
+    public void invisibleForDiscoveryTrue() {
+        Map<String, Object> config = newConfig(repoHome);
+        config.put("invisibleForDiscovery", true);
+        MockOsgi.setConfigForPid(context.bundleContext(), PID, config);
+        MockOsgi.activate(service, context.bundleContext());
+
+        DocumentNodeStore dns = context.getService(DocumentNodeStore.class);
+        assertTrue(dns.getClusterInfo().isInvisible());
+    }
+
+
+    @Test
     public void lenientLeaseCheckMode() {
         Map<String, Object> config = newConfig(repoHome);
         config.put("leaseCheckMode", LeaseCheckMode.LENIENT.name());


### PR DESCRIPTION
Make it configurable to disable discovery for the document node store service