### PR TITLE
OAK-11768: Repository on read-only NodeStore

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -696,7 +696,9 @@ public class Oak {
         initHooks.add(new EditorHook(new IndexUpdateProvider(indexEditors)));
 
         CommitHook initHook = CompositeHook.compose(initHooks);
-        OakInitializer.initialize(store, new CompositeInitializer(initializers), initHook);
+        if (!initializers.isEmpty()) {
+            OakInitializer.initialize(store, new CompositeInitializer(initializers), initHook);
+        }
 
         // FIXME: OAK-810 move to proper workspace initialization
         // initialize default workspace

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/OakInitializer.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/OakInitializer.java
@@ -54,14 +54,21 @@ public final class OakInitializer {
                                   @NotNull NodeStore store,
                                   @NotNull String workspaceName,
                                   @NotNull CommitHook hook) {
+        boolean needsMerge = false;
         NodeBuilder builder = store.getRoot().builder();
         for (WorkspaceInitializer wspInit : initializer) {
-            wspInit.initialize(builder, workspaceName);
+            // default initializer is a no-op -> ignore
+            if (wspInit != WorkspaceInitializer.DEFAULT) {
+                wspInit.initialize(builder, workspaceName);
+                needsMerge = true;
+            }
         }
-        try {
-            store.merge(builder, hook, createCommitInfo());
-        } catch (CommitFailedException e) {
-            throw new RuntimeException(e);
+        if (needsMerge) {
+            try {
+                store.merge(builder, hook, createCommitInfo());
+            } catch (CommitFailedException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/OakTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/OakTest.java
@@ -208,7 +208,7 @@ public class OakTest {
         CommitInfoCapturingStore store = new CommitInfoCapturingStore();
         Oak oak = new Oak(store);
 
-        ContentRepository repo = oak.with(new OpenSecurityProvider()).createContentRepository();
+        ContentRepository repo = oak.with(new OpenSecurityProvider()).with(new InitialContent()).createContentRepository();
         assertThat(store.infos, is(not(empty())));
         for (CommitInfo ci : store.infos){
             assertNotNull(ci.getInfo().get(CommitContext.NAME));

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ReadOnlyJcrTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/ReadOnlyJcrTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.jcr;
+
+import org.apache.jackrabbit.oak.Oak;
+import org.apache.jackrabbit.oak.jcr.repository.RepositoryImpl;
+import org.apache.jackrabbit.oak.segment.SegmentNodeStore;
+import org.apache.jackrabbit.oak.segment.SegmentNodeStoreBuilders;
+import org.apache.jackrabbit.oak.segment.file.FileStore;
+import org.apache.jackrabbit.oak.segment.file.FileStoreBuilder;
+import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
+import org.apache.jackrabbit.oak.spi.security.OpenSecurityProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.jcr.Repository;
+import javax.jcr.Session;
+import java.io.File;
+
+import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
+import static org.junit.Assert.assertNotNull;
+
+public class ReadOnlyJcrTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder(new File("target"));
+
+    @Test
+    public void createJcrOnReadOnlyNodeStore() throws Exception {
+        try (FileStore store = newFileStoreBuilder().build()) {
+            SegmentNodeStore ns = SegmentNodeStoreBuilders.builder(store).build();
+            // create and close immediately
+            close(new Jcr(ns).createRepository());
+        }
+        // now open read-only
+        try (ReadOnlyFileStore store = newFileStoreBuilder().buildReadOnly()) {
+            SegmentNodeStore ns = SegmentNodeStoreBuilders.builder(store).build();
+            Jcr jcr = new Jcr(new Oak(ns), false);
+            jcr.with(new OpenSecurityProvider());
+            Repository repo = jcr.createRepository();
+            Session s = repo.login();
+            try {
+                // do some basic read operation
+                assertNotNull(s.getRootNode().getPrimaryNodeType().getName());
+            } finally {
+                s.logout();
+            }
+            close(repo);
+        }
+    }
+
+    private FileStoreBuilder newFileStoreBuilder() {
+        return fileStoreBuilder(folder.getRoot());
+    }
+
+    private static void close(Repository repository) {
+        if (repository instanceof RepositoryImpl) {
+            ((RepositoryImpl) repository).shutdown();
+        } else {
+            throw new IllegalArgumentException("Repository is not an instance of RepositoryImpl");
+        }
+    }
+}


### PR DESCRIPTION
Call merge only when there are non-default initializers.
Add test and update one test to now force an initializer merge.