### PR TITLE
OAK-11777 - Fix flaky test introduced in OAK-11765

### DIFF
--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticsearchRetryPolicyTest.java
@@ -51,13 +51,17 @@ public class ElasticsearchRetryPolicyTest {
         }
 
         public void execute() throws IOException {
+            long now = System.nanoTime();
+            long elapsedTimeMillis;
             if (firstExecutionTime == -1) {
-                firstExecutionTime = System.nanoTime();
+                firstExecutionTime = now;
+                elapsedTimeMillis = 0;
+            } else {
+                elapsedTimeMillis = TimeUnit.NANOSECONDS.toMillis(now - firstExecutionTime);
             }
-            long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - firstExecutionTime);
-            if (elapsedTime < succeedAfterElapsedTimeMillis) {
+            if (elapsedTimeMillis < succeedAfterElapsedTimeMillis) {
                 // Simulate a failure until the elapsed time is reached
-                throw new IOException("Simulated failure. Elapsed time: " + elapsedTime + "ms, will succeed after " + succeedAfterElapsedTimeMillis + "ms.");
+                throw new IOException("Simulated failure. Elapsed time: " + elapsedTimeMillis + "ms, will succeed after " + succeedAfterElapsedTimeMillis + "ms.");
             }
         }
     }
@@ -80,9 +84,12 @@ public class ElasticsearchRetryPolicyTest {
         retryPolicy.withRetries(new PassAfterElapsedTime(20));
         assertTrue(System.nanoTime() - startTime >= TimeUnit.MILLISECONDS.toNanos(20));
 
-        // This task will fail for 60 ms, so the retry policy will also fail because it is set to wait for 50 ms.
+        // This check verifies that a retry policy will stop trying after the maximum amount of time has passed,
+        // 40 ms in this case. We use a task that will only succeed very far into the future, to avoid the case where the
+        // 40 ms have elapsed but the thread running the test is suspended until enough time passes that the task would
+        // succeed.
         try {
-            retryPolicy.withRetries(new PassAfterElapsedTime(60));
+            retryPolicy.withRetries(new PassAfterElapsedTime(Integer.MAX_VALUE));
             fail("Expected IOException not thrown");
         } catch (IOException e) {
             //pass


### PR DESCRIPTION
https://ci-builds.apache.org/job/Jackrabbit/job/jackrabbit-oak-trunk/org.apache.jackrabbit$oak-search-elastic/2248/testReport/org.apache.jackrabbit.oak.plugins.index.elastic.index/ElasticsearchRetryPolicyTest/succeedAfterTime/

```
Error MessageExpected IOException not thrown

Stacktracejava.lang.AssertionError: Expected IOException not thrown
	at org.junit.Assert.fail(Assert.java:89)
	at org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticsearchRetryPolicyTest.succeedAfterTime(ElasticsearchRetryPolicyTest.java:86)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) 
```