### PR TITLE
OAK-11793: remove usage of Guava common.hash

### DIFF
--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,9 +64,9 @@ public abstract class AbstractBlob implements Blob {
         String ai = a.getContentIdentity();
         String bi = b.getContentIdentity();
 
-        //Check for identity first. If they are same then its
-        //definitely same blob. If not we need to check further.
-        if (ai != null && bi != null && ai.equals(bi)){
+        // Check for identity first. If they are same then its
+        // definitely same blob. If not we need to check further.
+        if (ai != null && ai.equals(bi)){
             return true;
         }
 
@@ -80,31 +79,6 @@ public abstract class AbstractBlob implements Blob {
         } catch (IOException e) {
             throw new IllegalStateException("Blob equality check failed", e);
         }
-    }
-
-    public static HashCode calculateSha256(final Blob blob) {
-        AbstractBlob ab;
-        if (blob instanceof AbstractBlob) {
-            ab = ((AbstractBlob) blob);
-        } else {
-            ab = new AbstractBlob() {
-                @Override
-                public long length() {
-                    return blob.length();
-                }
-
-                @Override public boolean isInlined() {
-                    return blob.isInlined();
-                }
-
-                @NotNull
-                @Override
-                public InputStream getNewStream() {
-                    return blob.getNewStream();
-                }
-            };
-        }
-        return ab.getSha256();
     }
 
     private HashCode hashCode; // synchronized access

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
@@ -20,11 +20,12 @@ package org.apache.jackrabbit.oak.plugins.memory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.jackrabbit.guava.common.hash.HashCode;
-import org.apache.jackrabbit.guava.common.hash.Hashing;
-
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
 import org.jetbrains.annotations.NotNull;
@@ -120,20 +121,12 @@ public abstract class AbstractBlob implements Blob {
         // Blobs are immutable so we can safely cache the hash
         if (hashCode == null) {
             try {
-                hashCode = Hashing.sha256().hashBytes(this.getNewStream().readAllBytes());
+                hashCode = HashCode.of(this.getNewStream().readAllBytes());
             } catch (IOException e) {
                 throw new IllegalStateException("Hash calculation failed", e);
             }
         }
         return hashCode;
-    }
-
-    /**
-     * This hash code implementation returns the hash code of the underlying stream
-     * @return a byte array of the hash
-     */
-    protected byte[] sha256() {
-        return getSha256().asBytes();
     }
 
     //--------------------------------------------------------------< Blob >--
@@ -189,4 +182,39 @@ public abstract class AbstractBlob implements Blob {
         return getSha256().toString();
     }
 
+    public static class HashCode {
+
+        private byte[] digest;
+
+        private HashCode(byte[] digest){
+            this.digest = digest;
+        }
+
+        private static HashCode of(byte[] bytes) {
+            try {
+                return new HashCode(MessageDigest.getInstance("SHA-256").digest(bytes));
+            } catch (NoSuchAlgorithmException ex) {
+                throw new IllegalStateException("no SHA256 digest", ex);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            return Arrays.equals(digest, ((HashCode)o).digest);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(digest);
+        }
+
+        @Override
+        public String toString() {
+            // could use commons-coded
+            BigInteger bigInteger = new BigInteger(1, digest);
+            return String.format(
+            "%0" + (digest.length << 1) + "x", bigInteger);
+        }
+    }
 }


### PR DESCRIPTION
this could probably could be simplified to get rid of the internal HashCode class as well.