### PR TITLE
OAK-11481: Remove (once more) usage of Guava Files.createTempDir()

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AzureSegmentStoreExplorerBackend.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AzureSegmentStoreExplorerBackend.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.explorer;
 
-import org.apache.jackrabbit.guava.common.io.Files;
 import org.apache.jackrabbit.oak.segment.azure.v8.AzureStorageCredentialManagerV8;
 import org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils;
 import org.apache.jackrabbit.oak.segment.file.InvalidFileStoreVersionException;
@@ -26,6 +25,7 @@ import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
 import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentNodeStorePersistence;
 
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.apache.jackrabbit.oak.segment.azure.tool.ToolUtils.newSegmentNodeStorePersistence;
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
@@ -51,7 +51,7 @@ public class AzureSegmentStoreExplorerBackend extends AbstractSegmentTarExplorer
         this.persistence = newSegmentNodeStorePersistence(ToolUtils.SegmentStoreType.AZURE, path, azureStorageCredentialManagerV8);
 
         try {
-            this.store = fileStoreBuilder(Files.createTempDir())
+            this.store = fileStoreBuilder(Files.createTempDirectory(getClass().getSimpleName() + "-").toFile())
                     .withCustomPersistence(persistence)
                     .buildReadOnly();
         } catch (InvalidFileStoreVersionException e) {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/FileStoreDiffCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/FileStoreDiffCommand.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.jackrabbit.oak.run;
 
 import static java.util.Arrays.asList;
@@ -22,8 +21,8 @@ import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreB
 import static org.apache.jackrabbit.oak.segment.tool.Utils.newBasicReadOnlyBlobStore;
 
 import java.io.File;
+import java.nio.file.Files;
 
-import com.google.common.io.Files;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
@@ -89,7 +88,8 @@ class FileStoreDiffCommand implements Command {
             if (pathOrURI.startsWith("az:")) {
                 try (AzureStorageCredentialManagerV8 azureStorageCredentialManagerV8 = new AzureStorageCredentialManagerV8()) {
                     SegmentNodeStorePersistence azurePersistence = ToolUtils.newSegmentNodeStorePersistence(ToolUtils.SegmentStoreType.AZURE, pathOrURI, azureStorageCredentialManagerV8);
-                    ReadOnlyFileStore store = fileStoreBuilder(Files.createTempDir()).withCustomPersistence(azurePersistence).withBlobStore(newBasicReadOnlyBlobStore()).buildReadOnly();
+                    ReadOnlyFileStore store = fileStoreBuilder(Files.createTempDirectory(getClass().getSimpleName() + "-").toFile())
+                            .withCustomPersistence(azurePersistence).withBlobStore(newBasicReadOnlyBlobStore()).buildReadOnly();
                     statusCode = Diff.builder()
                             .withPath(pathOrURI)
                             .withReadOnlyFileStore(store)


### PR DESCRIPTION
(also assign prefixes to temp files to help debugging when they are left open)