### PR TITLE
OAK-9584: Support expanded names in JCR method arguments for prefix

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/namepath/impl/GlobalNameMapper.java
@@ -194,6 +194,9 @@ public class GlobalNameMapper implements NameMapper {
             String uri = expandedName.substring(1, brace);
             if (uri.isEmpty()) {
                 return expandedName.substring(2); // special case: {}name
+            } else if (uri.equals(NamespaceConstants.NAMESPACE_REP)) {
+                // special case: {internal}name -> no proper URI
+                return NamespaceConstants.PREFIX_REP + ':' + expandedName.substring(brace + 1);
             } else if (uri.indexOf(':') != -1) {
                 // It's an expanded name, look up the namespace prefix
                 String oakPrefix = getOakPrefixOrNull(uri);

--- a/oak-doc/src/site/markdown/constraints.md
+++ b/oak-doc/src/site/markdown/constraints.md
@@ -40,7 +40,7 @@ a (local) name (see [JCR v2.0 Specification, Section 5.2.2.1](https://s.apache.o
 Finally, the chosen persistence implementation might restrict node names even further.
 See [Node Name Length Limit](./differences.md#node-name-length-limit).
 
-The namespace for prefix `rep` (`internal`) is not a valid URI therefore you can only use the qualified names but not the expanded names ([JCR v2.0 Specification, Section 3.2.5](https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5%20Lexical%20Form%20of%20JCR%20Names)) when addressing items in that namespace([OAK-74](https://issues.apache.org/jira/browse/OAK-74)).
+The namespace for prefix `rep` (=`internal`) is not a valid URI, however still used in the namespace registry. Therefore local names starting with `{internal}` (which clashes with the [expanded name](https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.5%20Lexical%20Form%20of%20JCR%20Names) for namespace prefix `rep:`) are not allowed in Oak ([OAK-74](https://issues.apache.org/jira/browse/OAK-74)).
 
 ## Invalid Java Strings
 

--- a/oak-jcr/pom.xml
+++ b/oak-jcr/pom.xml
@@ -54,7 +54,6 @@
       org.apache.jackrabbit.test.api.WorkspaceMoveSameNameSibsTest#testMoveNodesOrderingSupportedByParent <!-- OAK-118 -->
       org.apache.jackrabbit.test.api.WorkspaceMoveTest#testMoveNodesLocked                             <!-- OAK-118 -->
       org.apache.jackrabbit.test.api.NamespaceRemappingTest#testPrefixRemapping                        <!-- OAK-10544 -->
-      org.apache.jackrabbit.oak.jcr.ValidNamesTest#testRepNamespaceUri                                 <!-- OAK-74 -->
 
       <!-- Locking : not fully implemented -->
       org.apache.jackrabbit.test.api.lock.LockTest#testNodeLocked <!-- OAK-3482 -->

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/JackrabbitNodeTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/JackrabbitNodeTest.java
@@ -336,4 +336,19 @@ public class JackrabbitNodeTest extends AbstractJCRTest {
         assertNotNull(jn.getPropertyOrNull(JcrConstants.JCR_PRIMARYTYPE));
         assertNotNull(jn.getPropertyOrNull("a/aa/p"));
     }
+    
+    public void testGetNodeWithExpandedName() throws Exception {
+        JackrabbitNode jn = (JackrabbitNode) testRootNode; 
+        Node a = jn.addNode(nodeName1, NodeTypeConstants.NT_OAK_UNSTRUCTURED);
+        // namespace prefix with valid URI
+        a.addNode("test:aa", NodeTypeConstants.NT_OAK_UNSTRUCTURED);
+        assertNotNull(a.getNode("test:aa"));
+        assertNotNull(a.getNode("{http://www.apache.org/jackrabbit/test}aa"));
+
+        // special namespace prefix having an invalid URI
+        a.addNode("rep:aa", NodeTypeConstants.NT_OAK_UNSTRUCTURED);
+        assertNotNull(a.getNode("rep:aa"));
+        assertNotNull(a.getNode("{internal}aa"));
+        
+    }
 }


### PR DESCRIPTION
"rep:"

Treat "{internal}" as namespace although it is no proper URI