### PR TITLE
OAK-11480 - Graceful handling when getErrorCode() returns null.

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
@@ -153,9 +153,11 @@ public class AzureRepositoryLock implements RepositoryLock {
 
                 if (e instanceof BlobStorageException) {
                     BlobStorageException storageException = (BlobStorageException) e;
-                    if (Set.of(BlobErrorCode.OPERATION_TIMED_OUT,
+                    BlobErrorCode errorCode = storageException.getErrorCode();
+                    if (errorCode != null &&
+                        Set.of(BlobErrorCode.OPERATION_TIMED_OUT,
                             BlobErrorCode.SERVER_BUSY,
-                            BlobErrorCode.INTERNAL_ERROR).contains(storageException.getErrorCode())) {
+                            BlobErrorCode.INTERNAL_ERROR).contains(errorCode)) {
                         log.warn("Could not renew the lease due to the operation timeout or service unavailability. Retry in progress ...", e);
                     } else {
                         log.warn("Could not renew lease due to storage exception. Retry in progress ... ", e);

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/v8/AzureRepositoryLockV8.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/v8/AzureRepositoryLockV8.java
@@ -155,10 +155,12 @@ public class AzureRepositoryLockV8 implements RepositoryLock {
 
                     if (e instanceof StorageException) {
                         StorageException storageException = (StorageException) e;
-                        if (Set.of(StorageErrorCodeStrings.OPERATION_TIMED_OUT
+                        String errorCode = storageException.getErrorCode();
+                        if (errorCode != null &&
+                                Set.of(StorageErrorCodeStrings.OPERATION_TIMED_OUT
                                 , StorageErrorCode.SERVICE_INTERNAL_ERROR
                                 , StorageErrorCodeStrings.SERVER_BUSY
-                                , StorageErrorCodeStrings.INTERNAL_ERROR).contains(storageException.getErrorCode())) {
+                                , StorageErrorCodeStrings.INTERNAL_ERROR).contains(errorCode)) {
                             log.warn("Could not renew the lease due to the operation timeout or service unavailability. Retry in progress ...", e);
                         } else if (storageException.getHttpStatusCode() == Constants.HeaderConstants.HTTP_UNUSED_306) {
                             log.warn("Client side error. Retry in progress ...", e);


### PR DESCRIPTION
Make sure Set.contains() does not throw an NPE if getErrorCode() returns null.