### PR TITLE
OAK-11570 oak-run fullGC fullGcMaxAge default value is wrongly calculated

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
@@ -207,8 +207,8 @@ public class RevisionsCommand implements Command {
                     .withRequiredArg().ofType(Integer.class).defaultsTo(10000);
             fullGcMaxAge = parser.accepts("fullGcMaxAge", "The maximum age of the document in seconds " +
                             "to be considered for Full GC i.e. Version Garbage Collector (Full GC) logic will only consider those " +
-                            "nodes for Full GC which are not accessed recently (currentTime - lastModifiedTime > fullGcMaxAge)")
-                    .withOptionalArg().ofType(Long.class).defaultsTo(TimeUnit.DAYS.toMillis(1));
+                            "nodes for Full GC which are not accessed recently (currentTime - lastModifiedTime > fullGcMaxAge). Default: 86400 (one day)")
+                    .withOptionalArg().ofType(Long.class).defaultsTo(TimeUnit.DAYS.toSeconds(1));
         }
 
         public RevisionsOptions parse(String[] args) {

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
@@ -191,18 +191,18 @@ public class RevisionsCommandTest {
         ns.dispose();
 
         String output = captureSystemOut(new RevisionsCmd("fullGC", "--entireRepo"));
-        assertTrue(output.contains("DryRun is enabled : true"));
-        assertTrue(output.contains("ResetFullGC is enabled : false"));
-        assertTrue(output.contains("Compaction is enabled : false"));
-        assertTrue(output.contains("starting gc collect"));
-        assertTrue(output.contains("IncludePaths are : [/]"));
-        assertTrue(output.contains("ExcludePaths are : []"));
-        assertTrue(output.contains("FullGcMode is : 0"));
-        assertTrue(output.contains("FullGcDelayFactory is : 2.0"));
-        assertTrue(output.contains("FullGcBatchSize is : 1000"));
-        assertTrue(output.contains("FullGcProgressSize is : 10000"));
+        assertTrue(output.contains("DryRun is enabled : true\n"));
+        assertTrue(output.contains("ResetFullGC is enabled : false\n"));
+        assertTrue(output.contains("Compaction is enabled : false\n"));
+        assertTrue(output.contains("starting gc collect\n"));
+        assertTrue(output.contains("IncludePaths are : [/]\n"));
+        assertTrue(output.contains("ExcludePaths are : []\n"));
+        assertTrue(output.contains("FullGcMode is : 0\n"));
+        assertTrue(output.contains("FullGcDelayFactory is : 2.0\n"));
+        assertTrue(output.contains("FullGcBatchSize is : 1000\n"));
+        assertTrue(output.contains("FullGcProgressSize is : 10000\n"));
         assertTrue(output.contains("FullGcMaxAgeInSecs is : 86400\n"));
-        assertTrue(output.contains("FullGcMaxAgeMillis is : 86400000"));
+        assertTrue(output.contains("FullGcMaxAgeMillis is : 86400000\n"));
     }
 
     @Test
@@ -210,8 +210,8 @@ public class RevisionsCommandTest {
         ns.dispose();
 
         String output = captureSystemOut(new RevisionsCmd("fullGC", "--fullGcMaxAge", "10000", "--entireRepo"));
-        assertTrue(output.contains("FullGcMaxAgeInSecs is : 10000"));
-        assertTrue(output.contains("FullGcMaxAgeMillis is : 10000000"));
+        assertTrue(output.contains("FullGcMaxAgeInSecs is : 10000\n"));
+        assertTrue(output.contains("FullGcMaxAgeMillis is : 10000000\n"));
         assertTrue(output.contains("starting gc collect"));
     }
 
@@ -220,7 +220,7 @@ public class RevisionsCommandTest {
         ns.dispose();
 
         String output = captureSystemOut(new RevisionsCmd("fullGC", "--fullGcDelayFactor", "2.5", "--entireRepo"));
-        assertTrue(output.contains("FullGcDelayFactory is : 2.5"));
+        assertTrue(output.contains("FullGcDelayFactory is : 2.5\n"));
         assertTrue(output.contains("starting gc collect"));
     }
 
@@ -229,7 +229,7 @@ public class RevisionsCommandTest {
         ns.dispose();
 
         String output = captureSystemOut(new RevisionsCmd("fullGC", "--fullGcBatchSize", "200", "--entireRepo"));
-        assertTrue(output.contains("FullGcBatchSize is : 200"));
+        assertTrue(output.contains("FullGcBatchSize is : 200\n"));
         assertTrue(output.contains("starting gc collect"));
     }
 
@@ -238,7 +238,7 @@ public class RevisionsCommandTest {
         ns.dispose();
 
         String output = captureSystemOut(new RevisionsCmd("fullGC", "--fullGcProgressSize", "20000", "--entireRepo"));
-        assertTrue(output.contains("FullGcProgressSize is : 20000"));
+        assertTrue(output.contains("FullGcProgressSize is : 20000\n"));
         assertTrue(output.contains("starting gc collect"));
     }
 

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
@@ -201,7 +201,7 @@ public class RevisionsCommandTest {
         assertTrue(output.contains("FullGcDelayFactory is : 2.0"));
         assertTrue(output.contains("FullGcBatchSize is : 1000"));
         assertTrue(output.contains("FullGcProgressSize is : 10000"));
-        assertTrue(output.contains("FullGcMaxAgeInSecs is : 86400"));
+        assertTrue(output.contains("FullGcMaxAgeInSecs is : 86400\n"));
         assertTrue(output.contains("FullGcMaxAgeMillis is : 86400000"));
     }
 


### PR DESCRIPTION
fixed conversion where default value is converted to millis not seconds