### PR TITLE
OAK-11800 - Simplify code of full text indexer

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/spi/IndexFieldProvider.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/spi/IndexFieldProvider.java
@@ -20,7 +20,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.lucene.document.Field;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 /**
  * Implementations of this interface would get callbacks while indexing documents. It's the responsibility
@@ -36,13 +36,13 @@ public interface IndexFieldProvider {
      */
     IndexFieldProvider DEFAULT = new IndexFieldProvider() {
         @Override
-        public Iterable<Field> getAugmentedFields(String path, NodeState document, NodeState indexDefinition) {
-            return Collections.EMPTY_LIST;
+        public @NotNull Iterable<Field> getAugmentedFields(String path, NodeState document, NodeState indexDefinition) {
+            return List.of();
         }
 
         @Override
-        public Set<String> getSupportedTypes() {
-            return Collections.EMPTY_SET;
+        public @NotNull Set<String> getSupportedTypes() {
+            return Set.of();
         }
     };
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/dynamicBoost/IndexFieldProviderImpl.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/dynamicBoost/IndexFieldProviderImpl.java
@@ -52,8 +52,8 @@ public class IndexFieldProviderImpl implements IndexFieldProvider {
     private static final String NT_DAM_ASSET = "dam:Asset";    
 
     @Override
-    public Set<String> getSupportedTypes() {
-        Set<String> supportedTypes = new HashSet<String>();
+    public @NotNull Set<String> getSupportedTypes() {
+        Set<String> supportedTypes = new HashSet<>();
         supportedTypes.add(NT_DAM_ASSET);
         return supportedTypes;
     }
@@ -65,14 +65,14 @@ public class IndexFieldProviderImpl implements IndexFieldProvider {
         for (String nodeName : dynaTags.getChildNodeNames()) {
             NodeState dynaTag = dynaTags.getChildNode(nodeName);
             String dynaTagName = dynaTag.getProperty(PREDICTED_TAG_NAME).getValue(Type.STRING);
-            Double dynaTagConfidence = dynaTag.getProperty(PREDICTED_TAG_CONFIDENCE).getValue(Type.DOUBLE);
+            double dynaTagConfidence = dynaTag.getProperty(PREDICTED_TAG_CONFIDENCE).getValue(Type.DOUBLE);
 
             List<String> tokens = new ArrayList<>(splitForIndexing(dynaTagName));
             if (tokens.size() > 1) { // Actual name not in tokens
                 tokens.add(dynaTagName);
             }
             for (String token : tokens) {
-                if (token.length() > 0) {
+                if (!token.isEmpty()) {
                     fields.add(new AugmentedField(PREDICTED_TAGS_REL_PATH + token.toLowerCase(), dynaTagConfidence));
                 }
             }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/Aggregate.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/Aggregate.java
@@ -72,7 +72,7 @@ public class Aggregate {
         this.includes = List.copyOf(includes);
         this.reAggregationLimit = recursionLimit;
         this.relativeNodeIncludes = findRelativeNodeIncludes(includes);
-        this.nodeAggregates = includes.stream().anyMatch(input -> input instanceof NodeInclude);
+        this.nodeAggregates = this.includes.stream().anyMatch(input -> input instanceof NodeInclude);
     }
 
     public List<? extends Include> getIncludes() {
@@ -176,7 +176,7 @@ public class Aggregate {
                     result.nextSet(nextSet);
                 }
             }
-            if (nextSet !=null && !nextSet.isEmpty()) {
+            if (nextSet != null && !nextSet.isEmpty()) {
                 collectAggregates(cne.getNodeState(), nextSet.toArray(new Matcher[0]), collector);
                 // Clear the set so it can be reused. This reduces object allocation overhead.
                 nextSet.clear();

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
@@ -184,10 +184,6 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
 
     public static final String CREATION_TIMESTAMP = "creationTimestamp";
     public static final String REINDEX_COMPLETION_TIMESTAMP = "reindexCompletionTimestamp";
-    /**
-     * Property to store paths for documents failed during index updates.
-     */
-    public static final String FAILED_DOC_PATHS = "failedDocPaths";
 
     /**
      * Meta property which provides the unique id
@@ -827,7 +823,7 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
                 }
                 includes.add(new Aggregate.NodeInclude(this, primaryType, path, relativeNode));
             }
-            aggregateMap.put(nodeType, new Aggregate(nodeType, List.copyOf(includes), recursionLimit));
+            aggregateMap.put(nodeType, new Aggregate(nodeType, includes, recursionLimit));
         }
 
         return Map.copyOf(aggregateMap);

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
@@ -182,13 +181,12 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
             facet |= pd.facet;
         }
 
-        boolean[] dirties = indexAggregates(path, document, state);
-        dirty |= dirties[0]; // any (aggregate) indexing happened
-        facet |= dirties[1]; // facet indexing during (index-time) aggregation
+        ResultCollector resultCollector = indexAggregates(path, document, state);
+        dirty |= resultCollector.dirtyFlag; // any (aggregate) indexing happened
+        facet |= resultCollector.facetFlag; // facet indexing during (index-time) aggregation
         dirty |= indexNullCheckEnabledProps(path, document, state);
         dirty |= indexFunctionRestrictions(path, document, state);
         dirty |= indexNotNullCheckEnabledProps(path, document, state);
-
         dirty |= augmentCustomFields(path, document, state);
 
         // Check if a node having a single property was modified/deleted
@@ -565,37 +563,41 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     /*
      * index aggregates on a certain path
      */
-    private boolean[] indexAggregates(final String path, final D document, final NodeState state) {
-        final AtomicBoolean dirtyFlag = new AtomicBoolean();
-        final AtomicBoolean facetFlag = new AtomicBoolean();
-        indexingRule.getAggregate().collectAggregates(state, new Aggregate.ResultCollector() {
-            @Override
-            public void onResult(Aggregate.NodeIncludeResult result) {
-                boolean dirty = indexAggregatedNode(path, document, result);
-                if (dirty) {
-                    dirtyFlag.set(true);
-                }
-            }
+    private ResultCollector indexAggregates(final String path, final D document, final NodeState state) {
+        ResultCollector resultCollector = new ResultCollector(path, document, state);
+        indexingRule.getAggregate().collectAggregates(state, resultCollector);
+        return resultCollector;
+    }
 
-            @Override
-            public void onResult(Aggregate.PropertyIncludeResult result) {
-                boolean dirty = false;
-                if (result.pd.ordered) {
-                    dirty |= addTypedOrderedFields(document, result.propertyState,
-                            result.propertyPath, result.pd);
-                }
-                dirty |= indexProperty(path, document, state, result.propertyState,
-                        result.propertyPath, result.pd);
+    private class ResultCollector implements Aggregate.ResultCollector {
+        private final String path;
+        private final D document;
+        private final NodeState state;
+        private boolean dirtyFlag = false;
+        private boolean facetFlag = false;
 
-                if (result.pd.facet) {
-                    facetFlag.set(true);
-                }
-                if (dirty) {
-                    dirtyFlag.set(true);
-                }
+        ResultCollector(String path, D document, NodeState state) {
+            this.path = path;
+            this.document = document;
+            this.state = state;
+        }
+
+        @Override
+        public void onResult(Aggregate.NodeIncludeResult result) {
+            dirtyFlag |= indexAggregatedNode(path, document, result);
+        }
+
+        @Override
+        public void onResult(Aggregate.PropertyIncludeResult result) {
+            if (result.pd.ordered) {
+                dirtyFlag |= addTypedOrderedFields(document, result.propertyState, result.propertyPath, result.pd);
             }
-        });
-        return new boolean[]{dirtyFlag.get(), facetFlag.get()};
+            dirtyFlag |= indexProperty(path, document, state, result.propertyState, result.propertyPath, result.pd);
+
+            if (result.pd.facet) {
+                facetFlag = true;
+            }
+        }
     }
 
     /*


### PR DESCRIPTION
Simplify code of callback that collects results from aggregates: remove workaround of using an AtomicBoolean to pass a value to a lambda and eliminate some object allocation.

Fix compilation warnings in some of the related classes.