### PR TITLE
OAK-11684 : Send fullGC metrics to Prometheus pushgateway on each garbage collection iteration

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
@@ -994,9 +994,6 @@ public class VersionGarbageCollector {
                             // now remove the garbage in one go, if any
                             if (gc.hasGarbage() && phases.start(GCPhase.FULL_GC_CLEANUP)) {
                                 gc.removeGarbage(phases.stats);
-                                if (fullGCMetricsExporter != null) {
-                                    fullGCMetricsExporter.onIterationComplete();
-                                }
                                 phases.stop(GCPhase.FULL_GC_CLEANUP);
                             } else {
                                 if (log.isDebugEnabled()) {
@@ -1006,6 +1003,9 @@ public class VersionGarbageCollector {
                             if (lastDoc != null) {
                                 fromModifiedMs = lastDoc.getModified() == null ? oldModifiedMs : SECONDS.toMillis(lastDoc.getModified());
                                 fromId = lastDoc.getId();
+                            }
+                            if (fullGCMetricsExporter != null) {
+                                fullGCMetricsExporter.onIterationComplete();
                             }
                         } finally {
                             Utils.closeIfCloseable(itr);


### PR DESCRIPTION
- moved code that exports fullGC metrics to Prometheus pushgateway so that it is called on each fullGC iteration in VersionGarbageCollector