### PR TITLE
OAK-11511 - Performance improvements to FullTextDocumentMaker class

### DIFF
--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -565,8 +565,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     /*
      * index aggregates on a certain path
      */
-    private boolean[] indexAggregates(final String path, final D document,
-                                      final NodeState state) {
+    private boolean[] indexAggregates(final String path, final D document, final NodeState state) {
         final AtomicBoolean dirtyFlag = new AtomicBoolean();
         final AtomicBoolean facetFlag = new AtomicBoolean();
         indexingRule.getAggregate().collectAggregates(state, new Aggregate.ResultCollector() {
@@ -613,8 +612,6 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
         for (PropertyState property : result.nodeState.getProperties()) {
             String pname = property.getName();
-            String propertyPath = PathUtils.concat(result.nodePath, pname);
-
             if (!isVisible(pname)) {
                 continue;
             }
@@ -634,6 +631,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
             //it from aggregation if
             // 1. It's not to be indexed i.e. index=false
             // 2. It's explicitly excluded from aggregation i.e. excludeFromAggregation=true
+            String propertyPath = PathUtils.concat(result.nodePath, pname);
             PropertyDefinition pdForRootNode = indexingRule.getConfig(propertyPath);
             if (pdForRootNode != null && (!pdForRootNode.index || pdForRootNode.excludeFromAggregate)) {
                 continue;

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -28,6 +28,7 @@ import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.FulltextBinaryTextExtractor;
+import org.apache.jackrabbit.oak.plugins.index.search.util.ConfigUtil;
 import org.apache.jackrabbit.oak.plugins.index.search.util.FunctionIndexProcessor;
 import org.apache.jackrabbit.oak.plugins.memory.StringPropertyState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -39,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import javax.jcr.PropertyType;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,8 +48,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.oak.commons.PathUtils.getName;
-import static org.apache.jackrabbit.oak.plugins.index.search.util.ConfigUtil.getPrimaryTypeName;
 
 /**
  * Abstract implementation of a {@link DocumentMaker}.
@@ -148,7 +146,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     @Nullable
     public D makeDocument(NodeState state) throws IOException {
-        return makeDocument(state, false, Collections.emptyList());
+        return makeDocument(state, false, List.of());
     }
 
     @Nullable
@@ -158,11 +156,11 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         D document = initDoc();
         boolean dirty = false;
 
+        String nodeName = PathUtils.getName(path);
         //We 'intentionally' are indexing node names only on root state as we don't support indexing relative or
         //regex for node name indexing
-        PropertyState nodenamePS =
-                new StringPropertyState(FieldNames.NODE_NAME, getName(path));
-        for (PropertyState property : IterableUtils.chainedIterable(state.getProperties(), Collections.singleton(nodenamePS))) {
+        PropertyState nodeNamePS = new StringPropertyState(FieldNames.NODE_NAME, nodeName);
+        for (PropertyState property : IterableUtils.chainedIterable(state.getProperties(), List.of(nodeNamePS))) {
             String pname = property.getName();
 
             if (!isVisible(pname) && !FieldNames.NODE_NAME.equals(pname)) {
@@ -203,9 +201,8 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
             return null;
         }
 
-        String name = getName(path);
         if (indexingRule.isNodeNameIndexed()) {
-            addNodeNameField(document, name);
+            addNodeNameField(document, nodeName);
             dirty = true;
         }
 
@@ -217,9 +214,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
         if (indexingRule.isFulltextEnabled()) {
             Pattern propertyRegex = definition.getPropertyRegex();
-            boolean shouldAdd = propertyRegex == null || propertyRegex.matcher(name).find();
+            boolean shouldAdd = propertyRegex == null || propertyRegex.matcher(nodeName).find();
             if (shouldAdd) {
-                indexFulltextValue(document, name);
+                indexFulltextValue(document, nodeName);
             }
         }
 
@@ -424,14 +421,13 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         return name.charAt(0) != ':';
     }
 
-    private List<String> newBinary(
-            PropertyState property, NodeState state, String path) {
+    private List<String> newBinary(PropertyState property, NodeState state, String path) {
         if (textExtractor == null) {
             //Skip text extraction for sync indexing
-            return Collections.emptyList();
+            return List.of();
+        } else {
+            return textExtractor.newBinary(property, state, path);
         }
-
-        return textExtractor.newBinary(property, state, path);
     }
 
     // TODO : extract more generic SPI for augmentor factory
@@ -456,7 +452,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private boolean indexNotNullCheckEnabledProps(String path, D doc, NodeState state) {
         boolean fieldAdded = false;
-        for (PropertyDefinition pd : indexingRule.getNotNullCheckEnabledProperties()) {
+        List<PropertyDefinition> props = indexingRule.getNotNullCheckEnabledProperties();
+        for (int i=0; i<props.size(); i++) {
+            PropertyDefinition pd = props.get(i);
             if (isPropertyNotNull(state, pd)) {
                 indexNotNullProperty(doc, pd);
                 fieldAdded = true;
@@ -467,7 +465,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private boolean indexNullCheckEnabledProps(String path, D doc, NodeState state) {
         boolean fieldAdded = false;
-        for (PropertyDefinition pd : indexingRule.getNullCheckEnabledProperties()) {
+        List<PropertyDefinition> props = indexingRule.getNullCheckEnabledProperties();
+        for (int i = 0; i < props.size(); i++) {
+            PropertyDefinition pd = props.get(i);
             if (isPropertyNull(state, pd)) {
                 indexNullProperty(doc, pd);
                 fieldAdded = true;
@@ -478,7 +478,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private boolean indexFunctionRestrictions(String path, D fields, NodeState state) {
         boolean fieldAdded = false;
-        for (PropertyDefinition pd : indexingRule.getFunctionRestrictions()) {
+        List<PropertyDefinition> functionRestrictions = indexingRule.getFunctionRestrictions();
+        for (int i = 0; i < functionRestrictions.size(); i++) {
+            PropertyDefinition pd = functionRestrictions.get(i);
             PropertyState functionValue = calculateValue(path, state, pd.functionCode);
             if (functionValue != null) {
                 if (pd.ordered) {
@@ -502,7 +504,8 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private boolean indexIfSinglePropertyRemoved(List<PropertyState> propertiesModified) {
         boolean dirty = false;
-        for (PropertyState ps : propertiesModified) {
+        for (int i=0; i<propertiesModified.size(); i++) {
+            PropertyState ps = propertiesModified.get(i);
             PropertyDefinition pd = indexingRule.getConfig(ps.getName());
             if (pd != null
                     && pd.index
@@ -601,7 +604,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         //are not indexed on their own. In such cases we rely on current
         //rule for some checks
         IndexDefinition.IndexingRule ruleAggNode = definition
-                .getApplicableIndexingRule(getPrimaryTypeName(result.nodeState));
+                .getApplicableIndexingRule(ConfigUtil.getPrimaryTypeName(result.nodeState));
         boolean dirty = false;
 
         for (PropertyState property : result.nodeState.getProperties()) {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -454,7 +454,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         boolean fieldAdded = false;
         List<PropertyDefinition> props = indexingRule.getNotNullCheckEnabledProperties();
         // Performance critical code: using indexed traversal to avoid creating an iterator instance.
-        for (int i=0; i<props.size(); i++) {
+        for (int i = 0; i < props.size(); i++) {
             PropertyDefinition pd = props.get(i);
             if (isPropertyNotNull(state, pd)) {
                 indexNotNullProperty(doc, pd);
@@ -508,7 +508,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     private boolean indexIfSinglePropertyRemoved(List<PropertyState> propertiesModified) {
         boolean dirty = false;
         // Performance critical code: using indexed traversal to avoid creating an iterator instance.
-        for (int i=0; i<propertiesModified.size(); i++) {
+        for (int i = 0; i < propertiesModified.size(); i++) {
             PropertyState ps = propertiesModified.get(i);
             PropertyDefinition pd = indexingRule.getConfig(ps.getName());
             if (pd != null

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -453,6 +453,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     private boolean indexNotNullCheckEnabledProps(String path, D doc, NodeState state) {
         boolean fieldAdded = false;
         List<PropertyDefinition> props = indexingRule.getNotNullCheckEnabledProperties();
+        // Performance critical code: using indexed traversal to avoid creating an iterator instance.
         for (int i=0; i<props.size(); i++) {
             PropertyDefinition pd = props.get(i);
             if (isPropertyNotNull(state, pd)) {
@@ -466,6 +467,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     private boolean indexNullCheckEnabledProps(String path, D doc, NodeState state) {
         boolean fieldAdded = false;
         List<PropertyDefinition> props = indexingRule.getNullCheckEnabledProperties();
+        // Performance critical code: using indexed traversal to avoid creating an iterator instance.
         for (int i = 0; i < props.size(); i++) {
             PropertyDefinition pd = props.get(i);
             if (isPropertyNull(state, pd)) {
@@ -479,6 +481,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     private boolean indexFunctionRestrictions(String path, D fields, NodeState state) {
         boolean fieldAdded = false;
         List<PropertyDefinition> functionRestrictions = indexingRule.getFunctionRestrictions();
+        // Performance critical code: using indexed traversal to avoid creating an iterator instance.
         for (int i = 0; i < functionRestrictions.size(); i++) {
             PropertyDefinition pd = functionRestrictions.get(i);
             PropertyState functionValue = calculateValue(path, state, pd.functionCode);
@@ -504,6 +507,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private boolean indexIfSinglePropertyRemoved(List<PropertyState> propertiesModified) {
         boolean dirty = false;
+        // Performance critical code: using indexed traversal to avoid creating an iterator instance.
         for (int i=0; i<propertiesModified.size(); i++) {
             PropertyState ps = propertiesModified.get(i);
             PropertyDefinition pd = indexingRule.getConfig(ps.getName());


### PR DESCRIPTION
- Eliminate duplicate call to `PathUtils.getName` in `makeDocument()`
- Replace traversals of lists using iterators by indexed traversals in performance critical methods.