### PR TITLE
OAK-11504 Elasticsearch: support flattened fields

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.collections.StreamUtils;
+import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
@@ -320,6 +321,12 @@ public class ElasticIndexDefinition extends IndexDefinition {
         if (propertyDefinitions == null) {
             // if there are no property definitions we return the default keyword name
             // this can happen for properties that were not explicitly defined (eg: created with a regex)
+            ElasticPropertyDefinition pd = getMatchingRegexPropertyDefinition(propertyName);
+            if (pd != null) {
+                if (pd.isFlattened()) {
+                    return FieldNames.FLATTENED_FIELD_PREFIX + pd.nodeName + "." + propertyName;
+                }
+            }
             return propertyName + ".keyword";
         }
 
@@ -330,6 +337,22 @@ public class ElasticIndexDefinition extends IndexDefinition {
             field += ".keyword";
         }
         return field;
+    }
+
+    /**
+     * Try to get the matching regular expression property definition, if any
+     *
+     * @param propertyName the property name (may not be null)
+     * @return the property definition, or null if not found
+     */
+    private ElasticPropertyDefinition getMatchingRegexPropertyDefinition(String propertyName) {
+        for (IndexingRule rule : getDefinedRules()) {
+            PropertyDefinition pd = rule.getConfig(propertyName);
+            if (pd != null && pd.isRegexp) {
+                return (ElasticPropertyDefinition) pd;
+            }
+        }
+        return null;
     }
 
     public boolean isAnalyzed(List<PropertyDefinition> propertyDefinitions) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyDefinition.java
@@ -46,6 +46,11 @@ public class ElasticPropertyDefinition extends PropertyDefinition {
     public static final String PROP_IS_FLATTENED = "isFlattened";
     private final boolean isFlattened;
 
+    /**
+     * The default value for the "isFlattened" property.
+     */
+    public static final boolean PROP_IS_FLATTENED_DEFAULT = false;
+
     public ElasticPropertyDefinition(IndexDefinition.IndexingRule idxDefn, String nodeName, NodeState defn) {
         super(idxDefn, nodeName, defn);
         if (this.useInSimilarity) {
@@ -56,7 +61,7 @@ public class ElasticPropertyDefinition extends PropertyDefinition {
                     getOptionalValue(defn, PROP_CANDIDATES, DEFAULT_CANDIDATES));
         }
         this.useInFullTextQuery = this.dynamicBoost && getOptionalValue(defn, PROP_USE_IN_FULL_TEXT_QUERY, true);
-        boolean flattened = getOptionalValue(defn, PROP_IS_FLATTENED, false);
+        boolean flattened = getOptionalValue(defn, PROP_IS_FLATTENED, PROP_IS_FLATTENED_DEFAULT);
         if (analyzed) {
             // if analyzed is enabled, then flattened needs to be disabled,
             // because flattened types do not support fulltext queries

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyDefinition.java
@@ -24,96 +24,119 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 
 public class ElasticPropertyDefinition extends PropertyDefinition {
 
-  public static final String DEFAULT_SIMILARITY_METRIC = "l2_norm";
-  static final String PROP_SIMILARITY_METRIC = "similarityMetric";
-  private static final String PROP_SIMILARITY = "similarity";
-  private static final String PROP_K = "k";
-  private static final String PROP_CANDIDATES = "candidates";
-  private static final float DEFAULT_SIMILARITY = 0.95f;
-  private static final int DEFAULT_K = 10;
-  private static final int DEFAULT_CANDIDATES = 500;
-  private KnnSearchParameters knnSearchParameters;
+    public static final String DEFAULT_SIMILARITY_METRIC = "l2_norm";
+    static final String PROP_SIMILARITY_METRIC = "similarityMetric";
+    private static final String PROP_SIMILARITY = "similarity";
+    private static final String PROP_K = "k";
+    private static final String PROP_CANDIDATES = "candidates";
+    private static final float DEFAULT_SIMILARITY = 0.95f;
+    private static final int DEFAULT_K = 10;
+    private static final int DEFAULT_CANDIDATES = 500;
+    private KnnSearchParameters knnSearchParameters;
 
-  /**
-   * Whether to use dynamic boosted values in full text queries, default is true
-   */
-  private static final String PROP_USE_IN_FULL_TEXT_QUERY = "useInFullTextQuery";
-  private final boolean useInFullTextQuery;
+    /**
+     * Whether to use dynamic boosted values in full text queries, default is true
+     */
+    private static final String PROP_USE_IN_FULL_TEXT_QUERY = "useInFullTextQuery";
+    private final boolean useInFullTextQuery;
 
-  public ElasticPropertyDefinition(IndexDefinition.IndexingRule idxDefn, String nodeName, NodeState defn) {
-    super(idxDefn, nodeName, defn);
-    if (this.useInSimilarity) {
-      knnSearchParameters = new KnnSearchParameters(
-          getOptionalValue(defn, PROP_SIMILARITY_METRIC, DEFAULT_SIMILARITY_METRIC),
-          getOptionalValue(defn, PROP_SIMILARITY, DEFAULT_SIMILARITY),
-          getOptionalValue(defn, PROP_K, DEFAULT_K),
-          getOptionalValue(defn, PROP_CANDIDATES, DEFAULT_CANDIDATES));
+    /**
+     * Whether regex properties are flattened (using the "flattened" field type)
+     */
+    public static final String PROP_IS_FLATTENED = "isFlattened";
+    private final boolean isFlattened;
+
+    public ElasticPropertyDefinition(IndexDefinition.IndexingRule idxDefn, String nodeName, NodeState defn) {
+        super(idxDefn, nodeName, defn);
+        if (this.useInSimilarity) {
+            knnSearchParameters = new KnnSearchParameters(
+                    getOptionalValue(defn, PROP_SIMILARITY_METRIC, DEFAULT_SIMILARITY_METRIC),
+                    getOptionalValue(defn, PROP_SIMILARITY, DEFAULT_SIMILARITY),
+                    getOptionalValue(defn, PROP_K, DEFAULT_K),
+                    getOptionalValue(defn, PROP_CANDIDATES, DEFAULT_CANDIDATES));
+        }
+        this.useInFullTextQuery = this.dynamicBoost && getOptionalValue(defn, PROP_USE_IN_FULL_TEXT_QUERY, true);
+        this.isFlattened = getOptionalValue(defn, PROP_IS_FLATTENED, false);
     }
-    this.useInFullTextQuery = this.dynamicBoost && getOptionalValue(defn, PROP_USE_IN_FULL_TEXT_QUERY, true);
-  }
 
-  public KnnSearchParameters getKnnSearchParameters() {
-    return knnSearchParameters;
-  }
+    public KnnSearchParameters getKnnSearchParameters() {
+        return knnSearchParameters;
+    }
 
     public boolean useInFullTextQuery() {
         return useInFullTextQuery;
     }
 
-  /**
-   * Class for defining parameters of approximate knn search on dense_vector fields
-   * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html">...</a> and
-   * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html">...</a>
-   */
-  public static class KnnSearchParameters {
-
-    public KnnSearchParameters(String similarityMetric, float similarity, int k, int candidates) {
-      this.similarityMetric = similarityMetric;
-      this.similarity = similarity;
-      this.k = k;
-      this.candidates = candidates;
-    }
-
     /**
-     * Similarity metric used to compare query and document vectors. Possible values are l2_norm (default), cosine,
-     * dot_product, max_inner_product
+     * Class for defining parameters of approximate knn search on dense_vector fields
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html">...</a> and
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html">...</a>
      */
-    private final String similarityMetric;
-    /**
-     * Minimum similarity for the document vector to be considered as a match. Required when cosine, dot_product
-     * or max_inner_product is set as similarityMetric
-     */
-    private final float similarity;
-    /**
-     * Number of nearest neighbours to return. Must be <= candidates
-     * vector added as a field
-     */
-    private final int k;
+    public static class KnnSearchParameters {
 
-    /**
-     * Take the top vectors with the most matching hashes and compute their exact similarity to the query vector. The
-     * candidates parameter controls the number of exact similarity computations. Specifically, we compute exact
-     * similarity for the top candidates candidate vectors in each segment. As a reminder, each Elasticsearch index has
-     * >= 1 shards, and each shard has >= 1 segments. That means if you set "candidates": 200 for an index with 2
-     * shards, each with 3 segments, then you’ll compute the exact similarity for 2 * 3 * 200 = 1200 vectors. candidates
-     * must be set to a number greater or equal to the number of Elasticsearch results you want to get. Higher values
-     * generally mean higher recall and higher latency.
-     */
-    private final int candidates;
+        public KnnSearchParameters(String similarityMetric, float similarity, int k, int candidates) {
+            this.similarityMetric = similarityMetric;
+            this.similarity = similarity;
+            this.k = k;
+            this.candidates = candidates;
+        }
 
-    public String getSimilarityMetric() {
-      return similarityMetric;
-    }
-    public float getSimilarity() {
-      return similarity;
+        /**
+         * Similarity metric used to compare query and document vectors. Possible values are l2_norm (default), cosine,
+         * dot_product, max_inner_product
+         */
+        private final String similarityMetric;
+
+        /**
+         * Minimum similarity for the document vector to be considered as a match. Required when cosine, dot_product
+         * or max_inner_product is set as similarityMetric
+         */
+        private final float similarity;
+
+        /**
+         * Number of nearest neighbours to return. Must be <= candidates
+         * vector added as a field
+         */
+        private final int k;
+
+        /**
+         * Take the top vectors with the most matching hashes and compute their exact similarity to the query vector. The
+         * candidates parameter controls the number of exact similarity computations. Specifically, we compute exact
+         * similarity for the top candidates candidate vectors in each segment. As a reminder, each Elasticsearch index has
+         * >= 1 shards, and each shard has >= 1 segments. That means if you set "candidates": 200 for an index with 2
+         * shards, each with 3 segments, then you’ll compute the exact similarity for 2 * 3 * 200 = 1200 vectors. candidates
+         * must be set to a number greater or equal to the number of Elasticsearch results you want to get. Higher values
+         * generally mean higher recall and higher latency.
+         */
+        private final int candidates;
+
+        public String getSimilarityMetric() {
+            return similarityMetric;
+        }
+
+        public float getSimilarity() {
+            return similarity;
+        }
+
+        public int getK() {
+            return k;
+        }
+
+        public int getCandidates() {
+            return candidates;
+        }
     }
 
-    public int getK() {
-      return k;
+    public boolean isFlattened() {
+        return isFlattened;
     }
 
-    public int getCandidates() {
-      return candidates;
+    @Override
+    public String toString() {
+        return "ElasticPropertyDefinition{" + super.toString() +
+                ", useInFullTextQuery=" + useInFullTextQuery +
+                ", isFlattened=" + isFlattened +
+                '}';
     }
-  }
+
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyDefinition.java
@@ -56,7 +56,14 @@ public class ElasticPropertyDefinition extends PropertyDefinition {
                     getOptionalValue(defn, PROP_CANDIDATES, DEFAULT_CANDIDATES));
         }
         this.useInFullTextQuery = this.dynamicBoost && getOptionalValue(defn, PROP_USE_IN_FULL_TEXT_QUERY, true);
-        this.isFlattened = getOptionalValue(defn, PROP_IS_FLATTENED, false);
+        boolean flattened = getOptionalValue(defn, PROP_IS_FLATTENED, false);
+        if (analyzed) {
+            // if analyzed is enabled, then flattened needs to be disabled,
+            // because flattened types do not support fulltext queries
+            // in the same way
+            flattened = false;
+        }
+        this.isFlattened = flattened;
     }
 
     public KnnSearchParameters getKnnSearchParameters() {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocument.java
@@ -195,4 +195,20 @@ public class ElasticDocument {
         return propertiesToRemove;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder buff = new StringBuilder();
+        buff.append("path:").append(path).append('\n');
+        if (!fulltext.isEmpty()) {
+            buff.append("fulltext:").append(fulltext).append('\n');
+        }
+        if (!properties.isEmpty()) {
+            buff.append("properties:").append(properties).append('\n');
+        }
+        if (!dynamicProperties.isEmpty()) {
+            buff.append("dynamicProperties:").append(dynamicProperties).append('\n');
+        }
+        return buff.toString();
+    }
+
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.log.LogSilencer;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticPropertyDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.Aggregate;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
@@ -169,6 +170,13 @@ public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument>
         // If the actual property value is different from the property type defined in the index definition/mapping - this will try to convert the property if possible,
         // otherwise will log a warning and not try and add the property to index. If we try and index incompatible data types (like String to Date),
         // we would get an exception while indexing the node on elastic search and other properties for the node will also don't get indexed. (See OAK-9665).
+        String fieldName = pname;
+        if (pd.isRegexp) {
+            ElasticPropertyDefinition epd = (ElasticPropertyDefinition) pd;
+            if (epd.isFlattened()) {
+                fieldName = FieldNames.FLATTENED_FIELD_PREFIX + epd.nodeName + "." + pname;
+            }
+        }
         int tag = pd.getType();
         Object f;
         try {
@@ -184,12 +192,12 @@ public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument>
                 f = property.getValue(Type.STRING, i);
             }
 
-            doc.addProperty(pname, f);
+            doc.addProperty(fieldName, f);
         } catch (Exception e) {
             if (!LOG_SILENCER.silence(LOG_KEY_COULD_NOT_CONVERT_PROPERTY)) {
                 LOG.warn(
-                        "[{}] Ignoring property. Could not convert property {} of type {} to type {} for path {}. Error: {}",
-                        getIndexName(), pname,
+                        "[{}] Ignoring property. Could not convert property {} (field {}) of type {} to type {} for path {}. Error: {}",
+                        getIndexName(), pname, fieldName,
                         Type.fromTag(property.getType().tag(), false),
                         Type.fromTag(tag, false), path, e.toString());
             }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticPropertyDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.IndexingRule;
 import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
 import org.jetbrains.annotations.NotNull;
 
@@ -235,22 +236,21 @@ class ElasticIndexHelper {
     private static void mapIndexRules(@NotNull TypeMapping.Builder builder,
                                       @NotNull ElasticIndexDefinition indexDefinition) {
         checkIndexRules(indexDefinition);
+        for (IndexingRule rule : indexDefinition.getDefinedRules()) {
+            Iterable<PropertyDefinition> iterable = rule.getNamePatternsProperties()::iterator;
+            for (PropertyDefinition pd : iterable) {
+                ElasticPropertyDefinition epd = (ElasticPropertyDefinition) pd;
+                if (epd.isFlattened()) {
+                    Property.Builder pBuilder = new Property.Builder();
+                    pBuilder.flattened(b2 -> b2.index(true));
+                    builder.properties(FieldNames.FLATTENED_FIELD_PREFIX + pd.nodeName, pBuilder.build());
+                }
+            }
+        }
         for (Map.Entry<String, List<PropertyDefinition>> entry : indexDefinition.getPropertiesByName().entrySet()) {
             final String name = entry.getKey();
             final List<PropertyDefinition> propertyDefinitions = entry.getValue();
             Type<?> type = null;
-            for (PropertyDefinition pd : propertyDefinitions) {
-                type = Type.fromTag(pd.getType(), false);
-                if (pd.isRegexp) {
-                    ElasticPropertyDefinition epd = (ElasticPropertyDefinition) pd;
-                    if (epd.isFlattened()) {
-                        Property.Builder pBuilder = new Property.Builder();
-                        pBuilder.flattened(b2 -> b2.index(true));
-                        builder.properties(FieldNames.FLATTENED_FIELD_PREFIX + pd.nodeName, pBuilder.build());
-                    }
-                }
-            }
-
             Property.Builder pBuilder = new Property.Builder();
             // https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
             if (Type.BINARY.equals(type)) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -241,6 +241,14 @@ class ElasticIndexHelper {
             Type<?> type = null;
             for (PropertyDefinition pd : propertyDefinitions) {
                 type = Type.fromTag(pd.getType(), false);
+                if (pd.isRegexp) {
+                    ElasticPropertyDefinition epd = (ElasticPropertyDefinition) pd;
+                    if (epd.isFlattened()) {
+                        Property.Builder pBuilder = new Property.Builder();
+                        pBuilder.flattened(b2 -> b2.index(true));
+                        builder.properties(FieldNames.FLATTENED_FIELD_PREFIX + pd.nodeName, pBuilder.build());
+                    }
+                }
             }
 
             Property.Builder pBuilder = new Property.Builder();

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -251,6 +251,10 @@ class ElasticIndexHelper {
             final String name = entry.getKey();
             final List<PropertyDefinition> propertyDefinitions = entry.getValue();
             Type<?> type = null;
+            for (PropertyDefinition pd : propertyDefinitions) {
+                type = Type.fromTag(pd.getType(), false);
+            }
+
             Property.Builder pBuilder = new Property.Builder();
             // https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html
             if (Type.BINARY.equals(type)) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -911,7 +911,6 @@ public class ElasticRequestHandler {
         }
 
         final String field = elasticIndexDefinition.getElasticKeyword(propertyName);
-
         Query in;
         switch (propType) {
             case PropertyType.DATE: {
@@ -932,18 +931,16 @@ public class ElasticRequestHandler {
             }
             default: {
                 if (pr.isLike) {
-                    return like(propertyName, pr.first.getValue(Type.STRING));
+                    in = like(propertyName, pr.first.getValue(Type.STRING));
+                } else {
+                    // TODO Confirm that all other types can be treated as string
+                    in = newPropertyRestrictionQuery(field, pr, value -> value.getValue(Type.STRING));
                 }
-
-                //TODO Confirm that all other types can be treated as string
-                in = newPropertyRestrictionQuery(field, pr, value -> value.getValue(Type.STRING));
             }
         }
-
         if (in != null) {
             return in;
         }
-
         throw new IllegalStateException("PropertyRestriction not handled " + pr + " for index " + defn);
     }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -901,7 +901,6 @@ public class ElasticRequestHandler {
     }
 
     private Query createQuery(String propertyName, Filter.PropertyRestriction pr, PropertyDefinition defn) {
-        int propType = FulltextIndex.determinePropertyType(defn, pr);
         final String field = elasticIndexDefinition.getElasticKeyword(propertyName);
 
         if (pr.isNullRestriction()) {
@@ -912,6 +911,7 @@ public class ElasticRequestHandler {
         }
 
         Query in;
+        int propType = FulltextIndex.determinePropertyType(defn, pr);
         switch (propType) {
             case PropertyType.DATE: {
                 in = newPropertyRestrictionQuery(field, pr, value -> parse(value.getValue(Type.DATE)).getTimeInMillis());

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -193,10 +193,10 @@ public class ElasticRequestHandler {
                         bqb.must(m -> m.moreLikeThis(mltQuery(mltParams)));
                     }
                 } else {
-                  similarityQuery(queryNodePath, sp).ifPresent(similarityQuery ->
-                    bqb.filter(fb -> fb.exists(ef -> ef.field(similarityQuery.field())))
-                        .should(s -> s.knn(similarityQuery))
-                  );
+                    similarityQuery(queryNodePath, sp).ifPresent(similarityQuery ->
+                        bqb.filter(fb -> fb.exists(ef -> ef.field(similarityQuery.field())))
+                            .should(s -> s.knn(similarityQuery))
+                            );
                 }
 
                 // Add should clause to improve relevance using similarity tags only when similarity is
@@ -902,15 +902,15 @@ public class ElasticRequestHandler {
 
     private Query createQuery(String propertyName, Filter.PropertyRestriction pr, PropertyDefinition defn) {
         int propType = FulltextIndex.determinePropertyType(defn, pr);
+        final String field = elasticIndexDefinition.getElasticKeyword(propertyName);
 
         if (pr.isNullRestriction()) {
-            return Query.of(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(propertyName)))));
+            return Query.of(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(field)))));
         }
         if (pr.isNotNullRestriction()) {
-            return Query.of(q -> q.exists(e -> e.field(propertyName)));
+            return Query.of(q -> q.exists(e -> e.field(field)));
         }
 
-        final String field = elasticIndexDefinition.getElasticKeyword(propertyName);
         Query in;
         switch (propType) {
             case PropertyType.DATE: {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/ElasticRequestHandler.java
@@ -565,7 +565,7 @@ public class ElasticRequestHandler {
                     if (elasticIndexDefinition.inferenceDefinition != null && elasticIndexDefinition.inferenceDefinition.queries != null) {
                         bqBuilder.must(m -> m.bool(b -> inference(b, propertyName, text, pr, includeDynamicBoostedValues)));
                     } else {
-                        QueryStringQuery.Builder qsqBuilder = fullTextQuery(text, getElasticFieldName(propertyName), pr, includeDynamicBoostedValues);
+                        QueryStringQuery.Builder qsqBuilder = fullTextQuery(text, getElasticFulltextFieldName(propertyName), pr, includeDynamicBoostedValues);
                         bqBuilder.must(m -> m.queryString(qsqBuilder.build()));
                     }
                 }
@@ -604,7 +604,7 @@ public class ElasticRequestHandler {
             }
         }
 
-        QueryStringQuery.Builder qsqBuilder = fullTextQuery(queryText, getElasticFieldName(propertyName), pr, dbEnabled);
+        QueryStringQuery.Builder qsqBuilder = fullTextQuery(queryText, getElasticFulltextFieldName(propertyName), pr, dbEnabled);
 
         // the query can be null if no inference query is eligible for the given text or the min terms are not met
         // in this case, we fall back to the default full-text query
@@ -944,18 +944,13 @@ public class ElasticRequestHandler {
         throw new IllegalStateException("PropertyRestriction not handled " + pr + " for index " + defn);
     }
 
-    private String getElasticFieldName(@Nullable String p) {
-        if (p == null) {
+    private String getElasticFulltextFieldName(@Nullable String propertyName) {
+        if (propertyName == null || "*".equals(propertyName)) {
             return FieldNames.FULLTEXT;
         }
-
         if (planResult.isPathTransformed()) {
-            p = PathUtils.getName(p);
+            propertyName = PathUtils.getName(propertyName);
         }
-
-        if ("*".equals(p)) {
-            p = FieldNames.FULLTEXT;
-        }
-        return p;
+        return propertyName;
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexQueryCommonTest.java
@@ -86,25 +86,25 @@ public class ElasticIndexQueryCommonTest extends IndexQueryCommonTest {
 
     @Override
     public String getContainsValueForInequalityQuery_native() {
-        return "\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}},{\"exists\":{\"field\":\"propa\"}}," +
+        return "\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}},{\"exists\":{\"field\":\"propa.keyword\"}}," +
                 "{\"bool\":{\"must_not\":[{\"term\":{\"propa.keyword\":{\"value\":\"bar\"}}}]";
     }
 
     @Override
     public String getContainsValueForInequalityQueryWithoutAncestorFilter_native() {
-        return "\"filter\":[{\"exists\":{\"field\":\"propa\"}},{\"bool\":" +
+        return "\"filter\":[{\"exists\":{\"field\":\"propa.keyword\"}},{\"bool\":" +
                 "{\"must_not\":[{\"term\":{\"propa.keyword\":{\"value\":\"bar\"}}}]";
     }
 
     @Override
     public String getContainsValueForEqualityInequalityCombined_native() {
         return "\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}},{\"term\":{\"propb.keyword\":{\"value\":\"world\"}}}," +
-                "{\"exists\":{\"field\":\"propa\"}},{\"bool\":{\"must_not\":[{\"term\":{\"propa.keyword\":{\"value\":\"bar\"}}}]";
+                "{\"exists\":{\"field\":\"propa.keyword\"}},{\"bool\":{\"must_not\":[{\"term\":{\"propa.keyword\":{\"value\":\"bar\"}}}]";
     }
 
     @Override
     public String getContainsValueForNotNullQuery_native() {
-        return "\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}},{\"exists\":{\"field\":\"propa\"}}]";
+        return "\"filter\":[{\"term\":{\":ancestors\":{\"value\":\"/test\"}}},{\"exists\":{\"field\":\"propa.keyword\"}}]";
     }
 
     @Override

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexTest.java
@@ -242,6 +242,13 @@ public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
 
     @Test
     public void indexFailuresWithFailOnErrorOn() throws Exception {
+        if (ElasticPropertyDefinition.PROP_IS_FLATTENED_DEFAULT) {
+            // if "flattened" enabled by default,
+            // then the test doesn't make sense.
+            // alternatively, disable "flattened" in the index definition;
+            // but this is already tested in ElasticRegexPropertyIndexTest
+            return;
+        }
         IndexDefinitionBuilder builder = createIndex("a");
         builder.includedPaths("/test")
                 .indexRule("nt:base")

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -21,8 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.List;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
@@ -114,11 +112,8 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
         } catch (CommitFailedException e) {
             String msg = e.getMessage();
             assertTrue(msg, msg.contains("Failed to index the node"));
-            StringWriter sw = new StringWriter();
-            PrintWriter p = new PrintWriter(sw);
-            e.printStackTrace(p);
-            String stackTrace = sw.toString();
-            assertTrue(stackTrace, stackTrace.contains("Limit of total fields [1000] has been exceeded"));
+            // Typically, the root cause is "Limit of total fields [1000] has been exceeded"
+            // but something this is suppressed, and so we can not have an assertion on it
         }
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -47,6 +47,10 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
         test.addChild("c").setProperty("propa", "foo2");
         test.addChild("d").setProperty("propc", "foo");
         test.addChild("e").setProperty("propd", "foo");
+       // create 10k nodes with different property names to have high cardinality
+        for (int i = 0; i < 10000; i++) {
+            test.addChild("node" + i).setProperty("prop" + i, "foo");
+        }
         root.commit();
 
         String propaQuery = "select [jcr:path] from [nt:base] where [propa] = 'foo'";

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -51,7 +51,8 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
         test.addChild("b").setProperty("propa", "foo");
         test.addChild("c").setProperty("propa", "foo2");
         test.addChild("d").setProperty("propc", "foo");
-        test.addChild("e").setProperty("propd", "foo");
+        test.addChild("e").setProperty("propd", "foo2");
+        test.addChild("f").setProperty("propd", "foo1");
 
         // create 10k nodes with different property names to have high cardinality;
         // without flattened fields, this will break the test with
@@ -69,6 +70,17 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
             assertThat(explain, containsString("[{\"term\":{\"flat:allProperties.propa\":{\"value\":\"foo\"}}}]"));
             assertQuery(propaQuery, List.of("/test/a", "/test/b"));
         });
+
+        String propaOrderQuery = "select [jcr:path] from [nt:base] where [propd] like 'foo%' order by [propd]";
+
+        assertEventually(() -> {
+            String explain = explain(propaOrderQuery);
+            assertThat(explain, containsString("elasticsearch:test1"));
+            assertThat(explain, containsString("\"query\":{\"bool\":{\"filter\":[{\"prefix\":{\"flat:allProperties.propd\":{\"value\":\"foo\"}}}]}}"));
+            assertThat(explain, containsString("sortOrder: [{ propertyName : propd, propertyType : UNDEFINED, order : ASCENDING }]"));
+            assertQuery(propaOrderQuery, List.of("/test/f", "/test/e"));
+        });
+
     }
 
     @Test

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -75,6 +75,7 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
             String explain = explain(propaOrderQuery);
             assertThat(explain, containsString("elasticsearch:test1"));
             assertThat(explain, containsString("\"query\":{\"bool\":{\"filter\":[{\"prefix\":{\"flat:allProperties.propd\":{\"value\":\"foo\"}}}]}}"));
+            assertThat(explain, containsString("\"sort\":[{\"flat:allProperties.propd\":{\"order\":\"asc\"}},{\":path\":{\"order\":\"asc\"}}]"));
             assertThat(explain, containsString("sortOrder: [{ propertyName : propd, propertyType : UNDEFINED, order : ASCENDING }]"));
             assertQuery(propaOrderQuery, List.of("/test/f", "/test/e"));
         });

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -47,8 +47,11 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
         test.addChild("c").setProperty("propa", "foo2");
         test.addChild("d").setProperty("propc", "foo");
         test.addChild("e").setProperty("propd", "foo");
-       // create 10k nodes with different property names to have high cardinality
-        for (int i = 0; i < 10000; i++) {
+
+        // create 10k nodes with different property names to have high cardinality;
+        // without flattened fields, this will break the test with
+        // "Limit of total fields [1000] has been exceeded"
+        for (int i = 0; i < 10_000; i++) {
             test.addChild("node" + i).setProperty("prop" + i, "foo");
         }
         root.commit();

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -18,9 +18,14 @@ package org.apache.jackrabbit.oak.plugins.index.elastic;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 
+import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
@@ -30,7 +35,7 @@ import org.junit.Test;
 public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
 
     @Test
-    public void regexProperty() throws Exception {
+    public void regexPropertyWithFlattened() throws Exception {
         IndexDefinitionBuilder builder = createIndex("allProperties");
         PropertyRule prop = builder.indexRule("nt:base").property("allProperties");
         prop.getBuilderTree().setProperty(FulltextIndexConstants.PROP_IS_REGEX, true);
@@ -64,6 +69,45 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
             assertThat(explain, containsString("[{\"term\":{\"flat:allProperties.propa\":{\"value\":\"foo\"}}}]"));
             assertQuery(propaQuery, List.of("/test/a", "/test/b"));
         });
+    }
+
+    @Test
+    public void regexPropertyWithoutFlattened() throws Exception {
+        IndexDefinitionBuilder builder = createIndex("allProperties");
+        PropertyRule prop = builder.indexRule("nt:base").property("allProperties");
+        prop.getBuilderTree().setProperty(FulltextIndexConstants.PROP_IS_REGEX, true);
+        prop.getBuilderTree().setProperty(FulltextIndexConstants.PROP_NAME, "^[^\\/]*$");
+        prop.nodeScopeIndex();
+        prop.getBuilderTree().setProperty(ElasticPropertyDefinition.PROP_IS_FLATTENED, false);
+
+        setIndex("test1", builder);
+        root.commit();
+
+        Tree test = root.getTree("/").addChild("test");
+        test.addChild("a").setProperty("propa", "foo");
+        test.addChild("b").setProperty("propa", "foo");
+        test.addChild("c").setProperty("propa", "foo2");
+        test.addChild("d").setProperty("propc", "foo");
+        test.addChild("e").setProperty("propd", "foo");
+
+        // create 10k nodes with different property names to have high cardinality;
+        // without flattened fields, this will break the test with
+        // "Limit of total fields [1000] has been exceeded"
+        for (int i = 0; i < 10_000; i++) {
+            test.addChild("node" + i).setProperty("prop" + i, "foo");
+        }
+        try {
+            root.commit();
+            fail();
+        } catch (CommitFailedException e) {
+            String msg = e.getMessage();
+            assertTrue(msg, msg.contains("Failed to index the node"));
+            StringWriter sw = new StringWriter();
+            PrintWriter p = new PrintWriter(sw);
+            e.printStackTrace(p);
+            String stackTrace = sw.toString();
+            assertTrue(stackTrace, stackTrace.contains("Limit of total fields [1000] has been exceeded"));
+        }
     }
 
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder.PropertyRule;
+import org.junit.Test;
+
+public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
+
+    @Test
+    public void regexProperty() throws Exception {
+        IndexDefinitionBuilder builder = createIndex("allProperties");
+        PropertyRule prop = builder.indexRule("nt:base").property("allProperties");
+        prop.getBuilderTree().setProperty(FulltextIndexConstants.PROP_IS_REGEX, true);
+        prop.getBuilderTree().setProperty(FulltextIndexConstants.PROP_NAME, "^[^\\/]*$");
+        prop.nodeScopeIndex();
+        prop.getBuilderTree().setProperty(ElasticPropertyDefinition.PROP_IS_FLATTENED, true);
+        
+        setIndex("test1", builder);
+        root.commit();
+
+        Tree test = root.getTree("/").addChild("test");
+        test.addChild("a").setProperty("propa", "foo");
+        test.addChild("b").setProperty("propa", "foo");
+        test.addChild("c").setProperty("propa", "foo2");
+        test.addChild("d").setProperty("propc", "foo");
+        test.addChild("e").setProperty("propd", "foo");
+        root.commit();
+
+        String propaQuery = "select [jcr:path] from [nt:base] where [propa] = 'foo'";
+
+        assertEventually(() -> {
+            String explain = explain(propaQuery);
+            assertThat(explain, containsString("elasticsearch:test1"));
+            assertThat(explain, containsString("[{\"term\":{\"flat:allProperties.propa\":{\"value\":\"foo\"}}}]"));
+            assertQuery(propaQuery, List.of("/test/a", "/test/b"));
+        });
+    }
+
+}

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FieldNames.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FieldNames.java
@@ -85,6 +85,11 @@ public final class FieldNames {
     public static final String ANALYZED_FIELD_PREFIX = "full:";
 
     /**
+     * Prefix for all field names that are flattened.
+     */
+    public static final String FLATTENED_FIELD_PREFIX = "flat:";
+
+    /**
      * Prefix used for storing fulltext of relative node
      */
     public static final String FULLTEXT_RELATIVE_NODE = "fullnode:";

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
@@ -1268,6 +1268,12 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
                 return config;
             } else if (namePatterns.size() > 0) {
                 // check patterns
+                if (NodeStateUtils.isHidden(propertyName)) {
+                    // hidden properties (eg. ":nodeName") do match the regex,
+                    // and we should probably ignore them;
+                    // but doing so would break "bug compatibility"
+                    // return null;
+                }
                 for (NamePattern np : namePatterns) {
                     if (np.matches(propertyName)) {
                         return np.getConfig();


### PR DESCRIPTION
Notes:
* Support is optional, and only enabled when using "isFlattened: true" in the property definition (the one that has "isRegexp: true")
* Flattened is not the default, for backward compatibility.
* If "analyzed" is enabled, then "flattened" is disabled (silently - logging it might log a lot, repeatedly - but we could make it an Oak-Pal rule).
* The hidden properties such as ":nodeName" are included still, even thought it is not needed. This is because changing it might break existing (weird) use cases. But we could consider doing that in the future. Best would be to make this optional or together with another breaking change (maybe the one above).
* Assuming we have a index definition regex property with the node name "allProperties" with a regular expression, and a property "propa", the document looks like this: `{:depth=2, flat:allProperties.propa=foo, :ancestors=/test, flat:allProperties.:nodeName=a}`
* Notice the `:nodeName` is also included, which is weird. Fixing that would break backward compatilibity, so I left it. Changing this would also affect Lucene. However, there is now disabled code where this is described, and that could be changed.
* I added a toString() method, to help debugging (there is no test case for this, and that's why code coverage complains).
* I fixed the indentation of `ElasticPropertyDefinition`, but I can undo this, if needed, to make the patch smaller.
* The query is `[{"term":{"flat:allProperties.propa":{"value":"foo"}}}]`
* The index definition is below; the last line is added:
* There are two test cases, one with many fields and flattened (including ordering), and another test without (disabled explicitly).


```
{  
    :depth=Property: {"type":"integer","doc_values":false}, 
    :fulltext=Property: {"type":"text","analyzer":"oak_analyzer"}, 
    :ancestors=Property: {"type":"text","analyzer":"ancestor_analyzer","search_analyzer":"keyword","search_quote_analyzer":"keyword"}, 
    :dynamic-boost-ft=Property: {"type":"text","analyzer":"oak_analyzer"}, 
    :suggest=Property: {"type":"nested","properties":{"value":{"type":"text","analyzer":"oak_analyzer"}}}, 
    :path=Property: {"type":"keyword"}, 
    :path-random-value=Property: {"type":"integer","doc_values":true,"index":false}, 
    :dynamic-properties=Property: {"type":"nested","properties":{"name":{"type":"keyword"},"value":{"type":"text","analyzer":"oak_analyzer"}}}, 
    :spellcheck=Property: {"type":"text","analyzer":"trigram"}, 
    :lastUpdated=Property: {"type":"date"}, 
    flat:allProperties=Property: {"type":"flattened","index":true}
}
```