### PR TITLE
OAK-11683: Optionally disallow registration of invalid namespace URIs

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistry.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistry.java
@@ -42,14 +42,13 @@ public abstract class ReadWriteNamespaceRegistry
     /**
      * Feature flag to allow registering invalid namespace URIs (without a colon).
      * Set the system property {@code oak.allowInvalidNamespaceUris} to {@code false} to disable this feature.
+     * Cannot be static in order to allow testing with different values.
      */
-    private final boolean allowInvalidNamespaceUris;
+    private final boolean allowInvalidNamespaceUris = SystemPropertySupplier.create("oak.allowInvalidNamespaceUris", true)
+            .loggingTo(LOG).get();;
 
     protected ReadWriteNamespaceRegistry(Root root) {
         super(root);
-        // cannot be static in order to allow testing with different values
-        allowInvalidNamespaceUris = SystemPropertySupplier.create("oak.allowInvalidNamespaceUris", true)
-                .loggingTo(LOG).get();
     }
 
     /**

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistry.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistry.java
@@ -41,14 +41,14 @@ public abstract class ReadWriteNamespaceRegistry
 
     /**
      * Feature flag to allow registering invalid namespace URIs (without a colon).
-     * Set the system property {@code oak.allowInvalidNamespaceUris} to {@code true} to enable this feature.
+     * Set the system property {@code oak.allowInvalidNamespaceUris} to {@code false} to disable this feature.
      */
     private final boolean allowInvalidNamespaceUris;
 
     protected ReadWriteNamespaceRegistry(Root root) {
         super(root);
         // cannot be static in order to allow testing with different values
-        allowInvalidNamespaceUris = SystemPropertySupplier.create("oak.allowInvalidNamespaceUris", false)
+        allowInvalidNamespaceUris = SystemPropertySupplier.create("oak.allowInvalidNamespaceUris", true)
                 .loggingTo(LOG).get();
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistry.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistry.java
@@ -25,6 +25,7 @@ import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Root;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.apache.jackrabbit.oak.spi.namespace.NamespaceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +39,17 @@ public abstract class ReadWriteNamespaceRegistry
 
     private static final Logger LOG = LoggerFactory.getLogger(ReadWriteNamespaceRegistry.class);
 
-    public ReadWriteNamespaceRegistry(Root root) {
+    /**
+     * Feature flag to allow registering invalid namespace URIs (without a colon).
+     * Set the system property {@code oak.allowInvalidNamespaceUris} to {@code true} to enable this feature.
+     */
+    private final boolean allowInvalidNamespaceUris;
+
+    protected ReadWriteNamespaceRegistry(Root root) {
         super(root);
+        // cannot be static in order to allow testing with different values
+        allowInvalidNamespaceUris = SystemPropertySupplier.create("oak.allowInvalidNamespaceUris", false)
+                .loggingTo(LOG).get();
     }
 
     /**
@@ -71,11 +81,13 @@ public abstract class ReadWriteNamespaceRegistry
 
         // sanity check for legal namespace names (excluding the "internal"
         // namespace, see OAK-74)
-        if (!NamespaceConstants.NAMESPACE_REP.equals(uri)) {
-            if (!uri.contains(":")) {
+        if (!NamespaceConstants.NAMESPACE_REP.equals(uri) && !uri.contains(":")) {
+            if (allowInvalidNamespaceUris) {
                 LOG.error("Registering invalid namespace name '" + uri + "' for prefix '" + prefix
-                        + "', please see https://developer.adobe.com/experience-manager/reference-materials/spec/jcr/2.0/3_Repository_Model.html#3.2.1%20Namespaces",
-                        new Exception("call stack"));
+                            + "', please see https://s.apache.org/jcr-2.0-spec/3_Repository_Model.html#3.2.1%20Namespaces",
+                            new Exception("call stack"));
+            } else {
+                throw new NamespaceException("Invalid namespace URI given: " + uri + ". It must contain a colon.");
             }
         }
 

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistryTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistryTest.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.plugins.name;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -68,13 +69,13 @@ public class ReadWriteNamespaceRegistryTest extends OakBaseTest {
         assertEquals("mix", r.getPrefix("http://www.jcp.org/jcr/mix/1.0"));
         assertEquals("xml", r.getPrefix("http://www.w3.org/XML/1998/namespace"));
 
-        r.registerNamespace("p", "n");
-        assertEquals(r.getURI("p"), "n");
-        assertEquals(r.getPrefix("n"), "p");
+        r.registerNamespace("p", "myscheme:n");
+        assertEquals(r.getURI("p"), "myscheme:n");
+        assertEquals(r.getPrefix("myscheme:n"), "p");
 
-        r.registerNamespace("p2", "n2");
-        assertEquals(r.getURI("p2"), "n2");
-        assertEquals(r.getPrefix("n2"), "p2");
+        r.registerNamespace("p2", "myscheme:n2");
+        assertEquals(r.getURI("p2"), "myscheme:n2");
+        assertEquals(r.getPrefix("myscheme:n2"), "p2");
 
         // xml namespace check
         assertTrue(SetUtils.toSet(r.getPrefixes()).contains("xml"));
@@ -87,13 +88,13 @@ public class ReadWriteNamespaceRegistryTest extends OakBaseTest {
     }
 
     @Test
-    public void testInvalidNamespace() throws Exception {
-        final ContentSession session = createContentSession();
-        final Root root = session.getLatestRoot();
-        NamespaceRegistry r = getNamespaceRegistry(session, root);
-
+    public void testInvalidNamespaceInLaxMode() throws Exception {
         LogCustomizer customLogs = LogCustomizer.forLogger("org.apache.jackrabbit.oak.plugins.name.ReadWriteNamespaceRegistry").enable(Level.ERROR).create();
+        String oldValue = System.setProperty("oak.allowInvalidNamespaceUris", "true");
         try {
+            final ContentSession session = createContentSession();
+            final Root root = session.getLatestRoot();
+            NamespaceRegistry r = getNamespaceRegistry(session, root);
             customLogs.starting();
             r.registerNamespace("foo", "example.com");
             r.unregisterNamespace("foo");
@@ -103,7 +104,20 @@ public class ReadWriteNamespaceRegistryTest extends OakBaseTest {
         }
         finally {
             customLogs.finished();
+            if (oldValue != null) {
+                System.setProperty("oak.allowInvalidNamespaceUris", oldValue);
+            } else {
+                System.clearProperty("oak.allowInvalidNamespaceUris");
+            }
         }
+    }
+
+    @Test
+    public void testInvalidNamespaceInDefaultMode() {
+        final ContentSession session = createContentSession();
+        final Root root = session.getLatestRoot();
+        NamespaceRegistry r = getNamespaceRegistry(session, root);
+        assertThrows(NamespaceException.class, () -> r.registerNamespace("foo", "example.com"));
     }
 
     private static NamespaceRegistry getNamespaceRegistry(ContentSession session, Root root) {

--- a/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistryTest.java
+++ b/oak-it/src/test/java/org/apache/jackrabbit/oak/plugins/name/ReadWriteNamespaceRegistryTest.java
@@ -88,9 +88,8 @@ public class ReadWriteNamespaceRegistryTest extends OakBaseTest {
     }
 
     @Test
-    public void testInvalidNamespaceInLaxMode() throws Exception {
+    public void testInvalidNamespaceInDefaultMode() throws Exception {
         LogCustomizer customLogs = LogCustomizer.forLogger("org.apache.jackrabbit.oak.plugins.name.ReadWriteNamespaceRegistry").enable(Level.ERROR).create();
-        String oldValue = System.setProperty("oak.allowInvalidNamespaceUris", "true");
         try {
             final ContentSession session = createContentSession();
             final Root root = session.getLatestRoot();
@@ -104,20 +103,25 @@ public class ReadWriteNamespaceRegistryTest extends OakBaseTest {
         }
         finally {
             customLogs.finished();
+            
+        }
+    }
+
+    @Test
+    public void testInvalidNamespaceInStrictMode() {
+        String oldValue = System.setProperty("oak.allowInvalidNamespaceUris", "true");
+        try {
+            final ContentSession session = createContentSession();
+            final Root root = session.getLatestRoot();
+            NamespaceRegistry r = getNamespaceRegistry(session, root);
+            assertThrows(NamespaceException.class, () -> r.registerNamespace("foo", "example.com"));
+        } finally {
             if (oldValue != null) {
                 System.setProperty("oak.allowInvalidNamespaceUris", oldValue);
             } else {
                 System.clearProperty("oak.allowInvalidNamespaceUris");
             }
         }
-    }
-
-    @Test
-    public void testInvalidNamespaceInDefaultMode() {
-        final ContentSession session = createContentSession();
-        final Root root = session.getLatestRoot();
-        NamespaceRegistry r = getNamespaceRegistry(session, root);
-        assertThrows(NamespaceException.class, () -> r.registerNamespace("foo", "example.com"));
     }
 
     private static NamespaceRegistry getNamespaceRegistry(ContentSession session, Root root) {


### PR DESCRIPTION
This feature is off by default and can be enabled by setting framework/system property "oak.allowInvalidNamespaceUris" to "false".