### PR TITLE
OAK-11753: Remove usage of Guava base.CaseFormat

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
@@ -24,7 +24,6 @@ import co.elastic.clients.elasticsearch._types.analysis.TokenFilterDefinition;
 import co.elastic.clients.elasticsearch._types.analysis.TokenizerDefinition;
 import co.elastic.clients.elasticsearch.indices.IndexSettingsAnalysis;
 import co.elastic.clients.json.JsonData;
-import org.apache.jackrabbit.guava.common.base.CaseFormat;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -350,7 +349,7 @@ public class ElasticCustomAnalyzer {
         // and take the last part
         String name = anlClassTokens[anlClassTokens.length - 1];
         // all options in elastic are in snake case
-        name = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);
+        name = ElasticIndexHelper.convertUpperCamelToLowerUnderscore(name);
         // if it ends with analyzer we need to get rid of it
         if (name.endsWith("_analyzer")) {
             name = name.substring(0, name.length() - "_analyzer".length());

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerMappings.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
-import org.apache.jackrabbit.guava.common.base.CaseFormat;
 import org.apache.lucene.analysis.AbstractAnalysisFactory;
 import org.apache.lucene.analysis.charfilter.MappingCharFilterFactory;
 import org.apache.lucene.analysis.cjk.CJKBigramFilterFactory;
@@ -233,7 +232,7 @@ public class ElasticCustomAnalyzerMappings {
         LUCENE_ELASTIC_TRANSFORMERS.put(AbstractAnalysisFactory.class, luceneParams ->
                 luceneParams.entrySet().stream()
                         .collect(Collectors.toMap(
-                                entry -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, entry.getKey()),
+                                entry -> ElasticIndexHelper.convertUpperCamelToLowerUnderscore(entry.getKey()),
                                 Map.Entry::getValue, // keep the original value
                                 (oldValue, newValue) -> oldValue, // in case of duplicate keys, keep the old value
                                 LinkedHashMap::new // preserve the original order

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -414,6 +414,28 @@ class ElasticIndexHelper {
         return typeMapping.properties();
     }
 
+    /**
+     * Convert a String from (upper case) CamelCase to lowercase underscore
+     * @param string
+     * @return converted string (best effort)
+     */
+    protected static String convertUpperCamelToLowerUnderscore(String string) {
+        StringBuilder result = new StringBuilder();
+        for (char c : string.toCharArray()) {
+            // start?
+            if (result.length() == 0) {
+                result.append(Character.toLowerCase(c));
+            } else {
+                if (Character.isUpperCase(c)) {
+                    result.append('_');
+                }
+                result.append(Character.toLowerCase(c));
+            }
+        }
+
+        return result.toString();
+    }
+
     // https://discuss.elastic.co/t/reusing-internal-implementation-to-transform-json-mapping-to-es-mapping/300597/3
 
     /**

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelperTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelperTest.java
@@ -25,6 +25,7 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.elasticsearch.indices.IndexSettingsAnalysis;
+import org.apache.jackrabbit.guava.common.base.CaseFormat;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
@@ -36,6 +37,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -392,4 +394,42 @@ public class ElasticIndexHelperTest {
         assertThat(status._kind(), is(Property.Kind.Keyword));
     }
 
+    private void testCamelConversion(Function<String, String> f) {
+        assertEquals("foo_bar", f.apply("FooBar"));
+        assertEquals("foo_bar", f.apply("fooBar"));
+        assertEquals("foo _bar", f.apply("foo Bar"));
+        assertEquals("foo _bar", f.apply("Foo Bar"));
+        assertEquals("f_o_o__b_a_r", f.apply("FOO_BAR"));
+        assertEquals("foo__bar", f.apply("Foo_Bar"));
+        assertEquals("foo_bar ", f.apply("FooBar "));
+        assertEquals(" _foo_bar", f.apply(" FooBar"));
+        assertEquals(" _foo_bar", f.apply(" FooBar"));
+    }
+
+    private String convertUpperCamelToLowerUnderscore(String s) {
+        StringBuilder result = new StringBuilder();
+        for (char c: s.toCharArray()) {
+            // start?
+            if (result.length() == 0) {
+                result.append(Character.toLowerCase(c));
+            } else {
+                if (Character.isUpperCase(c)) {
+                    result.append('_');
+                }
+                result.append(Character.toLowerCase(c));
+            }
+        }
+
+        return result.toString();
+    }
+
+    @Test
+    public void testCamelConversionGuava() {
+        testCamelConversion(s -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, s));
+    }
+
+    @Test
+    public void testCamelConversionOurs() {
+        testCamelConversion(this::convertUpperCamelToLowerUnderscore);
+    }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelperTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelperTest.java
@@ -25,7 +25,6 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import co.elastic.clients.elasticsearch.indices.IndexSettingsAnalysis;
-import org.apache.jackrabbit.guava.common.base.CaseFormat;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
@@ -406,30 +405,10 @@ public class ElasticIndexHelperTest {
         assertEquals(" _foo_bar", f.apply(" FooBar"));
     }
 
-    private String convertUpperCamelToLowerUnderscore(String s) {
-        StringBuilder result = new StringBuilder();
-        for (char c: s.toCharArray()) {
-            // start?
-            if (result.length() == 0) {
-                result.append(Character.toLowerCase(c));
-            } else {
-                if (Character.isUpperCase(c)) {
-                    result.append('_');
-                }
-                result.append(Character.toLowerCase(c));
-            }
-        }
 
-        return result.toString();
-    }
-
-    @Test
-    public void testCamelConversionGuava() {
-        testCamelConversion(s -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, s));
-    }
-
+    // verify that convertUpperCamelToLowerUnderscore does what it's supposed to do (see OAK-11753)
     @Test
     public void testCamelConversionOurs() {
-        testCamelConversion(this::convertUpperCamelToLowerUnderscore);
+        testCamelConversion(ElasticIndexHelper::convertUpperCamelToLowerUnderscore);
     }
 }


### PR DESCRIPTION
First commit only adds a replacement method and test coverage.

The actual change is in https://github.com/apache/jackrabbit-oak/pull/2336/commits/14f8b8494cfa03a16a91f9d1972ce13a76c8f622