### PR TITLE
OAK-11627: Fix NPE on isInheritedMember

### DIFF
--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/AutoMembershipPrincipals.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/AutoMembershipPrincipals.java
@@ -137,7 +137,10 @@ final class AutoMembershipPrincipals {
         }
 
         // to test for inherited membership collect automembership-ids and loop auto-membership groups
-        Set<String> automembershipIds = new HashSet<>(Arrays.asList(autoMembershipMapping.get(idpName)));
+        Set<String> automembershipIds = new HashSet<>();
+        if (autoMembershipMapping.containsKey(idpName)) {
+            automembershipIds.addAll(Arrays.asList(autoMembershipMapping.get(idpName)));
+        }
         AutoMembershipConfig config = autoMembershipConfigMap.get(idpName);
         if (config != null) {
             automembershipIds.addAll(config.getAutoMembership(authorizable));

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/AutoMembershipPrincipalsTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/principal/AutoMembershipPrincipalsTest.java
@@ -53,6 +53,8 @@ import static org.mockito.Mockito.when;
 
 public class AutoMembershipPrincipalsTest extends AbstractAutoMembershipTest {
     
+    private static final String IDP_NOT_MAPPED = "idp4";
+    
     private AutoMembershipPrincipals amp;
     private final Authorizable authorizable = mock(Authorizable.class);
     
@@ -366,6 +368,12 @@ public class AutoMembershipPrincipalsTest extends AbstractAutoMembershipTest {
         Group nested = userManager.createGroup("nestedGroup");
         nested.addMember(testGroup);
         assertFalse(amp.isInheritedMember(IDP_VALID_AM, nested, authorizable));
+    }
+
+    @Test
+    public void testNotMappedIsNotInheritedMember() throws Exception {
+        Group testGroup = getTestGroup();
+        assertFalse(amp.isInheritedMember(IDP_NOT_MAPPED, testGroup, authorizable));
     }
     
     @Test


### PR DESCRIPTION
Adding a check to prevent NullPointerException when a given Identity Provider name that has no auto membership mappings 