### PR TITLE
OAK-11765 - BulkProcessor unable to insert after a failure

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/TrackingCorruptIndexHandler.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/TrackingCorruptIndexHandler.java
@@ -95,7 +95,7 @@ public class TrackingCorruptIndexHandler implements CorruptIndexHandler {
         if (meter != null) {
             // indexes.size() gives us the number of remaining corrupt indices.
             // meter.mark(indexes.size()) increments the current meter count by indexes.size(). We don't want that here.
-            // We actually want to set the the meter count to indexes.size(), the api doesn't seem to support that.
+            // We actually want to set the meter count to indexes.size(), the api doesn't seem to support that.
             // So we instead add indexes.size() - meter.getCount() , which will always be <= 0. So this effectively will reduce the meter count
             // by number of indexes fixed in this call.
             meter.mark(indexes.size() - meter.getCount());

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticDocumentStoreIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticDocumentStoreIndexer.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.index.indexer.document.ElasticIndexerProvider;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexer;
 import org.apache.jackrabbit.oak.index.indexer.document.NodeStateIndexerProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 
 import java.io.IOException;
 import java.util.List;
@@ -39,6 +40,7 @@ public class ElasticDocumentStoreIndexer extends DocumentStoreIndexerBase {
     private final int port;
     private final String apiKeyId;
     private final String apiSecretId;
+    private final ElasticRetryPolicy retryPolicy;
 
     public ElasticDocumentStoreIndexer(IndexHelper indexHelper, IndexerSupport indexerSupport,
                                        String indexPrefix, String scheme,
@@ -52,6 +54,7 @@ public class ElasticDocumentStoreIndexer extends DocumentStoreIndexerBase {
         this.port = port;
         this.apiKeyId = apiKeyId;
         this.apiSecretId = apiSecretId;
+        this.retryPolicy = ElasticRetryPolicy.createRetryPolicyFromSystemProperties();
         setProvider();
     }
 
@@ -91,7 +94,7 @@ public class ElasticDocumentStoreIndexer extends DocumentStoreIndexerBase {
             connection = buildStep.build();
         }
         closer.register(connection);
-        return new ElasticIndexerProvider(indexHelper, connection);
+        return new ElasticIndexerProvider(indexHelper, connection, retryPolicy);
     }
 
 }

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticOutOfBandIndexer.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticOutOfBandIndexer.java
@@ -25,6 +25,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticMetricHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorProvider;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 
@@ -38,6 +39,7 @@ public class ElasticOutOfBandIndexer extends OutOfBandIndexerBase {
     private final int port;
     private final String apiKeyId;
     private final String apiSecretId;
+    private final ElasticRetryPolicy retryPolicy;
 
     public ElasticOutOfBandIndexer(IndexHelper indexHelper, IndexerSupport indexerSupport,
                                    String indexPrefix, String scheme,
@@ -50,6 +52,7 @@ public class ElasticOutOfBandIndexer extends OutOfBandIndexerBase {
         this.port = port;
         this.apiKeyId = apiKeyId;
         this.apiSecretId = apiSecretId;
+        this.retryPolicy = ElasticRetryPolicy.createRetryPolicyFromSystemProperties();
     }
 
     @Override
@@ -76,6 +79,6 @@ public class ElasticOutOfBandIndexer extends OutOfBandIndexerBase {
         ElasticIndexTracker indexTracker = new ElasticIndexTracker(connection,
                 new ElasticMetricHandler(StatisticsProvider.NOOP));
         return new ElasticIndexEditorProvider(indexTracker, connection,
-                new ExtractedTextCache(10 * FileUtils.ONE_MB, 100));
+                new ExtractedTextCache(10 * FileUtils.ONE_MB, 100), retryPolicy);
     }
 }

--- a/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexerProvider.java
+++ b/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/ElasticIndexerProvider.java
@@ -28,6 +28,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticBulkProcesso
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticDocument;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexWriterFactory;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 import org.apache.jackrabbit.oak.plugins.index.progress.IndexingProgressReporter;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.binary.FulltextBinaryTextExtractor;
@@ -55,13 +56,13 @@ public class ElasticIndexerProvider implements NodeStateIndexerProvider {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final ElasticIndexEditorProvider elasticIndexEditorProvider;
 
-    public ElasticIndexerProvider(IndexHelper indexHelper, ElasticConnection connection) {
+    public ElasticIndexerProvider(IndexHelper indexHelper, ElasticConnection connection, ElasticRetryPolicy retryPolicy) {
         this.indexHelper = indexHelper;
         this.connection = connection;
         this.bulkProcessorHandler = new ElasticBulkProcessorHandler(connection);
         ElasticIndexTracker indexTracker = new ElasticIndexTracker(connection, new ElasticMetricHandler(StatisticsProvider.NOOP));
-        this.indexWriterFactory = new ElasticIndexWriterFactory(connection, indexTracker, bulkProcessorHandler);
-        this.elasticIndexEditorProvider = new ElasticIndexEditorProvider(indexTracker, connection, null, bulkProcessorHandler);
+        this.indexWriterFactory = new ElasticIndexWriterFactory(connection, indexTracker, bulkProcessorHandler, retryPolicy);
+        this.elasticIndexEditorProvider = new ElasticIndexEditorProvider(indexTracker, connection, null, bulkProcessorHandler, retryPolicy);
 
     }
 

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -33,7 +33,7 @@
   <description>Oak Elasticsearch integration subproject</description>
 
   <properties>
-    <elasticsearch.java.client.version>8.18.1</elasticsearch.java.client.version>
+    <elasticsearch.java.client.version>8.18.2</elasticsearch.java.client.version>
     <lucene.version>9.12.1</lucene.version>
   </properties>
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
@@ -56,6 +56,7 @@ public class ElasticConnection implements Closeable {
     protected static final int DEFAULT_PORT = 9200;
     protected static final String DEFAULT_API_KEY_ID = "";
     protected static final String DEFAULT_API_KEY_SECRET = "";
+    protected static final int DEFAULT_MAX_RETRY_TIME = 0;
     protected static final int ES_SOCKET_TIMEOUT = 120000;
 
     private final String indexPrefix;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -74,6 +74,7 @@ public class ElasticIndexProviderService {
     protected static final String PROP_ELASTIC_PORT = "elasticsearch.port";
     protected static final String PROP_ELASTIC_API_KEY_ID = "elasticsearch.apiKeyId";
     protected static final String PROP_ELASTIC_API_KEY_SECRET = "elasticsearch.apiKeySecret";
+    protected static final String PROP_ELASTIC_MAX_RETRY_TIME = "elasticsearch.maxRetryTime";
     protected static final String PROP_LOCAL_TEXT_EXTRACTION_DIR = "localTextExtractionDir";
     private static final boolean DEFAULT_IS_INFERENCE_ENABLED = false;
     private static final String ENV_VAR_OAK_INFERENCE_STATISTICS_DISABLED = "OAK_INFERENCE_STATISTICS_DISABLED";
@@ -120,8 +121,8 @@ public class ElasticIndexProviderService {
 
         @AttributeDefinition(
                 name = "Elasticsearch Max Retry time",
-                description = "Time in seconds that Elasticsearch should retry failed operations. 0 means disabled, no retries. Default is 30 seconds.")
-        int elasticsearch_maxRetryTime() default 30;
+                description = "Time in seconds that Elasticsearch should retry failed operations. 0 means disabled, no retries. Default is 2 seconds.")
+        int elasticsearch_maxRetryTime() default ElasticConnection.DEFAULT_MAX_RETRY_TIME;
 
         @AttributeDefinition(name = "Local text extraction cache path",
                 description = "Local file system path where text extraction cache stores/load entries to recover from timed out operation")
@@ -234,7 +235,7 @@ public class ElasticIndexProviderService {
 
         registerIndexProvider(bundleContext);
         ElasticRetryPolicy retryPolicy = new ElasticRetryPolicy(100, config.elasticsearch_maxRetryTime() * 1000L, 5, 100);
-        this.elasticIndexEditorProvider = new ElasticIndexEditorProvider(indexTracker, elasticConnection, extractedTextCache,retryPolicy);
+        this.elasticIndexEditorProvider = new ElasticIndexEditorProvider(indexTracker, elasticConnection, extractedTextCache, retryPolicy);
         registerIndexEditor(bundleContext, elasticIndexEditorProvider);
         if (isElasticAvailable) {
             registerIndexCleaner(config);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -121,7 +121,7 @@ public class ElasticIndexProviderService {
 
         @AttributeDefinition(
                 name = "Elasticsearch Max Retry time",
-                description = "Time in seconds that Elasticsearch should retry failed operations. 0 means disabled, no retries. Default is 2 seconds.")
+                description = "Time in seconds that Elasticsearch should retry failed operations. 0 means disabled, no retries. Default is 0 seconds (disabled).")
         int elasticsearch_maxRetryTime() default ElasticConnection.DEFAULT_MAX_RETRY_TIME;
 
         @AttributeDefinition(name = "Local text extraction cache path",

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.plugins.index.AsyncIndexInfoService;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexInfoProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorProvider;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticIndexProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConstants;
@@ -116,6 +117,11 @@ public class ElasticIndexProviderService {
 
         @AttributeDefinition(name = "Elasticsearch API key secret", description = "Elasticsearch API key secret")
         String elasticsearch_apiKeySecret() default ElasticConnection.DEFAULT_API_KEY_SECRET;
+
+        @AttributeDefinition(
+                name = "Elasticsearch Max Retry time",
+                description = "Time in seconds that Elasticsearch should retry failed operations. 0 means disabled, no retries. Default is 30 seconds.")
+        int elasticsearch_maxRetryTime() default 30;
 
         @AttributeDefinition(name = "Local text extraction cache path",
                 description = "Local file system path where text extraction cache stores/load entries to recover from timed out operation")
@@ -227,7 +233,8 @@ public class ElasticIndexProviderService {
         LOG.info("Registering Index and Editor providers with connection {}", elasticConnection);
 
         registerIndexProvider(bundleContext);
-        this.elasticIndexEditorProvider = new ElasticIndexEditorProvider(indexTracker, elasticConnection, extractedTextCache);
+        ElasticRetryPolicy retryPolicy = new ElasticRetryPolicy(100, config.elasticsearch_maxRetryTime() * 1000L, 5, 100);
+        this.elasticIndexEditorProvider = new ElasticIndexEditorProvider(indexTracker, elasticConnection, extractedTextCache,retryPolicy);
         registerIndexEditor(bundleContext, elasticIndexEditorProvider);
         if (isElasticAvailable) {
             registerIndexCleaner(config);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -297,7 +297,6 @@ public class ElasticBulkProcessorHandler {
 
         // Some of the operations for this index pending may be buffered for sending in the bulk ingester.
         // Force sending them now.
-        LOG.trace("Flushing bulk ingester {}", bulkIngester);
         bulkIngester.flush();
 
         if (indexInfo.waitForESAcknowledgement) {
@@ -348,6 +347,7 @@ public class ElasticBulkProcessorHandler {
             }
         }
 
+        checkConnectionFailures();
         checkFailuresForIndex(indexInfo);
         LOG.trace("Bulk identifier -> update status = {}", registeredIndexes);
         return indexInfo.indexModified;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -374,7 +374,7 @@ public class ElasticBulkProcessorHandler {
 
     private void checkConnectionFailures() throws IOException {
         if (lastConnectionError != null) {
-            IOException ioe = new IOException("Exception while indexing.", lastConnectionError);
+            IOException ioe = new IOException("Service error while indexing.", lastConnectionError);
             lastConnectionError = null; // Clear the last connection error after throwing it
             throw ioe;
         }
@@ -387,7 +387,7 @@ public class ElasticBulkProcessorHandler {
             String overflowMessage = suppressedErrors.size() >= MAX_SUPPRESSED_ERROR_CAUSES ?
                     ". (Too many failed operations in last bulk request, including only " + suppressedErrors.size() + " errors)"
                     : "";
-            IOException ioe = new IOException("Exception while indexing " + indexInfo.indexName + ". See suppressed for details" + overflowMessage);
+            IOException ioe = new IOException("Error indexing documents for index: " + indexInfo.indexName + ". See suppressed errors for details" + overflowMessage);
             suppressedErrors.forEach(ec -> ioe.addSuppressed(new IllegalStateException(ec.reason())));
             throw ioe;
         }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticBulkProcessorHandler.java
@@ -26,11 +26,11 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.json.JsonData;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.log.LogSilencer;
 import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
 import org.apache.jackrabbit.oak.plugins.index.FormattingUtils;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
-import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -38,13 +38,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
@@ -58,6 +55,7 @@ import java.util.stream.Collectors;
 public class ElasticBulkProcessorHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticBulkProcessorHandler.class);
+    private static final LogSilencer LOG_SILENCER = new LogSilencer(Duration.ofSeconds(5).toMillis(), 50);
 
     /**
      * Keeps information about an index that is being written by the bulk processor
@@ -118,18 +116,20 @@ public class ElasticBulkProcessorHandler {
     private static final int BULK_MAX_CONCURRENT_REQUESTS_DEFAULT = 1;
     // when true, fails indexing in case of bulk failures
     public static final String FAIL_ON_ERROR_PROP = "oak.indexer.elastic.bulkProcessor.failOnError";
-    public static final boolean FAIL_ON_ERROR_DEFAULT = true;
+    public static final boolean FAIL_ON_ERROR_DEFAULT = false;
 
     private static final String SYNC_MODE_PROPERTY = "sync-mode";
     private static final String SYNC_RT_MODE = "rt";
     private static final int MAX_SUPPRESSED_ERROR_CAUSES = 50;
 
-    private final int failedDocCountForStatusNode = ConfigHelper.getSystemPropertyAsInt("oak.failedDocStatusLimit", 10000);
     private final int bulkMaxOperations = ConfigHelper.getSystemPropertyAsInt(BULK_ACTIONS_PROP, BULK_ACTIONS_DEFAULT);
     private final int bulkMaxSizeBytes = ConfigHelper.getSystemPropertyAsInt(BULK_SIZE_BYTES_PROP, BULK_SIZE_BYTES_DEFAULT);
     private final int bulkFlushIntervalMillis = ConfigHelper.getSystemPropertyAsInt(BULK_FLUSH_INTERVAL_MS_PROP, BULK_FLUSH_INTERVAL_MS_DEFAULT);
     private final int bulkMaxConcurrentRequests = ConfigHelper.getSystemPropertyAsInt(BULK_MAX_CONCURRENT_REQUESTS_PROP, BULK_MAX_CONCURRENT_REQUESTS_DEFAULT);
-    private final boolean failOnError = ConfigHelper.getSystemPropertyAsBoolean(FAIL_ON_ERROR_PROP, FAIL_ON_ERROR_DEFAULT);
+    // If false, failures to index documents will not throw an exception, but will be logged instead. If true, if a document
+    // fails to index, an exception will be thrown in the next call done to that particular index (add a document or close the index).
+    // Connection errors will always throw an exception, regardless of this setting, because they relate to the connection to the Elasticsearch server.
+    private final boolean failOnIndexingError = ConfigHelper.getSystemPropertyAsBoolean(FAIL_ON_ERROR_PROP, FAIL_ON_ERROR_DEFAULT);
 
     private final ElasticConnection elasticConnection;
     private final BulkIngester<OperationContext> bulkIngester;
@@ -142,7 +142,7 @@ public class ElasticBulkProcessorHandler {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final ConcurrentHashMap<String, IndexInfo> registeredIndexes = new ConcurrentHashMap<>();
-    private final ConcurrentLinkedQueue<ErrorCause> globalSuppressedErrorCauses = new ConcurrentLinkedQueue<>();
+    private volatile Throwable lastConnectionError = null;
 
     // Time blocked waiting to add operations to the bulk processor.
     private final long startTime = System.nanoTime();
@@ -368,24 +368,27 @@ public class ElasticBulkProcessorHandler {
             if (!registeredIndexes.isEmpty()) {
                 LOG.warn("Some indexes were not closed properly: {}", Collections.list(registeredIndexes.keys()));
             }
-            if (!globalSuppressedErrorCauses.isEmpty()) {
-                IOException ioe = new IOException("Exception while indexing. See suppressed for details");
-                globalSuppressedErrorCauses.stream().map(ec -> new IllegalStateException(ec.reason())).forEach(ioe::addSuppressed);
-                throw ioe;
-            }
+            checkConnectionFailures();
+        }
+    }
+
+    private void checkConnectionFailures() throws IOException {
+        if (lastConnectionError != null) {
+            IOException ioe = new IOException("Exception while indexing.", lastConnectionError);
+            lastConnectionError = null; // Clear the last connection error after throwing it
+            throw ioe;
         }
     }
 
     private void checkFailuresForIndex(IndexInfo indexInfo) throws IOException {
-        // Also consider the global failures
-        if (!(indexInfo.suppressedErrorCauses.isEmpty() && globalSuppressedErrorCauses.isEmpty())) {
-            List<ErrorCause> errors = new ArrayList<>();
-            errors.addAll(indexInfo.suppressedErrorCauses);
-            errors.addAll(globalSuppressedErrorCauses);
-            String overflowMessage = (errors.size() >= MAX_SUPPRESSED_ERROR_CAUSES) ?
-                    ". (Too many failed operations in last bulk request, including only " + errors.size() + " errors)" : "";
+        if (!indexInfo.suppressedErrorCauses.isEmpty()) {
+            List<ErrorCause> suppressedErrors = new ArrayList<>(indexInfo.suppressedErrorCauses);
+            indexInfo.suppressedErrorCauses.clear();
+            String overflowMessage = suppressedErrors.size() >= MAX_SUPPRESSED_ERROR_CAUSES ?
+                    ". (Too many failed operations in last bulk request, including only " + suppressedErrors.size() + " errors)"
+                    : "";
             IOException ioe = new IOException("Exception while indexing " + indexInfo.indexName + ". See suppressed for details" + overflowMessage);
-            errors.stream().map(ec -> new IllegalStateException(ec.reason())).forEach(ioe::addSuppressed);
+            suppressedErrors.forEach(ec -> ioe.addSuppressed(new IllegalStateException(ec.reason())));
             throw ioe;
         }
     }
@@ -400,7 +403,10 @@ public class ElasticBulkProcessorHandler {
 
     private void add(BulkOperation operation, OperationContext context) throws IOException {
         // fail fast: we don't want to wait until the processor gets closed to fail
-        checkFailuresForIndex(context.indexInfo);
+        checkConnectionFailures();
+        if (failOnIndexingError) {
+            checkFailuresForIndex(context.indexInfo);
+        }
         long start = System.nanoTime();
         bulkIngester.add(operation, context);
         long end = System.nanoTime();
@@ -418,44 +424,6 @@ public class ElasticBulkProcessorHandler {
     }
 
     private class OakBulkListener implements BulkListener<OperationContext> {
-
-        private final class FailedDocSetTracker {
-            final HashSet<String> failedDocSet;
-            private final NodeBuilder status;
-            private boolean updated = false;
-            private boolean overflow = false;
-
-            public FailedDocSetTracker(NodeBuilder definitionBuilder) {
-                this.failedDocSet = new LinkedHashSet<>();
-                this.status = definitionBuilder.child(IndexDefinition.STATUS_NODE);
-                // Read the current failed paths (if any) on the :status node into failedDocList
-                PropertyState failedDocsProperty = status.getProperty(IndexDefinition.FAILED_DOC_PATHS);
-                if (failedDocsProperty != null) {
-                    for (String str : failedDocsProperty.getValue(Type.STRINGS)) {
-                        failedDocSet.add(str);
-                    }
-                }
-            }
-
-            public void addFailedDocument(String documentId) {
-                if (failedDocSet.size() < failedDocCountForStatusNode) {
-                    failedDocSet.add(documentId);
-                    updated = true;
-                } else {
-                    this.overflow = true;
-                }
-            }
-
-            public void saveFailedDocSets() {
-                if (overflow) {
-                    LOG.info("Cannot store all new Failed Docs because {} has been filled up. " +
-                            "See previous log entries to find out the details of failed paths", IndexDefinition.FAILED_DOC_PATHS);
-                }
-                if (updated) {
-                    status.setProperty(IndexDefinition.FAILED_DOC_PATHS, failedDocSet, Type.STRINGS);
-                }
-            }
-        }
 
         @Override
         public void beforeBulk(long executionId, BulkRequest request, List<OperationContext> contexts) {
@@ -481,40 +449,34 @@ public class ElasticBulkProcessorHandler {
 
         @Override
         public void afterBulk(long executionId, BulkRequest request, List<OperationContext> contexts, BulkResponse response) {
+            // Bullk request has been processed successfully. Some operations may have failed, but the request itself was successful.
             try {
                 LOG.debug("Bulk with id {} processed in {} ms", executionId, response.took());
                 if (LOG.isTraceEnabled()) {
                     LOG.trace(response.toString());
                 }
 
-                HashMap<String, FailedDocSetTracker> failedDocSetMap = new HashMap<>();
                 for (int i = 0; i < contexts.size(); i++) {
                     IndexInfo indexInfo = contexts.get(i).indexInfo;
                     BulkResponseItem item = response.items().get(i);
                     if (item.error() == null) {
                         indexInfo.indexModified = true;
                     } else {
-                        FailedDocSetTracker failedDocSet = failedDocSetMap.computeIfAbsent(
-                                indexInfo.indexName,
-                                // TODO: this must be thread safe because there may be several callback threads.
-                                //   However, this is not performance critical so we can use coarse grained locking
-                                k -> new FailedDocSetTracker(indexInfo.definitionBuilder));
-
-                        if (failOnError && indexInfo.suppressedErrorCauses.size() < MAX_SUPPRESSED_ERROR_CAUSES) {
+                        if (failOnIndexingError && indexInfo.suppressedErrorCauses.size() < MAX_SUPPRESSED_ERROR_CAUSES) {
                             indexInfo.suppressedErrorCauses.add(item.error());
                         }
-                        String documentId = contexts.get(i).documentId;
-                        failedDocSet.addFailedDocument(documentId);
-
-                        // Log entry to be used to parse logs to get the failed doc id/path if needed
-                        LOG.error("ElasticIndex Update Doc Failure: Error while adding/updating doc with id: [{}]", documentId);
-                        LOG.error("Failure Details: BulkItem ID: {}, Index: {}, Failure Cause: {}",
-                                item.id(), item.index(), item.error());
+                        String type = item.error().type() != null ? item.error().type() : "type-unknown";
+                        String reason = item.error().reason() != null ? item.error().reason() : "reason-unknown";
+                        if (reason.length() > 20) {
+                            reason = reason.substring(0, 20) + "...";
+                        }
+                        String logSilenceKey = indexInfo.indexName + ":" + type + ":" + reason;
+                        if (!LOG_SILENCER.silence(logSilenceKey)) {
+                            // Log entry to be used to parse logs to get the failed doc id/path if needed
+                            LOG.warn("Failure Details: BulkItem ID: {}, Index: {}, Failure Cause: {} - {}",
+                                    item.id(), item.index(), item.error(), LogSilencer.SILENCING_POSTFIX);
+                        }
                     }
-                }
-
-                for (FailedDocSetTracker failedDocSet : failedDocSetMap.values()) {
-                    failedDocSet.saveFailedDocSets();
                 }
             } finally {
                 lock.lock();
@@ -532,14 +494,11 @@ public class ElasticBulkProcessorHandler {
 
         @Override
         public void afterBulk(long executionId, BulkRequest request, List<OperationContext> contexts, Throwable failure) {
+            // Called in case of a connection failure or other error that prevented the full bulk request from being executed
             try {
-                LOG.error("ElasticIndex Update Bulk Failure : Bulk with id {} threw an error", executionId, failure);
-                globalSuppressedErrorCauses.add(ErrorCause.of(ec -> {
-                    StringWriter sw = new StringWriter();
-                    PrintWriter pw = new PrintWriter(sw);
-                    failure.printStackTrace(pw);
-                    return ec.reason(failure.getMessage()).stackTrace(sw.toString());
-                }));
+                LOG.warn("ElasticIndex Update Bulk Failure : Bulk with id {} threw an error", executionId, failure);
+                // Keep only the last connection error
+                lastConnectionError = failure;
             } finally {
                 lock.lock();
                 try {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
@@ -59,7 +59,7 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
     public ElasticIndexEditorProvider(@NotNull ElasticIndexTracker indexTracker,
                                       @NotNull ElasticConnection elasticConnection,
                                       ExtractedTextCache extractedTextCache,
-                                      ElasticRetryPolicy retryPolicy) {
+                                      @NotNull ElasticRetryPolicy retryPolicy) {
         this(indexTracker, elasticConnection, extractedTextCache, new ElasticBulkProcessorHandler(elasticConnection), retryPolicy);
     }
 
@@ -67,7 +67,7 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
                                       @NotNull ElasticConnection elasticConnection,
                                       ExtractedTextCache extractedTextCache,
                                       ElasticBulkProcessorHandler bulkProcessorHandler,
-                                      ElasticRetryPolicy retryPolicy) {
+                                      @NotNull ElasticRetryPolicy retryPolicy) {
         this.indexTracker = indexTracker;
         this.elasticConnection = elasticConnection;
         this.extractedTextCache = extractedTextCache != null ? extractedTextCache : new ExtractedTextCache(0, 0);
@@ -109,6 +109,11 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
 
     public ExtractedTextCache getExtractedTextCache() {
         return extractedTextCache;
+    }
+
+    @NotNull
+    public ElasticRetryPolicy getRetryPolicy() {
+        return retryPolicy;
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
@@ -44,6 +44,7 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
     private final ElasticConnection elasticConnection;
     private final ExtractedTextCache extractedTextCache;
     private final ElasticBulkProcessorHandler bulkProcessorHandler;
+    private final ElasticRetryPolicy retryPolicy;
 
     public final static String OAK_INDEX_ELASTIC_WRITER_DISABLE_KEY = "oak.index.elastic.writer.disable";
 
@@ -52,17 +53,26 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
     public ElasticIndexEditorProvider(@NotNull ElasticIndexTracker indexTracker,
                                       @NotNull ElasticConnection elasticConnection,
                                       ExtractedTextCache extractedTextCache) {
-        this(indexTracker, elasticConnection, extractedTextCache, new ElasticBulkProcessorHandler(elasticConnection));
+        this(indexTracker, elasticConnection, extractedTextCache, new ElasticBulkProcessorHandler(elasticConnection), ElasticRetryPolicy.NO_RETRY);
     }
 
     public ElasticIndexEditorProvider(@NotNull ElasticIndexTracker indexTracker,
                                       @NotNull ElasticConnection elasticConnection,
                                       ExtractedTextCache extractedTextCache,
-                                      ElasticBulkProcessorHandler bulkProcessorHandler) {
+                                      ElasticRetryPolicy retryPolicy) {
+        this(indexTracker, elasticConnection, extractedTextCache, new ElasticBulkProcessorHandler(elasticConnection), retryPolicy);
+    }
+
+    public ElasticIndexEditorProvider(@NotNull ElasticIndexTracker indexTracker,
+                                      @NotNull ElasticConnection elasticConnection,
+                                      ExtractedTextCache extractedTextCache,
+                                      ElasticBulkProcessorHandler bulkProcessorHandler,
+                                      ElasticRetryPolicy retryPolicy) {
         this.indexTracker = indexTracker;
         this.elasticConnection = elasticConnection;
         this.extractedTextCache = extractedTextCache != null ? extractedTextCache : new ExtractedTextCache(0, 0);
         this.bulkProcessorHandler = bulkProcessorHandler;
+        this.retryPolicy = retryPolicy;
     }
 
     @Override
@@ -79,7 +89,7 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
             ElasticIndexDefinition indexDefinition =
                     new ElasticIndexDefinition(root, definition.getNodeState(), indexPath, elasticConnection.getIndexPrefix());
 
-            ElasticIndexWriterFactory writerFactory = new ElasticIndexWriterFactory(elasticConnection, indexTracker, bulkProcessorHandler);
+            ElasticIndexWriterFactory writerFactory = new ElasticIndexWriterFactory(elasticConnection, indexTracker, bulkProcessorHandler, retryPolicy);
 
             ElasticIndexEditorContext context = new ElasticIndexEditorContext(root,
                     definition, indexDefinition,

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -63,18 +63,21 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     private final ElasticBulkProcessorHandler bulkProcessorHandler;
     private final boolean reindex;
     private final String indexName;
+    private final ElasticRetryPolicy retryPolicy;
 
     ElasticIndexWriter(@NotNull ElasticIndexTracker indexTracker,
                        @NotNull ElasticConnection elasticConnection,
                        @NotNull ElasticIndexDefinition indexDefinition,
                        @NotNull NodeBuilder definitionBuilder,
                        boolean reindex, CommitInfo commitInfo,
-                       ElasticBulkProcessorHandler bulkProcessorHandler) {
+                       ElasticBulkProcessorHandler bulkProcessorHandler,
+                       ElasticRetryPolicy retryPolicy) {
         this.indexTracker = indexTracker;
         this.elasticConnection = elasticConnection;
         this.indexDefinition = indexDefinition;
         this.reindex = reindex;
         this.bulkProcessorHandler = bulkProcessorHandler;
+        this.retryPolicy = retryPolicy;
 
         // We don't use stored index definitions with elastic. Every time a new writer gets created we
         // use the actual index name (based on the current seed) while reindexing, or the alias (pointing to the
@@ -119,7 +122,7 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
                        @NotNull ElasticConnection elasticConnection,
                        @NotNull ElasticIndexDefinition indexDefinition,
                        @NotNull ElasticBulkProcessorHandler bulkProcessorHandler) {
-        this(indexTracker, elasticConnection, indexDefinition, bulkProcessorHandler, false);
+        this(indexTracker, elasticConnection, indexDefinition, bulkProcessorHandler, ElasticRetryPolicy.NO_RETRY, false);
     }
 
     @TestOnly
@@ -127,12 +130,14 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
                        @NotNull ElasticConnection elasticConnection,
                        @NotNull ElasticIndexDefinition indexDefinition,
                        @NotNull ElasticBulkProcessorHandler bulkProcessorHandler,
+                       @NotNull ElasticRetryPolicy retryPolicy,
                        boolean reindex) {
         this.indexTracker = indexTracker;
         this.elasticConnection = elasticConnection;
         this.indexDefinition = indexDefinition;
         this.bulkProcessorHandler = bulkProcessorHandler;
         this.indexName = indexDefinition.getIndexAlias();
+        this.retryPolicy = retryPolicy;
         this.reindex = reindex;
     }
 
@@ -153,15 +158,15 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
             || (!indexDefinition.isExternallyModifiable()
             && !InferenceConfig.getInstance().isInferenceEnabled()
             && (InferenceIndexConfig.NOOP.equals(InferenceConfig.getInstance().getInferenceIndexConfig(jcrIndexName))))) {
-            bulkProcessorHandler.index(indexName, ElasticIndexUtils.idFromPath(path), doc);
+            retryPolicy.withRetries(() -> bulkProcessorHandler.index(indexName, ElasticIndexUtils.idFromPath(path), doc));
         } else {
-            bulkProcessorHandler.update(indexName, ElasticIndexUtils.idFromPath(path), doc);
+            retryPolicy.withRetries(() -> bulkProcessorHandler.update(indexName, ElasticIndexUtils.idFromPath(path), doc));
         }
     }
 
     @Override
     public void deleteDocuments(String path) throws IOException {
-        bulkProcessorHandler.delete(indexName, ElasticIndexUtils.idFromPath(path));
+        retryPolicy.withRetries(() -> bulkProcessorHandler.delete(indexName, ElasticIndexUtils.idFromPath(path)));
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
@@ -29,11 +29,17 @@ public class ElasticIndexWriterFactory implements FulltextIndexWriterFactory<Ela
     private final ElasticConnection elasticConnection;
     private final ElasticIndexTracker indexTracker;
     private final ElasticBulkProcessorHandler bulkProcessorHandler;
+    private final ElasticRetryPolicy retryPolicy;
 
     public ElasticIndexWriterFactory(@NotNull ElasticConnection elasticConnection, @NotNull ElasticIndexTracker indexTracker, ElasticBulkProcessorHandler bulkProcessorHandler) {
+        this(elasticConnection, indexTracker, bulkProcessorHandler, ElasticRetryPolicy.NO_RETRY);
+    }
+
+    public ElasticIndexWriterFactory(@NotNull ElasticConnection elasticConnection, @NotNull ElasticIndexTracker indexTracker, ElasticBulkProcessorHandler bulkProcessorHandler, ElasticRetryPolicy retryPolicy) {
         this.elasticConnection = elasticConnection;
         this.indexTracker = indexTracker;
         this.bulkProcessorHandler = bulkProcessorHandler;
+        this.retryPolicy = retryPolicy;
     }
 
     @Override
@@ -46,6 +52,6 @@ public class ElasticIndexWriterFactory implements FulltextIndexWriterFactory<Ela
 
         ElasticIndexDefinition esDefinition = (ElasticIndexDefinition) definition;
 
-        return new ElasticIndexWriter(indexTracker, elasticConnection, esDefinition, definitionBuilder, reindex, commitInfo, bulkProcessorHandler);
+        return new ElasticIndexWriter(indexTracker, elasticConnection, esDefinition, definitionBuilder, reindex, commitInfo, bulkProcessorHandler, retryPolicy);
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
@@ -1,0 +1,82 @@
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class ElasticRetryPolicy {
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticRetryPolicy.class);
+
+    // 0 - disabled, > 0 - retry for this number of seconds to reconnect to Elastic
+    public static final String OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS = "oak.indexer.elastic.connectionRetrySeconds";
+    public static final int DEFAULT_OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS = 0;
+
+    public interface IOOperation {
+        void execute() throws IOException;
+    }
+
+    public static final ElasticRetryPolicy NO_RETRY = new ElasticRetryPolicy(0, 0, 0, 0);
+
+    public static ElasticRetryPolicy createRetryPolicyFromSystemProperties() {
+        long connectionRetrySeconds = ConfigHelper.getSystemPropertyAsInt(
+                OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS,
+                DEFAULT_OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS);
+        if (connectionRetrySeconds <= 0) {
+            return NO_RETRY;
+        }
+        return new ElasticRetryPolicy(100, connectionRetrySeconds * 1000, 50, 1000);
+    }
+
+    private final int maxRetries;
+    private final long maxRetryTimeMs;
+    private final long initialIntervalMs;
+    private final long maxIntervalMs;
+
+    public ElasticRetryPolicy(int maxRetries, long maxRetryTimeMs, long initialIntervalMs, long maxIntervalMs) {
+        this.maxRetries = maxRetries;
+        this.maxRetryTimeMs = maxRetryTimeMs;
+        this.initialIntervalMs = initialIntervalMs;
+        this.maxIntervalMs = maxIntervalMs;
+    }
+
+    public void withRetries(IOOperation callable) throws IOException {
+        int retried = 0;
+        long retryUntil = 0;
+        long waitTime = initialIntervalMs;
+        while (true) {
+            if (retried > 0) {
+                // Log the retry attempt only if it's not the first attempt
+                LOG.info("Retrying operation (attempt {}/{})", retried + 1, maxRetries + 1);
+            }
+            try {
+                callable.execute();
+                return; // Success, exit the loop
+            } catch (IOException e) {
+                retried++;
+                if (retried > maxRetries && maxRetries > 0) {
+                    LOG.warn("Max retries exceeded. Operation failed {} attempts. Exception: {}", retried, e.toString());
+                    throw e;
+                }
+                long now = System.nanoTime();
+                if (retryUntil == 0) {
+                    retryUntil = now + TimeUnit.MILLISECONDS.toNanos(maxRetryTimeMs);
+                }
+                if (now > retryUntil) {
+                    LOG.warn("Max retry time exceeded. Operation failed after {} ms and {} attempts", maxRetryTimeMs, retried, e);
+                    throw e;
+                }
+                LOG.warn("Operation failed. Retrying after {} ms (attempt {}/{})", waitTime, retried, maxRetries, e);
+                try {
+                    Thread.sleep(waitTime);
+                    // Exponential backoff with a cap at maxIntervalMs
+                    waitTime = Math.min(waitTime * 2, maxIntervalMs);
+                } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+    }
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
@@ -12,7 +12,7 @@ public class ElasticRetryPolicy {
 
     // 0 - disabled, > 0 - retry for this number of seconds to reconnect to Elastic
     public static final String OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS = "oak.indexer.elastic.connectionRetrySeconds";
-    public static final int DEFAULT_OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS = 0;
+    public static final int DEFAULT_OAK_INDEXER_ELASTIC_CONNECTION_RETRY_SECONDS = 30;
 
     public interface IOOperation {
         void execute() throws IOException;
@@ -33,7 +33,7 @@ public class ElasticRetryPolicy {
         if (connectionRetrySeconds <= 0) {
             return NO_RETRY;
         }
-        return new ElasticRetryPolicy(100, connectionRetrySeconds * 1000, 50, 1000);
+        return new ElasticRetryPolicy(100, connectionRetrySeconds * 1000, 50, 5000);
     }
 
     private final int maxRetries;
@@ -46,6 +46,19 @@ public class ElasticRetryPolicy {
         this.maxRetryTimeMs = maxRetryTimeMs;
         this.initialIntervalMs = initialIntervalMs;
         this.maxIntervalMs = maxIntervalMs;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+    public long getMaxRetryTimeMs() {
+        return maxRetryTimeMs;
+    }
+    public long getInitialIntervalMs() {
+        return initialIntervalMs;
+    }
+    public long getMaxIntervalMs() {
+        return maxIntervalMs;
     }
 
     public void withRetries(IOOperation callable) throws IOException {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
 import org.apache.jackrabbit.oak.plugins.index.ConfigHelper;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
@@ -18,7 +18,13 @@ public class ElasticRetryPolicy {
         void execute() throws IOException;
     }
 
-    public static final ElasticRetryPolicy NO_RETRY = new ElasticRetryPolicy(0, 0, 0, 0);
+    public static final ElasticRetryPolicy NO_RETRY = new ElasticRetryPolicy(0, 0, 0, 0) {
+        @Override
+        public void withRetries(IOOperation callable) throws IOException {
+            // No retries, just execute the operation
+            callable.execute();
+        }
+    };
 
     public static ElasticRetryPolicy createRetryPolicyFromSystemProperties() {
         long connectionRetrySeconds = ConfigHelper.getSystemPropertyAsInt(
@@ -43,21 +49,21 @@ public class ElasticRetryPolicy {
     }
 
     public void withRetries(IOOperation callable) throws IOException {
-        int retried = 0;
+        int timesRetried = 0;
         long retryUntil = 0;
         long waitTime = initialIntervalMs;
         while (true) {
-            if (retried > 0) {
+            if (timesRetried > 0) {
                 // Log the retry attempt only if it's not the first attempt
-                LOG.info("Retrying operation (attempt {}/{})", retried + 1, maxRetries + 1);
+                LOG.info("Retrying operation (attempt {}/{})", timesRetried + 1, maxRetries + 1);
             }
             try {
                 callable.execute();
                 return; // Success, exit the loop
             } catch (IOException e) {
-                retried++;
-                if (retried > maxRetries && maxRetries > 0) {
-                    LOG.warn("Max retries exceeded. Operation failed {} attempts. Exception: {}", retried, e.toString());
+                timesRetried++;
+                if (timesRetried > maxRetries) {
+                    LOG.warn("Maximum retries exceeded, giving up. Operation failed {} times. Exception: {}", timesRetried, e.toString());
                     throw e;
                 }
                 long now = System.nanoTime();
@@ -65,10 +71,10 @@ public class ElasticRetryPolicy {
                     retryUntil = now + TimeUnit.MILLISECONDS.toNanos(maxRetryTimeMs);
                 }
                 if (now > retryUntil) {
-                    LOG.warn("Max retry time exceeded. Operation failed after {} ms and {} attempts", maxRetryTimeMs, retried, e);
+                    LOG.warn("Max retry time exceeded. Operation failed after {} ms and {} attempts", maxRetryTimeMs, timesRetried, e);
                     throw e;
                 }
-                LOG.warn("Operation failed. Retrying after {} ms (attempt {}/{})", waitTime, retried, maxRetries, e);
+                LOG.warn("Operation failed. Retrying after {} ms (attempt {}/{})", waitTime, timesRetried, maxRetries, e);
                 try {
                     Thread.sleep(waitTime);
                     // Exponential backoff with a cap at maxIntervalMs

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticRetryPolicy.java
@@ -34,7 +34,7 @@ public class ElasticRetryPolicy {
         void execute() throws IOException;
     }
 
-    public static final ElasticRetryPolicy NO_RETRY = new ElasticRetryPolicy(0, 0, 0, 0) {
+    public static final ElasticRetryPolicy NO_RETRY = new ElasticRetryPolicy(1, 0, 0, 0) {
         @Override
         public void withRetries(IOOperation callable) throws IOException {
             // No retries, just execute the operation
@@ -52,47 +52,62 @@ public class ElasticRetryPolicy {
         return new ElasticRetryPolicy(100, connectionRetrySeconds * 1000, 50, 5000);
     }
 
-    private final int maxRetries;
+    private final int maxAttempts;
     private final long maxRetryTimeMs;
     private final long initialIntervalMs;
     private final long maxIntervalMs;
 
-    public ElasticRetryPolicy(int maxRetries, long maxRetryTimeMs, long initialIntervalMs, long maxIntervalMs) {
-        this.maxRetries = maxRetries;
+    public ElasticRetryPolicy(int maxAttempts, long maxRetryTimeMs, long initialIntervalMs, long maxIntervalMs) {
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException("Invalid value for maxAttempts: " + maxAttempts + ". Must be greater than 0");
+        }
+        if (maxRetryTimeMs < 0) {
+            throw new IllegalArgumentException("Invalid value for maxRetryTimeMs: " + maxRetryTimeMs + ". Must be non-negative");
+        }
+        if (initialIntervalMs < 0) {
+            throw new IllegalArgumentException("Invalid value for initialIntervalMs: " + initialIntervalMs + ". Must be non-negative");
+        }
+        if (maxIntervalMs < 0) {
+            throw new IllegalArgumentException("Invalid value for maxIntervalMs: " + maxIntervalMs + ". Must be non-negative");
+        }
+        this.maxAttempts = maxAttempts;
         this.maxRetryTimeMs = maxRetryTimeMs;
         this.initialIntervalMs = initialIntervalMs;
         this.maxIntervalMs = maxIntervalMs;
     }
 
-    public int getMaxRetries() {
-        return maxRetries;
+    public int getMaxAttempts() {
+        return maxAttempts;
     }
+
     public long getMaxRetryTimeMs() {
         return maxRetryTimeMs;
     }
+
     public long getInitialIntervalMs() {
         return initialIntervalMs;
     }
+
     public long getMaxIntervalMs() {
         return maxIntervalMs;
     }
 
     public void withRetries(IOOperation callable) throws IOException {
-        int timesRetried = 0;
+        int numberOfAttempts = 0;
         long retryUntil = 0;
         long waitTime = initialIntervalMs;
         while (true) {
-            if (timesRetried > 0) {
+            numberOfAttempts++;
+            if (numberOfAttempts > 1) {
                 // Log the retry attempt only if it's not the first attempt
-                LOG.info("Retrying operation (attempt {}/{})", timesRetried + 1, maxRetries + 1);
+                LOG.info("Retrying operation (attempt {}/{})", numberOfAttempts, maxAttempts);
             }
             try {
                 callable.execute();
                 return; // Success, exit the loop
             } catch (IOException e) {
-                timesRetried++;
-                if (timesRetried > maxRetries) {
-                    LOG.warn("Maximum retries exceeded, giving up. Operation failed {} times. Exception: {}", timesRetried, e.toString());
+                if (numberOfAttempts >= maxAttempts) {
+                    LOG.warn("Maximum retries exceeded, giving up. Operation failed {} times. Exception: {}", numberOfAttempts, e.toString());
                     throw e;
                 }
                 long now = System.nanoTime();
@@ -100,10 +115,10 @@ public class ElasticRetryPolicy {
                     retryUntil = now + TimeUnit.MILLISECONDS.toNanos(maxRetryTimeMs);
                 }
                 if (now > retryUntil) {
-                    LOG.warn("Max retry time exceeded. Operation failed after {} ms and {} attempts", maxRetryTimeMs, timesRetried, e);
+                    LOG.warn("Max retry time exceeded. Operation failed after {} ms and {} attempts", maxRetryTimeMs, numberOfAttempts, e);
                     throw e;
                 }
-                LOG.warn("Operation failed. Retrying after {} ms (attempt {}/{})", waitTime, timesRetried, maxRetries, e);
+                LOG.warn("Operation failed in attempt {}/{}. Retrying after {} ms", numberOfAttempts, maxAttempts, waitTime, e);
                 try {
                     Thread.sleep(waitTime);
                     // Exponential backoff with a cap at maxIntervalMs
@@ -113,5 +128,15 @@ public class ElasticRetryPolicy {
                 }
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ElasticRetryPolicy{" +
+                "maxRetries=" + maxAttempts +
+                ", maxRetryTimeMs=" + maxRetryTimeMs +
+                ", initialIntervalMs=" + initialIntervalMs +
+                ", maxIntervalMs=" + maxIntervalMs +
+                '}';
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -33,6 +33,7 @@ import org.apache.jackrabbit.oak.plugins.index.TestUtil;
 import org.apache.jackrabbit.oak.plugins.index.TrackingCorruptIndexHandler;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorProvider;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticIndexProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
@@ -134,6 +135,11 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
         return INDEX_CORRUPT_INTERVAL_IN_MILLIS;
     }
 
+    protected ElasticRetryPolicy getElasticRetryPolicy() {
+        // Override this in extending classes to provide a different retry policy
+        return ElasticRetryPolicy.NO_RETRY;
+    }
+
     protected Oak addAsyncIndexingLanesToOak(Oak oak) {
         // Override this in extending classes to configure different
         // indexing lanes with different time limits.
@@ -154,7 +160,8 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
         InferenceConfig.reInitialize(nodeStore, INFERENCE_CONFIG_PATH, isInferenceEnabled());
         indexTracker = new ElasticIndexTracker(esConnection, getMetricHandler());
         ElasticIndexEditorProvider editorProvider = new ElasticIndexEditorProvider(indexTracker, esConnection,
-            new ExtractedTextCache(10 * FileUtils.ONE_MB, 100));
+                new ExtractedTextCache(10 * FileUtils.ONE_MB, 100),
+                getElasticRetryPolicy());
         ElasticIndexProvider indexProvider = new ElasticIndexProvider(indexTracker);
 
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -154,7 +154,9 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
         InferenceConfig.reInitialize(nodeStore, INFERENCE_CONFIG_PATH, isInferenceEnabled());
         indexTracker = new ElasticIndexTracker(esConnection, getMetricHandler());
         ElasticIndexEditorProvider editorProvider = new ElasticIndexEditorProvider(indexTracker, esConnection,
-            new ExtractedTextCache(10 * FileUtils.ONE_MB, 100));
+            new ExtractedTextCache(10 * FileUtils.ONE_MB, 100)
+//            new ElasticRetryPolicy(10, 1000, 5,100)
+                );
         ElasticIndexProvider indexProvider = new ElasticIndexProvider(indexTracker);
 
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -154,9 +154,7 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
         InferenceConfig.reInitialize(nodeStore, INFERENCE_CONFIG_PATH, isInferenceEnabled());
         indexTracker = new ElasticIndexTracker(esConnection, getMetricHandler());
         ElasticIndexEditorProvider editorProvider = new ElasticIndexEditorProvider(indexTracker, esConnection,
-            new ExtractedTextCache(10 * FileUtils.ONE_MB, 100)
-//            new ElasticRetryPolicy(10, 1000, 5,100)
-                );
+            new ExtractedTextCache(10 * FileUtils.ONE_MB, 100));
         ElasticIndexProvider indexProvider = new ElasticIndexProvider(indexTracker);
 
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticAbstractQueryTest.java
@@ -130,6 +130,10 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
         return false;
     }
 
+    protected long getIndexCorruptIntervalInMillis() {
+        return INDEX_CORRUPT_INTERVAL_IN_MILLIS;
+    }
+
     protected Oak addAsyncIndexingLanesToOak(Oak oak) {
         // Override this in extending classes to configure different
         // indexing lanes with different time limits.
@@ -160,7 +164,7 @@ public abstract class ElasticAbstractQueryTest extends AbstractQueryTest {
         ));
 
         TrackingCorruptIndexHandler trackingCorruptIndexHandler = new TrackingCorruptIndexHandler();
-        trackingCorruptIndexHandler.setCorruptInterval(INDEX_CORRUPT_INTERVAL_IN_MILLIS, TimeUnit.MILLISECONDS);
+        trackingCorruptIndexHandler.setCorruptInterval(getIndexCorruptIntervalInMillis(), TimeUnit.MILLISECONDS);
         asyncIndexUpdate.setCorruptIndexHandler(trackingCorruptIndexHandler);
 
         Oak oak = new Oak(nodeStore)

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionRule.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionRule.java
@@ -125,6 +125,7 @@ public class ElasticConnectionRule extends ExternalResource {
             elasticConnectionModel.elasticApiKey = apiKey;
             elasticConnectionModel.elasticApiSecret = apiSecret;
             elasticConnectionModel.indexPrefix = indexPrefix;
+            elasticConnectionModel.maxRetryTime = 0;
         } catch (URISyntaxException e) {
             LOG.error("Provided elastic connection string is not valid ", e);
         }
@@ -138,6 +139,7 @@ public class ElasticConnectionRule extends ExternalResource {
         elasticConnectionModel.elasticApiKey = null;
         elasticConnectionModel.elasticApiSecret = null;
         elasticConnectionModel.indexPrefix = indexPrefix;
+        elasticConnectionModel.maxRetryTime = 0;
     }
 
     private Map<String, String> getUriQueryParams(URI uri) {
@@ -231,6 +233,7 @@ public class ElasticConnectionRule extends ExternalResource {
         private String elasticHost;
         private int elasticPort;
         private String indexPrefix;
+        private int maxRetryTime;
 
         public String getElasticApiSecret() {
             return elasticApiSecret;
@@ -254,6 +257,10 @@ public class ElasticConnectionRule extends ExternalResource {
 
         public String getIndexPrefix() {
             return indexPrefix;
+        }
+
+        public int getMaxRetryTime() {
+            return maxRetryTime;
         }
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderServiceTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexInfoService;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.query.QueryEngineSettings;
@@ -42,11 +43,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_DISABLED;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_ELASTIC_API_KEY_ID;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_ELASTIC_API_KEY_SECRET;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_ELASTIC_HOST;
+import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_ELASTIC_MAX_RETRY_TIME;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_ELASTIC_PORT;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_ELASTIC_SCHEME;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService.PROP_INDEX_PREFIX;
@@ -122,6 +125,9 @@ public class ElasticIndexProviderServiceTest {
 
         assertEquals(0, WhiteboardUtils.getServices(wb, Runnable.class).size());
 
+        ElasticIndexEditorProvider editorProvider = (ElasticIndexEditorProvider) context.getService(IndexEditorProvider.class);
+        assertEquals(0, editorProvider.getRetryPolicy().getMaxRetryTimeMs());
+
         MockOsgi.deactivate(service, context.bundleContext());
     }
 
@@ -177,6 +183,22 @@ public class ElasticIndexProviderServiceTest {
         MockOsgi.deactivate(serviceSpy, context.bundleContext());
     }
 
+    @Test
+    public void withMaxRetryInterval() {
+        Map<String, Object> props = new HashMap<>(getElasticConfig());
+        props.put(PROP_ELASTIC_MAX_RETRY_TIME, 600);
+        MockOsgi.activate(service, context.bundleContext(), props);
+
+        assertNotNull(context.getService(QueryIndexProvider.class));
+        assertNotNull(context.getService(IndexEditorProvider.class));
+
+        ElasticIndexEditorProvider editorProvider = (ElasticIndexEditorProvider) context.getService(IndexEditorProvider.class);
+        assertEquals(TimeUnit.SECONDS.toMillis(600), editorProvider.getRetryPolicy().getMaxRetryTimeMs());
+
+        MockOsgi.deactivate(service, context.bundleContext());
+    }
+
+
     private HashMap<String, Object> getElasticConfig() {
         HashMap<String, Object> config = new HashMap<>();
         config.put(PROP_INDEX_PREFIX, "elastic");
@@ -185,6 +207,7 @@ public class ElasticIndexProviderServiceTest {
         config.put(PROP_ELASTIC_PORT, elasticRule.getElasticConnectionModel().getElasticPort());
         config.put(PROP_ELASTIC_API_KEY_ID, elasticRule.getElasticConnectionModel().getElasticApiKey());
         config.put(PROP_ELASTIC_API_KEY_SECRET, elasticRule.getElasticConnectionModel().getElasticApiSecret());
+        config.put(PROP_ELASTIC_MAX_RETRY_TIME, elasticRule.getElasticConnectionModel().getMaxRetryTime());
         try {
             config.put(PROP_LOCAL_TEXT_EXTRACTION_DIR, folder.newFolder("localTextExtractionDir").getAbsolutePath());
         } catch (IOException e) {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexFailuresTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexFailuresTest.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilde
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import java.util.List;
 
@@ -32,6 +33,8 @@ public class ElasticPropertyIndexFailuresTest extends ElasticAbstractQueryTest {
 
     @Rule
     public TemporarySystemProperty temporarySystemProperty = new TemporarySystemProperty();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Before
     public void before() throws Exception {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexNonFailureTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexNonFailureTest.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilde
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,6 +35,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ElasticPropertyIndexNonFailureTest extends ElasticAbstractQueryTest {
     @Rule
     public TemporarySystemProperty temporarySystemProperty = new TemporarySystemProperty();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     // Tests are hardcoded for these values
     private final static int BULK_ACTIONS_TEST = 250;
@@ -44,6 +47,7 @@ public class ElasticPropertyIndexNonFailureTest extends ElasticAbstractQueryTest
         // Use a low value for the tests
         System.setProperty(ElasticBulkProcessorHandler.BULK_ACTIONS_PROP, Integer.toString(BULK_ACTIONS_TEST));
         System.setProperty(ElasticBulkProcessorHandler.BULK_SIZE_BYTES_PROP, Integer.toString(BULK_SIZE_BYTES_TEST));
+        System.setProperty(ElasticBulkProcessorHandler.FAIL_ON_ERROR_PROP, "true");
         super.before();
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticPropertyIndexTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import java.util.List;
 
@@ -42,6 +43,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ElasticPropertyIndexTest extends ElasticAbstractQueryTest {
     @Rule
     public TemporarySystemProperty temporarySystemProperty = new TemporarySystemProperty();
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     // Tests are hardcoded for these values
     private final static int BULK_ACTIONS_TEST = 250;

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -140,7 +140,7 @@ public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
             Throwable cause = e.getCause();
             String msg = cause.getMessage();
             assertTrue("Unexpected exception type. Expected IOException. Was " + cause, cause instanceof IOException);
-            assertTrue(msg, msg.contains("Exception while indexing "));
+            assertTrue(msg, msg.contains("Error indexing documents for index:"));
             // Typically, the root cause is "Limit of total fields [1000] has been exceeded"
             // but something this is suppressed, and so we can not have an assertion on it
         }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticRegexPropertyIndexTest.java
@@ -26,13 +26,28 @@ import java.util.List;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticBulkProcessorHandler;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
 import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder.PropertyRule;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 public class ElasticRegexPropertyIndexTest extends ElasticAbstractQueryTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Before
+    public void before() throws Exception {
+        // Use a low value for the tests
+        System.setProperty(ElasticBulkProcessorHandler.FAIL_ON_ERROR_PROP, "true");
+        super.before();
+    }
+
 
     @Test
     public void regexPropertyWithFlattened() throws Exception {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityAsyncIndexingTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityAsyncIndexingTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
 import eu.rekawek.toxiproxy.model.toxic.LimitData;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 import org.junit.Test;
 
 import java.util.List;
@@ -42,6 +43,11 @@ public class ElasticReliabilityAsyncIndexingTest extends ElasticReliabilityTest 
     @Override
     public long getIndexCorruptIntervalInMillis() {
         return TimeUnit.DAYS.toMillis(7);
+    }
+
+    @Override
+    public ElasticRetryPolicy getElasticRetryPolicy() {
+        return ElasticRetryPolicy.NO_RETRY;
     }
 
     @Test

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityAsyncIndexingTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityAsyncIndexingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic;
+
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import eu.rekawek.toxiproxy.model.toxic.LimitData;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ElasticReliabilityAsyncIndexingTest extends ElasticReliabilityTest {
+
+    @Override
+    public boolean useAsyncIndexing() {
+        return true;
+    }
+
+    @Override
+    public long getIndexCorruptIntervalInMillis() {
+        return TimeUnit.DAYS.toMillis(7);
+    }
+
+    @Test
+    public void connectionCutOnIndex() throws Exception {
+        String indexName = UUID.randomUUID().toString();
+        setIndex(indexName, createIndex("propa", "propb"));
+        root.commit();
+
+        // Do not wait for the lane to run, it would take too long, force it to run immediately
+        asyncIndexUpdate.run();
+        assertFalse(asyncIndexUpdate.isFailing());
+
+        // The query should use the index that was just created
+        String query = "select [jcr:path] from [nt:base] where propa is not null";
+        assertThat(explain(query), containsString("elasticsearch:" + indexName));
+
+        // Create initial content and check that it is indexed correctly
+        Tree testTree = root.getTree("/").addChild("test");
+        for (int i = 0; i < 10; i++) {
+            Tree child = testTree.addChild("child" + i);
+            child.setProperty("propa", "a" + i);
+            root.commit();
+        }
+        asyncIndexUpdate.run();
+        assertEventually(() -> {
+            assertThat(explain(query), containsString("elasticsearch:" + indexName));
+            assertQuery(query, IntStream.range(0, 10).mapToObj(i -> "/test/child" + i).collect(Collectors.toList()));
+        });
+
+        // Set a toxic to cut the connection to Elastic after further 4KB of data sent upstream
+        LimitData cutConnectionUpstream = proxy.toxics()
+                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 4096L);
+
+        // Add more children to the test tree
+        for (int i = 10; i < 50; i++) {
+            Tree child = testTree.addChild("child" + i);
+            child.setProperty("propa", "a" + i);
+            root.commit();
+        }
+        // This time the async index update should fail due to the connection cut
+        asyncIndexUpdate.run();
+        assertTrue(asyncIndexUpdate.isFailing());
+
+        // Remove the toxic to allow querying and further indexing
+        cutConnectionUpstream.remove();
+        // The query should still return the initial 10 children and eventually some of the new children , but none of the children that were added after the toxic was applied
+        assertEventually(() -> {
+            List<String> resultsAfter = executeQuery(query, SQL2);
+            assertThat(
+                    "Some but not all of the new entries should be reflected on the index",
+                    10 < resultsAfter.size() && resultsAfter.size() < 50
+            );
+        });
+
+        // Run a new async index cycle after the toxic is removed
+        asyncIndexUpdate.run();
+        assertFalse(asyncIndexUpdate.isFailing());
+
+        assertEventually(() -> {
+            assertThat(explain(query), containsString("elasticsearch:" + indexName));
+            assertQuery(query, IntStream.range(0, 50).mapToObj(i -> "/test/child" + i).collect(Collectors.toList()));
+        });
+    }
+}

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilitySyncIndexingTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilitySyncIndexingTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic;
+
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import eu.rekawek.toxiproxy.model.toxic.LimitData;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ElasticReliabilitySyncIndexingTest extends ElasticReliabilityTest {
+
+    @Override
+    public boolean useAsyncIndexing() {
+        return false;
+    }
+
+    @Test
+    public void connectionCutOnQuery() throws Exception {
+        String indexName = UUID.randomUUID().toString();
+        setIndex(indexName, createIndex("propa", "propb"));
+
+        Tree test = root.getTree("/").addChild("test");
+        test.addChild("a").setProperty("propa", "a");
+        test.addChild("b").setProperty("propa", "c");
+        test.addChild("c").setProperty("propb", "e");
+        root.commit(Map.of("sync-mode", "rt"));
+
+        String query = "select [jcr:path] from [nt:base] where propa is not null";
+
+        assertEventually(() -> {
+            assertThat(explain(query), containsString("elasticsearch:" + indexName));
+            assertQuery(query, List.of("/test/a", "/test/b"));
+        });
+
+        // simulate an upstream connection cut
+        LimitData cutConnectionUpstream = proxy.toxics()
+                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 0L);
+
+        assertEventually(() -> {
+            // elastic is down, query should not use it
+            assertThat(explain(query), not(containsString("elasticsearch:" + indexName)));
+
+            // result set should be correct anyway since traversal is enabled
+            assertQuery(query, List.of("/test/a", "/test/b"));
+        });
+
+        // re-establish connection
+        cutConnectionUpstream.remove();
+
+        assertEventually(() -> {
+            // result set should be the same as before but this time elastic should be used
+            assertThat(explain(query), containsString("elasticsearch:" + indexName));
+            assertQuery(query, List.of("/test/a", "/test/b"));
+        });
+    }
+
+    @Test
+    public void connectionCutOnIndex() throws Exception {
+        String indexName = UUID.randomUUID().toString();
+        setIndex(indexName, createIndex("propa", "propb"));
+
+        // simulate an upstream connection cut
+        LimitData cutConnectionUpstream = proxy.toxics()
+                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 8192L);
+
+        Tree testBefore = root.getTree("/").addChild("test");
+        try {
+            for (int i = 0; i < 100; i++) {
+                Tree child = testBefore.addChild("child" + i);
+                child.setProperty("propa", "a" + i);
+                root.commit();
+            }
+        } catch (CommitFailedException cfe) {
+            // ignore commit failures, we expect some due to the connection cut
+            // Remove the toxic to allow further indexing
+            cutConnectionUpstream.remove();
+        }
+
+        // Add a new child after the commit failure
+        Tree testAfter = root.getTree("/").addChild("test").addChild("child-added-after-failure");
+        testAfter.setProperty("propb", "b");
+        root.commit();
+
+        // Make sure that the child added after the commit failure is indexed correctly
+        String query = "select [jcr:path] from [nt:base] where propb is not null";
+        assertEventually(() -> {
+            assertThat(explain(query), containsString("elasticsearch:" + indexName));
+            assertQuery(query, List.of("/test/child-added-after-failure"));
+        });
+    }
+}

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityTest.java
@@ -34,6 +34,8 @@ import java.io.IOException;
  */
 abstract public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
 
+    public static final String TOXIPROXY_IMAGE_NAME = "ghcr.io/shopify/toxiproxy:2.12.0";
+
     // set cache expiration and refresh to low values to avoid cached results in tests
     @Rule
     public final ProvideSystemProperty updateSystemProperties
@@ -43,7 +45,7 @@ abstract public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.12.0");
+    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse(TOXIPROXY_IMAGE_NAME);
 
     protected ToxiproxyContainer toxiproxy;
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityTest.java
@@ -20,7 +20,9 @@ import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
 import eu.rekawek.toxiproxy.model.toxic.LimitData;
+import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticBulkProcessorHandler;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,8 +57,15 @@ public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
 
     private Proxy proxy;
 
+    // Tests are hardcoded for these values
+    private final static int BULK_ACTIONS_TEST = 2;
+    private final static int BULK_SIZE_BYTES_TEST = 2 * 1024;
+
     @Override
     public void before() throws Exception {
+        // Use a low value for the tests
+        System.setProperty(ElasticBulkProcessorHandler.BULK_ACTIONS_PROP, Integer.toString(BULK_ACTIONS_TEST));
+        System.setProperty(ElasticBulkProcessorHandler.BULK_SIZE_BYTES_PROP, Integer.toString(BULK_SIZE_BYTES_TEST));
         toxiproxy = new ToxiproxyContainer(TOXIPROXY_IMAGE)
                 .withStartupAttempts(3)
                 .withNetwork(elasticRule.elastic.getNetwork());
@@ -125,5 +134,35 @@ public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
             assertThat(explain(query), containsString("elasticsearch:" + indexName));
             assertQuery(query, List.of("/test/a", "/test/b"));
         });
+    }
+
+    @Test
+    public void connectionCutOnIndex() throws Exception {
+        String indexName = UUID.randomUUID().toString();
+        setIndex(indexName, createIndex("propa", "propb"));
+
+        // simulate an upstream connection cut
+        LimitData cutConnectionUpstream = proxy.toxics()
+                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 8192L);
+
+        System.out.println("Adding test node");
+        Tree testBefore = root.getTree("/").addChild("test");
+        try {
+            for (int i = 0; i < 100; i++) {
+                testBefore.setProperty("propa", "a" + i);
+                root.commit();
+            }
+        } catch (CommitFailedException cfe) {
+            // ignore commit failures, we expect some due to the connection cut
+            System.out.println("Commit failed: " + cfe.getMessage());
+            cfe.printStackTrace();
+            cutConnectionUpstream.remove();
+        }
+
+        Tree testAfter = root.getTree("/").addChild("test");
+        for (int i = 0; i < 10; i++) {
+            testAfter.setProperty("propa", "a" + i);
+            root.commit();
+        }
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticReliabilityTest.java
@@ -18,29 +18,21 @@ package org.apache.jackrabbit.oak.plugins.index.elastic;
 
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
-import eu.rekawek.toxiproxy.model.ToxicDirection;
-import eu.rekawek.toxiproxy.model.toxic.LimitData;
-import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticBulkProcessorHandler;
 import org.junit.After;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
+/**
+ * Tests for reliability of async indexing with connection cuts and failures.
+ * This test uses Toxiproxy to simulate network issues.
+ */
+abstract public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
 
     // set cache expiration and refresh to low values to avoid cached results in tests
     @Rule
@@ -53,13 +45,13 @@ public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
 
     private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.12.0");
 
-    private ToxiproxyContainer toxiproxy;
+    protected ToxiproxyContainer toxiproxy;
 
-    private Proxy proxy;
+    protected Proxy proxy;
 
     // Tests are hardcoded for these values
-    private final static int BULK_ACTIONS_TEST = 2;
-    private final static int BULK_SIZE_BYTES_TEST = 2 * 1024;
+    protected final static int BULK_ACTIONS_TEST = 2;
+    protected final static int BULK_SIZE_BYTES_TEST = 2 * 1024;
 
     @Override
     public void before() throws Exception {
@@ -94,75 +86,5 @@ public class ElasticReliabilityTest extends ElasticAbstractQueryTest {
         return elasticRule.useDocker() ?
                 elasticRule.getElasticConnectionForDocker(toxiproxy.getHost(), toxiproxy.getMappedPort(8666)) :
                 elasticRule.getElasticConnectionFromString();
-    }
-
-    @Test
-    public void connectionCutOnQuery() throws Exception {
-        String indexName = UUID.randomUUID().toString();
-        setIndex(indexName, createIndex("propa", "propb"));
-
-        Tree test = root.getTree("/").addChild("test");
-        test.addChild("a").setProperty("propa", "a");
-        test.addChild("b").setProperty("propa", "c");
-        test.addChild("c").setProperty("propb", "e");
-        root.commit(Map.of("sync-mode", "rt"));
-
-        String query = "select [jcr:path] from [nt:base] where propa is not null";
-
-        assertEventually(() -> {
-            assertThat(explain(query), containsString("elasticsearch:" + indexName));
-            assertQuery(query, List.of("/test/a", "/test/b"));
-        });
-
-        // simulate an upstream connection cut
-        LimitData cutConnectionUpstream = proxy.toxics()
-                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 0L);
-
-        assertEventually(() -> {
-            // elastic is down, query should not use it
-            assertThat(explain(query), not(containsString("elasticsearch:" + indexName)));
-
-            // result set should be correct anyway since traversal is enabled
-            assertQuery(query, List.of("/test/a", "/test/b"));
-        });
-
-        // re-establish connection
-        cutConnectionUpstream.remove();
-
-        assertEventually(() -> {
-            // result set should be the same as before but this time elastic should be used
-            assertThat(explain(query), containsString("elasticsearch:" + indexName));
-            assertQuery(query, List.of("/test/a", "/test/b"));
-        });
-    }
-
-    @Test
-    public void connectionCutOnIndex() throws Exception {
-        String indexName = UUID.randomUUID().toString();
-        setIndex(indexName, createIndex("propa", "propb"));
-
-        // simulate an upstream connection cut
-        LimitData cutConnectionUpstream = proxy.toxics()
-                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 8192L);
-
-        System.out.println("Adding test node");
-        Tree testBefore = root.getTree("/").addChild("test");
-        try {
-            for (int i = 0; i < 100; i++) {
-                testBefore.setProperty("propa", "a" + i);
-                root.commit();
-            }
-        } catch (CommitFailedException cfe) {
-            // ignore commit failures, we expect some due to the connection cut
-            System.out.println("Commit failed: " + cfe.getMessage());
-            cfe.printStackTrace();
-            cutConnectionUpstream.remove();
-        }
-
-        Tree testAfter = root.getTree("/").addChild("test");
-        for (int i = 0; i < 10; i++) {
-            testAfter.setProperty("propa", "a" + i);
-            root.commit();
-        }
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterITTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterITTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import eu.rekawek.toxiproxy.model.toxic.LimitData;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnectionRule;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticMetricHandler;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticReliabilityTest;
+import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.state.NodeStore;
+import org.apache.jackrabbit.oak.stats.StatisticsProvider;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
+
+public class ElasticIndexWriterITTest {
+
+    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse(ElasticReliabilityTest.TOXIPROXY_IMAGE_NAME);
+
+    protected ToxiproxyContainer toxiproxy;
+
+    protected Proxy proxy;
+
+    @ClassRule
+    public static final ElasticConnectionRule elasticRule = new ElasticConnectionRule();
+
+    public NodeStore nodeStore;
+    private ElasticConnection connection;
+    private ElasticIndexTracker indexTracker;
+
+    protected ElasticConnection getElasticConnection() {
+        return elasticRule.useDocker() ?
+                elasticRule.getElasticConnectionForDocker(toxiproxy.getHost(), toxiproxy.getMappedPort(8666)) :
+                elasticRule.getElasticConnectionFromString();
+    }
+
+    @Before
+    public void setup() throws Exception {
+        // Use a low value for the tests
+        System.setProperty(ElasticBulkProcessorHandler.BULK_ACTIONS_PROP, "2");
+        System.setProperty(ElasticBulkProcessorHandler.BULK_SIZE_BYTES_PROP, "2048");
+        this.toxiproxy = new ToxiproxyContainer(TOXIPROXY_IMAGE)
+                .withStartupAttempts(3)
+                .withNetwork(elasticRule.elastic.getNetwork());
+        this.toxiproxy.start();
+        ToxiproxyClient toxiproxyClient = new ToxiproxyClient(toxiproxy.getHost(), toxiproxy.getControlPort());
+        this.proxy = toxiproxyClient.createProxy("elastic", "0.0.0.0:8666", "elasticsearch:9200");
+
+        this.connection = getElasticConnection();
+        this.indexTracker = new ElasticIndexTracker(connection, new ElasticMetricHandler(StatisticsProvider.NOOP));
+        this.nodeStore = new MemoryNodeStore(INITIAL_CONTENT);
+    }
+
+
+    @Test
+    public void writerRecoversFromDisconnection() throws Exception {
+        @NotNull NodeState root = nodeStore.getRoot();
+        @NotNull NodeBuilder builder = root.builder();
+        String indexName = "test";
+        IndexDefinitionBuilder idxBuilder = new ElasticIndexDefinitionBuilder(builder.child("oak:index").child(indexName));
+        idxBuilder.indexRule("nt:base")
+                .property("propa")
+                .propertyIndex();
+        NodeState nodeState = idxBuilder.build();
+        ElasticIndexDefinition definition = new ElasticIndexDefinition(root, nodeState, indexName, connection.getIndexPrefix());
+        ElasticBulkProcessorHandler bulkProcessorHandler = new ElasticBulkProcessorHandler(connection);
+        bulkProcessorHandler.registerIndex(connection.getIndexPrefix() + "." + indexName, definition, builder.child("oak:index").getChildNode(indexName), CommitInfo.EMPTY, false);
+        ElasticIndexWriter writer = new ElasticIndexWriter(indexTracker, connection, definition, bulkProcessorHandler,
+                new ElasticRetryPolicy(10, 1000, 5, 100), false
+        );
+
+        for (int i = 0; i < 10; i++) {
+            String path = "/content/" + i;
+            writer.updateDocument(path, new ElasticDocument(path));
+        }
+
+        // Set a toxic to cut the connection to Elastic after further 4KB of data sent upstream
+        LimitData cutConnectionUpstream = proxy.toxics()
+                .limitData("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 4096L);
+
+        for (int i = 0; i < 30; i++) {
+            String path = "/content/" + i;
+            writer.updateDocument(path, new ElasticDocument(path));
+        }
+        writer.close(System.currentTimeMillis());
+    }
+}

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
@@ -65,8 +65,9 @@ public class ElasticsearchRetryPolicyTest {
     @Test
     public void succeedAfterNAttempts() throws IOException {
         testPolicy(ElasticRetryPolicy.NO_RETRY, 0);
-        testPolicy(new ElasticRetryPolicy(1, 1000, 1, 1), 1);
-        testPolicy(new ElasticRetryPolicy(5, 1000, 1, 1), 5);
+        testPolicy(new ElasticRetryPolicy(1, 1000, 1, 1), 0);
+        testPolicy(new ElasticRetryPolicy(2, 1000, 1, 1), 1);
+        testPolicy(new ElasticRetryPolicy(5, 1000, 1, 1), 4);
     }
 
     @Test

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
@@ -62,7 +62,6 @@ public class ElasticsearchRetryPolicyTest {
         }
     }
 
-
     @Test
     public void succeedAfterNAttempts() throws IOException {
         testPolicy(ElasticRetryPolicy.NO_RETRY, 0);
@@ -88,7 +87,6 @@ public class ElasticsearchRetryPolicyTest {
             //pass
         }
     }
-
 
     private void testPolicy(ElasticRetryPolicy retryPolicy, int expectedMaxRetries) throws IOException {
         // These should all succeed because the number of retries is higher than the number of attempts until the task succeeds

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ElasticsearchRetryPolicyTest {
+    static class PassAfterNAttemptsTask implements ElasticRetryPolicy.IOOperation {
+        private final int succeedAfterRetries;
+
+        public PassAfterNAttemptsTask(int succeedAfterRetries) {
+            this.succeedAfterRetries = succeedAfterRetries;
+        }
+
+        int executionCount = 0;
+
+        public void execute() throws IOException {
+            executionCount++;
+            if (executionCount <= succeedAfterRetries) {
+                throw new IOException("Simulated failure. Execution: " + executionCount + ", will succeed after " + succeedAfterRetries + " failed attempts.");
+            }
+        }
+    }
+
+    static class PassAfterElapsedTime implements ElasticRetryPolicy.IOOperation {
+        private final int succeedAfterElapsedTimeMillis;
+        private long firstExecutionTime = -1;
+
+        public PassAfterElapsedTime(int succeedAfterElapsedTimeMillis) {
+            this.succeedAfterElapsedTimeMillis = succeedAfterElapsedTimeMillis;
+        }
+
+        public void execute() throws IOException {
+            if (firstExecutionTime == -1) {
+                firstExecutionTime = System.nanoTime();
+            }
+            long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - firstExecutionTime);
+            if (elapsedTime < succeedAfterElapsedTimeMillis) {
+                // Simulate a failure until the elapsed time is reached
+                throw new IOException("Simulated failure. Elapsed time: " + elapsedTime + "ms, will succeed after " + succeedAfterElapsedTimeMillis + "ms.");
+            }
+        }
+    }
+
+
+    @Test
+    public void succeedAfterNAttempts() throws IOException {
+        testPolicy(ElasticRetryPolicy.NO_RETRY, 0);
+        testPolicy(new ElasticRetryPolicy(1, 1000, 1, 1), 1);
+        testPolicy(new ElasticRetryPolicy(5, 1000, 1, 1), 5);
+    }
+
+    @Test
+    public void succeedAfterTime() throws IOException {
+        // A policy that will keep trying for 40 ms
+        ElasticRetryPolicy retryPolicy = new ElasticRetryPolicy(1000, 40, 1, 1);
+
+        // The task will succeed after 20 ms, so we expect the retry policy to succeed after 20 ms
+        long startTime = System.nanoTime();
+        retryPolicy.withRetries(new PassAfterElapsedTime(20));
+        assertTrue(System.nanoTime() - startTime >= TimeUnit.MILLISECONDS.toNanos(20));
+
+        // This task will fail for 60 ms, so the retry policy will also fail because it is set to wait for 50 ms.
+        try {
+            retryPolicy.withRetries(new PassAfterElapsedTime(60));
+            fail("Expected IOException not thrown");
+        } catch (IOException e) {
+            //pass
+        }
+    }
+
+
+    private void testPolicy(ElasticRetryPolicy retryPolicy, int expectedMaxRetries) throws IOException {
+        // These should all succeed because the number of retries is higher than the number of attempts until the task succeeds
+        for (int i = 0; i <= expectedMaxRetries; i++) {
+            retryPolicy.withRetries(new PassAfterNAttemptsTask(i));
+        }
+
+        try {
+            // This should fail, we are not trying enough times
+            retryPolicy.withRetries(new PassAfterNAttemptsTask(expectedMaxRetries + 1));
+            fail("Expected IOException not thrown");
+        } catch (IOException e) {
+            //pass
+        }
+    }
+}

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -261,7 +261,7 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
                 return true;
             }
         } catch (IOException e) {
-            log.warn("Failed to index the node [{}] due to {}", path, e.getMessage());
+            log.warn("Failed to index the node [{}] due to {}", path, e.toString());
             CommitFailedException ce = new CommitFailedException("Fulltext", 3,
                     "Failed to index the node " + path, e);
             context.getIndexingContext().indexUpdateFailed(ce);


### PR DESCRIPTION
# Recovering from Elasticsearch connection errors 

## Handling of errors on Elasticsearch bulk processor
The Bulk processor sends requests to elastic asynchronously using the `BulkIngester` class of the Elasticsearch Java driver. When the driver receives a response from a bulk request, the `BulkIngester` invokes a callback in our `ElasticBulkProcessorHandler`, indicating the result of the bulk. In case of errors, this sets internal state in `ElasticBulkProcessorHandler` with the indication of the error. The next time the client of the bulk processor executes an operation on the processor (adding a document or flushing/closing an index), this error is propagated.

Previously, the error status was not being cleared after being propagated to the callers. So once an error occurred, any further call to the bulk processor handler would fail with the same error. This is incorrect, because the bulk processor in the Elastic Java driver is capable of recovering from failed connections and other errors, and errors on the operations of a particular index should not affect the other non-faulty indexes being updated in the same bulk. This PR fixes this issue, by clearing the error status after it is propagated to the caller.

A bulk can fail with two types of errors:
- **A connection or server error** - The server cannot be reached or cannot process the bulk. This means that no operation in the bulk was processed. In this case, we log the error and propagate the exception. It is up to the caller to decide to retry or to fail.
- **Individual documents in the bulk failed to process** - This is a partial failure, as other operations in the bulk might have been successful. Additionally, these errors affect only the operations on a particular index (e.g., trying to add documents to an index that does not exist). We log this error and optionally (controlled by `oak.indexer.elastic.bulkProcessor.failOnError`) propagate the error to the callers that are performing operations on the index of the operations that failed. If the operations on other indexes in the same bulk succeeded, the callers for these indexes do not observe any error.

The incremental indexing ([AsyncIndexUpdate](https://github.com/apache/jackrabbit-oak/blob/trunk/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java) already retries failed operations. If a cycle fails, the checkpoint is not advanced and the next cycle will retry the operations from the original checkpoint. Therefore, if there are transient failures, once the underlying connection problem is resolved, the incremental indexer will resume. So this PR does not make any changes to this logic, it is enough to fix the issue that prevented the bulk processor from clearing up the internal faulty state.

## Retry policy
Added a retry policy to [ElasticIndexWriter](https://github.com/apache/jackrabbit-oak/blob/trunk/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java). This policy will retry the operations either for a maximum number of times or a maximum time, using exponential backoff with a cap on the maximum interval between retries.

The policy can be configured in two ways, depending on whether the instance of `ElasticIndexWriter` is created for off-line reindexing or by the `ElasticIndexProviderService` for incremental indexing.

### Incremental indexing
The following property is exposed in the [ElasticIndexProviderService](https://github.com/apache/jackrabbit-oak/blob/trunk/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java):

- `maxRetryTime` - for how long to retry after a failure. Default: 0 seconds.

Disabled by default because the incremental indexer already retries failed indexing cycles. In the future, we can enable retry at the level of the ElasticIndexWriter as an optimization.

### Off-line reindexing

Currently, the Elastic off-line reindexers will abort reindexing in the case of a connection error. This PR adds the following system property that is read by [ElasticDocumentStoreIndexer](https://github.com/apache/jackrabbit-oak/blob/trunk/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticDocumentStoreIndexer.java) and [ElasticOutOfBandIndexer](https://github.com/apache/jackrabbit-oak/blob/trunk/oak-run-elastic/src/main/java/org/apache/jackrabbit/oak/index/ElasticOutOfBandIndexer.java):

- `oak.indexer.elastic.connectionRetrySeconds` - for how long to retry after a failure. Default: 30 seconds


Additional changes:
- Do not save the paths of failed documents in index definition in the node store. This feature is not being used and adds significant complexity.
- Upgrade ES Java driver from 8.18.1 to 8.18.2.
- Throttle logs of failed operations on bulks.