### PR TITLE
OAK-11252 Disabling flaky test

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BranchCommitGCTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BranchCommitGCTest.java
@@ -360,6 +360,7 @@ public class BranchCommitGCTest {
     }
 
     @Test
+    @Ignore("OAK-11252")
     public void unmergedAddsThenMergedAddsChildren() throws Exception {
         assumeTrue(fullGcMode != FullGCMode.ORPHANS_EMPTYPROPS_BETWEEN_CHECKPOINTS_WITH_UNMERGED_BC);
         RevisionVector br1 = unmergedBranchCommit(b -> {


### PR DESCRIPTION
```
expected:<12> but was:<10>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollectorIT.doAssertEquals(VersionGarbageCollectorIT.java:1588)
	at org.apache.jackrabbit.oak.plugins.document.VersionGarbageCollectorIT.assertStatsCountsEqual(VersionGarbageCollectorIT.java:1575)
	at org.apache.jackrabbit.oak.plugins.document.BranchCommitGCTest.unmergedAddsThenMergedAddsChildren(BranchCommitGCTest.java:392)
```