### PR TITLE
OAK-11748: Remove usage of Guava Escapers

### DIFF
--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/SharedDataStoreUtils.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/SharedDataStoreUtils.java
@@ -16,20 +16,18 @@
  */
 package org.apache.jackrabbit.oak.plugins.blob.datastore;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.jackrabbit.guava.common.base.Splitter;
 import org.apache.jackrabbit.guava.common.collect.FluentIterable;
-import org.apache.jackrabbit.guava.common.collect.Ordering;
 import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
 import org.apache.jackrabbit.oak.plugins.blob.SharedDataStore;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class for {@link SharedDataStore}.
@@ -53,14 +51,7 @@ public class SharedDataStoreUtils {
      * @return the earliest record
      */
     public static DataRecord getEarliestRecord(List<DataRecord> recs) {
-        return Ordering.natural().onResultOf(
-                new Function<DataRecord, Long>() {
-                    @Override
-                    @Nullable
-                    public Long apply(@NotNull DataRecord input) {
-                        return input.getLastModified();
-                    }
-                }::apply).min(recs);
+        return Collections.min(recs, Comparator.comparing(DataRecord::getLastModified, Comparator.naturalOrder()));
     }
 
     /**

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.oak.api.PropertyValue;
@@ -105,7 +106,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
-import org.apache.jackrabbit.guava.common.collect.Ordering;
 
 /**
  * Represents a parsed query.
@@ -124,12 +124,7 @@ public class QueryImpl implements Query {
 
     private boolean potentiallySlowTraversalQueryLogged;
 
-    private static final Ordering<QueryIndex> MINIMAL_COST_ORDERING = new Ordering<QueryIndex>() {
-        @Override
-        public int compare(QueryIndex left, QueryIndex right) {
-            return Double.compare(left.getMinimumCost(), right.getMinimumCost());
-        }
-    };
+    private static final Comparator<QueryIndex> MINIMAL_COST_ORDERING = Comparator.comparingDouble(QueryIndex::getMinimumCost);
 
     SourceImpl source;
     private String statement;
@@ -1092,8 +1087,8 @@ public class QueryImpl implements Query {
 
         // Sort the indexes according to their minimum cost to be able to skip the remaining indexes if the cost of the
         // current index is below the minimum cost of the next index.
-        List<? extends QueryIndex> queryIndexes = MINIMAL_COST_ORDERING
-                .sortedCopy(indexProvider.getQueryIndexes(rootState));
+        List<? extends QueryIndex> queryIndexes = indexProvider.getQueryIndexes(rootState).stream()
+                .sorted(MINIMAL_COST_ORDERING).collect(Collectors.toList());
         List<OrderEntry> sortOrder = getSortOrder(filter); 
         for (int i = 0; i < queryIndexes.size(); i++) {
             QueryIndex index = queryIndexes.get(i);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/RepMembersConflictHandler.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/RepMembersConflictHandler.java
@@ -33,8 +33,6 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 
-import org.apache.jackrabbit.guava.common.collect.Sets;
-
 /**
  * The {@code RepMembersConflictHandler} takes care of merging the {@code rep:members} property
  * during parallel updates.
@@ -162,13 +160,13 @@ class RepMembersConflictHandler implements ThreeWayConflictHandler {
         Set<String> ourMembers = Collections.unmodifiableSet(SetUtils.toLinkedSet(ours.getValue(Type.STRINGS)));
 
         // merge ours and theirs to a de-duplicated set
-        Set<String> combined = new LinkedHashSet<>(Sets.intersection(ourMembers, theirMembers));
-        for (String m : Sets.difference(ourMembers, theirMembers)) {
+        Set<String> combined = new LinkedHashSet<>(SetUtils.intersection(ourMembers, theirMembers));
+        for (String m : SetUtils.difference(ourMembers, theirMembers)) {
             if (!base.contains(m)) {
                 combined.add(m);
             }
         }
-        for (String m : Sets.difference(theirMembers, ourMembers)) {
+        for (String m : SetUtils.difference(theirMembers, ourMembers)) {
             if (!base.contains(m)) {
                 combined.add(m);
             }

--- a/oak-it-osgi/pom.xml
+++ b/oak-it-osgi/pom.xml
@@ -211,6 +211,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.5</version>

--- a/oak-it-osgi/test-bundles.xml
+++ b/oak-it-osgi/test-bundles.xml
@@ -39,6 +39,7 @@
         <include>commons-logging:commons-logging</include>
         <include>com.fasterxml.jackson.core:jackson-core</include>
         <include>org.apache.commons:commons-lang3</include>
+        <include>org.apache.commons:commons-text</include>
         <include>org.apache.commons:commons-collections4</include>
         <include>org.apache.jackrabbit:jackrabbit-jcr-commons</include>
         <include>org.apache.jackrabbit:jackrabbit-data</include>

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LucenePropertyIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LucenePropertyIndexTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -44,7 +45,6 @@ import java.util.concurrent.Executors;
 import javax.jcr.PropertyType;
 
 import org.apache.commons.io.input.CountingInputStream;
-import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.JcrConstants;
@@ -3264,11 +3264,10 @@ public class LucenePropertyIndexTest extends AbstractQueryTest {
         }
 
         @Override
-        public int compareTo(Tuple2 o) {
-            return ComparisonChain.start()
-                    .compare(value, o.value)
-                    .compare(value2, o.value2, Collections.reverseOrder())
-                    .result();
+        public int compareTo(@NotNull Tuple2 o) {
+            return Comparator.comparing((Tuple2 t) -> t.value)
+                    .thenComparing( t -> ((Tuple2) t).value2, Comparator.reverseOrder())
+                    .compare(this, o);
         }
 
         @Override

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -597,6 +597,11 @@
         <version>3.17.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.13.1</version>
+      </dependency>
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.18.0</version>

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -337,6 +337,11 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-text</artifactId>
+       <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>${h2.version}</version>

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/NodeStoreTree.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/NodeStoreTree.java
@@ -18,7 +18,6 @@
  */
 package org.apache.jackrabbit.oak.explorer;
 
-import static org.apache.jackrabbit.guava.common.escape.Escapers.builder;
 import static java.util.Collections.sort;
 import static javax.jcr.PropertyType.BINARY;
 import static javax.jcr.PropertyType.STRING;
@@ -52,6 +51,7 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -373,9 +373,7 @@ class NodeStoreTree extends JPanel implements TreeSelectionListener, Closeable {
             value = value.substring(0, MAX_CHAR_DISPLAY) + "... ("
                     + value.length() + " chars)";
         }
-        String escaped = builder().setSafeRange(' ', '~')
-                .addEscape('"', "\\\"").addEscape('\\', "\\\\").build()
-                .escape(value);
+        String escaped = StringEscapeUtils.ESCAPE_JAVA.translate(value);
         return '"' + escaped + '"';
     }
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/NodeStoreTree.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/NodeStoreTree.java
@@ -373,7 +373,7 @@ class NodeStoreTree extends JPanel implements TreeSelectionListener, Closeable {
             value = value.substring(0, MAX_CHAR_DISPLAY) + "... ("
                     + value.length() + " chars)";
         }
-        String escaped = StringEscapeUtils.ESCAPE_JAVA.translate(value);
+        String escaped = StringEscapeUtils.escapeJava(value);
         return '"' + escaped + '"';
     }
 

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/BinaryStats.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/BinaryStats.java
@@ -24,12 +24,13 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
 import org.codehaus.groovy.runtime.StringGroovyMethods;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.jackrabbit.oak.commons.IOUtils.humanReadableByteCount;
 
@@ -131,7 +132,7 @@ class BinaryStats {
         return sw.toString();
     }
 
-    private MimeTypeStats createStat(String mimeType) {
+    MimeTypeStats createStat(String mimeType) {
         MimeTypeStats stats = new MimeTypeStats(mimeType);
         stats.setIndexed(tika.isIndexed(mimeType));
         stats.setSupported(tika.isSupportedMediaType(mimeType));
@@ -142,7 +143,7 @@ class BinaryStats {
         return StringGroovyMethods.center(s, width);
     }
 
-    private static class MimeTypeStats implements Comparable<MimeTypeStats> {
+    static class MimeTypeStats implements Comparable<MimeTypeStats> {
         private final String mimeType;
         private int count;
         private long totalSize;
@@ -187,11 +188,11 @@ class BinaryStats {
         }
 
         @Override
-        public int compareTo(MimeTypeStats o) {
-            return ComparisonChain.start()
-                    .compareFalseFirst(indexed, o.indexed)
-                    .compare(totalSize, o.totalSize)
-                    .result();
+        public int compareTo(@NotNull MimeTypeStats o) {
+            return Comparator
+                    .comparing(MimeTypeStats::isIndexed)  // false comes before true by default
+                    .thenComparingLong(MimeTypeStats::getTotalSize)        // then compare by totalSize
+                    .compare(this, o);
         }
     }
 }

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/BinaryStatsTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/BinaryStatsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.tika;
+
+import org.apache.jackrabbit.guava.common.collect.FluentIterable;
+import org.apache.jackrabbit.oak.plugins.tika.BinaryStats.MimeTypeStats;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BinaryStatsTest {
+
+    @Test
+    public void testMimeTypeStatsComparison() throws IOException {
+        // Create BinaryStats instance with a minimal implementation of BinaryResourceProvider
+        BinaryStats stats = new BinaryStats(null, path -> FluentIterable.of());
+
+        // Create test MimeTypeStats instances
+        MimeTypeStats indexedLargeSize = stats.createStat("application/pdf");
+        indexedLargeSize.setIndexed(true);
+        indexedLargeSize.addSize(1000);
+
+        MimeTypeStats indexedSmallSize = stats.createStat("text/plain");
+        indexedSmallSize.setIndexed(true);
+        indexedSmallSize.addSize(100);
+
+        MimeTypeStats notIndexedLargeSize = stats.createStat("image/png");
+        notIndexedLargeSize.setIndexed(false);
+        notIndexedLargeSize.addSize(2000);
+
+        MimeTypeStats notIndexedSmallSize = stats.createStat("audio/mp3");
+        notIndexedSmallSize.setIndexed(false);
+        notIndexedSmallSize.addSize(500);
+
+        // Test case 1: Compare by indexed status (false first, then true)
+        Assert.assertTrue(notIndexedLargeSize.compareTo(indexedLargeSize) < 0);
+        Assert.assertTrue(indexedLargeSize.compareTo(notIndexedLargeSize) > 0);
+
+        // Test case 2: Same indexed status, compare by size (larger comes first)
+        Assert.assertTrue(indexedLargeSize.compareTo(indexedSmallSize) > 0);
+        Assert.assertTrue(notIndexedLargeSize.compareTo(notIndexedSmallSize) > 0);
+
+        // Test case 3: Sort a list and verify ordering
+        List<MimeTypeStats> statsList = new ArrayList<>();
+        statsList.add(indexedLargeSize);
+        statsList.add(notIndexedSmallSize);
+        statsList.add(indexedSmallSize);
+        statsList.add(notIndexedLargeSize);
+
+        Collections.sort(statsList);
+
+        // Verify sort order: not indexed first (larger to smaller), then indexed (larger to smaller)
+        Assert.assertSame(notIndexedSmallSize, statsList.get(0));
+        Assert.assertSame(notIndexedLargeSize, statsList.get(1));
+        Assert.assertSame(indexedSmallSize, statsList.get(2));
+        Assert.assertSame(indexedLargeSize, statsList.get(3));
+    }
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -75,6 +75,7 @@ public class ElasticIndexProviderService {
     protected static final String PROP_ELASTIC_API_KEY_SECRET = "elasticsearch.apiKeySecret";
     protected static final String PROP_LOCAL_TEXT_EXTRACTION_DIR = "localTextExtractionDir";
     private static final boolean DEFAULT_IS_INFERENCE_ENABLED = false;
+    private static final String ENV_VAR_OAK_INFERENCE_STATISTICS_DISABLED = "OAK_INFERENCE_STATISTICS_DISABLED";
 
     @ObjectClassDefinition(name = "ElasticIndexProviderService", description = "Apache Jackrabbit Oak ElasticIndexProvider")
     public @interface Config {
@@ -190,7 +191,12 @@ public class ElasticIndexProviderService {
         } else {
             this.isInferenceEnabled = config.isInferenceEnabled();
         }
-        InferenceConfig.reInitialize(nodeStore, statisticsProvider, config.inferenceConfigPath(), isInferenceEnabled);
+
+        if (isInferenceStatisticsDisabled()) {
+            InferenceConfig.reInitialize(nodeStore, config.inferenceConfigPath(), isInferenceEnabled);
+        } else {
+            InferenceConfig.reInitialize(nodeStore, statisticsProvider, config.inferenceConfigPath(), isInferenceEnabled);
+        }
 
         //initializeTextExtractionDir(bundleContext, config);
         //initializeExtractedTextCache(config, statisticsProvider);
@@ -296,5 +302,13 @@ public class ElasticIndexProviderService {
 
     public InferenceConfig getInferenceConfig() {
         return InferenceConfig.getInstance();
+    }
+
+    /**
+     * Checks if inference statistics are disabled via environment variable
+     * @return true if the environment variable is set to true
+     */
+    protected boolean isInferenceStatisticsDisabled() {
+        return Boolean.parseBoolean(System.getenv(ENV_VAR_OAK_INFERENCE_STATISTICS_DISABLED));
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/inference/InferenceServiceManager.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/inference/InferenceServiceManager.java
@@ -54,8 +54,7 @@ public class InferenceServiceManager {
 
     public static InferenceService getInstance(InferenceModelConfig inferenceModelConfig) {
         //TODO we should use hash here, as hash takes care of all properties in model config.
-        String key = inferenceModelConfig.getEmbeddingServiceUrl()
-            + "|" + inferenceModelConfig.getInferenceModelConfigName()
+        String key = inferenceModelConfig.getInferenceModelConfigName()
             + "|" + inferenceModelConfig.getModel();
 
         if (SERVICES.size() >= MAX_CACHED_SERVICES) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/inference/InferenceServiceMetrics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/inference/InferenceServiceMetrics.java
@@ -202,11 +202,11 @@ public class InferenceServiceMetrics {
     }
 
     private MeterStats getMeter(String name) {
-        return statisticsProvider.getMeter(getMetricName(this.metricsServiceKey + ";" + name), StatsOptions.DEFAULT);
+        return statisticsProvider.getMeter(getMetricName(this.metricsServiceKey + "-" + name), StatsOptions.DEFAULT);
     }
 
     private TimerStats getTimer(String name) {
-        return statisticsProvider.getTimer(this.metricsServiceKey + ";" + getMetricName(name), StatsOptions.DEFAULT);
+        return statisticsProvider.getTimer(this.metricsServiceKey + "-" + getMetricName(name), StatsOptions.DEFAULT);
     }
 
     /**

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderServiceTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexInfoService;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
+import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.query.QueryEngineSettings;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
@@ -152,6 +153,28 @@ public class ElasticIndexProviderServiceTest {
         assertEquals(0, WhiteboardUtils.getServices(wb, Runnable.class).size());
 
         MockOsgi.deactivate(service, context.bundleContext());
+    }
+
+    @Test
+    public void testDisabledInferenceStatistics() throws Exception {
+        // Create a spy of the service to be able to override just the environment check method
+        ElasticIndexProviderService serviceSpy = spy(service);
+        when(serviceSpy.isInferenceStatisticsDisabled()).thenReturn(true);
+
+        // Setup the rest as normal
+        MockOsgi.injectServices(serviceSpy, context.bundleContext());
+
+        // Activate the service with inference enabled
+        Map<String, Object> props = new HashMap<>(getElasticConfig());
+        props.put("isInferenceEnabled", true);
+        MockOsgi.activate(serviceSpy, context.bundleContext(), props);
+
+        // Verify that InferenceConfig.reInitialize was called with nodeStore and path but not statisticsProvider
+        InferenceConfig inferenceConfig = serviceSpy.getInferenceConfig();
+        assertNotNull(inferenceConfig);
+        assertEquals(StatisticsProvider.NOOP.getClass(), inferenceConfig.getStatisticsProvider().getClass());
+
+        MockOsgi.deactivate(serviceSpy, context.bundleContext());
     }
 
     private HashMap<String, Object> getElasticConfig() {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/inference/InferenceServiceMetricsTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/inference/InferenceServiceMetricsTest.java
@@ -237,7 +237,7 @@ public class InferenceServiceMetricsTest {
 
         @Override
         protected String getMetricName(String baseName) {
-            // This method is called with metricsServiceKey + ";" + name, so we need to preserve that format
+            // This method is called with metricsServiceKey + "-" + name, so we need to preserve that format
             // but still add our test prefix for uniqueness
             return testPrefix + "_" + baseName;
         }
@@ -245,12 +245,12 @@ public class InferenceServiceMetricsTest {
         // Methods to directly access the stats for verification
         public CounterStats getDirectCounter(String name) {
             // Format the name the same way it's done in the parent class
-            return statisticsProvider.getCounterStats(getMetricName(TEST_SERVICE_KEY + ";" + name), StatsOptions.DEFAULT);
+            return statisticsProvider.getCounterStats(getMetricName(TEST_SERVICE_KEY + "-" + name), StatsOptions.DEFAULT);
         }
 
         public MeterStats getDirectMeter(String name) {
             // Format the name the same way it's done in the parent getMeter() method
-            return statisticsProvider.getMeter(getMetricName(TEST_SERVICE_KEY + ";" + name), StatsOptions.DEFAULT);
+            return statisticsProvider.getMeter(getMetricName(TEST_SERVICE_KEY + "-" + name), StatsOptions.DEFAULT);
         }
     }
 } 

--- a/oak-segment-azure/pom.xml
+++ b/oak-segment-azure/pom.xml
@@ -69,6 +69,9 @@
                             org.apache.jackrabbit.oak.segment.azure,
                             org.apache.jackrabbit.oak.segment.azure.queue,
                             org.apache.jackrabbit.oak.segment.azure.util,
+                            com.microsoft.azure.storage,
+                            com.microsoft.azure.storage.core,
+                            com.microsoft.azure.storage.blob,
                         </Export-Package>
                         <Embed-Dependency>
                             azure-storage,

--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -241,6 +241,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+           <groupId>org.apache.commons</groupId>
+           <artifactId>commons-text</artifactId>
+           <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapEntry.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapEntry.java
@@ -24,7 +24,6 @@ import static org.apache.jackrabbit.oak.segment.MapRecord.HASH_MASK;
 import java.util.Comparator;
 import java.util.Map;
 
-import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.spi.state.AbstractChildNodeEntry;
 import org.jetbrains.annotations.NotNull;
@@ -149,11 +148,10 @@ class MapEntry extends AbstractChildNodeEntry
 
     @Override
     public int compareTo(@NotNull MapEntry that) {
-        return ComparisonChain.start()
-                .compare(getHash() & HASH_MASK, that.getHash() & HASH_MASK)
-                .compare(name, that.name)
-                .compare(value, that.value, Comparator.nullsLast(Comparator.naturalOrder()))
-                .result();
+        return Comparator.comparingLong((MapEntry me) -> me.getHash() & HASH_MASK)
+                .thenComparing(MapEntry::getName)
+                .thenComparing(MapEntry::getValue, Comparator.nullsLast(Comparator.naturalOrder()))
+                .compare(this, that);
     }
 
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapEntry.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapEntry.java
@@ -21,10 +21,10 @@ package org.apache.jackrabbit.oak.segment;
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.oak.segment.MapRecord.HASH_MASK;
 
+import java.util.Comparator;
 import java.util.Map;
 
 import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
-import org.apache.jackrabbit.guava.common.collect.Ordering;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.spi.state.AbstractChildNodeEntry;
 import org.jetbrains.annotations.NotNull;
@@ -152,7 +152,7 @@ class MapEntry extends AbstractChildNodeEntry
         return ComparisonChain.start()
                 .compare(getHash() & HASH_MASK, that.getHash() & HASH_MASK)
                 .compare(name, that.name)
-                .compare(value, that.value, Ordering.natural().nullsLast())
+                .compare(value, that.value, Comparator.nullsLast(Comparator.naturalOrder()))
                 .result();
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapRecord.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/MapRecord.java
@@ -27,11 +27,11 @@ import static org.apache.jackrabbit.oak.segment.MapEntry.newMapEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.spi.state.DefaultNodeStateDiff;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -631,10 +631,9 @@ public class MapRecord extends Record {
         } else if (after == null) {
             return -1;  // see above
         } else {
-            return ComparisonChain.start()
-                    .compare(before.getHash() & HASH_MASK, after.getHash() & HASH_MASK)
-                    .compare(before.getName(), after.getName())
-                    .result();
+            return Comparator.comparingLong((MapEntry me) -> me.getHash() & HASH_MASK)
+                    .thenComparing(MapEntry::getName)
+                    .compare(before, after);
         }
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/PropertyTemplate.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/PropertyTemplate.java
@@ -26,7 +26,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
+import java.util.Comparator;
 
 /**
  * A property definition within a template (the property name, the type, and the
@@ -74,11 +74,10 @@ public class PropertyTemplate implements Comparable<PropertyTemplate> {
     @Override
     public int compareTo(@NotNull PropertyTemplate template) {
         requireNonNull(template);
-        return ComparisonChain.start()
-                .compare(hashCode(), template.hashCode()) // important
-                .compare(name, template.name)
-                .compare(type, template.type)
-                .result();
+        return Comparator.comparingInt(PropertyTemplate::hashCode)
+                .thenComparing(PropertyTemplate::getName)
+                .thenComparing(PropertyTemplate::getType)
+                .compare(this, template);
     }
 
     //------------------------------------------------------------< Object >--

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/DebugTars.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/DebugTars.java
@@ -252,7 +252,7 @@ public class DebugTars {
             value = value.substring(0, maxCharDisplay) + "... (" + value.length() + " chars)";
         }
 
-        String escaped = StringEscapeUtils.ESCAPE_JAVA.translate(value);
+        String escaped = StringEscapeUtils.escapeJava(value);
 
         return '"' + escaped + '"';
     }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/DebugTars.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/tool/DebugTars.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 
 import javax.jcr.PropertyType;
 
-import org.apache.jackrabbit.guava.common.escape.Escapers;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
@@ -252,12 +252,7 @@ public class DebugTars {
             value = value.substring(0, maxCharDisplay) + "... (" + value.length() + " chars)";
         }
 
-        String escaped = Escapers.builder()
-                .setSafeRange(' ', '~')
-                .addEscape('"', "\\\"")
-                .addEscape('\\', "\\\\")
-                .build()
-                .escape(value);
+        String escaped = StringEscapeUtils.ESCAPE_JAVA.translate(value);
 
         return '"' + escaped + '"';
     }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/PropertyTemplateTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/PropertyTemplateTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.segment;
+
+import org.apache.jackrabbit.oak.api.Type;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PropertyTemplateTest {
+
+    @Test
+    public void testCompareToWithDifferentNames() {
+        PropertyTemplate p1 = new PropertyTemplate(0, "aName", Type.STRING);
+        PropertyTemplate p2 = new PropertyTemplate(1, "bName", Type.STRING);
+
+        // Since hashCode is used for primary comparison and hashCode uses only name,
+        // templates with different names should be ordered by name's hashCode
+        Assert.assertTrue(p1.hashCode() < p2.hashCode());
+        Assert.assertTrue(p1.compareTo(p2) < 0);
+        Assert.assertTrue(p2.compareTo(p1) > 0);
+    }
+
+    @Test
+    public void testCompareToWithSameNamesDifferentTypes() {
+        PropertyTemplate p1 = new PropertyTemplate(0, "sameName", Type.STRING);
+        PropertyTemplate p2 = new PropertyTemplate(0, "sameName", Type.BOOLEAN);
+
+        // Same name (so same hashCode), different types
+        Assert.assertEquals(p1.hashCode(), p2.hashCode());
+        // Type comparison is determined by the Type enum's natural order
+        Assert.assertNotEquals(0, p1.compareTo(p2));
+    }
+
+    @Test
+    public void testCompareToWithSameNamesSameTypesDifferentIndices() {
+        PropertyTemplate p1 = new PropertyTemplate(0, "sameName", Type.STRING);
+        PropertyTemplate p2 = new PropertyTemplate(1, "sameName", Type.STRING);
+
+        // Same name and type, different indices
+        Assert.assertEquals(p1.hashCode(), p2.hashCode());
+        Assert.assertEquals(0, p1.compareTo(p2)); // Index is not used in comparison
+        Assert.assertEquals(p1, p2); // Index is not used in equals either
+    }
+
+    @Test
+    public void testConsistencyBetweenEqualsAndCompareTo() {
+        PropertyTemplate p1 = new PropertyTemplate(0, "name", Type.STRING);
+        PropertyTemplate p2 = new PropertyTemplate(0, "name", Type.STRING);
+        PropertyTemplate p3 = new PropertyTemplate(0, "name", Type.BOOLEAN);
+
+        // Basic equality check
+        Assert.assertEquals(p1, p1); // Reflexivity
+        Assert.assertEquals(p1, p2); // Symmetry
+        Assert.assertEquals(0, p1.compareTo(p2));
+
+        // Different type
+        Assert.assertNotEquals(p1, p3);
+        Assert.assertNotEquals(0, p1.compareTo(p3));
+
+        // Not a PropertyTemplate
+        Assert.assertNotEquals("not a template", p1);
+    }
+
+    @Test
+    public void testSortingBehavior() {
+        List<PropertyTemplate> templates = new ArrayList<>();
+
+        // Create templates with varying names and types
+        templates.add(new PropertyTemplate(0, "c", Type.STRING));
+        templates.add(new PropertyTemplate(1, "a", Type.STRING));
+        templates.add(new PropertyTemplate(2, "b", Type.STRING));
+        templates.add(new PropertyTemplate(3, "a", Type.BOOLEAN));
+
+        Collections.sort(templates);
+
+        // Check the expected sort order based on hashCode, then name, then type
+        Assert.assertEquals("a", templates.get(0).getName()); // 'a' has lowest hashCode
+        // BOOLEAN comes after STRING for same name 'a'
+        // since they are compared by Type enum tag value (javax.jcr.PropertyType) which is higher for BOOLEAN
+        Assert.assertEquals(Type.STRING, templates.get(0).getType());
+        Assert.assertEquals("a", templates.get(1).getName());
+        Assert.assertEquals(Type.BOOLEAN, templates.get(1).getType());
+        Assert.assertEquals("b", templates.get(2).getName());
+        Assert.assertEquals("c", templates.get(3).getName());
+    }
+
+}

--- a/oak-shaded-guava/pom.xml
+++ b/oak-shaded-guava/pom.xml
@@ -61,6 +61,7 @@
                       <artifact>*:*</artifact>
                       <excludes>
                           <exclude>com/google/common/annotations/**</exclude>
+                          <exclude>com/google/common/escape/**</exclude>
                           <exclude>com/google/common/eventbus/**</exclude>
                           <exclude>com/google/common/html/**</exclude>
                           <exclude>com/google/common/io/**</exclude>
@@ -99,7 +100,6 @@
               ${pref}.common.base;version="33.5.0",
               ${pref}.common.cache;version="33.4.1";uses:="${pref}.common.base,${pref}.common.collect,${pref}.common.util.concurrent",
               ${pref}.common.collect;version="34.0.0";uses:="${pref}.common.base",
-              ${pref}.common.escape;version="33.4.1";uses:="${pref}.common.base",
               ${pref}.common.graph;version="33.4.1";uses:="${pref}.common.collect",
               ${pref}.common.hash;version="33.5.0";uses:="${pref}.common.base",
               ${pref}.common.math;version="33.4.1",

--- a/oak-store-composite/pom.xml
+++ b/oak-store-composite/pom.xml
@@ -274,5 +274,10 @@
       <artifactId>metrics-core</artifactId>
       <scope>test</scope>
     </dependency>
+   <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <scope>test</scope>
+   </dependency>
   </dependencies>
 </project>

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/CompositeTestSupport.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/CompositeTestSupport.java
@@ -97,6 +97,7 @@ public abstract class CompositeTestSupport extends TestSupport {
             mavenBundle().groupId("commons-io").artifactId("commons-io").versionAsInProject(),
             mavenBundle().groupId("org.apache.commons").artifactId("commons-collections4").versionAsInProject(),
             mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").versionAsInProject(),
+            mavenBundle().groupId("org.apache.commons").artifactId("commons-text").versionAsInProject(),
             mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-core").versionAsInProject(),
             mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-annotations").versionAsInProject(),
             mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-databind").versionAsInProject()

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FormatVersion.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/FormatVersion.java
@@ -17,9 +17,8 @@
 package org.apache.jackrabbit.oak.plugins.document;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-
-import org.apache.jackrabbit.guava.common.collect.ComparisonChain;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.oak.plugins.document.Collection.SETTINGS;
@@ -259,11 +258,10 @@ public final class FormatVersion implements Comparable<FormatVersion> {
     @Override
     public int compareTo(@NotNull FormatVersion other) {
         requireNonNull(other);
-        return ComparisonChain.start()
-                .compare(major, other.major)
-                .compare(minor, other.minor)
-                .compare(micro, other.micro)
-                .result();
+        return Comparator.comparingInt((FormatVersion fv) -> fv.major)
+                .thenComparingInt(fv -> fv.minor)
+                .thenComparingInt(fv -> fv.micro)
+                .compare(this, other);
     }
 
     private static DocumentStoreException concurrentUpdate() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
@@ -51,7 +51,6 @@ import java.util.function.Predicate;
 
 import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.guava.common.collect.AbstractIterator;
-import org.apache.jackrabbit.guava.common.collect.Ordering;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.DequeUtils;
@@ -2551,7 +2550,7 @@ public final class NodeDocument extends Document {
 
         static final Comparator<Entry<Revision, String>> REVERSE = Collections.reverseOrder(INSTANCE);
 
-        private static final Ordering<String> STRING_ORDERING = Ordering.natural().nullsFirst();
+        private static final Comparator<String> STRING_ORDERING = Comparator.nullsFirst(Comparator.naturalOrder());
 
         @Override
         public int compare(Entry<Revision, String> o1,

--- a/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/RepositoryUpgrade.java
+++ b/oak-upgrade/src/main/java/org/apache/jackrabbit/oak/upgrade/RepositoryUpgrade.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.jcr.NamespaceException;
 import javax.jcr.Node;
@@ -56,7 +57,6 @@ import javax.jcr.nodetype.NodeTypeTemplate;
 import javax.jcr.nodetype.PropertyDefinitionTemplate;
 import javax.jcr.security.Privilege;
 
-import org.apache.jackrabbit.guava.common.collect.Lists;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
@@ -772,8 +772,9 @@ public class RepositoryUpgrade {
             while (it.hasNext()) {
                 Privilege aggrPriv = it.next();
 
-                List<String> aggrNames = Lists.transform(Arrays.asList(aggrPriv.getDeclaredAggregatePrivileges()),
-                        input -> (input == null) ? null : input.getName());
+                List<String> aggrNames = Arrays.stream(aggrPriv.getDeclaredAggregatePrivileges())
+                        .map(input -> (input == null) ? null : input.getName())
+                        .collect(Collectors.toList());
                 if (allAggregatesRegistered(pMgr, aggrNames)) {
                     pMgr.registerPrivilege(aggrPriv.getName(), aggrPriv.isAbstract(), aggrNames.toArray(new String[aggrNames.size()]));
                     it.remove();


### PR DESCRIPTION
(unfortunately, this has zero test coverage)