### PR TITLE
OAK-11542 : replaced Guava's Iterables.elementsEqual with oak-commons…

### DIFF
--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContextTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/DynamicSyncContextTest.java
@@ -674,7 +674,7 @@ public class DynamicSyncContextTest extends AbstractDynamicTest {
         
         ExternalUser second = idp.getUser(ID_SECOND_USER);
         testuser.withGroups(second.getExternalId());
-        assertFalse(Iterables.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
+        assertFalse(IterableUtils.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
 
         sync(testuser, SyncResult.Status.ADD);
 
@@ -696,7 +696,7 @@ public class DynamicSyncContextTest extends AbstractDynamicTest {
         // in contrast to 'testSyncMembershipWithUserRef' the conflicting group-ref refers to a user in the repository
         // and the conflict is spotted as the existing synched identity is not a group.
         testuser.withGroups(previouslySyncedUser.getExternalId());
-        assertFalse(Iterables.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
+        assertFalse(IterableUtils.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
 
         sync(testuser, SyncResult.Status.ADD);
 

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/PrincipalResolutionTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/PrincipalResolutionTest.java
@@ -22,6 +22,7 @@ import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentity;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentityException;
@@ -131,7 +132,7 @@ public class PrincipalResolutionTest extends DynamicSyncContextTest {
         
         ExternalUser second = idp.getUser(ID_SECOND_USER);
         testuser.withGroups(second.getExternalId());
-        assertFalse(Iterables.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
+        assertFalse(IterableUtils.elementsEqual(groupRefs, testuser.getDeclaredGroups()));
 
         sync(testuser, SyncResult.Status.ADD);
 

--- a/oak-authorization-principalbased/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/principalbased/impl/PermissionProviderVersionStoreTest.java
+++ b/oak-authorization-principalbased/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/principalbased/impl/PermissionProviderVersionStoreTest.java
@@ -21,6 +21,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.plugins.tree.TreeLocation;
 import org.apache.jackrabbit.oak.plugins.tree.TreeType;
@@ -189,7 +190,7 @@ public class PermissionProviderVersionStoreTest extends AbstractPrincipalBasedTe
 
         grantReadOnVersionStoreTrees();
 
-        assertTrue(Iterables.elementsEqual(Set.of(PrivilegeConstants.JCR_READ), permissionProvider.getPrivileges(versionStore)));
+        assertTrue(IterableUtils.elementsEqual(Set.of(PrivilegeConstants.JCR_READ), permissionProvider.getPrivileges(versionStore)));
     }
 
     @Test

--- a/oak-authorization-principalbased/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/principalbased/impl/RepositoryPermissionTest.java
+++ b/oak-authorization-principalbased/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/principalbased/impl/RepositoryPermissionTest.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.spi.security.authorization.principalbased.impl;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.spi.security.authorization.permission.Permissions;
 import org.apache.jackrabbit.oak.spi.security.authorization.permission.RepositoryPermission;
@@ -129,7 +130,7 @@ public class RepositoryPermissionTest extends AbstractPrincipalBasedTest {
         permissionProvider.refresh();
 
         Set<String> privNames = permissionProvider.getPrivileges(null);
-        assertTrue(Iterables.elementsEqual(Set.of(JCR_WORKSPACE_MANAGEMENT), privNames));
+        assertTrue(IterableUtils.elementsEqual(Set.of(JCR_WORKSPACE_MANAGEMENT), privNames));
     }
 
     @Test

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/nodetype/TypeEditor.java
@@ -49,6 +49,7 @@ import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.commons.collections.ListUtils;
 import org.apache.jackrabbit.oak.commons.collections.StreamUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
@@ -451,7 +452,7 @@ public class TypeEditor extends DefaultEditor {
         } else if (pre.isEmpty() || post.isEmpty()) {
             return true;
         } else {
-            return !Iterables.elementsEqual(pre, post);
+            return !IterableUtils.elementsEqual(pre, post);
         }
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/ChildOrderDiff.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authorization/permission/ChildOrderDiff.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
 import org.apache.jackrabbit.oak.plugins.tree.TreeConstants;
 import org.jetbrains.annotations.NotNull;
@@ -54,6 +55,6 @@ final class ChildOrderDiff {
         beforeNames.retainAll(afterNames);
 
         // names got reordered if the elements in the 2 intersections aren't equal
-        return !Iterables.elementsEqual(afterNames, beforeNames);
+        return !IterableUtils.elementsEqual(afterNames, beforeNames);
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/core/SecureNodeBuilderTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/core/SecureNodeBuilderTest.java
@@ -346,7 +346,7 @@ public class SecureNodeBuilderTest {
     public void testGetNamesTypeNames() {
         Iterable<String> names = List.of("a", "b");
         secureNodeBuilder.setProperty("names", names, Type.NAMES);
-        assertTrue(Iterables.elementsEqual(names, secureNodeBuilder.getNames("names")));
+        assertTrue(IterableUtils.elementsEqual(names, secureNodeBuilder.getNames("names")));
     }
 
     @Test

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/impl/TreeUtilTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/tree/impl/TreeUtilTest.java
@@ -158,7 +158,7 @@ public class TreeUtilTest extends AbstractSecurityTest {
         Iterable<String> expected = TreeUtil.getMixinTypeNames(root.getTree(path));
         assertTrue(IterableUtils.contains(expected, "mix:title"));
 
-        assertTrue(Iterables.elementsEqual(expected, TreeUtil.getMixinTypeNames(testTree, new LazyValue<Tree>() {
+        assertTrue(IterableUtils.elementsEqual(expected, TreeUtil.getMixinTypeNames(testTree, new LazyValue<Tree>() {
             @Override
             protected Tree createValue() {
                 return testTree;
@@ -179,7 +179,7 @@ public class TreeUtilTest extends AbstractSecurityTest {
         try (ContentSession cs = login(new GuestCredentials())) {
             Root guestRoot = cs.getLatestRoot();
             assertTrue(IterableUtils.isEmpty(TreeUtil.getMixinTypeNames(guestRoot.getTree(path))));
-            assertTrue(Iterables.elementsEqual(expected, TreeUtil.getMixinTypeNames(guestRoot.getTree(path), new LazyValue<Tree>() {
+            assertTrue(IterableUtils.elementsEqual(expected, TreeUtil.getMixinTypeNames(guestRoot.getTree(path), new LazyValue<Tree>() {
                 @Override
                 protected Tree createValue() {
                     return testTree;

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/AuthorizationConfigurationImplOSGiTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/AuthorizationConfigurationImplOSGiTest.java
@@ -102,13 +102,13 @@ public class AuthorizationConfigurationImplOSGiTest extends AbstractSecurityTest
     @Test
     public void testGetCommitHooks() {
         List<Class> expected = List.of(VersionablePathHook.class, PermissionHook.class);
-        assertTrue(Iterables.elementsEqual(expected, IterableUtils.transform(authorizationConfiguration.getCommitHooks(adminSession.getWorkspaceName()), commitHook -> commitHook.getClass())));
+        assertTrue(IterableUtils.elementsEqual(expected, IterableUtils.transform(authorizationConfiguration.getCommitHooks(adminSession.getWorkspaceName()), commitHook -> commitHook.getClass())));
     }
 
     @Test
     public void testGetValidators() {
         List<Class> expected = List.of(PermissionStoreValidatorProvider.class, PermissionValidatorProvider.class, AccessControlValidatorProvider.class);
-        assertTrue(Iterables.elementsEqual(expected, IterableUtils.transform(authorizationConfiguration.getValidators(adminSession.getWorkspaceName(), Set.of(), new MoveTracker()), commitHook -> commitHook.getClass())));
+        assertTrue(IterableUtils.elementsEqual(expected, IterableUtils.transform(authorizationConfiguration.getValidators(adminSession.getWorkspaceName(), Set.of(), new MoveTracker()), commitHook -> commitHook.getClass())));
     }
 
     @Test

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/RemappedPrivilegeNamesTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/accesscontrol/RemappedPrivilegeNamesTest.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.security.authorization.accesscontrol;
 
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.namepath.impl.LocalNameMapper;
 import org.apache.jackrabbit.oak.namepath.impl.NamePathMapperImpl;
@@ -89,6 +90,6 @@ public class RemappedPrivilegeNamesTest extends AbstractAccessControlTest {
         getAccessControlManager(root).setPolicy(acl.getPath(), acl);
         Tree aceTree = root.getTree(acl.getPath()).getChild(REP_POLICY).getChildren().iterator().next();
         Iterable<String> privNames = TreeUtil.getNames(aceTree, PrivilegeConstants.REP_PRIVILEGES);
-        assertTrue(Iterables.elementsEqual(List.of(PrivilegeConstants.JCR_READ), privNames));
+        assertTrue(IterableUtils.elementsEqual(List.of(PrivilegeConstants.JCR_READ), privNames));
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/AbstractQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/AbstractQueryTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractQueryTest extends AbstractOakCoreTest {
         Result result = getTestRoot().getQueryEngine().executeQuery(getStatement(), Query.JCR_SQL2, Collections.emptyMap(), Collections.emptyMap());
 
         Iterable<String> expected = Set.of(node.getPath());
-        assertTrue(Iterables.elementsEqual(expected, IterableUtils.transform(result.getRows(), ResultRow::getPath)));
+        assertTrue(IterableUtils.elementsEqual(expected, IterableUtils.transform(result.getRows(), ResultRow::getPath)));
     }
 
     @Test
@@ -125,7 +125,7 @@ public abstract class AbstractQueryTest extends AbstractOakCoreTest {
         Result result = getTestRoot().getQueryEngine().executeQuery(getStatement(), Query.JCR_SQL2, Collections.emptyMap(), Collections.emptyMap());
 
         Iterable<String> expected = Set.of(node.getPath());
-        assertTrue(Iterables.elementsEqual(expected, IterableUtils.transform(result.getRows(), row -> row.getPath())));
+        assertTrue(IterableUtils.elementsEqual(expected, IterableUtils.transform(result.getRows(), row -> row.getPath())));
     }
 
     @Test
@@ -142,7 +142,7 @@ public abstract class AbstractQueryTest extends AbstractOakCoreTest {
         Result result = getTestRoot().getQueryEngine().executeQuery(getStatement(), Query.JCR_SQL2, Collections.emptyMap(), Collections.emptyMap());
 
         Iterable<String> expected = Set.of(node.getPath());
-        assertTrue(Iterables.elementsEqual(expected, IterableUtils.transform(result.getRows(), row -> row.getPath())));
+        assertTrue(IterableUtils.elementsEqual(expected, IterableUtils.transform(result.getRows(), row -> row.getPath())));
     }
 
     private void assertAccess(@NotNull String nodePath, @NotNull String subnodePath, boolean canReadPrimaryType) throws Exception {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/ChildOrderPropertyTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authorization/evaluation/ChildOrderPropertyTest.java
@@ -100,6 +100,6 @@ public class ChildOrderPropertyTest extends AbstractOakCoreTest {
 
         List<String> expected = List.of("/a/bb", "/a/b");
         Iterable<String> childPaths = IterableUtils.transform(aTree.getChildren(), input -> input.getPath());
-        assertTrue(childPaths.toString(), Iterables.elementsEqual(expected, childPaths));
+        assertTrue(childPaths.toString(), IterableUtils.elementsEqual(expected, childPaths));
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/internal/SecurityProviderRegistrationTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/internal/SecurityProviderRegistrationTest.java
@@ -887,7 +887,7 @@ public class SecurityProviderRegistrationTest extends AbstractSecurityTest {
         SortedMap m = (SortedMap) f.get(registration);
         assertEquals(3, m.size());
         Collection c = m.values();
-        assertTrue(Iterables.elementsEqual(List.of(service2, service3, service1), c));
+        assertTrue(IterableUtils.elementsEqual(List.of(service2, service3, service1), c));
     }
 
     @Test

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/AddMembersByIdBestEffortTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/AddMembersByIdBestEffortTest.java
@@ -28,6 +28,7 @@ import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.principal.EveryonePrincipal;
 import org.apache.jackrabbit.oak.spi.security.user.UserConfiguration;
@@ -110,7 +111,7 @@ public class AddMembersByIdBestEffortTest extends AbstractAddMembersByIdTest {
         assertTrue(failed.isEmpty());
 
         Iterable<String> memberIds = getMemberIds(testGroup);
-        Iterables.elementsEqual(Arrays.asList(NON_EXISTING_IDS), memberIds);
+        IterableUtils.elementsEqual(Arrays.asList(NON_EXISTING_IDS), memberIds);
 
         Iterator<Authorizable> members = testGroup.getDeclaredMembers();
         assertFalse(members.hasNext());

--- a/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/plugins/tree/TreeUtilTest.java
+++ b/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/plugins/tree/TreeUtilTest.java
@@ -144,13 +144,13 @@ public class TreeUtilTest extends AbstractTreeTest {
 
     @Test
     public void testGetMixinTypes() {
-        assertTrue(Iterables.elementsEqual(TreeUtil.getNames(child, JcrConstants.JCR_MIXINTYPES), TreeUtil.getMixinTypeNames(child)));
-        assertTrue(Iterables.elementsEqual(TreeUtil.getNames(rootTree, JcrConstants.JCR_MIXINTYPES), TreeUtil.getMixinTypeNames(rootTree)));
+        assertTrue(IterableUtils.elementsEqual(TreeUtil.getNames(child, JcrConstants.JCR_MIXINTYPES), TreeUtil.getMixinTypeNames(child)));
+        assertTrue(IterableUtils.elementsEqual(TreeUtil.getNames(rootTree, JcrConstants.JCR_MIXINTYPES), TreeUtil.getMixinTypeNames(rootTree)));
     }
 
     @Test
     public void testGetMixinTypeNamesUnusedLazy() {
-        assertTrue(Iterables.elementsEqual(
+        assertTrue(IterableUtils.elementsEqual(
                 TreeUtil.getNames(child, JcrConstants.JCR_MIXINTYPES),
                 TreeUtil.getMixinTypeNames(child, mock(LazyValue.class))));
     }
@@ -168,7 +168,7 @@ public class TreeUtilTest extends AbstractTreeTest {
 
     @Test
     public void testGetMixinTypeNamesFromLazy() {
-        assertTrue(Iterables.elementsEqual(TreeUtil.getNames(child, JcrConstants.JCR_MIXINTYPES), TreeUtil.getMixinTypeNames(rootTree.getChild("x"), new LazyValue<Tree>() {
+        assertTrue(IterableUtils.elementsEqual(TreeUtil.getNames(child, JcrConstants.JCR_MIXINTYPES), TreeUtil.getMixinTypeNames(rootTree.getChild("x"), new LazyValue<Tree>() {
             @Override
             protected Tree createValue() {
                 return child;

--- a/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/accesscontrol/ACETest.java
+++ b/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/accesscontrol/ACETest.java
@@ -21,6 +21,7 @@ import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.authorization.PrivilegeCollection;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.apache.jackrabbit.oak.plugins.value.jcr.ValueFactoryImpl;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.Restriction;
@@ -222,7 +223,7 @@ public class ACETest extends AbstractAccessControlTest {
         ACE ace = mockACE(testPrincipal, PrivilegeBits.BUILT_IN.get(JCR_READ), true, restrictions);
         assertFalse(ace.getRestrictions().isEmpty());
         assertNotSame(restrictions, ace.getRestrictions());
-        assertTrue(Iterables.elementsEqual(restrictions, ace.getRestrictions()));
+        assertTrue(IterableUtils.elementsEqual(restrictions, ace.getRestrictions()));
     }
 
     @Test

--- a/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/accesscontrol/ImmutableACLTest.java
+++ b/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/authorization/accesscontrol/ImmutableACLTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeBits;
@@ -235,7 +236,7 @@ public class ImmutableACLTest extends AbstractAccessControlListTest {
         ImmutableACL iacl = new ImmutableACL(aacl);
         assertImmutable(iacl);
 
-        assertTrue(Iterables.elementsEqual(entries, iacl.getEntries()));
+        assertTrue(IterableUtils.elementsEqual(entries, iacl.getEntries()));
         assertSame(aacl.getRestrictionProvider(), iacl.getRestrictionProvider());
         assertSame(aacl.getNamePathMapper(), iacl.getNamePathMapper());
 

--- a/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/privilege/PrivilegeBitsProviderTest.java
+++ b/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/privilege/PrivilegeBitsProviderTest.java
@@ -464,7 +464,7 @@ public class PrivilegeBitsProviderTest implements PrivilegeConstants {
         when(privTree.getChild(KNOWN_PRIV_NAME)).thenReturn(pTree);
 
         Iterable<String> result = bitsProvider.getAggregatedPrivilegeNames(KNOWN_PRIV_NAME);
-        assertTrue(Iterables.elementsEqual(List.of(KNOWN_PRIV_NAME), result));
+        assertTrue(IterableUtils.elementsEqual(List.of(KNOWN_PRIV_NAME), result));
     }
 
     @Test

--- a/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/privilege/PrivilegeUtilTest.java
+++ b/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/privilege/PrivilegeUtilTest.java
@@ -20,6 +20,7 @@ import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
 import org.apache.jackrabbit.oak.plugins.memory.PropertyStates;
 import org.jetbrains.annotations.NotNull;
@@ -75,7 +76,7 @@ public class PrivilegeUtilTest {
 
         PrivilegeDefinition def = PrivilegeUtil.readDefinition(defTree);
         assertEquals("name", def.getName());
-        assertTrue(Iterables.elementsEqual(aggregateNames, PrivilegeUtil.readDefinition(defTree).getDeclaredAggregateNames()));
+        assertTrue(IterableUtils.elementsEqual(aggregateNames, PrivilegeUtil.readDefinition(defTree).getDeclaredAggregateNames()));
     }
     
     @Test

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/MutableSegmentReferencesTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/MutableSegmentReferencesTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.jackrabbit.oak.segment;
 
-import static org.apache.jackrabbit.guava.common.collect.Iterables.elementsEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.segment.memory.MemoryStore;
 import org.junit.Test;
 
@@ -103,7 +103,7 @@ public class MutableSegmentReferencesTest {
         MutableSegmentReferences table = new MutableSegmentReferences();
         table.addOrReference(first);
         table.addOrReference(second);
-        assertTrue(elementsEqual(ids, table));
+        assertTrue(IterableUtils.elementsEqual(ids, table));
     }
 
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/standby/codec/ResponseDecoderTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/standby/codec/ResponseDecoderTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.segment.standby.codec;
 
-import static org.apache.jackrabbit.guava.common.collect.Iterables.elementsEqual;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.jackrabbit.oak.segment.standby.StandbyTestUtils.createBlobChunkBuffer;
@@ -37,6 +36,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.commons.io.IOUtils;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -175,7 +175,7 @@ public class ResponseDecoderTest {
         channel.writeInbound(buf);
         GetReferencesResponse response = (GetReferencesResponse) channel.readInbound();
         assertEquals("a", response.getSegmentId());
-        assertTrue(elementsEqual(asList("b", "c"), response.getReferences()));
+        assertTrue(IterableUtils.elementsEqual(asList("b", "c"), response.getReferences()));
     }
 
     @Test
@@ -205,7 +205,7 @@ public class ResponseDecoderTest {
         channel.writeInbound(buf);
         GetReferencesResponse response = (GetReferencesResponse) channel.readInbound();
         assertEquals("a", response.getSegmentId());
-        assertTrue(elementsEqual(List.of("b"), response.getReferences()));
+        assertTrue(IterableUtils.elementsEqual(List.of("b"), response.getReferences()));
     }
 
     @Test
@@ -221,7 +221,7 @@ public class ResponseDecoderTest {
         channel.writeInbound(buf);
         GetReferencesResponse response = (GetReferencesResponse) channel.readInbound();
         assertEquals("a", response.getSegmentId());
-        assertTrue(elementsEqual(emptyList(), response.getReferences()));
+        assertTrue(IterableUtils.elementsEqual(emptyList(), response.getReferences()));
     }
 
     @Test

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/JournalEntry.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
 import org.apache.jackrabbit.guava.common.collect.Iterables;
 
 import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.commons.json.JsopBuilder;
 import org.apache.jackrabbit.oak.commons.json.JsopReader;
 import org.apache.jackrabbit.oak.commons.json.JsopTokenizer;
@@ -213,7 +214,7 @@ public final class JournalEntry extends Document {
         Path p = node.getPath();
         int depthDiff = p.getDepth() - path.getDepth();
         return depthDiff >= 0
-                && Iterables.elementsEqual(path.elements(), p.getAncestor(depthDiff).elements());
+                && IterableUtils.elementsEqual(path.elements(), p.getAncestor(depthDiff).elements());
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Path.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Path.java
@@ -24,12 +24,12 @@ import java.util.Objects;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.StringUtils;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.jackrabbit.oak.commons.conditions.Validate.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static org.apache.jackrabbit.guava.common.collect.Iterables.elementsEqual;
 
 /**
  * The {@code Path} class is closely modeled after the semantics of
@@ -188,7 +188,7 @@ public final class Path implements CacheValue, Comparable<Path> {
         requireNonNull(other);
         int depthDiff = other.getDepth() - getDepth();
         return depthDiff > 0
-                && elementsEqual(elements(true), other.getAncestor(depthDiff).elements(true));
+                && IterableUtils.elementsEqual(elements(true), other.getAncestor(depthDiff).elements(true));
     }
 
     /**

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractPropertyState.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractPropertyState.java
@@ -27,6 +27,7 @@ import org.apache.jackrabbit.guava.common.collect.Iterables;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.plugins.value.BinaryBasedBlob;
 import org.apache.jackrabbit.oak.plugins.value.OakValue;
 
@@ -53,7 +54,7 @@ public abstract class AbstractPropertyState implements PropertyState {
             Type<?> type = a.getType();
             if (a.isArray()) {
                 return a.count() == b.count()
-                        && Iterables.elementsEqual(
+                        && IterableUtils.elementsEqual(
                                 (Iterable<?>) a.getValue(type),
                                 (Iterable<?>) b.getValue(type));
             } else {


### PR DESCRIPTION
… util