### PR TITLE
OAK-11456: oak-solr-osgi embeds vulnerable Zookeeper 3.9.2

### DIFF
--- a/oak-solr-osgi/pom.xml
+++ b/oak-solr-osgi/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.9.2</version>
+            <version>3.9.3</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updated to 3.6.3.