### PR TITLE
OAK-11642: oak-segment-tar uses unmaintained concurrentlinkedhashmap-lru

### DIFF
--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -32,10 +32,6 @@
 
     <name>Oak Segment Tar</name>
 
-    <properties>
-        <concurrentlinkedhashmap.version>1.4.2</concurrentlinkedhashmap.version>
-    </properties>
-
     <build>
         <plugins>
             <plugin>
@@ -331,15 +327,6 @@
             <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
-
-		<!-- ConcurrentLinkedHashMap -->
-
-        <dependency>
-            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-            <artifactId>concurrentlinkedhashmap-lru</artifactId>
-            <version>${concurrentlinkedhashmap.version}</version>
-            <scope>provided</scope>
-	    </dependency>
 
         <!-- Dependencies on Oak testing modules -->
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CommitsTracker.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CommitsTracker.java
@@ -22,7 +22,6 @@ import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -197,10 +196,10 @@ class CommitsTracker {
                 }
             }
         }
-        return commitsPerGroup;
+        return Collections.unmodifiableMap(commitsPerGroup);
     }
 
-    public Map<String, Long> getCommitsCountOthers() {
+    public Map<String, Long> getCommitsCountOthersLastMinute() {
         Map<String, Long> commitsOther = new LRUMap<>(otherWritersLimit);
         long t = System.currentTimeMillis() - 60000;
         for (Commit commit : commits) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CommitsTracker.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CommitsTracker.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.jackrabbit.oak.segment.file.tar.GCGeneration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -200,7 +201,7 @@ class CommitsTracker {
     }
 
     public Map<String, Long> getCommitsCountOthers() {
-        Map<String, Long> commitsOther = new LinkedHashMap(otherWritersLimit);
+        Map<String, Long> commitsOther = new LRUMap<>(otherWritersLimit);
         long t = System.currentTimeMillis() - 60000;
         for (Commit commit : commits) {
             if (commit.getQueued() > t) {
@@ -210,6 +211,6 @@ class CommitsTracker {
                 }
             }
         }
-        return commitsOther;
+        return Collections.unmodifiableMap(commitsOther);
     }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CommitsTracker.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CommitsTracker.java
@@ -19,8 +19,10 @@
 package org.apache.jackrabbit.oak.segment;
 
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +30,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
-import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
 import org.apache.jackrabbit.oak.segment.file.tar.GCGeneration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -199,8 +200,7 @@ class CommitsTracker {
     }
 
     public Map<String, Long> getCommitsCountOthers() {
-        Map<String, Long> commitsOther = new ConcurrentLinkedHashMap.Builder<String, Long>()
-                .maximumWeightedCapacity(otherWritersLimit).build();
+        Map<String, Long> commitsOther = new LinkedHashMap(otherWritersLimit);
         long t = System.currentTimeMillis() - 60000;
         for (Commit commit : commits) {
             if (commit.getQueued() > t) {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStoreStats.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStoreStats.java
@@ -132,7 +132,7 @@ public class SegmentNodeStoreStats implements SegmentNodeStoreStatsMBean, Segmen
 
     @Override
     public TabularData getCommitsCountForOtherWriters() throws OpenDataException {
-        return createTabularDataFromCountMap(commitsTracker.getCommitsCountOthers(), "commitsPerWriter",
+        return createTabularDataFromCountMap(commitsTracker.getCommitsCountOthersLastMinute(), "commitsPerWriter",
                 "writerName");
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStoreStats.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentNodeStoreStats.java
@@ -145,11 +145,9 @@ public class SegmentNodeStoreStats implements SegmentNodeStoreStatsMBean, Segmen
         TabularDataSupport tabularData = new TabularDataSupport(new TabularType(typeName, "Most active writers",
                 commitsPerWriterRowType, new String[] { writerDescription }));
 
-        if (commitsCountMap.isEmpty()) {
-            commitsCountMap.put("N/A", 0L);
-        }
+        Map<String, Long> map = commitsCountMap.isEmpty() ? Map.of("N/A", 0L) : commitsCountMap;
 
-        commitsCountMap.entrySet().stream()
+        map.entrySet().stream()
                 .sorted(Comparator.<Entry<String, Long>> comparingLong(Entry::getValue).reversed()).map(e -> {
                     Map<String, Object> m = new HashMap<>();
                     m.put("count", e.getValue());

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/CommitsTrackerTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/CommitsTrackerTest.java
@@ -85,7 +85,7 @@ public class CommitsTrackerTest {
             commitTask.queued();
             assertNull(commitsTracker.getCurrentWriter());
             assertEquals(queued.size(), commitsTracker.getQueuedWritersMap().size());
-            assertEquals(0, commitsTracker.getCommitsCountOthers().size());
+            assertEquals(0, commitsTracker.getCommitsCountOthersLastMinute().size());
             assertTrue(commitsTracker.getCommitsCountPerGroupLastMinute().isEmpty());
         }
 
@@ -102,7 +102,7 @@ public class CommitsTrackerTest {
             commitTask.executed();
             assertNull(commitsTracker.getCurrentWriter());
             assertEquals(queued.size(), commitsTracker.getQueuedWritersMap().size());
-            assertEquals(min(OTHER_WRITERS_LIMIT, executed.size()), commitsTracker.getCommitsCountOthers().size());
+            assertEquals(min(OTHER_WRITERS_LIMIT, executed.size()), commitsTracker.getCommitsCountOthersLastMinute().size());
             assertTrue(commitsTracker.getCommitsCountPerGroupLastMinute().isEmpty());
         }
     }
@@ -131,6 +131,6 @@ public class CommitsTrackerTest {
             assertEquals(10, (long) groupCount);
         }
 
-        assertEquals(10, commitsTracker.getCommitsCountOthers().size());
+        assertEquals(10, commitsTracker.getCommitsCountOthersLastMinute().size());
     }
 }


### PR DESCRIPTION
1. Use commons-collections LRU map, and just wrap in into Immutable
2. Fix the only case where I write operation was attempted.