### PR TITLE
OAK-11564 oak-run FullGC leaves background threads running

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
@@ -105,6 +105,20 @@ public class RevisionsCommand implements Command {
             "org.apache.jackrabbit.oak.plugins.document.VersionGCRecommendations"
     );
 
+    private final boolean exitWhenDone;
+
+    public RevisionsCommand() {
+        this(true);
+    }
+
+    /**
+     *
+     * @param exitWhenDone if true, the command will exit the JVM when done
+     */
+    public RevisionsCommand(boolean exitWhenDone) {
+        this.exitWhenDone = exitWhenDone;
+    }
+
     private static class RevisionsOptions extends Utils.NodeStoreOptions {
 
         static final String CMD_INFO = "info";
@@ -324,6 +338,10 @@ public class RevisionsCommand implements Command {
                 }
             } else {
                 System.err.println("unknown revisions command: " + subCmd);
+            }
+            if (exitWhenDone) {
+                System.out.printf("Command '%s' completed successfully.%n", subCmd);
+                System.exit(0);
             }
         } catch (Throwable e) {
             LOG.error("Command failed", e);

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
@@ -433,7 +433,7 @@ public class RevisionsCommandTest {
         @Override
         public void run() {
             try {
-                new RevisionsCommand().execute(args.toArray(new String[0]));
+                new RevisionsCommand(false).execute(args.toArray(new String[0]));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
command will exit jvm when command finishes and the shutdown hook will close gc resources