### PR TITLE
OAK-11759 Repo lock cannot be acquired if repo.lock blob is already present

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
@@ -89,7 +89,7 @@ public class AzureRepositoryLock implements RepositoryLock {
         Exception ex = null;
         do {
             try {
-                blockBlobClient.getBlobOutputStream().close();
+                blockBlobClient.getBlobOutputStream(true).close();
 
                 log.info("{} = {}", LEASE_DURATION_PROP, leaseDuration);
                 log.info("{} = {}", RENEWAL_INTERVAL_PROP, renewalInterval);

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLockTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLockTest.java
@@ -86,6 +86,20 @@ public class AzureRepositoryLockTest {
     }
 
     @Test
+    public void repoLockNotDeletedTest() throws IOException, BlobStorageException {
+        BlockBlobClient blockBlobClient = readBlobContainerClient.getBlobClient("oak/repo.lock").getBlockBlobClient();
+
+        // create repo.lock blob
+        blockBlobClient.getBlobOutputStream(true).close();
+
+        BlockBlobClient noRetrtBlockBlobClient = noRetryBlobContainerClient.getBlobClient("oak/repo.lock").getBlockBlobClient();
+        BlobLeaseClient blobLeaseClient = new BlobLeaseClientBuilder().blobClient(noRetrtBlockBlobClient).buildClient();
+
+        // no exception should be present when calling lock
+        new AzureRepositoryLock(blockBlobClient, blobLeaseClient, () -> {}, new WriteAccessController()).lock();
+    }
+
+    @Test
     public void testWaitingLock() throws BlobStorageException, InterruptedException, IOException {
         BlockBlobClient blockBlobClient = readBlobContainerClient.getBlobClient("oak/repo.lock").getBlockBlobClient();
         BlockBlobClient noRetrtBlockBlobClient = noRetryBlobContainerClient.getBlobClient("oak/repo.lock").getBlockBlobClient();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/OAK-11759