### PR TITLE
OAK-11712 :path does not need to be stored with index=true

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -102,7 +102,8 @@ class ElasticIndexHelper {
 
     private static void mapInternalProperties(@NotNull TypeMapping.Builder builder) {
         builder.properties(FieldNames.PATH,
-                        b1 -> b1.keyword(builder3 -> builder3))
+                        // path cannot be used for searches, just for sorting
+                        p -> p.keyword(k -> k.docValues(true).index(false)))
                 .properties(ElasticIndexDefinition.PATH_RANDOM_VALUE,
                         b1 -> b1.integer(b2 -> b2.docValues(true).index(false)))
                 .properties(FieldNames.ANCESTORS,

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -443,6 +443,6 @@ public interface FulltextIndexConstants {
      * needed from an outside process that does not have visibility to the specific index module.
      */
     Map<String, String> INDEX_VERSION_BY_TYPE = Map.of(
-            "elasticsearch", "1.3.0"
+            "elasticsearch", "1.3.1"
     );
 }


### PR DESCRIPTION
:path cannot be used for searches, just for sorting: docValues is more than enough. In some cases, this could decrease the space taken for this specific field up to 50%.