### PR TITLE
OAK-11783: DocViewImport fails for content not using namespace prefixes

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/TargetImportHandler.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/TargetImportHandler.java
@@ -136,7 +136,7 @@ public abstract class TargetImportHandler extends DefaultHandler {
         NameInfo(String docQualifiedName) throws RepositoryException {
             int idx = docQualifiedName.indexOf(':');
             if (idx == -1) {
-                docPrefix = null;
+                docPrefix = "";
                 localName = docQualifiedName;
             } else {
                 String[] splits = docQualifiedName.split(":", 2);
@@ -153,19 +153,14 @@ public abstract class TargetImportHandler extends DefaultHandler {
         }
 
         private void init() throws RepositoryException {
-            if (docPrefix == null) {
-                namespaceUri = "";
-                repoPrefix = null;
+            Tree rootTree = sessionContext.getSessionDelegate().getRoot().getTree("/");
+            List<String> uris = documentContext.get(docPrefix);
+            if (uris.isEmpty()) {
+                namespaceUri = Namespaces.getNamespaceURI(rootTree, docPrefix);
+                repoPrefix = docPrefix;
             } else {
-                List<String> uris = documentContext.get(docPrefix);
-                Tree tree = sessionContext.getSessionDelegate().getRoot().getTree("/");
-                if (uris.isEmpty()) {
-                    namespaceUri = Namespaces.getNamespaceURI(tree, docPrefix);
-                    repoPrefix = docPrefix;
-                } else {
-                    namespaceUri = uris.get(uris.size() - 1);
-                    repoPrefix = Namespaces.getNamespacePrefix(tree, namespaceUri);
-                }
+                namespaceUri = uris.get(uris.size() - 1);
+                repoPrefix = Namespaces.getNamespacePrefix(rootTree, namespaceUri);
             }
         }
 

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/RepositoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/RepositoryTest.java
@@ -25,6 +25,7 @@ import static org.apache.jackrabbit.commons.JcrUtils.getChildNodes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -2289,7 +2290,7 @@ public class RepositoryTest extends AbstractRepositoryTest {
         Node node = session.getRootNode().addNode("node", "fooType");
         node.setProperty("fooProp", "fooValue");
         session.save();
-        
+
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         session.exportDocumentView("/node", out, true, false);
         node.remove();
@@ -2341,29 +2342,15 @@ public class RepositoryTest extends AbstractRepositoryTest {
         assertTrue(nPrefBar.isSame(nExpBar));
     }
 
-    // tests DocViewImport with no namespace prefixes
-    @Ignore("OAK-11783")
-    @Test
-    public void noNameSpacePrefixesInDocViewImport() throws Exception {
-        String ns1 = "urn:uuid:" + UUID.randomUUID();
-        String ns2 = "urn:uuid:" + UUID.randomUUID();
-
-        String test =
-                "<foo xmlns=\"" + ns1 + "\">" +
-                "  <qux xmlns=\"" + ns2 + "\">" +
-                "    <xyz xmlns=\"" + ns1 + "\"/>" +
-                "  </qux>" +
-                "  <bar/>" +
-                "</foo>";
-
+    private void internalNoNameSpacePrefixesInImport(String xml, String ns1, String ns2) throws Exception {
         Session session = getAdminSession();
         session.getWorkspace().importXML(
-                "/", new ByteArrayInputStream(test.getBytes(StandardCharsets.UTF_8)), IMPORT_UUID_CREATE_NEW);
+                "/", new ByteArrayInputStream(xml.getBytes()) , IMPORT_UUID_CREATE_NEW);
         session.save();
 
         String pref1 = session.getNamespacePrefix(ns1);
         String pref2 = session.getNamespacePrefix(ns2);
-        assertFalse("prefixes should be different - " + pref1 + " vs " + pref2, pref1.equals(pref2));
+        assertNotEquals("prefixes should be different - " + pref1 + " vs " + pref2, pref1, pref2);
 
         Node nPrefFoo = session.getNode("/" + pref1 + ":foo");
         Node nExpFoo = session.getNode("/{" + ns1 + "}foo");
@@ -2380,6 +2367,39 @@ public class RepositoryTest extends AbstractRepositoryTest {
         Node nPrefBar = nPrefFoo.getNode( pref1 + ":" + "bar");
         Node nExpBar = nExpFoo.getNode("{" + ns1 + "}bar");
         assertTrue(nPrefBar.isSame(nExpBar));
+    }
+
+    // tests import with no namespace prefixes
+    @Test
+    public void noNameSpacePrefixesInImport() throws Exception {
+        String ns1 = "urn:uuid:" + UUID.randomUUID();
+        String ns2 = "urn:uuid:" + UUID.randomUUID();
+
+        String docView =
+                "<foo xmlns=\"" + ns1 + "\">" +
+                        "  <qux xmlns=\"" + ns2 + "\">" +
+                        "    <xyz xmlns=\"" + ns1 + "\"/>" +
+                        "  </qux>" +
+                        "  <bar/>" +
+                        "</foo>";
+        String sysView =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                        "<sv:node xmlns:nt=\"http://www.jcp.org/jcr/nt/1.0\"" +
+                        "         xmlns:sv=\"http://www.jcp.org/jcr/sv/1.0\"" +
+                        "         xmlns:jcr=\"http://www.jcp.org/jcr/1.0\"" +
+                        "         xmlns=\"" + ns1 + "\"" +
+                        "         sv:name=\"foo\">" +
+                        "    <sv:property sv:name=\"jcr:primaryType\" sv:type=\"Name\">" +
+                        "        <sv:value>nt:unstructured</sv:value>" +
+                        "    </sv:property>" +
+                        "    <sv:node xmlns=\"" + ns2 + "\" sv:name=\"qux\">" +
+                        "        <sv:node xmlns=\"" + ns1 + "\" sv:name=\"xyz\"/>" +
+                        "    </sv:node>" +
+                        "    <sv:node sv:name=\"bar\"/>" +
+                        "</sv:node>";
+
+        internalNoNameSpacePrefixesInImport(docView, ns1, ns2);
+        internalNoNameSpacePrefixesInImport(sysView, ns1, ns2);
     }
 
     @Test

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/RepositoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/RepositoryTest.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.jcr.Binary;
@@ -2297,6 +2299,87 @@ public class RepositoryTest extends AbstractRepositoryTest {
                 "/", new ByteArrayInputStream(out.toByteArray()), IMPORT_UUID_CREATE_NEW);
         session.save();
         assertEquals("fooValue", session.getProperty("/node/fooProp").getString());
+    }
+
+    // tests DocViewImport with namespace prefixes re-used for different namespace names
+    @Test
+    public void reusedNameSpacePrefixesInDocViewImport() throws Exception {
+        String ns1 = "urn:uuid:" + UUID.randomUUID();
+        String ns2 = "urn:uuid:" + UUID.randomUUID();
+
+        String test =
+                "<a:foo xmlns:a=\"" + ns1 + "\">" +
+                "  <a:qux xmlns:a=\"" + ns2 + "\">" +
+                "    <a:xyz xmlns:a=\"" + ns1 + "\"/>" +
+                "  </a:qux>" +
+                "  <a:bar/>" +
+                "</a:foo>";
+
+        Session session = getAdminSession();
+        session.getWorkspace().importXML(
+                "/", new ByteArrayInputStream(test.getBytes(StandardCharsets.UTF_8)), IMPORT_UUID_CREATE_NEW);
+        session.save();
+
+        String pref1 = session.getNamespacePrefix(ns1);
+        String pref2 = session.getNamespacePrefix(ns2);
+        assertFalse("prefixes should be different - " + pref1 + " vs " + pref2, pref1.equals(pref2));
+
+        Node nPrefFoo = session.getNode("/" + pref1 + ":foo");
+        Node nExpFoo = session.getNode("/{" + ns1 + "}foo");
+        assertTrue(nPrefFoo.isSame(nExpFoo));
+
+        Node nPrefQux = nPrefFoo.getNode(pref2 + ":qux");
+        Node nExpQux = nExpFoo.getNode("{" + ns2 + "}qux");
+        assertTrue(nPrefQux.isSame(nExpQux));
+
+        Node nPrefXyz = nPrefQux.getNode(pref1 + ":xyz");
+        Node nExpXyz = nExpQux.getNode("{" + ns1 + "}xyz");
+        assertTrue(nPrefXyz.isSame(nExpXyz));
+
+        Node nPrefBar = nPrefFoo.getNode( pref1 + ":" + "bar");
+        Node nExpBar = nExpFoo.getNode("{" + ns1 + "}bar");
+        assertTrue(nPrefBar.isSame(nExpBar));
+    }
+
+    // tests DocViewImport with no namespace prefixes
+    @Ignore("OAK-11783")
+    @Test
+    public void noNameSpacePrefixesInDocViewImport() throws Exception {
+        String ns1 = "urn:uuid:" + UUID.randomUUID();
+        String ns2 = "urn:uuid:" + UUID.randomUUID();
+
+        String test =
+                "<foo xmlns=\"" + ns1 + "\">" +
+                "  <qux xmlns=\"" + ns2 + "\">" +
+                "    <xyz xmlns=\"" + ns1 + "\"/>" +
+                "  </qux>" +
+                "  <bar/>" +
+                "</foo>";
+
+        Session session = getAdminSession();
+        session.getWorkspace().importXML(
+                "/", new ByteArrayInputStream(test.getBytes(StandardCharsets.UTF_8)), IMPORT_UUID_CREATE_NEW);
+        session.save();
+
+        String pref1 = session.getNamespacePrefix(ns1);
+        String pref2 = session.getNamespacePrefix(ns2);
+        assertFalse("prefixes should be different - " + pref1 + " vs " + pref2, pref1.equals(pref2));
+
+        Node nPrefFoo = session.getNode("/" + pref1 + ":foo");
+        Node nExpFoo = session.getNode("/{" + ns1 + "}foo");
+        assertTrue(nPrefFoo.isSame(nExpFoo));
+
+        Node nPrefQux = nPrefFoo.getNode(pref2 + ":qux");
+        Node nExpQux = nExpFoo.getNode("{" + ns2 + "}qux");
+        assertTrue(nPrefQux.isSame(nExpQux));
+
+        Node nPrefXyz = nPrefQux.getNode(pref1 + ":xyz");
+        Node nExpXyz = nExpQux.getNode("{" + ns1 + "}xyz");
+        assertTrue(nPrefXyz.isSame(nExpXyz));
+
+        Node nPrefBar = nPrefFoo.getNode( pref1 + ":" + "bar");
+        Node nExpBar = nExpFoo.getNode("{" + ns1 + "}bar");
+        assertTrue(nPrefBar.isSame(nExpBar));
     }
 
     @Test

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/RepositoryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/RepositoryTest.java
@@ -2302,50 +2302,10 @@ public class RepositoryTest extends AbstractRepositoryTest {
         assertEquals("fooValue", session.getProperty("/node/fooProp").getString());
     }
 
-    // tests DocViewImport with namespace prefixes re-used for different namespace names
-    @Test
-    public void reusedNameSpacePrefixesInDocViewImport() throws Exception {
-        String ns1 = "urn:uuid:" + UUID.randomUUID();
-        String ns2 = "urn:uuid:" + UUID.randomUUID();
-
-        String test =
-                "<a:foo xmlns:a=\"" + ns1 + "\">" +
-                "  <a:qux xmlns:a=\"" + ns2 + "\">" +
-                "    <a:xyz xmlns:a=\"" + ns1 + "\"/>" +
-                "  </a:qux>" +
-                "  <a:bar/>" +
-                "</a:foo>";
-
+    private void internalShadedNamespaceMappingsInImport(String xml, String ns1, String ns2) throws Exception {
         Session session = getAdminSession();
         session.getWorkspace().importXML(
-                "/", new ByteArrayInputStream(test.getBytes(StandardCharsets.UTF_8)), IMPORT_UUID_CREATE_NEW);
-        session.save();
-
-        String pref1 = session.getNamespacePrefix(ns1);
-        String pref2 = session.getNamespacePrefix(ns2);
-        assertFalse("prefixes should be different - " + pref1 + " vs " + pref2, pref1.equals(pref2));
-
-        Node nPrefFoo = session.getNode("/" + pref1 + ":foo");
-        Node nExpFoo = session.getNode("/{" + ns1 + "}foo");
-        assertTrue(nPrefFoo.isSame(nExpFoo));
-
-        Node nPrefQux = nPrefFoo.getNode(pref2 + ":qux");
-        Node nExpQux = nExpFoo.getNode("{" + ns2 + "}qux");
-        assertTrue(nPrefQux.isSame(nExpQux));
-
-        Node nPrefXyz = nPrefQux.getNode(pref1 + ":xyz");
-        Node nExpXyz = nExpQux.getNode("{" + ns1 + "}xyz");
-        assertTrue(nPrefXyz.isSame(nExpXyz));
-
-        Node nPrefBar = nPrefFoo.getNode( pref1 + ":" + "bar");
-        Node nExpBar = nExpFoo.getNode("{" + ns1 + "}bar");
-        assertTrue(nPrefBar.isSame(nExpBar));
-    }
-
-    private void internalNoNameSpacePrefixesInImport(String xml, String ns1, String ns2) throws Exception {
-        Session session = getAdminSession();
-        session.getWorkspace().importXML(
-                "/", new ByteArrayInputStream(xml.getBytes()) , IMPORT_UUID_CREATE_NEW);
+                "/", new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)) , IMPORT_UUID_CREATE_NEW);
         session.save();
 
         String pref1 = session.getNamespacePrefix(ns1);
@@ -2367,6 +2327,39 @@ public class RepositoryTest extends AbstractRepositoryTest {
         Node nPrefBar = nPrefFoo.getNode( pref1 + ":" + "bar");
         Node nExpBar = nExpFoo.getNode("{" + ns1 + "}bar");
         assertTrue(nPrefBar.isSame(nExpBar));
+    }
+
+    // tests import with namespace prefixes re-used for different namespace names
+    @Test
+    public void reusedNameSpacePrefixesInDocViewImport() throws Exception {
+        String ns1 = "urn:uuid:" + UUID.randomUUID();
+        String ns2 = "urn:uuid:" + UUID.randomUUID();
+
+        String docView =
+                "<a:foo xmlns:a=\"" + ns1 + "\">" +
+                "  <a:qux xmlns:a=\"" + ns2 + "\">" +
+                "    <a:xyz xmlns:a=\"" + ns1 + "\"/>" +
+                "  </a:qux>" +
+                "  <a:bar/>" +
+                "</a:foo>";
+        String sysView =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<sv:node xmlns:nt=\"http://www.jcp.org/jcr/nt/1.0\"" +
+                "         xmlns:sv=\"http://www.jcp.org/jcr/sv/1.0\"" +
+                "         xmlns:jcr=\"http://www.jcp.org/jcr/1.0\"" +
+                "         xmlns:a=\"" + ns1 + "\"" +
+                "         sv:name=\"a:foo\">" +
+                "    <sv:property sv:name=\"jcr:primaryType\" sv:type=\"Name\">" +
+                "        <sv:value>nt:unstructured</sv:value>" +
+                "    </sv:property>" +
+                "    <sv:node xmlns:a=\"" + ns2 + "\" sv:name=\"a:qux\">" +
+                "        <sv:node xmlns:a=\"" + ns1 + "\" sv:name=\"a:xyz\"/>" +
+                "    </sv:node>" +
+                "    <sv:node sv:name=\"a:bar\"/>" +
+                "</sv:node>";
+
+        internalShadedNamespaceMappingsInImport(docView, ns1, ns2);
+        internalShadedNamespaceMappingsInImport(sysView, ns1, ns2);
     }
 
     // tests import with no namespace prefixes
@@ -2398,8 +2391,8 @@ public class RepositoryTest extends AbstractRepositoryTest {
                         "    <sv:node sv:name=\"bar\"/>" +
                         "</sv:node>";
 
-        internalNoNameSpacePrefixesInImport(docView, ns1, ns2);
-        internalNoNameSpacePrefixesInImport(sysView, ns1, ns2);
+        internalShadedNamespaceMappingsInImport(docView, ns1, ns2);
+        internalShadedNamespaceMappingsInImport(sysView, ns1, ns2);
     }
 
     @Test


### PR DESCRIPTION
This adds two similar tests, one using prefixes (passing), one not using prefixes (failing).