### PR TITLE
OAK-11536: elastic synonym filter has to be lenient to incorrect rules

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
@@ -187,9 +187,14 @@ public class ElasticCustomAnalyzerMappings {
                 reKey.apply(luceneParams, Map.of("mapping", "mappings"))
         );
 
-        LUCENE_ELASTIC_TRANSFORMERS.put(SynonymFilterFactory.class, luceneParams ->
-                reKey.apply(luceneParams, Map.of("tokenizerFactory", "tokenizer"))
-        );
+        LUCENE_ELASTIC_TRANSFORMERS.put(SynonymFilterFactory.class, luceneParams -> {
+            // lucene does not support this option (see UNSUPPORTED_LUCENE_PARAMETERS) and it's lenient by default
+            // elastic is not lenient by default, so we need to set it to true in case it's not present
+            if (!luceneParams.containsKey("lenient")) {
+                luceneParams.put("lenient", "true");
+            }
+            return reKey.apply(luceneParams, Map.of("tokenizerFactory", "tokenizer"));
+        });
 
         LUCENE_ELASTIC_TRANSFORMERS.put(KeywordMarkerFilterFactory.class, luceneParams ->
                 reKey.apply(luceneParams, Map.of("protected", "keywords"))

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -27,6 +27,7 @@ import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesResponse;
+import co.elastic.clients.json.JsonpUtils;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
-import co.elastic.clients.elasticsearch._types.AcknowledgedResponseBase;
+import co.elastic.clients.elasticsearch._types.AcknowledgedResponse;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
@@ -239,13 +239,7 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
         deleteOldIndices(client, aliasResponse.result().keySet());
     }
 
-    private void checkResponseAcknowledgement(AcknowledgedResponseBase response, String exceptionMessage) {
-        if (!response.acknowledged()) {
-            throw new IllegalStateException(exceptionMessage);
-        }
-    }
-
-    private void checkResponseAcknowledgement(CreateIndexResponse response, String exceptionMessage) {
+    private void checkResponseAcknowledgement(AcknowledgedResponse response, String exceptionMessage) {
         if (!response.acknowledged()) {
             throw new IllegalStateException(exceptionMessage);
         }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -27,7 +27,6 @@ import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest;
 import co.elastic.clients.elasticsearch.indices.UpdateAliasesResponse;
-import co.elastic.clients.json.JsonpUtils;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
@@ -186,11 +185,7 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
         }
 
         final CreateIndexRequest request = ElasticIndexHelper.createIndexRequest(indexName, indexDefinition);
-        if (LOG.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder();
-            JsonpUtils.toString(request, sb);
-            LOG.debug("Creating Index with request {}", sb);
-        }
+        LOG.debug("Creating Index with request {}", request);
         // create the new index
         try {
             final CreateIndexResponse response = esClient.create(request);

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextAnalyzerCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextAnalyzerCommonTest.java
@@ -1005,7 +1005,11 @@ public abstract class FullTextAnalyzerCommonTest extends AbstractQueryTest {
             Tree synFilter = addFilter(filters, "Synonym");
             synFilter.setProperty("synonyms", "syn.txt");
             synFilter.addChild("syn.txt").addChild(JCR_CONTENT)
-                    .setProperty(JCR_DATA, "plane, airplane, aircraft\nflies=>scars");
+                    .setProperty(JCR_DATA, "plane, airplane, aircraft\n" +
+                            "flies=>scars\n" +
+                            // this rule is incorrect: "term: + was completely eliminated by analyzer"
+                            // by default, the configuration has to be lenient and not fail on such cases
+                            "plus,+,addition");
         });
 
         Tree content = root.getTree("/").addChild("content");


### PR DESCRIPTION
Lucene synonym rules are lenient (an incorrect rule will be skipped).
Aligning Elastic to behave in the same way.