### PR TITLE
OAK-11608 Fix AzureConstants.java

### DIFF
--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobContainerProvider.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobContainerProvider.java
@@ -152,7 +152,7 @@ public class AzureBlobContainerProvider implements Closeable {
 
         public Builder initializeWithProperties(Properties properties) {
             withAzureConnectionString(properties.getProperty(AzureConstants.AZURE_CONNECTION_STRING, ""));
-            withAccountName(properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, ""));
+            withAccountName(properties.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, ""));
             withBlobEndpoint(properties.getProperty(AzureConstants.AZURE_BLOB_ENDPOINT, ""));
             withSasToken(properties.getProperty(AzureConstants.AZURE_SAS, ""));
             withAccountKey(properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, ""));

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -260,7 +260,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
     private void initAzureDSConfig() {
         AzureBlobContainerProvider.Builder builder = AzureBlobContainerProvider.Builder.builder(properties.getProperty(AzureConstants.AZURE_BLOB_CONTAINER_NAME))
                 .withAzureConnectionString(properties.getProperty(AzureConstants.AZURE_CONNECTION_STRING, ""))
-                .withAccountName(properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, ""))
+                .withAccountName(properties.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, ""))
                 .withBlobEndpoint(properties.getProperty(AzureConstants.AZURE_BLOB_ENDPOINT, ""))
                 .withSasToken(properties.getProperty(AzureConstants.AZURE_SAS, ""))
                 .withAccountKey(properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, ""))
@@ -1105,7 +1105,7 @@ public class AzureBlobStoreBackend extends AbstractSharedBackend {
     }
 
     private String getDefaultBlobStorageDomain() {
-        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, "");
+        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, "");
         if (StringUtils.isEmpty(accountName)) {
             LOG.warn("Can't generate presigned URI - Azure account name not found in properties");
             return null;

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureConstants.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureConstants.java
@@ -21,9 +21,14 @@ package org.apache.jackrabbit.oak.blob.cloud.azure.blobstorage;
 
 public final class AzureConstants {
     /**
+     * Azure storage access key
+     */
+    public static final String AZURE_STORAGE_ACCESS_KEY = "accessKey";
+
+    /**
      * Azure storage account name
      */
-    public static final String AZURE_STORAGE_ACCOUNT_NAME = "accessKey";
+    public static final String AZURE_STORAGE_ACCOUNT_NAME = "accountName";
 
     /**
      * Azure storage account key

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/Utils.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/Utils.java
@@ -127,7 +127,7 @@ public final class Utils {
         String sasUri = properties.getProperty(AzureConstants.AZURE_SAS, "");
         String blobEndpoint = properties.getProperty(AzureConstants.AZURE_BLOB_ENDPOINT, "");
         String connectionString = properties.getProperty(AzureConstants.AZURE_CONNECTION_STRING, "");
-        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, "");
+        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, "");
         String accountKey = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, "");
 
         if (!connectionString.isEmpty()) {

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
@@ -176,7 +176,7 @@ public class AzureBlobStoreBackendTest {
         final String clientSecret = getEnvironmentVariable(AZURE_CLIENT_SECRET);
 
         Properties properties = new Properties();
-        properties.setProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, accountName);
+        properties.setProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, accountName);
         properties.setProperty(AzureConstants.AZURE_TENANT_ID, tenantId);
         properties.setProperty(AzureConstants.AZURE_CLIENT_ID, clientId);
         properties.setProperty(AzureConstants.AZURE_CLIENT_SECRET, clientSecret);
@@ -221,7 +221,7 @@ public class AzureBlobStoreBackendTest {
     private static Properties getBasicConfiguration() {
         Properties properties = new Properties();
         properties.setProperty(AzureConstants.AZURE_BLOB_CONTAINER_NAME, CONTAINER_NAME);
-        properties.setProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, AzuriteDockerRule.ACCOUNT_NAME);
+        properties.setProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, AzuriteDockerRule.ACCOUNT_NAME);
         properties.setProperty(AzureConstants.AZURE_BLOB_ENDPOINT, azurite.getBlobEndpoint());
         properties.setProperty(AzureConstants.AZURE_CREATE_CONTAINER, "");
         return properties;

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataRecordAccessProviderCDNTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataRecordAccessProviderCDNTest.java
@@ -137,7 +137,7 @@ public class AzureDataRecordAccessProviderCDNTest extends AzureDataRecordAccessP
         assertNotEquals(DOWNLOAD_URI_DOMAIN, downloadUri.getHost());
 
         Properties properties = AzureDataStoreUtils.getDirectAccessDataStoreProperties();
-        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, null);
+        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, null);
         assertNotNull(accountName);
         assertEquals(String.format("%s.blob.core.windows.net", accountName), downloadUri.getHost());
     }
@@ -151,7 +151,7 @@ public class AzureDataRecordAccessProviderCDNTest extends AzureDataRecordAccessP
         assertTrue(upload.getUploadURIs().size() > 0);
 
         Properties properties = AzureDataStoreUtils.getDirectAccessDataStoreProperties();
-        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, null);
+        String accountName = properties.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY, null);
         assertNotNull(accountName);
         String defaultDomain = String.format("%s.blob.core.windows.net", accountName);
         for (URI uri : upload.getUploadURIs()) {

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataStoreUtils.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureDataStoreUtils.java
@@ -65,12 +65,12 @@ public class AzureDataStoreUtils extends DataStoreUtils {
     public static boolean isAzureConfigured() {
         Properties props = getAzureConfig();
         //need either access keys or sas or service principal
-        if (!props.containsKey(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY) || !props.containsKey(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME)
+        if (!props.containsKey(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY) || !props.containsKey(AzureConstants.AZURE_STORAGE_ACCESS_KEY)
                 || !(props.containsKey(AzureConstants.AZURE_BLOB_CONTAINER_NAME))) {
             if (!props.containsKey(AzureConstants.AZURE_SAS) || !props.containsKey(AzureConstants.AZURE_BLOB_ENDPOINT)
                     || !(props.containsKey(AzureConstants.AZURE_BLOB_CONTAINER_NAME))) {
                 // service principal
-                return props.containsKey(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME) && props.containsKey(AzureConstants.AZURE_TENANT_ID) &&
+                return props.containsKey(AzureConstants.AZURE_STORAGE_ACCESS_KEY) && props.containsKey(AzureConstants.AZURE_TENANT_ID) &&
                         props.containsKey(AzureConstants.AZURE_CLIENT_ID) && props.containsKey(AzureConstants.AZURE_CLIENT_SECRET) &&
                         props.containsKey(AzureConstants.AZURE_BLOB_CONTAINER_NAME);
             }

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/UtilsTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/UtilsTest.java
@@ -46,7 +46,7 @@ public class UtilsTest {
     public void testConnectionStringIsBasedOnSASWithoutEndpoint() {
         Properties properties = new Properties();
         properties.put(AzureConstants.AZURE_SAS, "sas");
-        properties.put(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, "account");
+        properties.put(AzureConstants.AZURE_STORAGE_ACCESS_KEY, "account");
         String connectionString = Utils.getConnectionStringFromProperties(properties);
         assertEquals(connectionString,
                 String.format("AccountName=%s;SharedAccessSignature=%s", "account", "sas"));
@@ -55,7 +55,7 @@ public class UtilsTest {
     @Test
     public void testConnectionStringIsBasedOnAccessKeyIfSASMissing() {
         Properties properties = new Properties();
-        properties.put(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, "accessKey");
+        properties.put(AzureConstants.AZURE_STORAGE_ACCESS_KEY, "accessKey");
         properties.put(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, "secretKey");
 
         String connectionString = Utils.getConnectionStringFromProperties(properties);
@@ -69,7 +69,7 @@ public class UtilsTest {
         properties.put(AzureConstants.AZURE_SAS, "sas");
         properties.put(AzureConstants.AZURE_BLOB_ENDPOINT, "endpoint");
 
-        properties.put(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, "accessKey");
+        properties.put(AzureConstants.AZURE_STORAGE_ACCESS_KEY, "accessKey");
         properties.put(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, "secretKey");
 
         String connectionString = Utils.getConnectionStringFromProperties(properties);

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/fixture/DataStoreUtils.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/fixture/DataStoreUtils.java
@@ -177,7 +177,7 @@ public class DataStoreUtils {
         final String clientId = (String) config.get(AzureConstants.AZURE_CLIENT_ID);
         final String clientSecret = (String) config.get(AzureConstants.AZURE_CLIENT_SECRET);
         final String tenantId = (String) config.get(AzureConstants.AZURE_TENANT_ID);
-        final String accountName = (String) config.get(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME);
+        final String accountName = (String) config.get(AzureConstants.AZURE_STORAGE_ACCESS_KEY);
         final String accountKey = (String) config.get(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY);
         final String blobEndpoint = (String) config.get(AzureConstants.AZURE_BLOB_ENDPOINT);
         final String sasToken = (String) config.get(AzureConstants.AZURE_SAS);

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/fixture/DataStoreUtilsTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/fixture/DataStoreUtilsTest.java
@@ -233,7 +233,7 @@ public class DataStoreUtilsTest {
                                         String tenantId) {
         Map<String, String> config = new HashMap<>();
         config.put(AzureConstants.AZURE_CONNECTION_STRING, connectionString);
-        config.put(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME, accountName);
+        config.put(AzureConstants.AZURE_STORAGE_ACCESS_KEY, accountName);
         config.put(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY, accessKey);
         config.put(AzureConstants.AZURE_BLOB_ENDPOINT, blobEndpoint);
         config.put(AzureConstants.AZURE_CLIENT_ID, clientId);

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/run/DataStoreCommandTest.java
@@ -1132,7 +1132,7 @@ public class DataStoreCommandTest {
 
             @Override public NodeStore init(DataStoreBlobStore blobStore, File storeFile) throws Exception {
                 Properties props = AzureDataStoreUtils.getAzureConfig();
-                String accessKey = props.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_NAME);
+                String accessKey = props.getProperty(AzureConstants.AZURE_STORAGE_ACCESS_KEY);
                 String secretKey = props.getProperty(AzureConstants.AZURE_STORAGE_ACCOUNT_KEY);
                 container = props.getProperty(AzureConstants.AZURE_BLOB_CONTAINER_NAME);
                 container = container + System.currentTimeMillis();


### PR DESCRIPTION
OAK-11608 Fix AzureConstants.java

Changes:
- Renamed AZURE_STORAGE_ACCOUNT_NAME to AZURE_STORAGE_ACCESS_KEY 
- Added AZURE_STORAGE_ACCOUNT_NAME