### PR TITLE
OAK-11538 - Cleanups and small performance improvements to CompositeEditor and CompositeIndexEditorProvider

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/CompositeIndexEditorProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/CompositeIndexEditorProvider.java
@@ -16,12 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CompositeEditor;
 import org.apache.jackrabbit.oak.spi.commit.Editor;
@@ -29,19 +23,37 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Aggregation of a list of editor providers into a single provider.
  */
 public class CompositeIndexEditorProvider implements IndexEditorProvider {
 
     @NotNull
-    public static IndexEditorProvider compose(@NotNull Collection<IndexEditorProvider> providers) {
-        if (providers.isEmpty()) {
-            return (type, builder, root, callback) -> null;
-        } else if (providers.size() == 1) {
-            return providers.iterator().next();
-        } else {
-            return new CompositeIndexEditorProvider(List.copyOf(providers));
+    public static IndexEditorProvider compose(IndexEditorProvider... providers) {
+        switch (providers.length) {
+            case 0:
+                return (type, builder, root, callback) -> null;
+            case 1:
+                return providers[0];
+            default:
+                return new CompositeIndexEditorProvider(providers);
+        }
+    }
+
+    @NotNull
+    public static IndexEditorProvider compose(@NotNull List<IndexEditorProvider> providers) {
+        switch (providers.size()) {
+            case 0:
+                return (type, builder, root, callback) -> null;
+            case 1:
+                return providers.iterator().next();
+            default:
+                return new CompositeIndexEditorProvider(providers);
         }
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUpdate.java
@@ -39,8 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.jackrabbit.guava.common.collect.Iterables;
-
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -184,7 +182,7 @@ public class IndexUpdate implements Editor, PathSource {
 
         // no-op when reindex is empty
         CommitFailedException exception = EditorDiff.process(
-                VisibleEditor.wrap(wrapProgress(CompositeEditor.compose(reindex.values()))),
+                VisibleEditor.wrap(wrapProgress(CompositeEditor.compose(List.copyOf(reindex.values())))),
                 MISSING_NODE,
                 after);
         rootState.progressReporter.reindexingTraversalEnd();
@@ -197,31 +195,31 @@ public class IndexUpdate implements Editor, PathSource {
         }
     }
 
-    public boolean isReindexingPerformed(){
+    public boolean isReindexingPerformed() {
         return !getReindexStats().isEmpty();
     }
 
-    public List<String> getReindexStats(){
+    public List<String> getReindexStats() {
         return rootState.progressReporter.getReindexStats();
     }
 
-    public Set<String> getUpdatedIndexPaths(){
+    public Set<String> getUpdatedIndexPaths() {
         return rootState.progressReporter.getUpdatedIndexPaths();
     }
 
-    public void setTraversalRateEstimator(TraversalRateEstimator estimator){
+    public void setTraversalRateEstimator(TraversalRateEstimator estimator) {
         rootState.progressReporter.setTraversalRateEstimator(estimator);
     }
 
-    public void setNodeCountEstimator(NodeCountEstimator nodeCountEstimator){
+    public void setNodeCountEstimator(NodeCountEstimator nodeCountEstimator) {
         rootState.progressReporter.setNodeCountEstimator(nodeCountEstimator);
     }
 
-    public String getIndexingStats(){
+    public String getIndexingStats() {
         return rootState.getIndexingStats();
     }
 
-    public void setIgnoreReindexFlags(boolean ignoreReindexFlag){
+    public void setIgnoreReindexFlags(boolean ignoreReindexFlag) {
         rootState.setIgnoreReindexFlags(ignoreReindexFlag);
     }
 
@@ -271,7 +269,7 @@ public class IndexUpdate implements Editor, PathSource {
         return result;
     }
 
-    private static boolean hasAnyHiddenNodes(NodeBuilder builder){
+    private static boolean hasAnyHiddenNodes(NodeBuilder builder) {
         for (String name : builder.getChildNodeNames()) {
             if (NodeStateUtils.isHidden(name)) {
                 NodeBuilder childNode = builder.getChildNode(name);
@@ -284,8 +282,7 @@ public class IndexUpdate implements Editor, PathSource {
         return false;
     }
 
-    private void collectIndexEditors(NodeBuilder definitions,
-            NodeState before) throws CommitFailedException {
+    private void collectIndexEditors(NodeBuilder definitions, NodeState before) throws CommitFailedException {
         for (String name : definitions.getChildNodeNames()) {
             NodeBuilder definition = definitions.getChildNode(name);
             if (isIncluded(rootState.async, definition)) {
@@ -312,7 +309,7 @@ public class IndexUpdate implements Editor, PathSource {
 
                 boolean shouldReindex = shouldReindex(definition, before, name);
                 String indexPath = getIndexPath(getPath(), name);
-                if (definition.hasProperty(IndexConstants.CORRUPT_PROPERTY_NAME) && !shouldReindex){
+                if (definition.hasProperty(IndexConstants.CORRUPT_PROPERTY_NAME) && !shouldReindex) {
                     String corruptSince = definition.getProperty(IndexConstants.CORRUPT_PROPERTY_NAME).getValue(Type.DATE);
                     rootState.corruptIndexHandler.skippingCorruptIndex(rootState.async, indexPath, ISO8601.parse(corruptSince));
                     continue;
@@ -341,7 +338,7 @@ public class IndexUpdate implements Editor, PathSource {
                             long now = System.nanoTime();
                             long last = lastMissingProviderMessageTime.get();
                             if (now > last + silenceMessagesNanos
-                                    && lastMissingProviderMessageTime.compareAndSet(last,  now)) {
+                                    && lastMissingProviderMessageTime.compareAndSet(last, now)) {
                                 log.warn("Missing provider for nrt/sync index: {}. " +
                                         "Please note, it means that index data should be trusted only after this index " +
                                         "is processed in an async indexing cycle. " +
@@ -429,7 +426,7 @@ public class IndexUpdate implements Editor, PathSource {
      * <p>Note that this differs from #isIncluded which also considers the value of <code>async</code>
      * property to determine if the index should be selected for current IndexUpdate run.
      */
-    private boolean isMatchingIndexMode(NodeBuilder definition){
+    private boolean isMatchingIndexMode(NodeBuilder definition) {
         boolean async = definition.hasProperty(ASYNC_PROPERTY_NAME);
         //Either
         // 1. async index and async index update
@@ -439,7 +436,7 @@ public class IndexUpdate implements Editor, PathSource {
 
     private void incrementReIndexCount(NodeBuilder definition) {
         long count = 0;
-        if(definition.hasProperty(REINDEX_COUNT)){
+        if (definition.hasProperty(REINDEX_COUNT)) {
             count = definition.getProperty(REINDEX_COUNT).getValue(Type.LONG);
         }
         definition.setProperty(REINDEX_COUNT, count + 1);
@@ -463,7 +460,7 @@ public class IndexUpdate implements Editor, PathSource {
             editor.leave(before, after);
         }
 
-        if (parent == null){
+        if (parent == null) {
             rootState.progressReporter.logReport();
         }
     }
@@ -562,7 +559,7 @@ public class IndexUpdate implements Editor, PathSource {
         return path + "/" + INDEX_DEFINITIONS_NAME + "/" + indexName;
     }
 
-    private Editor wrapProgress(Editor editor){
+    private Editor wrapProgress(Editor editor) {
         return rootState.progressReporter.wrapProgress(editor);
     }
 
@@ -651,7 +648,7 @@ public class IndexUpdate implements Editor, PathSource {
             return new ReportingCallback(indexPath, reindex);
         }
 
-        public boolean isAsync(){
+        public boolean isAsync() {
             return async != null;
         }
 
@@ -660,7 +657,7 @@ public class IndexUpdate implements Editor, PathSource {
             progressReporter.traversedNode(pathSource);
         }
 
-        public void propertyChanged(String name){
+        public void propertyChanged(String name) {
             changedPropertyCount++;
         }
 
@@ -702,7 +699,7 @@ public class IndexUpdate implements Editor, PathSource {
 
             @Override
             public void indexUpdate() throws CommitFailedException {
-               progressReporter.indexUpdate(indexPath);
+                progressReporter.indexUpdate(indexPath);
             }
 
             //~------------------------------< ContextAwareCallback >

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/NodeStoreUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/importer/NodeStoreUtils.java
@@ -29,7 +29,6 @@ import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdateProvider;
 import org.apache.jackrabbit.oak.spi.commit.CommitContext;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
-import org.apache.jackrabbit.oak.spi.commit.CompositeEditorProvider;
 import org.apache.jackrabbit.oak.spi.commit.CompositeHook;
 import org.apache.jackrabbit.oak.spi.commit.EditorHook;
 import org.apache.jackrabbit.oak.spi.commit.ResetCommitAttributeHook;
@@ -37,7 +36,6 @@ import org.apache.jackrabbit.oak.spi.commit.SimpleCommitContext;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 
-import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 final class NodeStoreUtils {
@@ -46,7 +44,7 @@ final class NodeStoreUtils {
         CompositeHook hooks = new CompositeHook(
                 ResetCommitAttributeHook.INSTANCE,
                 new ConflictHook(new AnnotatingConflictHandler()),
-                new EditorHook(CompositeEditorProvider.compose(singletonList(new ConflictValidatorProvider())))
+                new EditorHook(new ConflictValidatorProvider())
         );
         nodeStore.merge(builder, hooks, createCommitInfo());
     }
@@ -57,7 +55,7 @@ final class NodeStoreUtils {
                 ResetCommitAttributeHook.INSTANCE,
                 new EditorHook(new IndexUpdateProvider(indexEditorProvider, null, true)),
                 new ConflictHook(new AnnotatingConflictHandler()),
-                new EditorHook(CompositeEditorProvider.compose(singletonList(new ConflictValidatorProvider())))
+                new EditorHook(new ConflictValidatorProvider())
         );
         nodeStore.merge(builder, hooks, createCommitInfo());
     }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -1032,8 +1032,7 @@ public class AsyncIndexUpdateTest {
                         .getString(missingAsync));
 
         // second run, simulate an index going away
-        provider = CompositeIndexEditorProvider
-                .compose(new ArrayList<IndexEditorProvider>());
+        provider = CompositeIndexEditorProvider.compose();
         async = new AsyncIndexUpdate(missingAsync, store, provider);
         async.run();
         assertTrue(async.isFailing());
@@ -1083,7 +1082,7 @@ public class AsyncIndexUpdateTest {
         store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
 
         // second run, simulate an index going away
-        provider = CompositeIndexEditorProvider.compose(new ArrayList<IndexEditorProvider>());
+        provider = CompositeIndexEditorProvider.compose();
         async = new AsyncIndexUpdate(missingAsyncName, store, provider);
         async.run();
         assertTrue(async.isFailing());

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/AsyncIndexStatsUpdateCallbackTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/AsyncIndexStatsUpdateCallbackTest.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.api.ContentSession;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.ActiveDeletedBlobCollectorFactory;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexDefinitionBuilder;
@@ -42,26 +43,22 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests AsyncIndexStatsUpdateCallback works as scheduled callback
  */
 public class AsyncIndexStatsUpdateCallbackTest {
-    private int SCHEDULED_CALLBACK_TIME_IN_MILLIS = 1000; //1 second
+    private final int SCHEDULED_CALLBACK_TIME_IN_MILLIS = 1000; //1 second
     protected Root root;
     private AsyncIndexUpdate asyncIndexUpdate;
     private LuceneIndexEditorProvider luceneIndexEditorProvider;
     private LogCustomizer customLogger;
-    private AsyncIndexesSizeStatsUpdateImpl asyncIndexesSizeStatsUpdate =
+    private final AsyncIndexesSizeStatsUpdateImpl asyncIndexesSizeStatsUpdate =
             new AsyncIndexesSizeStatsUpdateImpl(SCHEDULED_CALLBACK_TIME_IN_MILLIS);
-    private LuceneIndexMBeanImpl mBean = Mockito.mock(LuceneIndexMBeanImpl.class);
+    private final LuceneIndexMBeanImpl mBean = Mockito.mock(LuceneIndexMBeanImpl.class);
 
     @Before
     public void before() throws Exception {
@@ -87,10 +84,10 @@ public class AsyncIndexStatsUpdateCallbackTest {
                 null, Mounts.defaultMountInfoProvider(),
                 ActiveDeletedBlobCollectorFactory.NOOP, mBean, StatisticsProvider.NOOP);
 
-        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, compose(List.of(
+        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 luceneIndexEditorProvider,
                 new NodeCounterEditorProvider()
-        )), StatisticsProvider.NOOP, false);
+        ), StatisticsProvider.NOOP, false);
         return new Oak(nodeStore)
                 .with(new InitialContent())
                 .with(new OpenSecurityProvider())
@@ -111,16 +108,16 @@ public class AsyncIndexStatsUpdateCallbackTest {
         customLogger.starting();
         asyncIndexUpdate.run();
         List<String> logs = customLogger.getLogs();
-        assertTrue(logs.size() == 1);
+        assertEquals(1, logs.size());
         root.getTree("/content").addChild("c2").setProperty("foo", "bar");
         root.commit();
         asyncIndexUpdate.run();
-        assertTrue(logs.size() == 1);
+        assertEquals(1, logs.size());
         root.getTree("/content").addChild("c3").setProperty("foo", "bar");
         root.commit();
         Thread.sleep(2000);
         asyncIndexUpdate.run();
-        assertTrue(logs.size() == 2);
+        assertEquals(2, logs.size());
         validateLogs(logs);
     }
 
@@ -138,16 +135,16 @@ public class AsyncIndexStatsUpdateCallbackTest {
         customLogger.starting();
         asyncIndexUpdate.run();
         List<String> logs = customLogger.getLogs();
-        assertTrue(logs.size() == 0);
+        assertEquals(0, logs.size());
         root.getTree("/content").addChild("c2").setProperty("foo", "bar");
         root.commit();
         asyncIndexUpdate.run();
-        assertTrue(logs.size() == 0);
+        assertEquals(0, logs.size());
         root.getTree("/content").addChild("c3").setProperty("foo", "bar");
         root.commit();
         Thread.sleep(2000);
         asyncIndexUpdate.run();
-        assertTrue(logs.size() == 0);
+        assertEquals(0, logs.size());
         //validateLogs(logs);
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/AsyncIndexUpdateCorruptMarkingTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/AsyncIndexUpdateCorruptMarkingTest.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.api.ContentSession;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.TrackingCorruptIndexHandler;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexDefinitionBuilder;
@@ -39,10 +40,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -76,10 +75,10 @@ public class AsyncIndexUpdateCorruptMarkingTest {
         LuceneIndexProvider provider = new LuceneIndexProvider();
         luceneIndexEditorProvider.setBlobStore(blobStore);
 
-        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, compose(List.of(
+        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 luceneIndexEditorProvider,
                 new NodeCounterEditorProvider()
-        )));
+        ));
         TrackingCorruptIndexHandler trackingCorruptIndexHandler = new TrackingCorruptIndexHandler();
         trackingCorruptIndexHandler.setCorruptInterval(INDEX_CORRUPT_INTERVAL_IN_MILLIS, TimeUnit.MILLISECONDS);
         asyncIndexUpdate.setCorruptIndexHandler(trackingCorruptIndexHandler);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexlaneRepositoryTraversalTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexlaneRepositoryTraversalTest.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.TrackingCorruptIndexHandler;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.property.RecursiveDelete;
@@ -51,7 +52,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -101,14 +101,14 @@ public class IndexlaneRepositoryTraversalTest {
         LuceneIndexProvider provider = new LuceneIndexProvider();
         luceneIndexEditorProvider.setBlobStore(blobStore);
 
-        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, compose(List.of(
+        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 luceneIndexEditorProvider,
                 new NodeCounterEditorProvider()
-        )));
-        asyncIndexUpdateFulltext = new AsyncIndexUpdate("fulltext-async", nodeStore, compose(List.of(
+        ));
+        asyncIndexUpdateFulltext = new AsyncIndexUpdate("fulltext-async", nodeStore, CompositeIndexEditorProvider.compose(
                 luceneIndexEditorProvider,
                 new NodeCounterEditorProvider()
-        )));
+        ));
         TrackingCorruptIndexHandler trackingCorruptIndexHandler = new TrackingCorruptIndexHandler();
         trackingCorruptIndexHandler.setCorruptInterval(INDEX_CORRUPT_INTERVAL_IN_MILLIS, TimeUnit.MILLISECONDS);
         asyncIndexUpdate.setCorruptIndexHandler(trackingCorruptIndexHandler);
@@ -163,7 +163,7 @@ public class IndexlaneRepositoryTraversalTest {
     }
 
     @Test
-    public void repositoryTraversalAsyncNodeContainsAsyncProperty() throws Exception {
+    public void repositoryTraversalAsyncNodeContainsAsyncProperty() {
         // first run to populate /:async node.
         asyncIndexUpdate.run();
         asyncIndexUpdate.run();
@@ -173,7 +173,7 @@ public class IndexlaneRepositoryTraversalTest {
     }
 
     @Test
-    public void repositoryTraversalAsyncNodeDonotContainsFulltextAsyncProperty() throws Exception {
+    public void repositoryTraversalAsyncNodeDonotContainsFulltextAsyncProperty() {
         // first run to populate /:async node.
         asyncIndexUpdate.run();
         List<String> logs = customLogger.getLogs();

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/InvalidIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/InvalidIndexTest.java
@@ -25,6 +25,7 @@ import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.*;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdate;
 import org.apache.jackrabbit.oak.plugins.index.TrackingCorruptIndexHandler;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
@@ -45,7 +46,6 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -96,10 +96,10 @@ public class InvalidIndexTest {
         LuceneIndexProvider provider = new LuceneIndexProvider();
         luceneIndexEditorProvider.setBlobStore(blobStore);
 
-        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, compose(List.of(
+        asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 luceneIndexEditorProvider,
                 new NodeCounterEditorProvider()
-        )));
+        ));
         TrackingCorruptIndexHandler trackingCorruptIndexHandler = new TrackingCorruptIndexHandler();
         trackingCorruptIndexHandler.setCorruptInterval(INDEX_CORRUPT_INTERVAL_IN_MILLIS, TimeUnit.MILLISECONDS);
         asyncIndexUpdate.setCorruptIndexHandler(trackingCorruptIndexHandler);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneTestRepositoryBuilder.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneTestRepositoryBuilder.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.InitialContentHelper;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.TestRepository;
 import org.apache.jackrabbit.oak.plugins.index.TestRepositoryBuilder;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
@@ -33,15 +34,13 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 
 public class LuceneTestRepositoryBuilder extends TestRepositoryBuilder {
 
-    private ResultCountingIndexProvider resultCountingIndexProvider;
-    private TestUtil.OptionalEditorProvider optionalEditorProvider;
+    private final ResultCountingIndexProvider resultCountingIndexProvider;
+    private final TestUtil.OptionalEditorProvider optionalEditorProvider;
 
     public LuceneTestRepositoryBuilder(ExecutorService executorService, TemporaryFolder temporaryFolder) {
         IndexCopier copier = null;
@@ -52,10 +51,10 @@ public class LuceneTestRepositoryBuilder extends TestRepositoryBuilder {
         }
         this.editorProvider = new LuceneIndexEditorProvider(copier, new ExtractedTextCache(10 * FileUtils.ONE_MB, 100));
         this.indexProvider = new LuceneIndexProvider(copier);
-        this.asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, compose(List.of(
+        this.asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 editorProvider,
                 new NodeCounterEditorProvider()
-        )));
+        ));
 
         resultCountingIndexProvider = new ResultCountingIndexProvider(indexProvider);
         queryEngineSettings = new QueryEngineSettings();

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersion.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/indexversion/PurgeOldIndexVersion.java
@@ -18,21 +18,11 @@
  */
 package org.apache.jackrabbit.oak.indexversion;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.jackrabbit.guava.common.io.Closer;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
-import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexName;
 import org.apache.jackrabbit.oak.plugins.index.IndexPathService;
 import org.apache.jackrabbit.oak.plugins.index.IndexPathServiceImpl;
@@ -48,6 +38,15 @@ import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.ORIGINAL_TYPE_PROPERTY_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.TYPE_DISABLED;
@@ -227,9 +226,9 @@ public abstract class PurgeOldIndexVersion implements Closeable {
             NodeBuilder nodeBuilder = PurgeOldVersionUtils.getNode(rootBuilder, nodeName);
             if (nodeBuilder.exists()) {
                 String type = nodeBuilder.getProperty(TYPE_PROPERTY_NAME).getValue(Type.STRING);
-                List<IndexEditorProvider> indexEditorProviders = List.of(
-                        new ReferenceEditorProvider(), new PropertyIndexEditorProvider(), new NodeCounterEditorProvider());
-                EditorHook hook = new EditorHook(new IndexUpdateProvider(CompositeIndexEditorProvider.compose(indexEditorProviders)));
+                EditorHook hook = new EditorHook(new IndexUpdateProvider(
+                        CompositeIndexEditorProvider.compose(new ReferenceEditorProvider(), new PropertyIndexEditorProvider(), new NodeCounterEditorProvider())
+                ));
                 if (toDeleteIndexNameObject.getOperation() == IndexVersionOperation.Operation.DELETE_HIDDEN_AND_DISABLE) {
                     LOG.info("Disabling {}", nodeName);
                     nodeBuilder.setProperty(TYPE_PROPERTY_NAME, TYPE_DISABLED, Type.STRING);

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticOutOfBandIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticOutOfBandIndexer.java
@@ -28,8 +28,6 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorP
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 
-import java.util.Collections;
-
 /*
 Out of band indexer for Elasticsearch. Provides support to index segment store for  given index definitions or reindex existing indexes
  */
@@ -57,7 +55,7 @@ public class ElasticOutOfBandIndexer extends OutOfBandIndexerBase {
     @Override
     protected IndexEditorProvider createIndexEditorProvider() {
         IndexEditorProvider elastic = createElasticEditorProvider();
-        return CompositeIndexEditorProvider.compose(Collections.singletonList(elastic));
+        return CompositeIndexEditorProvider.compose(elastic);
     }
 
     private IndexEditorProvider createElasticEditorProvider() {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/OutOfBandIndexer.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/OutOfBandIndexer.java
@@ -20,7 +20,6 @@ package org.apache.jackrabbit.oak.index;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
@@ -45,7 +44,7 @@ public class OutOfBandIndexer extends OutOfBandIndexerBase {
         LuceneIndexEditorProvider lucene = createLuceneEditorProvider();
         SegmentPropertyIndexEditorProvider property = createPropertyEditorProvider();
 
-        return CompositeIndexEditorProvider.compose(List.of(lucene, property));
+        return CompositeIndexEditorProvider.compose(lucene, property);
     }
 
     private SegmentPropertyIndexEditorProvider createPropertyEditorProvider() throws IOException {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/index/async/AsyncIndexerLucene.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/index/async/AsyncIndexerLucene.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 
@@ -47,8 +46,7 @@ public class AsyncIndexerLucene extends AsyncIndexerBase {
     @Override
     public IndexEditorProvider getIndexEditorProvider() {
         try {
-            return CompositeIndexEditorProvider
-                    .compose(Arrays.asList(createLuceneEditorProvider(), new NodeCounterEditorProvider()));
+            return CompositeIndexEditorProvider.compose(createLuceneEditorProvider(), new NodeCounterEditorProvider());
         } catch (IOException e) {
             log.error("Exception while initializing IndexEditorProvider", e);
             return null;

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -25,6 +25,7 @@ import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.TestUtil;
 import org.apache.jackrabbit.oak.plugins.index.TrackingCorruptIndexHandler;
@@ -54,7 +55,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 import static org.apache.jackrabbit.oak.plugins.index.IndexConstants.INDEX_DEFINITIONS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition.BULK_FLUSH_INTERVAL_MS_DEFAULT;
 import static org.junit.Assert.assertEquals;
@@ -148,10 +148,10 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
 
         nodeStore = getNodeStore();
 
-        asyncIndexUpdate = getAsyncIndexUpdate("async", nodeStore, compose(List.of(
+        asyncIndexUpdate = getAsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 editorProvider,
                 new NodeCounterEditorProvider()
-        )));
+        ));
 
         TrackingCorruptIndexHandler trackingCorruptIndexHandler = new TrackingCorruptIndexHandler();
         trackingCorruptIndexHandler.setCorruptInterval(INDEX_CORRUPT_INTERVAL_IN_MILLIS, TimeUnit.MILLISECONDS);

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestRepositoryBuilder.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticTestRepositoryBuilder.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.InitialContentHelper;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
+import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.TestRepository;
 import org.apache.jackrabbit.oak.plugins.index.TestRepositoryBuilder;
@@ -34,9 +35,6 @@ import org.apache.jackrabbit.oak.query.QueryEngineSettings;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 
-import java.util.List;
-
-import static org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider.compose;
 
 public class ElasticTestRepositoryBuilder extends TestRepositoryBuilder {
 
@@ -50,10 +48,10 @@ public class ElasticTestRepositoryBuilder extends TestRepositoryBuilder {
         this.indexTracker = new ElasticIndexTracker(esConnection, new ElasticMetricHandler(StatisticsProvider.NOOP));
         this.editorProvider = getIndexEditorProvider();
         this.indexProvider = new ElasticIndexProvider(indexTracker);
-        this.asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, compose(List.of(
+        this.asyncIndexUpdate = new AsyncIndexUpdate("async", nodeStore, CompositeIndexEditorProvider.compose(
                 editorProvider,
                 new NodeCounterEditorProvider()
-        )));
+        ));
         queryEngineSettings = new QueryEngineSettings();
         asyncIndexUpdate.setCorruptIndexHandler(trackingCorruptIndexHandler);
     }

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/commit/CompositeEditor.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/commit/CompositeEditor.java
@@ -16,8 +16,6 @@
  */
 package org.apache.jackrabbit.oak.spi.commit;
 
-import static java.util.Objects.requireNonNull;
-
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -25,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -33,13 +30,8 @@ import java.util.List;
  */
 public class CompositeEditor implements Editor {
 
-    public static Editor compose(@NotNull Collection<? extends Editor> editors) {
-        return compose(new ArrayList<>(editors));
-    }
-
     @Nullable
     public static Editor compose(@NotNull List<? extends Editor> editors) {
-        requireNonNull(editors);
         switch (editors.size()) {
             case 0:
                 return null;
@@ -79,24 +71,27 @@ public class CompositeEditor implements Editor {
     @Override
     public void propertyAdded(PropertyState after)
             throws CommitFailedException {
-        for (Editor editor : editors) {
-            editor.propertyAdded(after);
+        // Performance critical code, avoid creating an iterator object
+        for (int i = 0; i < editors.size(); i++) {
+            editors.get(i).propertyAdded(after);
         }
     }
 
     @Override
     public void propertyChanged(PropertyState before, PropertyState after)
             throws CommitFailedException {
-        for (Editor editor : editors) {
-            editor.propertyChanged(before, after);
+        // Performance critical code, avoid creating an iterator object
+        for (int i = 0; i < editors.size(); i++) {
+            editors.get(i).propertyChanged(before, after);
         }
     }
 
     @Override
     public void propertyDeleted(PropertyState before)
             throws CommitFailedException {
-        for (Editor editor : editors) {
-            editor.propertyDeleted(before);
+        // Performance critical code, avoid creating an iterator object
+        for (int i = 0; i < editors.size(); i++) {
+            editors.get(i).propertyDeleted(before);
         }
     }
 
@@ -104,8 +99,9 @@ public class CompositeEditor implements Editor {
     public Editor childNodeAdded(String name, NodeState after)
             throws CommitFailedException {
         List<Editor> list = new ArrayList<>(editors.size());
-        for (Editor editor : editors) {
-            Editor child = editor.childNodeAdded(name, after);
+        // Performance critical code, avoid creating an iterator object
+        for (int i = 0; i < editors.size(); i++) {
+            Editor child = editors.get(i).childNodeAdded(name, after);
             if (child != null) {
                 list.add(child);
             }
@@ -114,12 +110,12 @@ public class CompositeEditor implements Editor {
     }
 
     @Override
-    public Editor childNodeChanged(
-            String name, NodeState before, NodeState after)
+    public Editor childNodeChanged(String name, NodeState before, NodeState after)
             throws CommitFailedException {
         List<Editor> list = new ArrayList<>(editors.size());
-        for (Editor editor : editors) {
-            Editor child = editor.childNodeChanged(name, before, after);
+        // Performance critical code, avoid creating an iterator object
+        for (int i = 0; i < editors.size(); i++) {
+            Editor child = editors.get(i).childNodeChanged(name, before, after);
             if (child != null) {
                 list.add(child);
             }
@@ -131,8 +127,9 @@ public class CompositeEditor implements Editor {
     public Editor childNodeDeleted(String name, NodeState before)
             throws CommitFailedException {
         List<Editor> list = new ArrayList<>(editors.size());
-        for (Editor editor : editors) {
-            Editor child = editor.childNodeDeleted(name, before);
+        // Performance critical code, avoid creating an iterator object
+        for (int i = 0; i < editors.size(); i++) {
+            Editor child = editors.get(i).childNodeDeleted(name, before);
             if (child != null) {
                 list.add(child);
             }


### PR DESCRIPTION
Add a var-args constructor to CompositeIndexEditorProvider to simplify calling this method.

Use an indexed for loop in CompositeEditor to avoid creating iterator object. This method is performance critical for indexing.