### PR TITLE
OAK-11686: Provide method to lookup value from OSGi framework property

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/osgi/OsgiUtil.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/osgi/OsgiUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.jackrabbit.oak.osgi;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
@@ -34,6 +35,29 @@ public class OsgiUtil {
 
     private OsgiUtil() {
         // Prevent instantiation.
+    }
+
+    /**
+     * Looks up a property by name in the set of framework properties if running inside an OSGi runtime
+     * (falling back to looking it up in the system properties if not found in framework properties). 
+     * Otherwise tries to look it up in from the system properties.
+     * Returns {@code null} if the property is not found or if the property is found but
+     * it is an empty string.
+     *
+     * @param name    Name of the property.
+     * @return The property value serialized as a string, or {@code null}.
+     * @since 1.80
+     */
+    public static String lookup(String name) {
+        Objects.requireNonNull(name);
+        Bundle bundle = FrameworkUtil.getBundle(OsgiUtil.class);
+        final String value;
+        if (bundle == null) {
+            value = System.getProperty(name);
+        } else {
+            value = bundle.getBundleContext().getProperty(name);
+        }
+        return asString(value);
     }
 
     /**

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/osgi/package-info.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/osgi/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.0.1")
+@Version("1.1.0")
 package org.apache.jackrabbit.oak.osgi;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/osgi/OsgiUtilTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/osgi/OsgiUtilTest.java
@@ -234,4 +234,32 @@ public class OsgiUtilTest {
         assertEquals(FrameworkUtil.createFilter("(&(objectClass=java.lang.String)(foo=bar)(!(empty=*))(escaped=\\*xyz\\)))"), getFilter(String.class, m));
         b.setLength(0);
     }
+
+    @Test
+    public void testLookupWithoutOsgiRuntime() {
+        String oldValue = System.setProperty("name", "value");
+        try {
+            assertEquals("value", lookup("name"));
+        } finally {
+            if (oldValue == null) {
+                System.clearProperty("name");
+            } else {
+                System.setProperty("name", oldValue);
+            }
+        }
+    }
+
+    @Test
+    public void testLookupEmptyStringWithoutOsgiRuntime() {
+        String oldValue = System.setProperty("name", "");
+        try {
+            assertNull(lookup("name"));
+        } finally {
+            if (oldValue == null) {
+                System.clearProperty("name");
+            } else {
+                System.setProperty("name", oldValue);
+            }
+        }
+    }
 }


### PR DESCRIPTION
without passing BundleContext

This falls back to using System properties when running outside OSGi