### PR TITLE
OAK-11541: Reduce logQueryExplain to only happen if Trace logs are enabled

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -197,10 +197,9 @@ public class MongoVersionGCSupport extends VersionGCSupport {
     }
 
     /**
-     * Logs an explain of a mongo query. If log level is INFO it does it one-lined,
-     * if log level is DEBUG it does it pretty print multi-lined.
+     * Logs an explain of a mongo query if trace is enabled
      *
-     * This is done once every 24h of livetime of this particular object.
+     * This is done once every 24h of lifetime of this particular object.
      *
      * @param logMsg the log message to use - should contain two "{}" for the hint
      *               and the explain json
@@ -209,24 +208,19 @@ public class MongoVersionGCSupport extends VersionGCSupport {
      * @param hint   the hint for the query, or null
      */
     private void logQueryExplain(String logMsg, @NotNull Bson query, Bson hint) {
-        final long timeSinceLastLog = System.currentTimeMillis() - lastExplainLogMs;
-        if (timeSinceLastLog < EXPLAIN_LOG_INTERVAL_MS) {
-            // then don't log
-            return;
+        if (LOG.isTraceEnabled()) {
+            final long timeSinceLastLog = System.currentTimeMillis() - lastExplainLogMs;
+            if (timeSinceLastLog < EXPLAIN_LOG_INTERVAL_MS) {
+                // then don't log
+                return;
+            }
+            final BasicDBObject explainResult = MongoUtils.explain(store.getDatabase(),
+                    getNodeCollection(), query, hint);
+            final BasicDBObject winningPlan = MongoUtils.getWinningPlan(explainResult);
+            final BasicDBObject result = winningPlan == null ? explainResult : winningPlan;
+            LOG.trace(logMsg, hint, result);
+            lastExplainLogMs = System.currentTimeMillis();
         }
-        final BasicDBObject explainResult = MongoUtils.explain(store.getDatabase(),
-                getNodeCollection(), query, hint);
-        final BasicDBObject winningPlan = MongoUtils.getWinningPlan(explainResult);
-        final BasicDBObject result = winningPlan == null ? explainResult : winningPlan;
-        if (LOG.isDebugEnabled()) {
-            // if log level is DEBUG, let's do a pretty print
-            String prettyPrinted = JsopBuilder.prettyPrint(result.toJson());
-            LOG.debug(logMsg, hint, prettyPrinted);
-        } else {
-            // otherwise let's just do a compact print
-            LOG.info(logMsg, hint, result);
-        }
-        lastExplainLogMs = System.currentTimeMillis();
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoVersionGCSupport.java
@@ -208,19 +208,17 @@ public class MongoVersionGCSupport extends VersionGCSupport {
      * @param hint   the hint for the query, or null
      */
     private void logQueryExplain(String logMsg, @NotNull Bson query, Bson hint) {
-        if (LOG.isTraceEnabled()) {
-            final long timeSinceLastLog = System.currentTimeMillis() - lastExplainLogMs;
-            if (timeSinceLastLog < EXPLAIN_LOG_INTERVAL_MS) {
-                // then don't log
-                return;
-            }
-            final BasicDBObject explainResult = MongoUtils.explain(store.getDatabase(),
-                    getNodeCollection(), query, hint);
-            final BasicDBObject winningPlan = MongoUtils.getWinningPlan(explainResult);
-            final BasicDBObject result = winningPlan == null ? explainResult : winningPlan;
-            LOG.trace(logMsg, hint, result);
-            lastExplainLogMs = System.currentTimeMillis();
+        final long timeSinceLastLog = System.currentTimeMillis() - lastExplainLogMs;
+        if (timeSinceLastLog < EXPLAIN_LOG_INTERVAL_MS) {
+            // then don't log
+            return;
         }
+        final BasicDBObject explainResult = MongoUtils.explain(store.getDatabase(),
+                getNodeCollection(), query, hint);
+        final BasicDBObject winningPlan = MongoUtils.getWinningPlan(explainResult);
+        final BasicDBObject result = winningPlan == null ? explainResult : winningPlan;
+        LOG.trace(logMsg, hint, result);
+        lastExplainLogMs = System.currentTimeMillis();
     }
 
     /**
@@ -265,7 +263,10 @@ public class MongoVersionGCSupport extends VersionGCSupport {
         // first sort by _modified and then by _id
         final Bson sort = ascending(MODIFIED_IN_SECS, ID);
 
-        logQueryExplain("fullGC query explain details, hint : {} - explain : {}", query, modifiedIdHint);
+        if (LOG.isTraceEnabled()) {
+            logQueryExplain("fullGC query explain details, hint : {} - explain : {}", query, modifiedIdHint);
+        }
+
         if (LOG.isDebugEnabled()) {
             BsonDocument bson = query.toBsonDocument(BsonDocument.class, MongoClient.getDefaultCodecRegistry());
             LOG.debug("getModifiedDocs : query is {}", bson);


### PR DESCRIPTION
Apparently the query explain in Mongo can take `ages` to run. One of my local executions took more than 7 hours to run, on a database with a massive amount of documents.