### PR TITLE
OAK-11499: Remove parameter "aggregate"

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -127,7 +127,6 @@
           <configuration>
             <doclint>none</doclint>
             <detectJavaApiLink>true</detectJavaApiLink>
-            <aggregate>true</aggregate>
             <links>
               <link>https://s.apache.org/jcr-2.0-javadoc/</link>
               <link>https://jackrabbit.apache.org/api/2.20/</link>


### PR DESCRIPTION
It is no longer evaluated since m-javadoc-p 3.0
(https://issues.apache.org/jira/browse/MJAVADOC-457)