### PR TITLE
OAK-11733: Adding information to access denied

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/security/AccessManager.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/security/AccessManager.java
@@ -24,8 +24,12 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.jcr.delegate.SessionDelegate;
 import org.apache.jackrabbit.oak.jcr.session.operation.SessionOperation;
 import org.apache.jackrabbit.oak.spi.security.authorization.permission.PermissionProvider;
+import org.apache.jackrabbit.oak.spi.security.authorization.permission.Permissions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * AccessManager
@@ -62,13 +66,15 @@ public class AccessManager {
 
     public void checkPermissions(@NotNull String oakPath, @NotNull String actions) throws RepositoryException {
         if (!hasPermissions(oakPath, actions)) {
-            throw new AccessDeniedException("Access denied.");
+            String msg = String.format(Locale.ROOT, "Access denied in path %s for actions %s", oakPath, actions);
+            throw new AccessDeniedException(msg);
         }
     }
 
     public void checkPermissions(@NotNull Tree tree, @Nullable PropertyState property, long permissions) throws RepositoryException {
         if (!hasPermissions(tree, property, permissions)) {
-            throw new AccessDeniedException("Access denied.");
+            String msg = String.format(Locale.ROOT, "Access denied in path %s for permissions %s", tree.getPath(), Permissions.getNames(permissions));
+            throw new AccessDeniedException(msg);
         }
     }
 }

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/security/AccessManager.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/security/AccessManager.java
@@ -24,12 +24,10 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.jcr.delegate.SessionDelegate;
 import org.apache.jackrabbit.oak.jcr.session.operation.SessionOperation;
 import org.apache.jackrabbit.oak.spi.security.authorization.permission.PermissionProvider;
-import org.apache.jackrabbit.oak.spi.security.authorization.permission.Permissions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
-import java.util.Set;
 
 /**
  * AccessManager

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/security/AccessManager.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/security/AccessManager.java
@@ -66,15 +66,13 @@ public class AccessManager {
 
     public void checkPermissions(@NotNull String oakPath, @NotNull String actions) throws RepositoryException {
         if (!hasPermissions(oakPath, actions)) {
-            String msg = String.format(Locale.ROOT, "Access denied in path %s for actions %s", oakPath, actions);
-            throw new AccessDeniedException(msg);
+            throw new AccessDeniedException(String.format(Locale.ROOT, "Access denied at path '%s'", oakPath));
         }
     }
 
     public void checkPermissions(@NotNull Tree tree, @Nullable PropertyState property, long permissions) throws RepositoryException {
         if (!hasPermissions(tree, property, permissions)) {
-            String msg = String.format(Locale.ROOT, "Access denied in path %s for permissions %s", tree.getPath(), Permissions.getNames(permissions));
-            throw new AccessDeniedException(msg);
+            throw new AccessDeniedException(String.format(Locale.ROOT, "Access denied at path '%s'", tree.getPath()));
         }
     }
 }


### PR DESCRIPTION
When getting an access denied exception it's hard to identify the path and what was the options evaluated. 