### PR TITLE
OAK-11737: Properly set embeddedVerification value on FullGC revisions command

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
@@ -72,10 +72,12 @@ public class DocumentNodeStoreHelper {
 
     public static VersionGarbageCollector createVersionGC(final DocumentNodeStore nodeStore, final VersionGCSupport gcSupport,
                                                           boolean isFullGCDryRun, final DocumentNodeStoreBuilder<?> builder) {
-        return new VersionGarbageCollector(nodeStore, gcSupport, isFullGCEnabled(builder), isFullGCDryRun,
+        VersionGarbageCollector gc = new VersionGarbageCollector(nodeStore, gcSupport, isFullGCEnabled(builder), isFullGCDryRun,
                 isEmbeddedVerificationEnabled(builder), builder.getFullGCMode(), builder.getFullGCDelayFactor(),
                 builder.getFullGCBatchSize(), builder.getFullGCProgressSize(), builder.getFullGcMaxAgeMillis(),
                 builder.getFullGCGeneration());
+        gc.setFullGCPaths(builder.getFullGCIncludePaths(), builder.getFullGCExcludePaths());
+        return gc;
     }
 
     public static DocumentNodeState readNode(DocumentNodeStore documentNodeStore, Path path, RevisionVector rootRevision) {

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
@@ -419,19 +419,19 @@ public class RevisionsCommand implements Command {
         useMemoryBlobStore(builder);
         // create a version GC that operates on a read-only DocumentNodeStore
         // and a GC support with a writable DocumentStore
-        System.out.println("DryRun is enabled : " + options.isDryRun());
-        System.out.println("EmbeddedVerification is enabled : " + options.isEmbeddedVerificationEnabled());
+        VersionGarbageCollector gc = createVersionGC(builder.build(), gcSupport, options.isDryRun(), builder);
+        System.out.println("DryRun is enabled : " + gc.isFullGCDryRun());
+        System.out.println("EmbeddedVerification is enabled : " + gc.isEmbeddedVerificationEnabled());
         System.out.println("ResetFullGC is enabled : " + options.isResetFullGC());
         System.out.println("Compaction is enabled : " + options.doCompaction());
-        System.out.println("IncludePaths are : " + Arrays.toString(options.getIncludePaths()));
-        System.out.println("ExcludePaths are : " + Arrays.toString(options.getExcludePaths()));
-        System.out.println("FullGcMode is : " + options.getFullGcMode());
-        System.out.println("FullGcDelayFactory is : " + options.getFullGcDelayFactor());
-        System.out.println("FullGcBatchSize is : " + options.getFullGcBatchSize());
-        System.out.println("FullGcProgressSize is : " + options.getFullGcProgressSize());
+        System.out.println("IncludePaths are : " + gc.getFullGCIncludePaths());
+        System.out.println("ExcludePaths are : " + gc.getFullGCExcludePaths());
+        System.out.println("FullGcMode is : " + VersionGarbageCollector.getFullGcMode());
+        System.out.println("FullGcDelayFactor is : " + gc.getFullGcDelayFactor());
+        System.out.println("FullGcBatchSize is : " + gc.getFullGcBatchSize());
+        System.out.println("FullGcProgressSize is : " + gc.getFullGcProgressSize());
         System.out.println("FullGcMaxAgeInSecs is : " + options.getFullGcMaxAge());
-        System.out.println("FullGcMaxAgeMillis is : " + builder.getFullGcMaxAgeMillis());
-        VersionGarbageCollector gc = createVersionGC(builder.build(), gcSupport, options.isDryRun(), builder);
+        System.out.println("FullGcMaxAgeMillis is : " + gc.getFullGcMaxAgeInMillis());
 
         VersionGCOptions gcOptions = gc.getOptions();
         gcOptions = gcOptions.withDelayFactor(options.getDelay());

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/run/RevisionsCommand.java
@@ -411,9 +411,7 @@ public class RevisionsCommand implements Command {
                     version);
             System.exit(1);
         }
-        if (options.isEmbeddedVerificationEnabled()) {
-            builder.setEmbeddedVerificationEnabled(true);
-        }
+        builder.setEmbeddedVerificationEnabled(options.isEmbeddedVerificationEnabled());
         // set it read-only before the DocumentNodeStore is created
         // this prevents the DocumentNodeStore from writing a new
         // clusterId to the clusterNodes and nodes collections
@@ -654,6 +652,7 @@ public class RevisionsCommand implements Command {
         DocumentStore documentStore = builder.getDocumentStore();
         builder.setReadOnlyMode();
         useMemoryBlobStore(builder);
+        builder.setEmbeddedVerificationEnabled(options.isEmbeddedVerificationEnabled());
         DocumentNodeStore documentNodeStore = builder.build();
 
         VersionGarbageCollector gc = bootstrapVGC(options, closer, true);

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/document/RevisionsCommandTest.java
@@ -195,10 +195,10 @@ public class RevisionsCommandTest {
         assertTrue(output.contains("ResetFullGC is enabled : false\n"));
         assertTrue(output.contains("Compaction is enabled : false\n"));
         assertTrue(output.contains("starting gc collect\n"));
-        assertTrue(output.contains("IncludePaths are : [/]\n"));
+        assertTrue(output.contains("IncludePaths are : []\n"));
         assertTrue(output.contains("ExcludePaths are : []\n"));
-        assertTrue(output.contains("FullGcMode is : 0\n"));
-        assertTrue(output.contains("FullGcDelayFactory is : 2.0\n"));
+        assertTrue(output.contains("FullGcMode is : NONE\n"));
+        assertTrue(output.contains("FullGcDelayFactor is : 2.0\n"));
         assertTrue(output.contains("FullGcBatchSize is : 1000\n"));
         assertTrue(output.contains("FullGcProgressSize is : 10000\n"));
         assertTrue(output.contains("FullGcMaxAgeInSecs is : 86400\n"));
@@ -220,7 +220,7 @@ public class RevisionsCommandTest {
         ns.dispose();
 
         String output = captureSystemOut(new RevisionsCmd("fullGC", "--fullGcDelayFactor", "2.5", "--entireRepo"));
-        assertTrue(output.contains("FullGcDelayFactory is : 2.5\n"));
+        assertTrue(output.contains("FullGcDelayFactor is : 2.5\n"));
         assertTrue(output.contains("starting gc collect"));
     }
 
@@ -251,7 +251,19 @@ public class RevisionsCommandTest {
         assertTrue(output.contains("ResetFullGC is enabled : false"));
         assertTrue(output.contains("Compaction is enabled : false"));
         assertTrue(output.contains("starting gc collect"));
-        assertTrue(output.contains("FullGcMode is : 3"));
+        assertTrue(output.contains("FullGcMode is : GAP_ORPHANS_EMPTYPROPS"));
+    }
+
+    @Test
+    public void fullGCWithModeAllOrphans() {
+        ns.dispose();
+
+        String output = captureSystemOut(new RevisionsCmd("fullGC", "--entireRepo", "--fullGcMode", "4"));
+        assertTrue(output.contains("DryRun is enabled : true"));
+        assertTrue(output.contains("ResetFullGC is enabled : false"));
+        assertTrue(output.contains("Compaction is enabled : false"));
+        assertTrue(output.contains("starting gc collect"));
+        assertTrue(output.contains("FullGcMode is : ALL_ORPHANS_EMPTYPROPS"));
     }
 
     @Test

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGCMode.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FullGCMode.java
@@ -27,7 +27,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * Ultimately the goal is to clean up all possible garbage. After hardening these modes
  * might no longer be supported.
  */
-enum FullGCMode {
+public enum FullGCMode {
     /**
      * no full GC is done at all
      */

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollector.java
@@ -173,8 +173,44 @@ public class VersionGarbageCollector {
     private static FullGCMode fullGcMode = GAP_ORPHANS_EMPTYPROPS;
     private final long fullGcGen;
 
-    static FullGCMode getFullGcMode() {
+    public static FullGCMode getFullGcMode() {
         return fullGcMode;
+    }
+    
+    public boolean isFullGCEnabled() {
+        return fullGCEnabled;
+    }
+
+    public boolean isFullGCDryRun() {
+        return isFullGCDryRun;
+    }
+
+    public boolean isEmbeddedVerificationEnabled() {
+        return embeddedVerification;
+    }
+
+    public double getFullGcDelayFactor() {
+        return fullGCDelayFactor;
+    }
+
+    public long getFullGcMaxAgeInMillis() {
+        return fullGcMaxAgeInMillis;
+    }
+
+    public int getFullGcBatchSize() {
+        return fullGCBatchSize;
+    }
+
+    public int getFullGcProgressSize() {
+        return fullGCProgressSize;
+    }
+
+    public Set<String> getFullGCIncludePaths() {
+        return fullGCIncludePaths;
+    }
+
+    public Set<String> getFullGCExcludePaths() {
+        return fullGCExcludePaths;
     }
 
     /**


### PR DESCRIPTION
So there were 2 issues:

1. `EmbeddedVerification` is enabled by default, so it was impossible to disable it because it only set the value to the builder if it is true, in case of false it was never executed, so it remained enabled.
2. `collectDocument` method was not setting `EmbeddedVerification` value at all.