### PR TITLE
OAK-11505 - Reduce object allocation in FullTextIndexEditor

### DIFF
--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -723,5 +723,4 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         //cameCase file name to allow faster like search
         indexNodeName(doc, value);
     }
-
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -173,9 +172,9 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
     public void propertyAdded(PropertyState after) {
         if (isIndexable()) {
             markPropertyChanged(after.getName());
-            checkAggregates(after.getName());
             propertyUpdated(null, after);
         }
+        checkAggregates(after.getName());
     }
 
     @Override
@@ -183,9 +182,9 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         if (isIndexable()) {
             markPropertyChanged(before.getName());
             propertiesModified.add(before);
-            checkAggregates(before.getName());
             propertyUpdated(before, after);
         }
+        checkAggregates(before.getName());
     }
 
     @Override
@@ -193,9 +192,9 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         if (isIndexable()) {
             markPropertyChanged(before.getName());
             propertiesModified.add(before);
-            checkAggregates(before.getName());
             propertyUpdated(before, null);
         }
+        checkAggregates(before.getName());
     }
 
     @Override
@@ -297,14 +296,14 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             Aggregate.Matcher result = m.match(name, after);
             if (result.getStatus() == Aggregate.Matcher.Status.MATCH_FOUND) {
                 if (matched == EMPTY_AGGREGATE_MATCHER_LIST) {
-                    matched = new ArrayList<>(2);
+                    matched = new ArrayList<>();
                 }
                 matched.add(result);
             }
 
             if (result.getStatus() != Aggregate.Matcher.Status.FAIL) {
                 if (inherited == EMPTY_AGGREGATE_MATCHER_LIST) {
-                    inherited = new ArrayList<>(2);
+                    inherited = new ArrayList<>();
                 }
                 inherited.addAll(result.nextSet());
             }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -20,7 +20,6 @@ package org.apache.jackrabbit.oak.plugins.index.search.spi.editor;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -41,361 +40,366 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.oak.commons.PathUtils.concat;
-
 /**
  * Generic implementation of an {@link IndexEditor} which supports index time aggregation.
  */
 public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateRoot {
 
-  private static final Logger log =
-      LoggerFactory.getLogger(FulltextIndexEditor.class);
+    public static final String TEXT_EXTRACTION_ERROR = "TextExtractionError";
+    private static final Logger log = LoggerFactory.getLogger(FulltextIndexEditor.class);
+    private static final List<Aggregate.Matcher> EMPTY_AGGREGATE_MATCHER_LIST = List.of();
 
-  public static final String TEXT_EXTRACTION_ERROR = "TextExtractionError";
+    private final FulltextIndexEditorContext<D> context;
 
-  private final FulltextIndexEditorContext<D> context;
+    /* Name of this node, or {@code null} for the root node. */
+    private final String name;
 
-  /* Name of this node, or {@code null} for the root node. */
-  private final String name;
+    /* Parent editor or {@code null} if this is the root editor. */
+    private final FulltextIndexEditor<D> parent;
 
-  /* Parent editor or {@code null} if this is the root editor. */
-  private final FulltextIndexEditor<D> parent;
+    /* Path of this editor, built lazily in {@link #getPath()}. */
+    private String path;
 
-  /* Path of this editor, built lazily in {@link #getPath()}. */
-  private String path;
+    private boolean propertiesChanged = false;
 
-  private boolean propertiesChanged = false;
+    private final List<PropertyState> propertiesModified = new ArrayList<>();
 
-  private final List<PropertyState> propertiesModified = new ArrayList<>();
+    /*
+     * Flag indicating if the current tree being traversed has a deleted parent.
+     */
+    private final boolean isDeleted;
 
-  /*
-   * Flag indicating if the current tree being traversed has a deleted parent.
-   */
-  private final boolean isDeleted;
+    private IndexDefinition.IndexingRule indexingRule;
 
-  private IndexDefinition.IndexingRule indexingRule;
+    private List<Aggregate.Matcher> currentMatchers = List.of();
 
-  private List<Aggregate.Matcher> currentMatchers = Collections.emptyList();
+    private final MatcherState matcherState;
 
-  private final MatcherState matcherState;
+    private final PathFilter.Result pathFilterResult;
 
-  private final PathFilter.Result pathFilterResult;
-
-  public FulltextIndexEditor(FulltextIndexEditorContext<D> context) {
-    this.parent = null;
-    this.name = null;
-    this.path = "/";
-    this.context = context;
-    this.isDeleted = false;
-    this.matcherState = MatcherState.NONE;
-    this.pathFilterResult = context.getDefinition().getPathFilter().filter(PathUtils.ROOT_PATH);
-  }
-
-  public FulltextIndexEditor(FulltextIndexEditor<D> parent, String name,
-                             MatcherState matcherState,
-                             PathFilter.Result pathFilterResult,
-                             boolean isDeleted) {
-    this.parent = parent;
-    this.name = name;
-    this.path = null;
-    this.context = parent.context;
-    this.isDeleted = isDeleted;
-    this.matcherState = matcherState;
-    this.pathFilterResult = pathFilterResult;
-  }
-
-  public String getPath() {
-    if (path == null) { // => parent != null
-      path = concat(parent.getPath(), name);
-    }
-    return path;
-  }
-
-  @Override
-  public void enter(NodeState before, NodeState after) {
-    if (EmptyNodeState.MISSING_NODE == before && parent == null){
-      context.enableReindexMode();
+    public FulltextIndexEditor(FulltextIndexEditorContext<D> context) {
+        this.parent = null;
+        this.name = null;
+        this.path = "/";
+        this.context = context;
+        this.isDeleted = false;
+        this.matcherState = MatcherState.NONE;
+        this.pathFilterResult = context.getDefinition().getPathFilter().filter(PathUtils.ROOT_PATH);
     }
 
-    //Only check for indexing if the result is include.
-    //In case like TRAVERSE nothing needs to be indexed for those
-    //path
-    if (pathFilterResult == PathFilter.Result.INCLUDE) {
-      //For traversal in deleted sub tree before state has to be used
-      NodeState current = after.exists() ? after : before;
-      indexingRule = getDefinition().getApplicableIndexingRule(current);
-
-      if (indexingRule != null) {
-        currentMatchers = indexingRule.getAggregate().createMatchers(this);
-      }
+    public FulltextIndexEditor(FulltextIndexEditor<D> parent, String name,
+                               MatcherState matcherState,
+                               PathFilter.Result pathFilterResult,
+                               boolean isDeleted) {
+        this.parent = parent;
+        this.name = name;
+        this.path = null;
+        this.context = parent.context;
+        this.isDeleted = isDeleted;
+        this.matcherState = matcherState;
+        this.pathFilterResult = pathFilterResult;
     }
-  }
 
-  @Override
-  public void leave(NodeState before, NodeState after)
-      throws CommitFailedException {
-    if (propertiesChanged || !before.exists()) {
-      String path = getPath();
-      if (addOrUpdate(path, after, before.exists())) {
-        long indexed = context.incIndexedNodes();
-        if (indexed % 1000 == 0) {
-          log.debug("[{}] => Indexed {} nodes...", getIndexName(), indexed);
+    public String getPath() {
+        if (path == null) { // => parent != null
+            path = PathUtils.concat(parent.getPath(), name);
         }
-      }
+        return path;
     }
 
-    for (Aggregate.Matcher m : matcherState.affectedMatchers){
-      m.markRootDirty();
-    }
-
-    if (parent == null) {
-      PropertyUpdateCallback callback = context.getPropertyUpdateCallback();
-      if (callback != null) {
-        callback.done();
-      }
-
-      try {
-        context.closeWriter();
-      } catch (IOException e) {
-        CommitFailedException ce = new CommitFailedException("Fulltext", 4,
-            "Failed to close the Fulltext index " + context.getIndexingContext().getIndexPath(), e);
-        context.getIndexingContext().indexUpdateFailed(ce);
-        throw ce;
-      }
-      if (context.getIndexedNodes() > 0) {
-        log.debug("[{}] => Indexed {} nodes, done.", getIndexName(), context.getIndexedNodes());
-      }
-    }
-  }
-
-  @Override
-  public void propertyAdded(PropertyState after) {
-    markPropertyChanged(after.getName());
-    checkAggregates(after.getName());
-    propertyUpdated(null, after);
-  }
-
-  @Override
-  public void propertyChanged(PropertyState before, PropertyState after) {
-    markPropertyChanged(before.getName());
-    propertiesModified.add(before);
-    checkAggregates(before.getName());
-    propertyUpdated(before, after);
-  }
-
-  @Override
-  public void propertyDeleted(PropertyState before) {
-    markPropertyChanged(before.getName());
-    propertiesModified.add(before);
-    checkAggregates(before.getName());
-    propertyUpdated(before, null);
-  }
-
-  @Override
-  public Editor childNodeAdded(String name, NodeState after) {
-    PathFilter.Result filterResult = getPathFilterResult(name);
-    if (filterResult != PathFilter.Result.EXCLUDE) {
-      return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), filterResult, false);
-    }
-    return null;
-  }
-
-  @Override
-  public Editor childNodeChanged(
-      String name, NodeState before, NodeState after) {
-    PathFilter.Result filterResult = getPathFilterResult(name);
-    if (filterResult != PathFilter.Result.EXCLUDE) {
-      return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), filterResult, false);
-    }
-    return null;
-  }
-
-  @Override
-  public Editor childNodeDeleted(String name, NodeState before)
-      throws CommitFailedException {
-    PathFilter.Result filterResult = getPathFilterResult(name);
-    if (filterResult == PathFilter.Result.EXCLUDE) {
-      return null;
-    }
-
-    if (!isDeleted) {
-      // tree deletion is handled on the parent node
-      String path = concat(getPath(), name);
-      try {
-        FulltextIndexWriter<D> writer = context.getWriter();
-        // Remove all index entries in the removed subtree
-        writer.deleteDocuments(path);
-        this.context.indexUpdate();
-      } catch (IOException e) {
-        CommitFailedException ce = new CommitFailedException("Fulltext", 5, "Failed to remove the index entries of"
-            + " the removed subtree " + path + "for index " + context.getIndexingContext().getIndexPath(), e);
-        context.getIndexingContext().indexUpdateFailed(ce);
-        throw ce;
-      }
-    }
-
-    MatcherState ms = getMatcherState(name, before);
-    if (!ms.isEmpty()){
-      return new FulltextIndexEditor<>(this, name, ms, filterResult, true);
-    }
-    return null; // no need to recurse down the removed subtree
-  }
-
-  public FulltextIndexEditorContext<D> getContext() {
-    return context;
-  }
-
-  private boolean addOrUpdate(String path, NodeState state, boolean isUpdate)
-      throws CommitFailedException {
-    try {
-      D d = makeDocument(path, state, isUpdate);
-      if (d != null) {
-        if (log.isTraceEnabled()) {
-          log.trace("[{}] Indexed document for {} is {}", getIndexName(), path, d);
+    @Override
+    public void enter(NodeState before, NodeState after) {
+        if (EmptyNodeState.MISSING_NODE == before && parent == null) {
+            context.enableReindexMode();
         }
-        context.indexUpdate();
-        context.getWriter().updateDocument(path, d);
-        return true;
-      }
-    } catch (IOException e) {
-      log.warn("Failed to index the node [{}] due to {}", path, e.getMessage());
-      CommitFailedException ce = new CommitFailedException("Fulltext", 3,
-          "Failed to index the node " + path, e);
-      context.getIndexingContext().indexUpdateFailed(ce);
-      throw ce;
-    } catch (IllegalArgumentException ie) {
-      log.warn("Failed to index the node [{}]", path, ie);
-    }
-    return false;
-  }
 
-  private D makeDocument(String path, NodeState state, boolean isUpdate) throws IOException {
-    if (!isIndexable()) {
-      return null;
-    }
-    return context.newDocumentMaker(indexingRule, path).makeDocument(state, isUpdate, propertiesModified);
-  }
+        //Only check for indexing if the result is include.
+        //In case like TRAVERSE nothing needs to be indexed for those
+        //path
+        if (pathFilterResult == PathFilter.Result.INCLUDE) {
+            //For traversal in deleted sub tree before state has to be used
+            NodeState current = after.exists() ? after : before;
+            indexingRule = getDefinition().getApplicableIndexingRule(current);
 
-
-  //~-------------------------------------------------------< Aggregate >
-
-  @Override
-  public void markDirty() {
-    propertiesChanged = true;
-  }
-
-  private MatcherState getMatcherState(String name, NodeState after) {
-    List<Aggregate.Matcher> matched = new ArrayList<>();
-    List<Aggregate.Matcher> inherited = new ArrayList<>();
-    for (Aggregate.Matcher m : Iterables.concat(matcherState.inherited, currentMatchers)) {
-      Aggregate.Matcher result = m.match(name, after);
-      if (result.getStatus() == Aggregate.Matcher.Status.MATCH_FOUND){
-        matched.add(result);
-      }
-
-      if (result.getStatus() != Aggregate.Matcher.Status.FAIL){
-        inherited.addAll(result.nextSet());
-      }
-    }
-
-    if (!matched.isEmpty() || !inherited.isEmpty()) {
-      return new MatcherState(matched, inherited);
-    }
-    return MatcherState.NONE;
-  }
-
-
-  /*
-   * Determines which all matchers are affected by this property change
-   *
-   * @param name modified property name
-   */
-  private void checkAggregates(String name) {
-    for (Aggregate.Matcher m : matcherState.matched) {
-      if (!matcherState.affectedMatchers.contains(m)
-          && m.aggregatesProperty(name)) {
-        matcherState.affectedMatchers.add(m);
-      }
-    }
-  }
-
-  static class MatcherState {
-    final static MatcherState NONE = new MatcherState(List.of(), List.of());
-
-    final List<Aggregate.Matcher> matched;
-    final List<Aggregate.Matcher> inherited;
-    final Set<Aggregate.Matcher> affectedMatchers;
-
-    public MatcherState(List<Aggregate.Matcher> matched,
-                        List<Aggregate.Matcher> inherited){
-      this.matched = matched;
-      this.inherited = inherited;
-
-      //Affected matches would only be used when there are
-      //some matched matchers
-      if (matched.isEmpty()){
-        affectedMatchers = Collections.emptySet();
-      } else {
-        affectedMatchers = SetUtils.newIdentityHashSet();
-      }
-    }
-
-    public boolean isEmpty() {
-      return matched.isEmpty() && inherited.isEmpty();
-    }
-  }
-
-  private void markPropertyChanged(String name) {
-    if (isIndexable()
-        && !propertiesChanged
-        && indexingRule.isIndexed(name)) {
-      propertiesChanged = true;
-    }
-  }
-
-  private void propertyUpdated(PropertyState before, PropertyState after) {
-    PropertyUpdateCallback callback = context.getPropertyUpdateCallback();
-
-    //Avoid further work if no callback is present
-    if (callback == null) {
-      return;
-    }
-
-    String propertyName = before != null ? before.getName() : after.getName();
-
-    if (isIndexable()) {
-      PropertyDefinition pd = indexingRule.getConfig(propertyName);
-      if (pd != null) {
-        callback.propertyUpdated(getPath(), propertyName, pd, before, after);
-      }
-    }
-
-    for (Aggregate.Matcher m : matcherState.matched) {
-      if (m.aggregatesProperty(propertyName)) {
-        Aggregate.Include i = m.getCurrentInclude();
-        if (i instanceof Aggregate.PropertyInclude) {
-          PropertyDefinition pd = ((Aggregate.PropertyInclude) i).getPropertyDefinition();
-          String propertyRelativePath = PathUtils.concat(m.getMatchedPath(), propertyName);
-
-          callback.propertyUpdated(m.getRootPath(), propertyRelativePath, pd, before, after);
+            if (indexingRule != null) {
+                currentMatchers = indexingRule.getAggregate().createMatchers(this);
+            }
         }
-      }
     }
-  }
 
-  private IndexDefinition getDefinition() {
-    return context.getDefinition();
-  }
+    @Override
+    public void leave(NodeState before, NodeState after)
+            throws CommitFailedException {
+        if (propertiesChanged || !before.exists()) {
+            String path = getPath();
+            if (addOrUpdate(path, after, before.exists())) {
+                long indexed = context.incIndexedNodes();
+                if (indexed % 1000 == 0) {
+                    log.debug("[{}] => Indexed {} nodes...", getIndexName(), indexed);
+                }
+            }
+        }
 
-  private boolean isIndexable(){
-    return indexingRule != null;
-  }
+        for (Aggregate.Matcher m : matcherState.affectedMatchers) {
+            m.markRootDirty();
+        }
 
-  private PathFilter.Result getPathFilterResult(String childNodeName) {
-    return context.getDefinition().getPathFilter().filter(concat(getPath(), childNodeName));
-  }
+        if (parent == null) {
+            PropertyUpdateCallback callback = context.getPropertyUpdateCallback();
+            if (callback != null) {
+                callback.done();
+            }
 
-  private String getIndexName() {
-    return context.getDefinition().getIndexName();
-  }
+            try {
+                context.closeWriter();
+            } catch (IOException e) {
+                CommitFailedException ce = new CommitFailedException("Fulltext", 4,
+                        "Failed to close the Fulltext index " + context.getIndexingContext().getIndexPath(), e);
+                context.getIndexingContext().indexUpdateFailed(ce);
+                throw ce;
+            }
+            if (context.getIndexedNodes() > 0) {
+                log.debug("[{}] => Indexed {} nodes, done.", getIndexName(), context.getIndexedNodes());
+            }
+        }
+    }
+
+    @Override
+    public void propertyAdded(PropertyState after) {
+        markPropertyChanged(after.getName());
+        checkAggregates(after.getName());
+        propertyUpdated(null, after);
+    }
+
+    @Override
+    public void propertyChanged(PropertyState before, PropertyState after) {
+        markPropertyChanged(before.getName());
+        propertiesModified.add(before);
+        checkAggregates(before.getName());
+        propertyUpdated(before, after);
+    }
+
+    @Override
+    public void propertyDeleted(PropertyState before) {
+        markPropertyChanged(before.getName());
+        propertiesModified.add(before);
+        checkAggregates(before.getName());
+        propertyUpdated(before, null);
+    }
+
+    @Override
+    public Editor childNodeAdded(String name, NodeState after) {
+        PathFilter.Result filterResult = getPathFilterResult(name);
+        if (filterResult != PathFilter.Result.EXCLUDE) {
+            return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), filterResult, false);
+        }
+        return null;
+    }
+
+    @Override
+    public Editor childNodeChanged(String name, NodeState before, NodeState after) {
+        PathFilter.Result filterResult = getPathFilterResult(name);
+        if (filterResult != PathFilter.Result.EXCLUDE) {
+            return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), filterResult, false);
+        }
+        return null;
+    }
+
+    @Override
+    public Editor childNodeDeleted(String name, NodeState before)
+            throws CommitFailedException {
+        PathFilter.Result filterResult = getPathFilterResult(name);
+        if (filterResult == PathFilter.Result.EXCLUDE) {
+            return null;
+        }
+
+        if (!isDeleted) {
+            // tree deletion is handled on the parent node
+            String path = PathUtils.concat(getPath(), name);
+            try {
+                FulltextIndexWriter<D> writer = context.getWriter();
+                // Remove all index entries in the removed subtree
+                writer.deleteDocuments(path);
+                this.context.indexUpdate();
+            } catch (IOException e) {
+                CommitFailedException ce = new CommitFailedException("Fulltext", 5, "Failed to remove the index entries of"
+                        + " the removed subtree " + path + "for index " + context.getIndexingContext().getIndexPath(), e);
+                context.getIndexingContext().indexUpdateFailed(ce);
+                throw ce;
+            }
+        }
+
+        MatcherState ms = getMatcherState(name, before);
+        if (!ms.isEmpty()) {
+            return new FulltextIndexEditor<>(this, name, ms, filterResult, true);
+        }
+        return null; // no need to recurse down the removed subtree
+    }
+
+    public FulltextIndexEditorContext<D> getContext() {
+        return context;
+    }
+
+    private boolean addOrUpdate(String path, NodeState state, boolean isUpdate)
+            throws CommitFailedException {
+        try {
+            D d = makeDocument(path, state, isUpdate);
+            if (d != null) {
+                if (log.isTraceEnabled()) {
+                    log.trace("[{}] Indexed document for {} is {}", getIndexName(), path, d);
+                }
+                context.indexUpdate();
+                context.getWriter().updateDocument(path, d);
+                return true;
+            }
+        } catch (IOException e) {
+            log.warn("Failed to index the node [{}] due to {}", path, e.getMessage());
+            CommitFailedException ce = new CommitFailedException("Fulltext", 3,
+                    "Failed to index the node " + path, e);
+            context.getIndexingContext().indexUpdateFailed(ce);
+            throw ce;
+        } catch (IllegalArgumentException ie) {
+            log.warn("Failed to index the node [{}]", path, ie);
+        }
+        return false;
+    }
+
+    private D makeDocument(String path, NodeState state, boolean isUpdate) throws IOException {
+        if (!isIndexable()) {
+            return null;
+        }
+        return context.newDocumentMaker(indexingRule, path).makeDocument(state, isUpdate, propertiesModified);
+    }
+
+
+    //~-------------------------------------------------------< Aggregate >
+
+    @Override
+    public void markDirty() {
+        propertiesChanged = true;
+    }
+
+    private MatcherState getMatcherState(String name, NodeState after) {
+        List<Aggregate.Matcher> matched = EMPTY_AGGREGATE_MATCHER_LIST;
+        List<Aggregate.Matcher> inherited = EMPTY_AGGREGATE_MATCHER_LIST;
+        for (Aggregate.Matcher m : Iterables.concat(matcherState.inherited, currentMatchers)) {
+            Aggregate.Matcher result = m.match(name, after);
+            if (result.getStatus() == Aggregate.Matcher.Status.MATCH_FOUND) {
+                if (matched == EMPTY_AGGREGATE_MATCHER_LIST) {
+                    matched = new ArrayList<>(2);
+                }
+                matched.add(result);
+            }
+
+            if (result.getStatus() != Aggregate.Matcher.Status.FAIL) {
+                if (inherited == EMPTY_AGGREGATE_MATCHER_LIST) {
+                    inherited = new ArrayList<>(2);
+                }
+                inherited.addAll(result.nextSet());
+            }
+        }
+
+        if (!matched.isEmpty() || !inherited.isEmpty()) {
+            return new MatcherState(matched, inherited);
+        }
+        return MatcherState.NONE;
+    }
+
+    /*
+     * Determines which all matchers are affected by this property change
+     *
+     * @param name modified property name
+     */
+    private void checkAggregates(String name) {
+        // Avoid allocating the iterator over matcherState.matched in the common case of the list being empty
+        if (!matcherState.matched.isEmpty()) {
+            for (Aggregate.Matcher m : matcherState.matched) {
+                if (!matcherState.affectedMatchers.contains(m) && m.aggregatesProperty(name)) {
+                    matcherState.affectedMatchers.add(m);
+                }
+            }
+        }
+    }
+
+    public static class MatcherState {
+        final static MatcherState NONE = new MatcherState(List.of(), List.of());
+
+        final List<Aggregate.Matcher> matched;
+        final List<Aggregate.Matcher> inherited;
+        final Set<Aggregate.Matcher> affectedMatchers;
+
+        public MatcherState(List<Aggregate.Matcher> matched, List<Aggregate.Matcher> inherited) {
+            this.matched = matched;
+            this.inherited = inherited;
+
+            //Affected matches would only be used when there are
+            //some matched matchers
+            if (matched.isEmpty()) {
+                affectedMatchers = Set.of();
+            } else {
+                affectedMatchers = SetUtils.newIdentityHashSet();
+            }
+        }
+
+        public boolean isEmpty() {
+            return matched.isEmpty() && inherited.isEmpty();
+        }
+    }
+
+    private void markPropertyChanged(String name) {
+        if (isIndexable()
+                && !propertiesChanged
+                && indexingRule.isIndexed(name)) {
+            propertiesChanged = true;
+        }
+    }
+
+    private void propertyUpdated(PropertyState before, PropertyState after) {
+        PropertyUpdateCallback callback = context.getPropertyUpdateCallback();
+
+        //Avoid further work if no callback is present
+        if (callback == null) {
+            return;
+        }
+
+        String propertyName = before != null ? before.getName() : after.getName();
+
+        if (isIndexable()) {
+            PropertyDefinition pd = indexingRule.getConfig(propertyName);
+            if (pd != null) {
+                callback.propertyUpdated(getPath(), propertyName, pd, before, after);
+            }
+        }
+
+        // Avoid allocating the iterator over matcherState.matched in the common case of the list being empty
+        if (!matcherState.matched.isEmpty()) {
+            for (Aggregate.Matcher m : matcherState.matched) {
+                if (m.aggregatesProperty(propertyName)) {
+                    Aggregate.Include i = m.getCurrentInclude();
+                    if (i instanceof Aggregate.PropertyInclude) {
+                        PropertyDefinition pd = ((Aggregate.PropertyInclude) i).getPropertyDefinition();
+                        String propertyRelativePath = PathUtils.concat(m.getMatchedPath(), propertyName);
+
+                        callback.propertyUpdated(m.getRootPath(), propertyRelativePath, pd, before, after);
+                    }
+                }
+            }
+        }
+    }
+
+    private IndexDefinition getDefinition() {
+        return context.getDefinition();
+    }
+
+    private boolean isIndexable() {
+        return indexingRule != null;
+    }
+
+    private PathFilter.Result getPathFilterResult(String childNodeName) {
+        return context.getDefinition().getPathFilter().filter(PathUtils.concat(getPath(), childNodeName));
+    }
+
+    private String getIndexName() {
+        return context.getDefinition().getIndexName();
+    }
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -309,10 +309,11 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             }
         }
 
-        if (!matched.isEmpty() || !inherited.isEmpty()) {
+        if (matched.isEmpty() && inherited.isEmpty()) {
+            return MatcherState.NONE;
+        } else {
             return new MatcherState(matched, inherited);
         }
-        return MatcherState.NONE;
     }
 
     /*

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -344,7 +344,6 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         }
     }
 
-
     public static class MatcherState {
         final static MatcherState NONE = new MatcherState(List.of(), List.of());
         private final static BitSet EMPTY_BITSET = new BitSet(0);
@@ -356,11 +355,9 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         public MatcherState(List<Aggregate.Matcher> matched, List<Aggregate.Matcher> inherited) {
             this.matched = matched;
             this.inherited = inherited;
-
             // Affected matches would only be used when there are some matched matchers
-            affectedMatchers = matched.isEmpty() ? EMPTY_BITSET : new BitSet(matched.size());
+            this.affectedMatchers = matched.isEmpty() ? EMPTY_BITSET : new BitSet(matched.size());
         }
-
 
         public boolean isEmpty() {
             return matched.isEmpty() && inherited.isEmpty();

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -145,11 +145,10 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             }
         }
 
-        for (int i = 0; i < matcherState.matched.size(); i++) {
-            if (matcherState.affectedMatchers.get(i)) {
-                Aggregate.Matcher m = matcherState.matched.get(i);
-                m.markRootDirty();
-            }
+        BitSet bitSet = matcherState.affectedMatchers;
+        for (int i = bitSet.nextSetBit(0); i != -1; i = bitSet.nextSetBit(i + 1)) {
+            Aggregate.Matcher m = matcherState.matched.get(i);
+            m.markRootDirty();
         }
 
         if (parent == null) {
@@ -345,8 +344,8 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
     }
 
     public static class MatcherState {
-        final static MatcherState NONE = new MatcherState(List.of(), List.of());
         private final static BitSet EMPTY_BITSET = new BitSet(0);
+        final static MatcherState NONE = new MatcherState(List.of(), List.of());
 
         final List<Aggregate.Matcher> matched;
         final List<Aggregate.Matcher> inherited;

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -37,11 +37,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import static org.apache.jackrabbit.oak.commons.PathUtils.concat;
 
 /**
  * Generic implementation of an {@link IndexEditor} which supports index time aggregation.
@@ -124,8 +121,7 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         }
 
         //Only check for indexing if the result is include.
-        //In case like TRAVERSE nothing needs to be indexed for those
-        //path
+        //In case like TRAVERSE nothing needs to be indexed for those paths
         if (pathFilterResult == PathFilter.Result.INCLUDE) {
             //For traversal in deleted sub tree before state has to be used
             NodeState current = after.exists() ? after : before;

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -175,31 +175,29 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
 
     @Override
     public void propertyAdded(PropertyState after) {
-        if (isIndexable()) {
-            markPropertyChanged(after.getName());
-            propertyUpdated(null, after);
-        }
+        markPropertyChanged(after.getName());
         checkAggregates(after.getName());
+        propertyUpdated(null, after);
     }
 
     @Override
     public void propertyChanged(PropertyState before, PropertyState after) {
+        markPropertyChanged(before.getName());
         if (isIndexable()) {
-            markPropertyChanged(before.getName());
             propertiesModified.add(before);
-            propertyUpdated(before, after);
         }
         checkAggregates(before.getName());
+        propertyUpdated(before, after);
     }
 
     @Override
     public void propertyDeleted(PropertyState before) {
+        markPropertyChanged(before.getName());
         if (isIndexable()) {
-            markPropertyChanged(before.getName());
             propertiesModified.add(before);
-            propertyUpdated(before, null);
         }
         checkAggregates(before.getName());
+        propertyUpdated(before, null);
     }
 
     @Override

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -22,7 +22,6 @@ import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
-import org.apache.jackrabbit.oak.commons.collections.SetUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditor;
 import org.apache.jackrabbit.oak.plugins.index.search.Aggregate;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
@@ -37,8 +36,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Generic implementation of an {@link IndexEditor} which supports index time aggregation.
@@ -146,8 +145,9 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             }
         }
 
-        if (!matcherState.affectedMatchers.isEmpty()) {
-            for (Aggregate.Matcher m : matcherState.affectedMatchers) {
+        for (int i = 0; i < matcherState.matched.size(); i++) {
+            if (matcherState.affectedMatchers.get(i)) {
+                Aggregate.Matcher m = matcherState.matched.get(i);
                 m.markRootDirty();
             }
         }
@@ -296,6 +296,10 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
     }
 
     private MatcherState getMatcherState(String name, NodeState after) {
+        // Short circuit if there are no matchers to avoid creating the iterator over these two lists
+        if (matcherState.inherited.isEmpty() && currentMatchers.isEmpty()) {
+            return MatcherState.NONE;
+        }
         List<Aggregate.Matcher> matched = EMPTY_AGGREGATE_MATCHER_LIST;
         List<Aggregate.Matcher> inherited = EMPTY_AGGREGATE_MATCHER_LIST;
         for (Aggregate.Matcher m : IterableUtils.chainedIterable(matcherState.inherited, currentMatchers)) {
@@ -323,43 +327,38 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
     }
 
 
-
     /*
      * Determines which all matchers are affected by this property change
      *
      * @param name modified property name
      */
     private void checkAggregates(String name) {
-        // Avoid allocating the iterator over matcherState.matched in the common case of the list being empty
-        if (!matcherState.matched.isEmpty()) {
-            for (Aggregate.Matcher m : matcherState.matched) {
-                if (!matcherState.affectedMatchers.contains(m) && m.aggregatesProperty(name)) {
-                    matcherState.affectedMatchers.add(m);
+        // Performance critical code, iterate using an index to avoid allocating an iterator
+        for (int i = 0; i < matcherState.matched.size(); i++) {
+            if (!matcherState.affectedMatchers.get(i)) {
+                Aggregate.Matcher m = matcherState.matched.get(i);
+                if (m.aggregatesProperty(name)) {
+                    matcherState.affectedMatchers.set(i);
                 }
             }
         }
     }
 
 
-
     public static class MatcherState {
         final static MatcherState NONE = new MatcherState(List.of(), List.of());
+        private final static BitSet EMPTY_BITSET = new BitSet(0);
 
         final List<Aggregate.Matcher> matched;
         final List<Aggregate.Matcher> inherited;
-        final Set<Aggregate.Matcher> affectedMatchers;
+        final BitSet affectedMatchers;
 
         public MatcherState(List<Aggregate.Matcher> matched, List<Aggregate.Matcher> inherited) {
             this.matched = matched;
             this.inherited = inherited;
 
-            //Affected matches would only be used when there are
-            //some matched matchers
-            if (matched.isEmpty()) {
-                affectedMatchers = Set.of();
-            } else {
-                affectedMatchers = SetUtils.newIdentityHashSet();
-            }
+            // Affected matches would only be used when there are some matched matchers
+            affectedMatchers = matched.isEmpty() ? EMPTY_BITSET : new BitSet(matched.size());
         }
 
 
@@ -393,17 +392,15 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             }
         }
 
-        // Avoid allocating the iterator over matcherState.matched in the common case of the list being empty
-        if (!matcherState.matched.isEmpty()) {
-            for (Aggregate.Matcher m : matcherState.matched) {
-                if (m.aggregatesProperty(propertyName)) {
-                    Aggregate.Include i = m.getCurrentInclude();
-                    if (i instanceof Aggregate.PropertyInclude) {
-                        PropertyDefinition pd = ((Aggregate.PropertyInclude) i).getPropertyDefinition();
-                        String propertyRelativePath = PathUtils.concat(m.getMatchedPath(), propertyName);
-
-                        callback.propertyUpdated(m.getRootPath(), propertyRelativePath, pd, before, after);
-                    }
+        // Performance critical code, iterate using an index to avoid allocating an iterator
+        for (int i = 0; i < matcherState.matched.size(); i++) {
+            Aggregate.Matcher m = matcherState.matched.get(i);
+            if (m.aggregatesProperty(propertyName)) {
+                Aggregate.Include aggregateInclude = m.getCurrentInclude();
+                if (aggregateInclude instanceof Aggregate.PropertyInclude) {
+                    PropertyDefinition pd = ((Aggregate.PropertyInclude) aggregateInclude).getPropertyDefinition();
+                    String propertyRelativePath = PathUtils.concat(m.getMatchedPath(), propertyName);
+                    callback.propertyUpdated(m.getRootPath(), propertyRelativePath, pd, before, after);
                 }
             }
         }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -47,9 +47,9 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
 
     private static final Logger log = LoggerFactory.getLogger(FulltextIndexEditor.class);
 
-    private static final List<Aggregate.Matcher> EMPTY_AGGREGATE_MATCHER_LIST = List.of();
-
     public static final String TEXT_EXTRACTION_ERROR = "TextExtractionError";
+
+    private static final List<Aggregate.Matcher> EMPTY_AGGREGATE_MATCHER_LIST = List.of();
 
     private final FulltextIndexEditorContext<D> context;
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -142,8 +142,10 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             }
         }
 
-        for (Aggregate.Matcher m : matcherState.affectedMatchers) {
-            m.markRootDirty();
+        if (!matcherState.affectedMatchers.isEmpty()) {
+            for (Aggregate.Matcher m : matcherState.affectedMatchers) {
+                m.markRootDirty();
+            }
         }
 
         if (parent == null) {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -170,25 +170,31 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
 
     @Override
     public void propertyAdded(PropertyState after) {
-        markPropertyChanged(after.getName());
-        checkAggregates(after.getName());
-        propertyUpdated(null, after);
+        if (isIndexable()) {
+            markPropertyChanged(after.getName());
+            checkAggregates(after.getName());
+            propertyUpdated(null, after);
+        }
     }
 
     @Override
     public void propertyChanged(PropertyState before, PropertyState after) {
-        markPropertyChanged(before.getName());
-        propertiesModified.add(before);
-        checkAggregates(before.getName());
-        propertyUpdated(before, after);
+        if (isIndexable()) {
+            markPropertyChanged(before.getName());
+            propertiesModified.add(before);
+            checkAggregates(before.getName());
+            propertyUpdated(before, after);
+        }
     }
 
     @Override
     public void propertyDeleted(PropertyState before) {
-        markPropertyChanged(before.getName());
-        propertiesModified.add(before);
-        checkAggregates(before.getName());
-        propertyUpdated(before, null);
+        if (isIndexable()) {
+            markPropertyChanged(before.getName());
+            propertiesModified.add(before);
+            checkAggregates(before.getName());
+            propertyUpdated(before, null);
+        }
     }
 
     @Override

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -77,6 +77,8 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
 
     private final MatcherState matcherState;
 
+    private final PathFilter pathFilter;
+
     private final PathFilter.Result pathFilterResult;
 
     public FulltextIndexEditor(FulltextIndexEditorContext<D> context) {
@@ -86,11 +88,13 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         this.context = context;
         this.isDeleted = false;
         this.matcherState = MatcherState.NONE;
-        this.pathFilterResult = context.getDefinition().getPathFilter().filter(PathUtils.ROOT_PATH);
+        this.pathFilter = context.getDefinition().getPathFilter();
+        this.pathFilterResult = this.pathFilter.filter(PathUtils.ROOT_PATH);
     }
 
     public FulltextIndexEditor(FulltextIndexEditor<D> parent, String name,
                                MatcherState matcherState,
+                               PathFilter pathFilter,
                                PathFilter.Result pathFilterResult,
                                boolean isDeleted) {
         this.parent = parent;
@@ -99,6 +103,7 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         this.context = parent.context;
         this.isDeleted = isDeleted;
         this.matcherState = matcherState;
+        this.pathFilter = pathFilter;
         this.pathFilterResult = pathFilterResult;
     }
 
@@ -199,37 +204,39 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
 
     @Override
     public Editor childNodeAdded(String name, NodeState after) {
-        PathFilter.Result filterResult = getPathFilterResult(name);
+        PathFilter.Result filterResult = pathFilter.filter(PathUtils.concat(getPath(), name));
         if (filterResult != PathFilter.Result.EXCLUDE) {
-            return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), filterResult, false);
+            return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), pathFilter, filterResult, false);
+        } else {
+            return null;
         }
-        return null;
     }
 
     @Override
     public Editor childNodeChanged(String name, NodeState before, NodeState after) {
-        PathFilter.Result filterResult = getPathFilterResult(name);
+        PathFilter.Result filterResult = pathFilter.filter(PathUtils.concat(getPath(), name));
         if (filterResult != PathFilter.Result.EXCLUDE) {
-            return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), filterResult, false);
+            return new FulltextIndexEditor<>(this, name, getMatcherState(name, after), pathFilter, filterResult, false);
+        } else {
+            return null;
         }
-        return null;
     }
 
     @Override
     public Editor childNodeDeleted(String name, NodeState before)
             throws CommitFailedException {
-        PathFilter.Result filterResult = getPathFilterResult(name);
+        String childPath = PathUtils.concat(getPath(), name);
+        PathFilter.Result filterResult = pathFilter.filter(childPath);
         if (filterResult == PathFilter.Result.EXCLUDE) {
             return null;
         }
 
         if (!isDeleted) {
             // tree deletion is handled on the parent node
-            String path = PathUtils.concat(getPath(), name);
             try {
                 FulltextIndexWriter<D> writer = context.getWriter();
                 // Remove all index entries in the removed subtree
-                writer.deleteDocuments(path);
+                writer.deleteDocuments(childPath);
                 this.context.indexUpdate();
             } catch (IOException e) {
                 CommitFailedException ce = new CommitFailedException("Fulltext", 5, "Failed to remove the index entries of"
@@ -240,10 +247,11 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
         }
 
         MatcherState ms = getMatcherState(name, before);
-        if (!ms.isEmpty()) {
-            return new FulltextIndexEditor<>(this, name, ms, filterResult, true);
+        if (ms.isEmpty()) {
+            return null; // no need to recurse down the removed subtree
+        } else {
+            return new FulltextIndexEditor<>(this, name, ms, pathFilter, filterResult, true);
         }
-        return null; // no need to recurse down the removed subtree
     }
 
     public FulltextIndexEditorContext<D> getContext() {
@@ -275,10 +283,11 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
     }
 
     private D makeDocument(String path, NodeState state, boolean isUpdate) throws IOException {
-        if (!isIndexable()) {
+        if (isIndexable()) {
+            return context.newDocumentMaker(indexingRule, path).makeDocument(state, isUpdate, propertiesModified);
+        } else {
             return null;
         }
-        return context.newDocumentMaker(indexingRule, path).makeDocument(state, isUpdate, propertiesModified);
     }
 
 
@@ -296,14 +305,14 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
             Aggregate.Matcher result = m.match(name, after);
             if (result.getStatus() == Aggregate.Matcher.Status.MATCH_FOUND) {
                 if (matched == EMPTY_AGGREGATE_MATCHER_LIST) {
-                    matched = new ArrayList<>();
+                    matched = new ArrayList<>(4);
                 }
                 matched.add(result);
             }
 
             if (result.getStatus() != Aggregate.Matcher.Status.FAIL) {
                 if (inherited == EMPTY_AGGREGATE_MATCHER_LIST) {
-                    inherited = new ArrayList<>();
+                    inherited = new ArrayList<>(4);
                 }
                 inherited.addAll(result.nextSet());
             }
@@ -404,10 +413,6 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
 
     private boolean isIndexable() {
         return indexingRule != null;
-    }
-
-    private PathFilter.Result getPathFilterResult(String childNodeName) {
-        return context.getDefinition().getPathFilter().filter(PathUtils.concat(getPath(), childNodeName));
     }
 
     private String getIndexName() {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -45,9 +45,11 @@ import org.slf4j.LoggerFactory;
  */
 public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateRoot {
 
-    public static final String TEXT_EXTRACTION_ERROR = "TextExtractionError";
     private static final Logger log = LoggerFactory.getLogger(FulltextIndexEditor.class);
+
     private static final List<Aggregate.Matcher> EMPTY_AGGREGATE_MATCHER_LIST = List.of();
+
+    public static final String TEXT_EXTRACTION_ERROR = "TextExtractionError";
 
     private final FulltextIndexEditorContext<D> context;
 


### PR DESCRIPTION
The methods `#getMatcherState(String name, NodeState after)` and `#checkAggregates(String name)` are called multiple times for every node traversed by the indexer, so they are critical for performance. This PR reduces the number of objects allocated by these methods.

Change the collection type of `MatcherState.affectedMatchers` from a `Set<Aggregate.Matcher>` to a more compact and efficient `BitSet`.

Replace all loops on matcher state that were using iterators with indexed loops, to avoid allocating iterator objects.


## Comparing performance of iterating over empty list vs pre-checking for empty

The program below compares iterating over a list using three approaches:
- unconditional iterator - enhanced for loop with iterator
- conditional iteration with empty check - check if collection is empty before iterating
- indexed traversal - using a classic for loop with an index



Results after 10 repetitions:

`List<String> l = List.of();`
- unconditional iterator: 654ms 
- conditional iteration with empty check: 0 ms
- indexed traversal: 0 ms

`List<String> l = List.of("a");`
- unconditional iterator: 1327 ms 
- conditional iteration with empty check: 1328 ms
- indexed traversal: 623 ms

`List<String> l = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");`
- unconditional iterator: 8783 ms 
- conditional iteration with empty check: 8764 ms
- indexed traversal: 8302 ms

Using an indexed traversal is always faster, with the relative difference being greater for smaller lists.

```java
import java.util.List;

class Scratch {
    private static long count1 = 0;
    private static long count2 = 0;
    private static long count3 = 0;

    private static void test1(List<String> list) {
        long start = System.nanoTime();
        for (int i = 0; i < 1_000_000_000; i++) {
            for (String s : list) {
                count1 += s.length();
            }
        }
        System.out.println("count: " + count1 + " test1: " + (System.nanoTime() - start) / 1_000_000);
    }

    private static void test2(List<String> list) {
        long start = System.nanoTime();
        for (int i = 0; i < 1_000_000_000; i++) {
            if (!list.isEmpty()) {
                for (String s : list) {
                    count2 += s.length();
                }
            }
        }
        System.out.println("count: " + count2 + " test2: " + (System.nanoTime() - start) / 1_000_000);
    }

    private static void test3(List<String> list) {
        long start = System.nanoTime();
        for (int i = 0; i < 1_000_000_000; i++) {
            for (int j = 0; j < list.size(); j++) {
                count3 += list.get(j).length();
            }
        }
        System.out.println("count: " + count3 + " test3: " + (System.nanoTime() - start) / 1_000_000);
    }


    public static void main(String[] args) {
        List<String> l = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
        for (int i = 0; i < 10; i++) {
            count1 = count2 = count2 = 0;
            test1(l);
            test2(l);
            test3(l);
        }
    }
}
```