### PR TITLE
OAK-11687 DataStore FileCache Memory Usage

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/DataStoreCacheUtils.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/DataStoreCacheUtils.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.plugins.blob;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -30,6 +31,8 @@ import org.slf4j.LoggerFactory;
  */
 public class DataStoreCacheUtils {
     private static final Logger LOG = LoggerFactory.getLogger(DataStoreCacheUtils.class);
+    private static final AtomicLong lastLogMessage = new AtomicLong();
+    private static final long TEN_SECONDS_IN_MILLIS = 10 * 1000;
 
     /**
      * Delete the file from the given root directory all its empty parent-directories.
@@ -39,8 +42,14 @@ public class DataStoreCacheUtils {
      */
     public static void recursiveDelete(File f, File root) throws IOException {
         if (f.exists()) {
+            long last = lastLogMessage.get();
             FileUtils.forceDelete(f);
-            LOG.info("Deleted file [{}]", f);
+            long now = System.currentTimeMillis();
+            if (now - last >= TEN_SECONDS_IN_MILLIS) {
+                if (lastLogMessage.compareAndSet(last, now)) {
+                    LOG.info("Deleted file [{}]", f);
+                }
+            }
         }
 
         // delete empty parent folders (except the main directory)

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -72,25 +72,16 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
      */
     private File cacheRoot;
 
-    private CacheLIRS<String, File> cache;
+    private CacheLIRS<String, String> cache;
 
     private FileCacheStats cacheStats;
 
     private ExecutorService executor;
 
-    private CacheLoader<String, File> cacheLoader;
+    private CacheLoader<String, String> cacheLoader;
 
-    /**
-     * Convert the size calculation to KB to support max file size of 2 TB
-     */
-    private static final Weigher<String, File> weigher = (key, value) -> {
-        // convert to number of 4 KB blocks
-        return Math.round(value.length() / (4 * 1024));
-    };
-
-    //Rough estimate of the in-memory key, value pair
-    private static final Weigher<String, File> memWeigher = (key, value) -> (StringUtils.estimateMemoryUsage(key) +
-        StringUtils.estimateMemoryUsage(value.getAbsolutePath()) + 48);
+    private Weigher<String, String> weigher;
+    private Weigher<String, String> memWeigher;
 
     private FileCache(long maxSize /* bytes */, File root,
         final CacheLoader<String, InputStream> loader, @Nullable final ExecutorService executor) {
@@ -99,15 +90,27 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         this.cacheRoot = new File(root, DOWNLOAD_DIR);
 
         // convert to number of 4 KB blocks
-        long size = Math.round(maxSize / (1024L * 4));
+        long size = Math.round(maxSize / 4096);
+
+        /**
+         * Convert the size calculation to KB to support max file size of 2 TB
+         */
+        weigher = (key, value) -> {
+            // convert to number of 4 KB blocks, plus an overhead of 4 blocks per file
+            return Math.round(getFile(value).length() / 4096) + 4;
+        };
+
+        //Rough estimate of the in-memory key, value pair
+        memWeigher = (key, value) -> (StringUtils.estimateMemoryUsage(key) +
+            StringUtils.estimateMemoryUsage(value) + 48);
 
         cacheLoader = new CacheLoader<>() {
             @Override
-            public File load(String key) throws Exception {
+            public String load(String key) throws Exception {
                 // Fetch from local cache directory and if not found load from backend
-                File cachedFile = DataStoreCacheUtils.getFile(key, cacheRoot);
+                File cachedFile = getFile(key);
                 if (cachedFile.exists()) {
-                    return cachedFile;
+                    return key;
                 } else {
                     long startNanos = System.nanoTime();
                     try (InputStream is = loader.load(key))  {
@@ -119,22 +122,22 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Loaded file: {} in {}", key, (System.nanoTime() - startNanos) / 1_000_000);
                     }
-                    return cachedFile;
+                    return key;
                 }
             }
         };
 
-        cache = new CacheLIRS.Builder<String, File>()
+        cache = new CacheLIRS.Builder<String, String>()
             .maximumWeight(size)
             .recordStats()
             .weigher(weigher)
             .segmentCount(SEGMENT_COUNT)
-            .evictionCallback((key, cachedFile, cause) -> {
+            .evictionCallback((key, cachedKey, cause) -> {
                 try {
-                    if (cachedFile != null && cachedFile.exists()
+                    if (cachedKey != null && getFile(cachedKey).exists()
                         && cause != RemovalCause.REPLACED) {
-                        DataStoreCacheUtils.recursiveDelete(cachedFile, cacheRoot);
-                        LOG.info("File [{}] evicted with reason [{}]", cachedFile, cause);
+                        DataStoreCacheUtils.recursiveDelete(getFile(cachedKey), cacheRoot);
+                        LOG.info("File [{}] evicted with reason [{}]", getFile(cachedKey), cause);
                     }
                 } catch (IOException e) {
                     LOG.info("Cached file deletion failed after eviction", e);
@@ -156,6 +159,10 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     }
 
     private FileCache() {
+    }
+
+    private File getFile(String key) {
+        return DataStoreCacheUtils.getFile(key, cacheRoot);
     }
 
     public static FileCache build(long maxSize /* bytes */, File root,
@@ -186,7 +193,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
             }
 
             @Override public DataStoreCacheStatsMBean getStats() {
-                return new FileCacheStats(cache, weigher, memWeigher, 0);
+                return new FileCacheStats(cache, (key, value) -> 1, (key, value) -> 1, 0);
             }
 
             @Override public void close() {
@@ -218,7 +225,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                     FileUtils.moveFile(file, cached);
                 }
             }
-            cache.put(key, cached);
+            cache.put(key, key);
         } catch (IOException e) {
             LOG.error("Exception adding id [{}] with file [{}] to cache, root cause: {}", key, file, e.getMessage());
             LOG.debug("Root cause", e);
@@ -238,7 +245,8 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     @Nullable
     public File getIfPresent(String key) {
         try {
-            return cache.getIfPresent(key);
+            String cached = cache.getIfPresent(key);
+            return cached == null ? null : getFile(cached);
         } catch (Exception e) {
             LOG.error("Error in retrieving [{}] from cache", key, e);
         }
@@ -254,7 +262,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     public File get(String key) throws IOException {
         try {
             // get from cache and download if not available
-            return cache.get(key, () -> cacheLoader.load(key));
+            return getFile(cache.get(key, () -> cacheLoader.load(key)));
         } catch (ExecutionException e) {
             LOG.error("Error loading [{}] from cache", key);
             throw new IOException(e);
@@ -319,7 +327,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
 }
 
 class FileCacheStats extends CacheStats implements DataStoreCacheStatsMBean {
-    private static final long KB = 4 * 1024;
+    private static final long BLOCK_SIZE = 4096;
     private final Weigher<Object, Object> memWeigher;
     private final Weigher<Object, Object> weigher;
     private final Cache<Object, Object> cache;
@@ -361,8 +369,9 @@ class FileCacheStats extends CacheStats implements DataStoreCacheStatsMBean {
         for (Map.Entry<?, ?> e : cache.asMap().entrySet()) {
             Object k = e.getKey();
             Object v = e.getValue();
-            size += weigher.weigh(k, v) * KB;
+            size += weigher.weigh(k, v) * BLOCK_SIZE;
         }
         return size;
     }
+
 }

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -102,6 +102,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     // the limit is adjusted
     private long currentBlockLimit;
     private long highWaterMark;
+    private long loggedWaterMark;
 
     private FileCache(long maxSize /* bytes */, File root,
         final CacheLoader<String, InputStream> loader, @Nullable final ExecutorService executor) {
@@ -322,8 +323,10 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         long currentSize = cache.size();
         if (currentSize > highWaterMark) {
             highWaterMark = currentSize;
-            if (highWaterMark % 50_000 == 0) {
-                LOG.info("New high water mark: {} entries", highWaterMark);
+            // low for each additional 50'000 entries
+            while (highWaterMark > loggedWaterMark + 50_000) {
+                loggedWaterMark += 50_000;
+                LOG.info("New high water mark: {} entries", loggedWaterMark);
             }
         }
         if (currentSize < maxEntryCount * 0.9 && currentBlockLimit  == maxBlocks) {

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -60,6 +60,9 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
 
     private static final int SEGMENT_COUNT = Integer.getInteger("oak.blob.fileCache.segmentCount", 1);
 
+    // the maximum number of entries (default: 0.5 million)
+    private static final int MAX_ENTRY_COUNT = Integer.getInteger("oak.blob.fileCache.maxEntryCount", 500_000);
+
     protected static final String DOWNLOAD_DIR = "download";
 
     /**
@@ -83,6 +86,17 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     private Weigher<String, String> weigher;
     private Weigher<String, String> memWeigher;
 
+    // the maximum number of entries (files)
+    private long maxEntryCount = MAX_ENTRY_COUNT;
+
+    // the maximum number of blocks, as configured via maxSize
+    private final long maxBlocks;
+
+    // the current block limit. by default, this is maxBlocks,
+    // unless if there are too many entries, in which cache
+    // the limit is adjusted
+    private long currentBlockLimit;
+
     private FileCache(long maxSize /* bytes */, File root,
         final CacheLoader<String, InputStream> loader, @Nullable final ExecutorService executor) {
 
@@ -90,19 +104,20 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         this.cacheRoot = new File(root, DOWNLOAD_DIR);
 
         // convert to number of 4 KB blocks
-        long size = Math.round(maxSize / 4096);
+        maxBlocks = Math.round(maxSize / (1024L * 4));
+        currentBlockLimit = maxBlocks;
 
         /**
          * Convert the size calculation to KB to support max file size of 2 TB
          */
         weigher = (key, value) -> {
-            // convert to number of 4 KB blocks, plus an overhead of 4 blocks per file
-            return Math.round(getFile(value).length() / 4096) + 4;
+            long value2 = getFile(key).length();
+            // convert to number of 4 KB blocks, plus an overhead of 1 blocks per file
+            return Math.round(value2 / (4 * 1024)) + 0;
         };
 
         //Rough estimate of the in-memory key, value pair
-        memWeigher = (key, value) -> (StringUtils.estimateMemoryUsage(key) +
-            StringUtils.estimateMemoryUsage(value) + 48);
+        memWeigher = (key, value) -> (StringUtils.estimateMemoryUsage(key) + 128);
 
         cacheLoader = new CacheLoader<>() {
             @Override
@@ -128,16 +143,16 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         };
 
         cache = new CacheLIRS.Builder<String, String>()
-            .maximumWeight(size)
+            .maximumWeight(maxBlocks)
             .recordStats()
             .weigher(weigher)
             .segmentCount(SEGMENT_COUNT)
-            .evictionCallback((key, cachedKey, cause) -> {
+            .evictionCallback((key, value, cause) -> {
                 try {
-                    if (cachedKey != null && getFile(cachedKey).exists()
+                    if (value != null && getFile(key).exists()
                         && cause != RemovalCause.REPLACED) {
-                        DataStoreCacheUtils.recursiveDelete(getFile(cachedKey), cacheRoot);
-                        LOG.info("File [{}] evicted with reason [{}]", getFile(cachedKey), cause);
+                        DataStoreCacheUtils.recursiveDelete(getFile(key), cacheRoot);
+                        LOG.info("File [{}] evicted with reason [{}]", getFile(key), cause);
                     }
                 } catch (IOException e) {
                     LOG.info("Cached file deletion failed after eviction", e);
@@ -158,7 +173,22 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         this.executor.submit(new CacheBuildJob());
     }
 
+    /**
+     * Set the maximum number of files.
+     */
+    public void setMaxEntryCount(long maxEntryCount) {
+        this.maxEntryCount = maxEntryCount;
+    }
+
+    /**
+     * Get the current entry count (number of files).
+     */
+    public long getEntryCount() {
+        return cache.size();
+    }
+
     private FileCache() {
+        maxBlocks = 0;
     }
 
     private File getFile(String key) {
@@ -212,6 +242,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
      */
     @Override
     public void put(String key, File file) {
+        adjustSize();
         put(key, file, true);
     }
 
@@ -245,8 +276,8 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     @Nullable
     public File getIfPresent(String key) {
         try {
-            String cached = cache.getIfPresent(key);
-            return cached == null ? null : getFile(cached);
+            String value = cache.getIfPresent(key);
+            return value == null ? null : getFile(key);
         } catch (Exception e) {
             LOG.error("Error in retrieving [{}] from cache", key, e);
         }
@@ -260,13 +291,47 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     }
 
     public File get(String key) throws IOException {
+        adjustSize();
         try {
             // get from cache and download if not available
-            return getFile(cache.get(key, () -> cacheLoader.load(key)));
+            cache.get(key, () -> cacheLoader.load(key));
+            return getFile(key);
         } catch (ExecutionException e) {
             LOG.error("Error loading [{}] from cache", key);
             throw new IOException(e);
         }
+    }
+
+    private void adjustSize() {
+        if (cache.size() < maxEntryCount * 0.9 && currentBlockLimit  == maxBlocks) {
+            // normal case:
+            // less than 90% of the max number of entries,
+            // and the limit is unchanged
+            return;
+        }
+        if (cache.size() < maxEntryCount) {
+            if (cache.size() >= maxEntryCount * 0.9) {
+                // more than 90% full: keep current limit
+                return;
+            }
+            // possibly increase the limit, to allow for more files
+            if (currentBlockLimit < maxBlocks) {
+                // not yet at the maximum:
+                // grow the maximum size, one block at the time, starting at the current
+                currentBlockLimit = Math.max(currentBlockLimit + 1, cache.getUsedMemory() + 1);
+                // never grow larger than the configured size
+                currentBlockLimit = Math.min(currentBlockLimit, maxBlocks);
+                LOG.info("Grow the cache size to {}", currentBlockLimit);
+                cache.setMaxMemory(currentBlockLimit);
+            }
+            return;
+        }
+        // shrink the cache, one block at the time, starting at the current size
+        currentBlockLimit = Math.min(currentBlockLimit - 1, cache.getUsedMemory() - 1);
+        // never grow larger than the configured size
+        currentBlockLimit = Math.min(currentBlockLimit, maxBlocks);
+        LOG.info("Shrink the cache size to {}", currentBlockLimit);
+        cache.setMaxMemory(currentBlockLimit);
     }
 
     @Override
@@ -327,7 +392,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
 }
 
 class FileCacheStats extends CacheStats implements DataStoreCacheStatsMBean {
-    private static final long BLOCK_SIZE = 4096;
+    private static final long BLOCK_SIZE = 4 * 1024;
     private final Weigher<Object, Object> memWeigher;
     private final Weigher<Object, Object> weigher;
     private final Cache<Object, Object> cache;

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
@@ -65,6 +66,10 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
 
     protected static final String DOWNLOAD_DIR = "download";
 
+    private static final long ONE_SECOND_IN_MILLIS = 1000;
+
+    private static final AtomicLong lastLogMessage = new AtomicLong();
+
     /**
      * Parent of the cache root directory
      */
@@ -96,6 +101,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     // unless if there are too many entries, in which cache
     // the limit is adjusted
     private long currentBlockLimit;
+    private long highWaterMark;
 
     private FileCache(long maxSize /* bytes */, File root,
         final CacheLoader<String, InputStream> loader, @Nullable final ExecutorService executor) {
@@ -151,8 +157,18 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
                 try {
                     if (value != null && getFile(key).exists()
                         && cause != RemovalCause.REPLACED) {
+                        long last = lastLogMessage.get();
                         DataStoreCacheUtils.recursiveDelete(getFile(key), cacheRoot);
-                        LOG.info("File [{}] evicted with reason [{}]", getFile(key), cause);
+                        long now = System.currentTimeMillis();
+                        if (now - last >= ONE_SECOND_IN_MILLIS) {
+                            if (lastLogMessage.compareAndSet(last, now)) {
+                                String reason = cause.toString();
+                                if ("SIZE".equals(reason) && currentBlockLimit != maxBlocks) {
+                                    reason = "ENTRY_COUNT > " + maxEntryCount;
+                                }
+                                LOG.info("File [{}] evicted with reason [{}]", getFile(key), reason);
+                            }
+                        }
                     }
                 } catch (IOException e) {
                     LOG.info("Cached file deletion failed after eviction", e);
@@ -303,34 +319,47 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     }
 
     private void adjustSize() {
-        if (cache.size() < maxEntryCount * 0.9 && currentBlockLimit  == maxBlocks) {
+        long currentSize = cache.size();
+        if (currentSize > highWaterMark) {
+            highWaterMark = currentSize;
+            if (highWaterMark % 50_000 == 0) {
+                LOG.info("New high water mark: {} entries", highWaterMark);
+            }
+        }
+        if (currentSize < maxEntryCount * 0.9 && currentBlockLimit  == maxBlocks) {
             // normal case:
             // less than 90% of the max number of entries,
             // and the limit is unchanged
             return;
         }
-        if (cache.size() < maxEntryCount) {
-            if (cache.size() >= maxEntryCount * 0.9) {
+        if (currentSize < maxEntryCount) {
+            if (currentSize >= maxEntryCount * 0.9) {
                 // more than 90% full: keep current limit
                 return;
             }
             // possibly increase the limit, to allow for more files
             if (currentBlockLimit < maxBlocks) {
                 // not yet at the maximum:
-                // grow the maximum size, one block at the time, starting at the current
-                currentBlockLimit = Math.max(currentBlockLimit + 1, cache.getUsedMemory() + 1);
+                // grow the maximum size, 10 blocks at the time,
+                // starting at the current size
+                currentBlockLimit = Math.max(
+                        currentBlockLimit + 10,
+                        cache.getUsedMemory() + 10);
                 // never grow larger than the configured size
                 currentBlockLimit = Math.min(currentBlockLimit, maxBlocks);
-                LOG.info("Grow the cache size to {}", currentBlockLimit);
+                LOG.debug("Grow the cache size to {}", currentBlockLimit);
                 cache.setMaxMemory(currentBlockLimit);
             }
             return;
         }
-        // shrink the cache, one block at the time, starting at the current size
-        currentBlockLimit = Math.min(currentBlockLimit - 1, cache.getUsedMemory() - 1);
+        // shrink the cache, 2 percent at the time, starting at the current size
+        currentBlockLimit = Math.min(
+                (int) (currentBlockLimit * 0.98 - 1),
+                (int) (cache.getUsedMemory() * 0.98 - 1));
         // never grow larger than the configured size
         currentBlockLimit = Math.min(currentBlockLimit, maxBlocks);
-        LOG.info("Shrink the cache size to {}", currentBlockLimit);
+        LOG.info("Shrinking the file cache size to {} because there are {} files (limit: {})",
+                currentBlockLimit, cache.size(), maxEntryCount);
         cache.setMaxMemory(currentBlockLimit);
     }
 

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/AbstractDataStoreCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/AbstractDataStoreCacheTest.java
@@ -113,7 +113,7 @@ public class AbstractDataStoreCacheTest {
     }
 
 
-    static class TestCacheLoader<S, I> extends CacheLoader<String, FileInputStream> {
+    static class TestCacheLoader extends CacheLoader<String, InputStream> {
         protected File root;
 
         public TestCacheLoader(File dir) {
@@ -164,7 +164,7 @@ public class AbstractDataStoreCacheTest {
     /**
      * Test loader which uses the ErrorInputStream for load
      */
-    static class TestErrorCacheLoader<S, I> extends TestCacheLoader<String, FileInputStream> {
+    static class TestErrorCacheLoader extends TestCacheLoader {
         private long max;
 
         public TestErrorCacheLoader(File dir, long max) {

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/CompositeDataStoreCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/CompositeDataStoreCacheTest.java
@@ -85,7 +85,7 @@ public class CompositeDataStoreCacheTest extends AbstractDataStoreCacheTest {
         LOG.info("Starting setup");
 
         root = folder.newFolder();
-        loader = new TestCacheLoader<String, InputStream>(folder.newFolder());
+        loader = new TestCacheLoader(folder.newFolder());
         uploader = new TestStagingUploader(folder.newFolder());
 
         // create executor

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/FileCacheTest.java
@@ -20,7 +20,6 @@ package org.apache.jackrabbit.oak.plugins.blob;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +37,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
@@ -48,6 +46,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * - Tests for {@link FileCache}
@@ -58,9 +57,6 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
     private File root;
     private TestCacheLoader loader;
     private Closer closer;
-
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File("target"));
@@ -75,7 +71,7 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
 
         root = folder.newFolder();
         closer = Closer.create();
-        loader = new TestCacheLoader<String, InputStream>(folder.newFolder());
+        loader = new TestCacheLoader(folder.newFolder());
 
         CountDownLatch beforeLatch = new CountDownLatch(1);
         CountDownLatch afterLatch = new CountDownLatch(1);
@@ -132,17 +128,22 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
     public void loadError() throws Exception {
         LOG.info("Started loadError");
 
-        loader = new TestErrorCacheLoader<String, InputStream>(folder.newFolder(), 8192);
+        loader = new TestErrorCacheLoader(folder.newFolder(), 8192);
         cache = FileCache.build(12 * 1024/* KB */, root, loader, null);
         closer.register(cache);
         createFile(0, loader, cache, folder, 12 * 1024);
         try {
             cache.get(ID_PREFIX + 0);
+            fail();
         } catch (IOException e) {
+            // expected
         }
-
-        expectedEx.expect(IOException.class);
-        cache.get(ID_PREFIX + 0);
+        try {
+            cache.get(ID_PREFIX + 0);
+            fail();
+        } catch (IOException e) {
+            // expected
+        }
 
         LOG.info("Finished loadError");
     }
@@ -394,7 +395,7 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
             retrieveThread(executorService, ID_PREFIX + 10, cache, thread1Start);
         thread1Start.countDown();
 
-        File f = createFile(4, loader, cache, folder);
+        createFile(4, loader, cache, folder);
         CountDownLatch thread2Start = new CountDownLatch(1);
         SettableFuture<File> future2 =
             retrieveThread(executorService, ID_PREFIX + 4, cache, thread2Start);
@@ -484,6 +485,36 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
         LOG.info("Finished upgrade");
     }
 
+    @Test
+    public void limitEntryCount() throws Exception {
+        try (FileCache cache = FileCache.build(1024 * 1024 * 1024/* bytes */, root, loader, null)) {
+            cache.setMaxEntryCount(100);
+            for(int i=0; i<200; i++) {
+                int fileSize = 4 * 1024;
+                if (i > 100 && i < 150) {
+                    // files now get larger and larger
+                    fileSize = 4 * 1024 + i * 100;
+                } else if (i > 150) {
+                    // files get smaller again
+                    fileSize = 4 * 1024;
+                }
+                createFile(i, loader, cache, folder, fileSize);
+                cache.get(ID_PREFIX + i);
+                // ensure we don't go over the limit
+                assertTrue(cache.getEntryCount() <= 100);
+                if (i < 100) {
+                    // at the beginning (less than 100 files),
+                    // we expect the limit to stay
+                    assertEquals(i + 1, cache.getEntryCount());
+                } else {
+                    // from then on, we expect that we have at least 90%
+                    // of the limit
+                    assertTrue(cache.getEntryCount() >= 80);
+                }
+            }
+        }
+    }
+
     /**------------------------------ Helper methods --------------------------------------------**/
 
     private static SettableFuture<File> retrieveThread(ListeningExecutorService executor,
@@ -506,8 +537,6 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
         return future;
     }
 
-
-
     private static SettableFuture<Boolean> putThread(ListeningExecutorService executor,
         final int seed, final File f, final FileCache cache, final CountDownLatch start) {
         final SettableFuture<Boolean> future = SettableFuture.create();
@@ -529,8 +558,7 @@ public class FileCacheTest extends AbstractDataStoreCacheTest {
     }
 
     private static int getWeight(String key, File value) {
-        return StringUtils.estimateMemoryUsage(key) +
-            StringUtils.estimateMemoryUsage(value.getAbsolutePath()) + 48;
+        return StringUtils.estimateMemoryUsage(key) + 128;
     }
 
     private static void assertCacheIfPresent(int seed, FileCache cache, File f) throws IOException {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/tree/Prefetcher.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/tree/Prefetcher.java
@@ -65,7 +65,7 @@ public class Prefetcher {
 
     private String blobSuffix;
 
-    private volatile long blobReadAheadSize = 4 * 1024 * 1024 * 1024L;
+    private volatile long blobReadAheadSize = 16 * 1024 * 1024L;
     private volatile long nodeReadAheadCount = 64 * 1024;
     private volatile long maxBlobSize;
 
@@ -127,7 +127,7 @@ public class Prefetcher {
     }
 
     public void sleep(String status) throws InterruptedException {
-        Thread.sleep(10);
+        Thread.sleep(1);
     }
 
     Runnable iterator(PrefetchType prefetchType) {


### PR DESCRIPTION
This PR reduces the memory usage.
It also limit the number of files to half a million, because eg. on Docker, when using the OverlayFS, each file also requires memory.