### PR TITLE
OAK-11695: consistently route the same queries to the same shards

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -42,7 +42,6 @@ import co.elastic.clients.elasticsearch.core.search.Highlight;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceConfig;
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
-import co.elastic.clients.json.JsonpUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -203,7 +202,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
      */
     @Override
     public String explain() {
-        return JsonpUtils.toString(elasticQueryScanner.searchRequest, new StringBuilder()).toString();
+        return elasticQueryScanner.searchRequest.toString();
     }
 
     @Override
@@ -245,7 +244,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
         ElasticQueryScanner(List<ElasticResponseListener> listeners) {
             this.query = elasticRequestHandler.baseQuery();
-            this.sessionId = "session-" + ElasticIndexUtils.sha256Hash(this.query.toString().getBytes(StandardCharsets.UTF_8));
+            this.sessionId = "oak-" + ElasticIndexUtils.sha256Hash(this.query.toString().getBytes(StandardCharsets.UTF_8));
             this.sorts = elasticRequestHandler.baseSorts();
             this.highlight = elasticRequestHandler.highlight();
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticQueryIterato
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticRequestHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticResponseHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.facets.ElasticFacetProvider;
+import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.query.FulltextIndex.FulltextResultRow;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex.IndexPlan;
@@ -43,6 +44,7 @@ import co.elastic.clients.elasticsearch.core.search.SourceConfig;
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import co.elastic.clients.json.JsonpUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
@@ -220,6 +222,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
         private final List<SearchHitListener> searchHitListeners = new ArrayList<>();
         private final List<AggregationListener> aggregationListeners = new ArrayList<>();
 
+        private final String sessionId;
         private final Query query;
         private final SearchRequest searchRequest;
         private final @NotNull List<SortOptions> sorts;
@@ -242,6 +245,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
         ElasticQueryScanner(List<ElasticResponseListener> listeners) {
             this.query = elasticRequestHandler.baseQuery();
+            this.sessionId = "session-" + ElasticIndexUtils.sha256Hash(this.query.toString().getBytes(StandardCharsets.UTF_8));
             this.sorts = elasticRequestHandler.baseSorts();
             this.highlight = elasticRequestHandler.highlight();
 
@@ -275,7 +279,9 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                                 .highlight(highlight)
                                 // use a smaller size when the query contains aggregations. This improves performance
                                 // when the client is only interested in insecure facets
-                                .size(needsAggregations.get() ? Math.min(SMALL_RESULT_SET_SIZE, getFetchSize(requests)) : getFetchSize(requests));
+                                .size(needsAggregations.get() ? Math.min(SMALL_RESULT_SET_SIZE, getFetchSize(requests)) : getFetchSize(requests))
+                                // consistently route the same queries to the same shard copy (primary or replica) within the shard set
+                                .preference(sessionId);
                         if (needsAggregations.get()) {
                             builder.aggregations(elasticRequestHandler.aggregations());
                         }
@@ -404,6 +410,8 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                         .query(query)
                         .highlight(highlight)
                         .size(getFetchSize(requests++))
+                        // consistently route the same queries to the same shard copy (primary or replica) within the shard set
+                        .preference(sessionId)
                 );
                 LOG.trace("Kicking new search after query {}", searchReq);
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
@@ -106,14 +106,23 @@ public class ElasticIndexUtils {
     public static String idFromPath(@NotNull String path) {
         byte[] pathBytes = path.getBytes(StandardCharsets.UTF_8);
         if (pathBytes.length > 512) {
-            try {
-                return new String(MessageDigest.getInstance("SHA-256").digest(pathBytes),
-                        StandardCharsets.UTF_8);
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalStateException(e);
-            }
+            return sha256Hash(pathBytes);
         }
         return path;
+    }
+
+    /**
+     * Computes the SHA-256 hash of the given byte array and returns it as a UTF-8 string.
+     *
+     * @param input the byte array to hash
+     * @return the SHA-256 hash as a string
+     */
+    public static String sha256Hash(byte[] input) {
+        try {
+            return new String(MessageDigest.getInstance("SHA-256").digest(input), StandardCharsets.UTF_8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     /**

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/ElasticIndexUtils.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.util;
 
+import org.apache.jackrabbit.oak.commons.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,7 +120,8 @@ public class ElasticIndexUtils {
      */
     public static String sha256Hash(byte[] input) {
         try {
-            return new String(MessageDigest.getInstance("SHA-256").digest(input), StandardCharsets.UTF_8);
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(input);
+            return StringUtils.convertBytesToHex(digest);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -177,6 +178,23 @@ public class ElasticContentTest extends ElasticAbstractQueryTest {
         root.commit();
 
         assertEventually(() -> assertThat(countDocuments(index), equalTo(1L)));
+    }
+
+    @Test
+    public void shardPreference() throws Exception {
+        IndexDefinitionBuilder builder = createIndex("a").noAsync();
+        builder.includedPaths("/content");
+        builder.indexRule("nt:base").property("a").propertyIndex();
+        setIndex(UUID.randomUUID().toString(), builder);
+        root.commit();
+
+        String query = "select [jcr:path] from [nt:base] where [a] = 'text'";
+        String explain = explain(query);
+        assertThat(explain, containsString("preference=oak-"));
+
+        // preference session should be the same across the same query
+        String explain2 = explain(query);
+        assertThat(explain2, equalTo(explain));
     }
 
     @Test


### PR DESCRIPTION
In multi shards scenarios (eg: 1 primary, 1 replica) queries might produce inconsistent results (from the second iteration onwards we might miss results).
This happens when the primary sort field is the score. The different shards might have slightly different stats producing inconsistent values for the score. This value is used from the second iteration as argument of the `search_after`.
To avoid this we can set a `preference` with a custom session identifier shared for the same queries. This identifier is used by ES to consistently route the search requests to the same shard.

TODO: the current test setup includes a single ES node. To fully test these kind of scenarios we need a multi node ES cluster. This will be tackled in a separate PR.