### PR TITLE
OAK-11784 instantiate the NamespaceHelper once

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImportHandler.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/xml/ImportHandler.java
@@ -65,6 +65,7 @@ public class ImportHandler extends DefaultHandler {
     protected Locator locator;
     private TargetImportHandler targetHandler;
     private final Map<String, String> tempPrefixMap = new HashMap<String, String>();
+    private final NamespaceHelper namespaceHelper;
 
     public ImportHandler(String absPath, SessionContext sessionContext,
                          int uuidBehavior, boolean isWorkspaceImport) throws RepositoryException {
@@ -74,6 +75,7 @@ public class ImportHandler extends DefaultHandler {
         SessionDelegate sd = sessionContext.getSessionDelegate();
         root = (isWorkspaceImport) ? sd.getContentSession().getLatestRoot() : sd.getRoot();
         importer = new ImporterImpl(absPath, sessionContext, root, uuidBehavior, isWorkspaceImport);
+        namespaceHelper = new NamespaceHelper(sessionContext.getSession());
     }
 
     //---------------------------------------------------------< ErrorHandler >
@@ -136,7 +138,7 @@ public class ImportHandler extends DefaultHandler {
     public void startPrefixMapping(String prefix, String uri)
             throws SAXException {
         try {
-            new NamespaceHelper(sessionContext.getSession()).registerNamespace(
+            namespaceHelper.registerNamespace(
                     prefix, uri);
             if (targetHandler != null) {
                 targetHandler.startPrefixMapping(prefix, uri);


### PR DESCRIPTION
with JCR-5161 in place the NamespaceRegistry is retrieved once during the lifetime of the NamespaceHelper object.

(no change when JCR-5161 is not present.)