### PR TITLE
OAK-11464: oak-it-osgi fails to load oak-search-elastic if the profil…

### DIFF
--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -60,6 +60,7 @@
               !com.sun.management.*,
               !jakarta.json.bind.*,
               !java.net.http.*,
+              !com.oracle.bmc.*,
               *
             </Import-Package>
             <Embed-Dependency>


### PR DESCRIPTION
…e rdb-mysql is used for building and testing.

Removed package import.