### PR TITLE
OAK-11483 - Throttle log warn messages during indexing in Elastic

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -58,18 +58,19 @@ import static org.apache.jackrabbit.oak.plugins.index.lucene.FieldFactory.newPro
 public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     // Lucene doesn't support indexing data larger than 32766 (OAK-9707)
     public static final int STRING_PROPERTY_MAX_LENGTH = 32766;
-    private static final Logger log = LoggerFactory.getLogger(LuceneDocumentMaker.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LuceneDocumentMaker.class);
 
     private static final String DYNAMIC_BOOST_SPLIT_REGEX = "[:/]";
-    
+
     private final FacetsConfigProvider facetsConfigProvider;
     private final IndexAugmentorFactory augmentorFactory;
-    
+
     private static final LogSilencer LOG_SILENCER = new LogSilencer(Duration.ofSeconds(10).toMillis(), 10);
     private static final String LOG_KEY_DUPLICATE = "Duplicate value";
     private static final String LOG_KEY_NOT_A_DATE_STRING = "Not a date string";
     private static final String LOG_KEY_UNABLE_TO_PARSE = "Unable to parse the provided date field";
     private static final String LOG_KEY_FOR_INPUT_STRING = "For input string";
+    private static final String LOG_KEY_IGNORING_FACET_PROPERTY = "Ignoring facet property";
 
     public LuceneDocumentMaker(IndexDefinition definition,
                                IndexDefinition.IndexingRule indexingRule,
@@ -180,24 +181,26 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
                 getFacetsConfig().setMultiValued(pname, true);
                 Iterable<String> values = property.getValue(Type.STRINGS);
                 for (String value : values) {
-                    if (value != null && value.length() > 0) {
+                    if (value != null && !value.isEmpty()) {
                         doc.add(new SortedSetDocValuesFacetField(pname, value));
                     }
                 }
                 fieldAdded = true;
             } else if (tag == Type.STRING.tag()) {
                 String value = property.getValue(Type.STRING);
-                if (value.length() > 0) {
+                if (!value.isEmpty()) {
                     doc.add(new SortedSetDocValuesFacetField(pname, value));
                     fieldAdded = true;
                 }
             }
 
         } catch (Throwable e) {
-            log.warn("[{}] Ignoring facet property. Could not convert property {} of type {} to type {} for path {}",
-                    getIndexName(), pname,
-                    Type.fromTag(property.getType().tag(), false),
-                    Type.fromTag(tag, false), path, e);
+            if (!LOG_SILENCER.silence(LOG_KEY_IGNORING_FACET_PROPERTY)) {
+                LOG.warn("[{}] Ignoring facet property. Could not convert property {} of type {} to type {} for path {}",
+                        getIndexName(), pname,
+                        Type.fromTag(property.getType().tag(), false),
+                        Type.fromTag(tag, false), path, e);
+            }
         }
         return fieldAdded;
     }
@@ -302,41 +305,47 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
                     fieldAdded = true;
                 } else {
                     if (!LOG_SILENCER.silence(LOG_KEY_DUPLICATE)) {
-                        log.warn("Duplicate value for ordered field {}; ignoring. Possibly duplicate index definition.", f.name());
+                        LOG.warn("Duplicate value for ordered field {}; ignoring. Possibly duplicate index definition.", f.name());
                     }
                 }
             }
         } catch (Exception e) {
             String message = e.getMessage();
-            String key = null;
+            String key;
             // This is a known warning, one of:
             // - IllegalArgumentException: Not a date string
             // - RuntimeException: Unable to parse the provided date field
             // - NumberFormatException: For input string
             // For these we do not log a stack trace, and we only log once every 10 seconds
             // (the location of the code can be found if needed, as it's in Oak)
+            boolean logStackTrace = false;
             if (message.startsWith("Not a date string")) {
                 key = LOG_KEY_NOT_A_DATE_STRING;
             } else if (message.startsWith("Unable to parse the provided date field")) {
                 key = LOG_KEY_UNABLE_TO_PARSE;
             } else if (message.startsWith("For input string")) {
                 key = LOG_KEY_FOR_INPUT_STRING;
+            } else {
+                key = message.substring(0, Math.min(20, message.length()));
+                logStackTrace = true;
             }
-            if (key != null) {
+            if (!logStackTrace) {
                 if (!LOG_SILENCER.silence(key)) {
                     // log without stack trace (as it is known)
-                    log.warn(
+                    LOG.warn(
                             "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}, message {}",
                             getIndexName(), pname,
                             Type.fromTag(property.getType().tag(), false),
                             Type.fromTag(tag, false), path, e.getMessage());
                 }
             } else {
-                log.warn(
-                        "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}",
-                        getIndexName(), pname,
-                        Type.fromTag(property.getType().tag(), false),
-                        Type.fromTag(tag, false), path, e);
+                if (!LOG_SILENCER.silence(key)) {
+                    LOG.warn(
+                            "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}",
+                            getIndexName(), pname,
+                            Type.fromTag(property.getType().tag(), false),
+                            Type.fromTag(tag, false), path, e);
+                }
             }
         }
         return fieldAdded;
@@ -365,11 +374,11 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         if (ref.length <= maxLength) {
             return ref;
         }
-        
-        log.trace("Property {} at path:[{}] has value {}", prop, path, value);
-        log.info("Truncating property {} at path:[{}] as length after encoding {} is > {} ",
+
+        LOG.trace("Property {} at path:[{}] has value {}", prop, path, value);
+        LOG.info("Truncating property {} at path:[{}] as length after encoding {} is > {} ",
             prop, path, ref.length, maxLength);
-        
+
         int end = maxLength - 1;
         // skip over tails of utf-8 multi-byte sequences (up to 3 bytes)
         while ((ref.bytes[end] & 0b11000000) == 0b10000000) {
@@ -382,12 +391,12 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         byte[] truncatedBytes = Arrays.copyOf(ref.bytes, end + 1);
         String truncated = new String(truncatedBytes, StandardCharsets.UTF_8);
         ref = new BytesRef(truncated);
-        if (log.isTraceEnabled()) {
-            log.trace("Truncated property {} at path:[{}] to {}", prop, path, ref.utf8ToString());
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Truncated property {} at path:[{}] to {}", prop, path, ref.utf8ToString());
         }
 
         while (ref.length > maxLength) {
-            log.error("Truncation did not work: still {} bytes", ref.length);
+            LOG.error("Truncation did not work: still {} bytes", ref.length);
             // this may not properly work with unicode surrogates:
             // it is an "emergency" procedure and should never happen
             truncated = truncated.substring(0, truncated.length() - 10);
@@ -444,7 +453,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         }
         boolean added = false;
         for (String token : tokens) {
-            if (token.length() > 0) {
+            if (!token.isEmpty()) {
                 AugmentedField f = new AugmentedField(parent + "/" + token.toLowerCase(), confidence);
                 if (doc.getField(f.name()) == null) {
                     doc.add(f);
@@ -454,8 +463,8 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
         }
 
         if (added) {
-            if (log.isTraceEnabled()) {
-                log.trace(
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
                         "Added augmented fields: {}[{}], {}",
                         parent + "/", String.join(", ", tokens), confidence
                 );

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -71,6 +71,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     private static final String LOG_KEY_UNABLE_TO_PARSE = "Unable to parse the provided date field";
     private static final String LOG_KEY_FOR_INPUT_STRING = "For input string";
     private static final String LOG_KEY_IGNORING_FACET_PROPERTY = "Ignoring facet property";
+    private static final String LOG_KEY_UNKNOWN = "Unknown";
 
     public LuceneDocumentMaker(IndexDefinition definition,
                                IndexDefinition.IndexingRule indexingRule,
@@ -148,7 +149,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     }
 
     private String constructAnalyzedPropertyName(String pname) {
-        if (definition.getVersion().isAtLeast(IndexFormatVersion.V2)){
+        if (definition.getVersion().isAtLeast(IndexFormatVersion.V2)) {
             return FieldNames.createAnalyzedFieldName(pname);
         }
         return pname;
@@ -208,7 +209,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     @Override
     protected void indexAggregateValue(Document doc, Aggregate.NodeIncludeResult result, String value, PropertyDefinition pd) {
         Field field = result.isRelativeNode() ?
-                newFulltextField(result.rootIncludePath, value) : newFulltextField(value) ;
+                newFulltextField(result.rootIncludePath, value) : newFulltextField(value);
         if (pd != null) {
             field.setBoost(pd.boost);
         }
@@ -318,7 +319,6 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
             // - NumberFormatException: For input string
             // For these we do not log a stack trace, and we only log once every 10 seconds
             // (the location of the code can be found if needed, as it's in Oak)
-            boolean logStackTrace = false;
             if (message.startsWith("Not a date string")) {
                 key = LOG_KEY_NOT_A_DATE_STRING;
             } else if (message.startsWith("Unable to parse the provided date field")) {
@@ -326,25 +326,25 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
             } else if (message.startsWith("For input string")) {
                 key = LOG_KEY_FOR_INPUT_STRING;
             } else {
-                key = message.substring(0, Math.min(20, message.length()));
-                logStackTrace = true;
+                key = LOG_KEY_UNKNOWN;
             }
-            if (!logStackTrace) {
-                if (!LOG_SILENCER.silence(key)) {
+            if (!LOG_SILENCER.silence(key)) {
+                if (key.equals(LOG_KEY_UNKNOWN)) {
+                    // unknown error, log with stack trace
+                    LOG.warn(
+                            "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}",
+                            getIndexName(), pname,
+                            Type.fromTag(property.getType().tag(), false),
+                            Type.fromTag(tag, false), path, e);
+                } else {
                     // log without stack trace (as it is known)
                     LOG.warn(
                             "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}, message {}",
                             getIndexName(), pname,
                             Type.fromTag(property.getType().tag(), false),
                             Type.fromTag(tag, false), path, e.getMessage());
-                }
-            } else {
-                if (!LOG_SILENCER.silence(key)) {
-                    LOG.warn(
-                            "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}",
-                            getIndexName(), pname,
-                            Type.fromTag(property.getType().tag(), false),
-                            Type.fromTag(tag, false), path, e);
+
+
                 }
             }
         }
@@ -377,7 +377,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
 
         LOG.trace("Property {} at path:[{}] has value {}", prop, path, value);
         LOG.info("Truncating property {} at path:[{}] as length after encoding {} is > {} ",
-            prop, path, ref.length, maxLength);
+                prop, path, ref.length, maxLength);
 
         int end = maxLength - 1;
         // skip over tails of utf-8 multi-byte sequences (up to 3 bytes)
@@ -484,6 +484,7 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
 
     private static class AugmentedField extends Field {
         private static final FieldType ft = new FieldType();
+
         static {
             ft.setIndexed(true);
             ft.setStored(false);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
@@ -21,6 +21,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.log.LogSilencer;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.Aggregate;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
@@ -35,12 +36,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 
 public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticDocumentMaker.class);
     private static final int BLOB_LENGTH_DIVISOR = 4;
+
+    private static final LogSilencer LOG_SILENCER = new LogSilencer(Duration.ofSeconds(10).toMillis(), 10);
+    private static final String LOG_KEY_COULD_NOT_CONVERT_PROPERTY = "Could not convert property";
+    private static final String LOG_KEY_SIMILARITY_BINARIES_WRONG_DIMENSION = "Similarity binaries wrong dimension";
 
     public ElasticDocumentMaker(@Nullable FulltextBinaryTextExtractor textExtractor,
                                 @NotNull IndexDefinition definition,
@@ -180,11 +186,13 @@ public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument>
 
             doc.addProperty(pname, f);
         } catch (Exception e) {
-            LOG.warn(
-                    "[{}] Ignoring property. Could not convert property {} of type {} to type {} for path {}",
-                    getIndexName(), pname,
-                    Type.fromTag(property.getType().tag(), false),
-                    Type.fromTag(tag, false), path, e);
+            if (!LOG_SILENCER.silence(LOG_KEY_COULD_NOT_CONVERT_PROPERTY)) {
+                LOG.warn(
+                        "[{}] Ignoring property. Could not convert property {} of type {} to type {} for path {}. Error: {}",
+                        getIndexName(), pname,
+                        Type.fromTag(property.getType().tag(), false),
+                        Type.fromTag(tag, false), path, e.toString());
+            }
         }
     }
 
@@ -238,8 +246,10 @@ public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument>
             // see https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html
             doc.addSimilarityField(pd.name, blob);
         } else {
-            LOG.warn("[{}] Ignoring binary property {} for path {}. Expected dimension is {} but got {}",
-                    getIndexName(), pd.name, this.path, pd.getSimilaritySearchDenseVectorSize(), blob.length() / BLOB_LENGTH_DIVISOR);
+            if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_BINARIES_WRONG_DIMENSION)) {
+                LOG.warn("[{}] Ignoring binary property {} for path {}. Expected dimension is {} but got {}",
+                        getIndexName(), pd.name, this.path, pd.getSimilaritySearchDenseVectorSize(), blob.length() / BLOB_LENGTH_DIVISOR);
+            }
         }
     }
 


### PR DESCRIPTION
Throttle warning messages in ElasticDocumentMaker and add missing cases of throttling to LuceneDocumentMaker