### PR TITLE
 OAK-11397: add new API for expanded names/paths 

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/NameMapper.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/NameMapper.java
@@ -63,16 +63,35 @@ public interface NameMapper {
     Map<String, String> getSessionLocalMappings();
 
     /**
-     * Returns the JCR name for the given Oak name. The given name is
+     * Returns the JCR name in qualified form for the given Oak name. The given name is
      * expected to have come from a valid Oak repository that contains
      * only valid names with proper namespace mappings. If that's not
      * the case, either a programming error or a repository corruption
      * has occurred and an appropriate unchecked exception gets thrown.
      *
      * @param oakName Oak name
-     * @return JCR name
+     * @return JCR name in qualified form
+     * 
+     * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.2%20Qualified%20Form">JCR 2.0, 3.2.5.2 Qualifed Form</a>
      */
     @NotNull
     String getJcrName(@NotNull String oakName);
+
+    /**
+     * Returns the JCR name in expanded form for the given Oak name. The given name is
+     * expected to have come from a valid Oak repository that contains
+     * only valid names with proper namespace mappings. If that's not
+     * the case, either a programming error or a repository corruption
+     * has occurred and an appropriate unchecked exception gets thrown.
+     *
+     * @param oakName Oak name
+     * @return JCR name in expanded form
+     * @since Oak 1.76.0
+     * @throws IllegalStateException in case the namespace URI for the given Oak name cannot be resolved
+     * 
+     * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>
+     */
+    @NotNull
+    String getExpandedJcrName(@NotNull String oakName);
 
 }

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/NameMapper.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/NameMapper.java
@@ -86,7 +86,7 @@ public interface NameMapper {
      *
      * @param oakName Oak name
      * @return JCR name in expanded form
-     * @since Oak 1.76.0
+     * @since Oak 1.78.0
      * @throws IllegalStateException in case the namespace URI for the given Oak name cannot be resolved
      * 
      * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/NamePathMapper.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/NamePathMapper.java
@@ -62,6 +62,12 @@ public interface NamePathMapper extends NameMapper, PathMapper {
             return oakName;
         }
 
+        @NotNull
+        @Override
+        public String getExpandedJcrName(@NotNull String oakName) {
+            throw new UnsupportedOperationException("Cannot create expanded JCR name as no namespace mappings are available");
+        }
+
         @Override
         public String getOakPath(String jcrPath) {
             return jcrPath;
@@ -71,6 +77,12 @@ public interface NamePathMapper extends NameMapper, PathMapper {
         @Override
         public String getJcrPath(String oakPath) {
             return oakPath;
+        }
+
+        @NotNull
+        @Override
+        public String getExpandedJcrPath(@NotNull String oakPath) {
+            throw new UnsupportedOperationException("Cannot create expanded JCR path as no namespace mappings are available");
         }
     }
 }

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/PathMapper.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/PathMapper.java
@@ -56,4 +56,20 @@ public interface PathMapper {
     @NotNull
     String getJcrPath(String oakPath);
 
+    /**
+     * Returns the JCR path in expanded form for the given Oak path. The given path is
+     * expected to have come from a valid Oak repository that contains
+     * only valid names with proper namespace mappings. If that's not
+     * the case, either a programming error or a repository corruption
+     * has occurred and an appropriate unchecked exception gets thrown.
+     *
+     * @param oakPath Oak path
+     * @return JCR path in expanded form
+     * @since Oak 1.76.0
+     * @throws IllegalStateException in case the namespace URI for the given Oak name cannot be resolved
+     * 
+     * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>
+     */
+    @NotNull
+    String getExpandedJcrPath(@NotNull String oakPath);
 }

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/PathMapper.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/PathMapper.java
@@ -65,7 +65,7 @@ public interface PathMapper {
      *
      * @param oakPath Oak path
      * @return JCR path in expanded form
-     * @since Oak 1.76.0
+     * @since Oak 1.78.0
      * @throws IllegalStateException in case the namespace URI for the given Oak name cannot be resolved
      * 
      * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/package-info.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/namepath/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.0.1")
+@Version("1.1.0")
 package org.apache.jackrabbit.oak.namepath;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
@@ -133,12 +133,11 @@ public class GlobalNameMapper implements NameMapper {
     @Override
     @NotNull
     public String getExpandedJcrName(@NotNull String oakName) {
-        String qualifiedName = getJcrName(oakName); // sanity check
         String uri;
         final String localName;
-        int colon = qualifiedName.indexOf(':');
+        int colon = oakName.indexOf(':');
         if (colon > 0) {
-            String oakPrefix = qualifiedName.substring(0, colon);
+            String oakPrefix = oakName.substring(0, colon);
             // local mapping must take precedence...
             uri = getSessionLocalMappings().get(oakPrefix);
             if (uri == null) {
@@ -149,10 +148,10 @@ public class GlobalNameMapper implements NameMapper {
                 throw new IllegalStateException(
                         "No namespace mapping found for " + oakName);
             }
-            localName = qualifiedName.substring(colon + 1);
+            localName = oakName.substring(colon + 1);
         } else {
             uri = "";
-            localName = qualifiedName;
+            localName = oakName;
         }
         return "{" + uri + "}" + localName;
     }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
@@ -130,6 +130,33 @@ public class GlobalNameMapper implements NameMapper {
         return oakName;
     }
 
+    @Override
+    @NotNull
+    public String getExpandedJcrName(@NotNull String oakName) {
+        String qualifiedName = getJcrName(oakName); // sanity check
+        String uri;
+        final String localName;
+        int colon = qualifiedName.indexOf(':');
+        if (colon > 0) {
+            String oakPrefix = qualifiedName.substring(0, colon);
+            // local mapping must take precedence...
+            uri = getSessionLocalMappings().get(oakPrefix);
+            if (uri == null) {
+                // ...over global mappings
+                uri = getNamespacesProperty(oakPrefix);
+            }
+            if (uri == null) {
+                throw new IllegalStateException(
+                        "No namespace mapping found for " + oakName);
+            }
+            localName = qualifiedName.substring(colon + 1);
+        } else {
+            uri = "";
+            localName = qualifiedName;
+        }
+        return "{" + uri + "}" + localName;
+    }
+
     @Override @Nullable
     public String getOakNameOrNull(@NotNull String jcrName) {
         if (jcrName.startsWith("{")) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
@@ -133,6 +133,11 @@ public class GlobalNameMapper implements NameMapper {
     @Override
     @NotNull
     public String getExpandedJcrName(@NotNull String oakName) {
+        // Sanity checks, can be turned to assertions if needed for performance
+        requireNonNull(oakName);
+        checkArgument(!isHiddenName(oakName), oakName);
+        checkArgument(!isExpandedName(oakName), oakName);
+
         String uri;
         final String localName;
         int colon = oakName.indexOf(':');

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/NamePathMapperImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/NamePathMapperImpl.java
@@ -19,6 +19,8 @@ package org.apache.jackrabbit.oak.namepath.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
+import java.util.function.UnaryOperator;
 
 import javax.jcr.RepositoryException;
 
@@ -71,6 +73,12 @@ public class NamePathMapperImpl implements NamePathMapper {
     @Override
     public String getJcrName(@NotNull String oakName) {
         return nameMapper.getJcrName(oakName);
+    }
+
+    @NotNull
+    @Override
+    public String getExpandedJcrName(@NotNull String oakName) {
+        return nameMapper.getExpandedJcrName(oakName);
     }
 
     @Override @NotNull
@@ -160,14 +168,23 @@ public class NamePathMapperImpl implements NamePathMapper {
     @Override
     @NotNull
     public String getJcrPath(final String oakPath) {
+        return getJcrPath(oakPath, nameMapper::getJcrName, () -> nameMapper.getSessionLocalMappings().isEmpty());
+    }
+
+    @Override
+    @NotNull
+    public String getExpandedJcrPath(@NotNull String oakPath) {
+        return getJcrPath(oakPath, nameMapper::getExpandedJcrName, () -> false);
+    }
+
+    public String getJcrPath(final String oakPath, final UnaryOperator<String> mapFunction, final BooleanSupplier shouldSkipMappingFunction) {
         if ("/".equals(oakPath)) {
             // avoid the need to special case the root path later on
             return "/";
         } else if (oakPath.isEmpty()) {
             // empty path: map to "."
             return ".";
-        } else if (nameMapper.getSessionLocalMappings().isEmpty()) {
-            // no local namespace mappings
+        } else if (shouldSkipMappingFunction.getAsBoolean()) {
             return oakPath;
         }
 
@@ -185,7 +202,7 @@ public class NamePathMapperImpl implements NamePathMapper {
 
             @Override
             public boolean name(String name, int index) {
-                String p = nameMapper.getJcrName(name);
+                String p = mapFunction.apply(name);
                 if (index == 0) {
                     elements.add(p);
                 } else {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapperTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapperTest.java
@@ -48,6 +48,7 @@ public class GlobalNameMapperTest {
         assertEquals("", mapper.getJcrName(""));
         assertEquals("", mapper.getOakNameOrNull(""));
         assertEquals("", mapper.getOakName(""));
+        assertEquals("{}", mapper.getExpandedJcrName(""));
     }
 
 
@@ -84,6 +85,11 @@ public class GlobalNameMapperTest {
         for (String jcrName : jcrToOak.keySet()) {
             assertEquals(jcrToOak.get(jcrName), mapper.getOakNameOrNull(jcrName));
             assertEquals(jcrToOak.get(jcrName), mapper.getOakName(jcrName));
+            if (GlobalNameMapper.isExpandedName(jcrName)) {
+                assertEquals(jcrName, mapper.getExpandedJcrName(jcrToOak.get(jcrName)));
+            } else {
+                assertEquals("{}"+jcrName, mapper.getExpandedJcrName(jcrToOak.get(jcrName)));
+            }
         }
 
         assertNull(mapper.getOakNameOrNull("{http://www.example.com/bar}bar"));
@@ -97,17 +103,28 @@ public class GlobalNameMapperTest {
 
     @Test
     public void testPrefixedNames() throws RepositoryException {
-        List<String> prefixed = new ArrayList<String>();
-        prefixed.add("nt:base");
-        prefixed.add("foo: bar");
-        prefixed.add("quu:bar ");
-        // unknown prefixes are only captured by the NameValidator
-        prefixed.add("unknown:bar");
+        Map<String, String> prefixedToExpanded = new HashMap<>();
+        prefixedToExpanded.put("nt:base", "{http://www.jcp.org/jcr/nt/1.0}base");
+        prefixedToExpanded.put("foo: bar", "{http://www.example.com/foo} bar");
+        prefixedToExpanded.put("quu:bar ", "{http://www.example.com/quu}bar ");
 
-        for (String name : prefixed) {
+        for (String name : prefixedToExpanded.keySet()) {
             assertEquals(name, mapper.getOakNameOrNull(name));
             assertEquals(name, mapper.getOakName(name));
             assertEquals(name, mapper.getJcrName(name));
+            assertEquals(prefixedToExpanded.get(name), mapper.getExpandedJcrName(name));
+        }
+
+        // unknown prefixes are only captured by the NameValidator
+        String unknownPrefix = "unknown:bar";
+        assertEquals(unknownPrefix, mapper.getOakNameOrNull(unknownPrefix));
+        assertEquals(unknownPrefix, mapper.getOakName(unknownPrefix));
+        assertEquals(unknownPrefix, mapper.getJcrName(unknownPrefix));
+        try {
+            mapper.getExpandedJcrName(unknownPrefix);
+            fail("IllegalStateException expected");
+        } catch (IllegalStateException e) {
+            // successs
         }
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/namepath/impl/NamePathMapperImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/namepath/impl/NamePathMapperImplTest.java
@@ -136,6 +136,26 @@ public class NamePathMapperImplTest {
     }
 
     @Test
+    public void testOakToExpandedJcr() {
+        assertEquals("/{http://www.example.com/foo}bar", npMapper.getExpandedJcrPath("/oak-foo:bar"));
+        assertEquals("/{http://www.example.com/foo}bar/{http://www.example.com/quu}qux", npMapper.getExpandedJcrPath("/oak-foo:bar/oak-quu:qux"));
+        assertEquals("{http://www.example.com/foo}bar", npMapper.getExpandedJcrPath("oak-foo:bar"));
+        assertEquals(".", npMapper.getExpandedJcrPath(""));
+
+        try {
+            npMapper.getExpandedJcrPath("{http://www.jcp.org/jcr/nt/1.0}unstructured");
+            fail("expanded name should not be accepted");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        try {
+            npMapper.getExpandedJcrPath("foobar/{http://www.jcp.org/jcr/1.0}content");
+            fail("expanded name should not be accepted");
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
     public void testInvalidJcrPaths() {
         String[] paths = {
                 "//",

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/namepath/impl/NamePathMapperImplTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/namepath/impl/NamePathMapperImplTest.java
@@ -140,6 +140,7 @@ public class NamePathMapperImplTest {
         assertEquals("/{http://www.example.com/foo}bar", npMapper.getExpandedJcrPath("/oak-foo:bar"));
         assertEquals("/{http://www.example.com/foo}bar/{http://www.example.com/quu}qux", npMapper.getExpandedJcrPath("/oak-foo:bar/oak-quu:qux"));
         assertEquals("{http://www.example.com/foo}bar", npMapper.getExpandedJcrPath("oak-foo:bar"));
+        // this is the self-segment from https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.4.2%20Path%20Resolution
         assertEquals(".", npMapper.getExpandedJcrPath(""));
 
         try {

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/JackrabbitSession.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/JackrabbitSession.java
@@ -277,4 +277,24 @@ public interface JackrabbitSession extends Session {
             return null;
         }
     }
+
+    /**
+     * Returns the expanded name of the given {@code Item}.
+     * @param item the item for which to retrieve the name
+     * @return the name of the item in expanded form.
+     * @throws RepositoryException if another error occurs.
+     * @since 1.76.0
+     * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>
+     */
+    @NotNull String getExpandedName(@NotNull Item item) throws RepositoryException;
+    
+    /**
+     * Returns the expanded path of the given {@code Item}.
+     * @param item the item for which to retrieve the name
+     * @return the path of the item in expanded form.
+     * @throws RepositoryException if another error occurs.
+     * @since 1.76.0
+     * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>
+     */
+    @NotNull String getExpandedPath(@NotNull Item item) throws RepositoryException;
 }

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/JackrabbitSession.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/JackrabbitSession.java
@@ -283,17 +283,17 @@ public interface JackrabbitSession extends Session {
      * @param item the item for which to retrieve the name
      * @return the name of the item in expanded form.
      * @throws RepositoryException if another error occurs.
-     * @since 1.76.0
+     * @since 1.78.0
      * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>
      */
     @NotNull String getExpandedName(@NotNull Item item) throws RepositoryException;
-    
+
     /**
      * Returns the expanded path of the given {@code Item}.
      * @param item the item for which to retrieve the name
      * @return the path of the item in expanded form.
      * @throws RepositoryException if another error occurs.
-     * @since 1.76.0
+     * @since 1.78.0
      * @see <a href="https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5.1%20Expanded%20Form">JCR 2.0, 3.2.5.1 Expanded Form</a>
      */
     @NotNull String getExpandedPath(@NotNull Item item) throws RepositoryException;

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/package-info.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/package-info.java
@@ -18,6 +18,6 @@
 /**
  * Jackrabbit extensions for JCR core interfaces
  */
-@org.osgi.annotation.versioning.Version("2.9.0")
+@org.osgi.annotation.versioning.Version("2.10.0")
 package org.apache.jackrabbit.api;
 

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/ItemImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/ItemImpl.java
@@ -121,19 +121,9 @@ abstract class ItemImpl<T extends ItemDelegate> implements Item {
     @Override
     @NotNull
     public String getName() throws RepositoryException {
-        String oakName = perform(new ItemOperation<String>(dlg, "getName") {
-            @NotNull
-            @Override
-            public String perform() {
-                return item.getName();
-            }
-            @Override
-            public String toString() {
-                return format("getName [%s]", dlg.getPath());
-            }
-        });
+        String oakName = getOakName();
         // special case name of root node
-        return oakName.isEmpty() ? "" : toJcrPath(dlg.getName());
+        return oakName.isEmpty() ? "" : toJcrPath(oakName);
     }
 
     /**
@@ -142,13 +132,7 @@ abstract class ItemImpl<T extends ItemDelegate> implements Item {
     @Override
     @NotNull
     public String getPath() throws RepositoryException {
-        return toJcrPath(perform(new ItemOperation<String>(dlg, "getPath") {
-            @NotNull
-            @Override
-            public String perform() {
-                return item.getPath();
-            }
-        }));
+        return toJcrPath(getOakPath());
     }
 
     @Override @NotNull
@@ -319,8 +303,39 @@ abstract class ItemImpl<T extends ItemDelegate> implements Item {
 
     //-----------------------------------------------------------< internal >---
     @NotNull
-    String getOakName(String name) throws RepositoryException {
-        return sessionContext.getOakName(name);
+    String getOakName() throws RepositoryException {
+        return perform(new ItemOperation<String>(dlg, "getName") {
+            @NotNull
+            @Override
+            public String perform() {
+                return item.getName();
+            }
+            @Override
+            public String toString() {
+                return format("getName [%s]", dlg.getPath());
+            }
+        });
+    }
+    
+    @NotNull
+    String getOakPath() throws RepositoryException {
+        return perform(new ItemOperation<String>(dlg, "getPath") {
+            @NotNull
+            @Override
+            public String perform() {
+                return item.getPath();
+            }
+
+            @Override
+            public String toString() {
+                return format("getPath [%s]", dlg.getPath());
+            }
+        });
+    }
+
+    @NotNull
+    String getOakName(String jcrName) throws RepositoryException {
+        return sessionContext.getOakName(jcrName);
     }
 
     @NotNull

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionContext.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionContext.java
@@ -353,6 +353,12 @@ public class SessionContext implements NamePathMapper {
         return namePathMapper.getJcrName(oakName);
     }
 
+    @NotNull
+    @Override
+    public String getExpandedJcrName(@NotNull String oakName) {
+        return namePathMapper.getExpandedJcrName(oakName);
+    }
+
     @Override
     @Nullable
     public String getOakPath(String jcrPath) {

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionContext.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionContext.java
@@ -371,6 +371,12 @@ public class SessionContext implements NamePathMapper {
         return namePathMapper.getJcrPath(oakPath);
     }
 
+    @Override
+    @NotNull
+    public String getExpandedJcrPath(@NotNull String oakPath) {
+        return namePathMapper.getExpandedJcrPath(oakPath);
+    }
+
     /**
      * Returns the Oak path for the given JCR path, or throws a
      * {@link javax.jcr.RepositoryException} if the path can not be mapped.

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
@@ -852,4 +852,16 @@ public class SessionImpl implements JackrabbitSession {
         }
         return "null";
     }
+
+    @Override
+    @NotNull
+    public String getExpandedName(@NotNull Item item) throws RepositoryException {
+        return checkItemImpl(item).sessionContext.getExpandedJcrName(item.getName());
+    }
+
+    @Override
+    @NotNull
+    public String getExpandedPath(@NotNull Item item) throws RepositoryException {
+        return checkItemImpl(item).sessionContext.getExpandedJcrPath(item.getPath());
+    }
 }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
@@ -857,7 +857,8 @@ public class SessionImpl implements JackrabbitSession {
     @NotNull
     public String getExpandedName(@NotNull Item item) throws RepositoryException {
         try {
-            return checkItemImpl(item).sessionContext.getExpandedJcrName(item.getName());
+            ItemImpl<?> itemImpl = checkItemImpl(item);
+            return itemImpl.sessionContext.getExpandedJcrName(itemImpl.getOakName());
         } catch (IllegalStateException e) {
             throw new RepositoryException("Namespace exception " + e.getMessage());
         }
@@ -867,7 +868,8 @@ public class SessionImpl implements JackrabbitSession {
     @NotNull
     public String getExpandedPath(@NotNull Item item) throws RepositoryException {
         try {
-            return checkItemImpl(item).sessionContext.getExpandedJcrPath(item.getPath());
+            ItemImpl<?> itemImpl = checkItemImpl(item);
+            return itemImpl.sessionContext.getExpandedJcrPath(itemImpl.getOakPath());
         } catch (IllegalStateException e) {
             throw new RepositoryException("Namespace exception " + e.getMessage());
         }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
@@ -856,12 +856,20 @@ public class SessionImpl implements JackrabbitSession {
     @Override
     @NotNull
     public String getExpandedName(@NotNull Item item) throws RepositoryException {
-        return checkItemImpl(item).sessionContext.getExpandedJcrName(item.getName());
+        try {
+            return checkItemImpl(item).sessionContext.getExpandedJcrName(item.getName());
+        } catch (IllegalStateException e) {
+            throw new RepositoryException("Namespace exception " + e.getMessage());
+        }
     }
 
     @Override
     @NotNull
     public String getExpandedPath(@NotNull Item item) throws RepositoryException {
-        return checkItemImpl(item).sessionContext.getExpandedJcrPath(item.getPath());
+        try {
+            return checkItemImpl(item).sessionContext.getExpandedJcrPath(item.getPath());
+        } catch (IllegalStateException e) {
+            throw new RepositoryException("Namespace exception " + e.getMessage());
+        }
     }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
@@ -37,7 +37,6 @@ public class JackrabbitSessionTest extends AbstractJCRTest {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        
         if (superuser instanceof JackrabbitSession) {
             s = (JackrabbitSession) superuser;
         } else {
@@ -85,13 +84,11 @@ public class JackrabbitSessionTest extends AbstractJCRTest {
     public void testGetExpandedName() throws RepositoryException {
         // empty namespace uri
         assertEquals("{}testroot", s.getExpandedName(testRootNode));
-        // global namespace uri
-        s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
-        Node n = testRootNode.addNode("foo:bar");
-        assertEquals("{urn:foo}bar", s.getExpandedName(n));
+        Node n = testRootNode.addNode("test:bar");
+        assertEquals("{http://www.apache.org/jackrabbit/test}bar", s.getExpandedName(n));
         // now remap namespace uri
-        s.setNamespacePrefix("foo", "http://www.foo.com");
-        assertEquals("{http://www.foo.com}bar", s.getExpandedName(n));
+        s.setNamespacePrefix("test", "urn:foo");
+        assertEquals("{urn:foo}bar", s.getExpandedName(n));
         // use special namespace uri
         n = testRootNode.addNode("rep:bar");
         assertEquals("{internal}bar", s.getExpandedName(n));
@@ -99,12 +96,10 @@ public class JackrabbitSessionTest extends AbstractJCRTest {
 
     public void testGetExpandedPath() throws RepositoryException {
         assertEquals("/{}testroot", s.getExpandedPath(testRootNode));
-        // global namespace url
-        s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
-        Node n = testRootNode.addNode("foo:bar").addNode("rep:bar");
-        assertEquals("/{}testroot/{urn:foo}bar/{internal}bar", s.getExpandedPath(n));
+        Node n = testRootNode.addNode("test:bar").addNode("rep:bar");
+        assertEquals("/{}testroot/{http://www.apache.org/jackrabbit/test}bar/{internal}bar", s.getExpandedPath(n));
         // now remap namespace uri
-        s.setNamespacePrefix("foo", "http://www.foo.com");
-        assertEquals("/{}testroot/{http://www.foo.com}bar/{internal}bar", s.getExpandedPath(n));
+        s.setNamespacePrefix("test", "urn:foo");
+        assertEquals("/{}testroot/{urn:foo}bar/{internal}bar", s.getExpandedPath(n));
     }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
@@ -84,16 +84,17 @@ public class JackrabbitSessionTest extends AbstractJCRTest {
 
     public void testGetExpandedName() throws RepositoryException {
         assertEquals("{}testroot", s.getExpandedName(testRootNode));
-        Node n = testRootNode.addNode("foo:bar");
-        try {
-            s.getExpandedName(n);
-            fail("expanded name for unmapped namespace prefix should fail");
-        } catch (IllegalStateException unexpected) {
-            // unexpected -- shouldn't this be a RepositoryException?
-        }
+        Node n = testRootNode.addNode("foo:bar"); // a save() would fail due to unmapped namespace
+//        try {
+//            s.getExpandedName(n);
+//            fail("expanded name for unmapped namespace prefix should fail");
+//        } catch (RepositoryException unexpected) {
+//            // success
+//        }
         s.setNamespacePrefix("foo", "urn:foo");
+        n.getName();
         // s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
-        assertEquals("{urn:foo}bar", s.getExpandedName(n));
+        //assertEquals("{urn:foo}bar", s.getExpandedName(n));
     }
 
     public void testGetExpandedPath() throws RepositoryException {

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
@@ -83,21 +83,28 @@ public class JackrabbitSessionTest extends AbstractJCRTest {
     }
 
     public void testGetExpandedName() throws RepositoryException {
+        // empty namespace uri
         assertEquals("{}testroot", s.getExpandedName(testRootNode));
-        Node n = testRootNode.addNode("foo:bar"); // a save() would fail due to unmapped namespace
-//        try {
-//            s.getExpandedName(n);
-//            fail("expanded name for unmapped namespace prefix should fail");
-//        } catch (RepositoryException unexpected) {
-//            // success
-//        }
-        s.setNamespacePrefix("foo", "urn:foo");
-        n.getName();
-        // s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
-        //assertEquals("{urn:foo}bar", s.getExpandedName(n));
+        // global namespace uri
+        s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
+        Node n = testRootNode.addNode("foo:bar");
+        assertEquals("{urn:foo}bar", s.getExpandedName(n));
+        // now remap namespace uri
+        s.setNamespacePrefix("foo", "http://www.foo.com");
+        assertEquals("{http://www.foo.com}bar", s.getExpandedName(n));
+        // use special namespace uri
+        n = testRootNode.addNode("rep:bar");
+        assertEquals("{internal}bar", s.getExpandedName(n));
     }
 
     public void testGetExpandedPath() throws RepositoryException {
         assertEquals("/{}testroot", s.getExpandedPath(testRootNode));
+        // global namespace url
+        s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
+        Node n = testRootNode.addNode("foo:bar").addNode("rep:bar");
+        assertEquals("/{}testroot/{urn:foo}bar/{internal}bar", s.getExpandedPath(n));
+        // now remap namespace uri
+        s.setNamespacePrefix("foo", "http://www.foo.com");
+        assertEquals("/{}testroot/{http://www.foo.com}bar/{internal}bar", s.getExpandedPath(n));
     }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/session/JackrabbitSessionTest.java
@@ -81,6 +81,22 @@ public class JackrabbitSessionTest extends AbstractJCRTest {
             // success
         }
     }
-    
-    
+
+    public void testGetExpandedName() throws RepositoryException {
+        assertEquals("{}testroot", s.getExpandedName(testRootNode));
+        Node n = testRootNode.addNode("foo:bar");
+        try {
+            s.getExpandedName(n);
+            fail("expanded name for unmapped namespace prefix should fail");
+        } catch (IllegalStateException unexpected) {
+            // unexpected -- shouldn't this be a RepositoryException?
+        }
+        s.setNamespacePrefix("foo", "urn:foo");
+        // s.getWorkspace().getNamespaceRegistry().registerNamespace("foo", "urn:foo");
+        assertEquals("{urn:foo}bar", s.getExpandedName(n));
+    }
+
+    public void testGetExpandedPath() throws RepositoryException {
+        assertEquals("/{}testroot", s.getExpandedPath(testRootNode));
+    }
 }


### PR DESCRIPTION
This cherry-picks the changes from @kwin for this ticket, except for some whitespace and import order changes.

That said, my IDE says that the new JackrabbitSession methods are unused, because test coverage is missing for the API (rather than the impl).