### PR TITLE
OAK-11816: oak-run should ignore unknown properties in --fds config b…

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PropertiesUtil.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/PropertiesUtil.java
@@ -275,6 +275,8 @@ public final class PropertiesUtil {
                 throw new IllegalArgumentException(
                         "Configured class " + objectClass.getName()
                                 + " does not contain a property named " + name);
+            } else {
+                log.warn("Ignoring unknow property {}", name);
             }
         }
         buff.append('}');

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/BlobStoreFixtureProvider.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/BlobStoreFixtureProvider.java
@@ -96,7 +96,7 @@ public class BlobStoreFixtureProvider {
             } else {
                 String cfgPath = bsopts.getFDSConfigPath();
                 Properties props = loadAndTransformProps(cfgPath);
-                populate(delegate, asMap(props), true);
+                populate(delegate, asMap(props), bsopts.isStrictConfigCheck());
             }
             delegate.init(null);
         }

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/BlobStoreOptions.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/run/cli/BlobStoreOptions.java
@@ -36,6 +36,7 @@ public class BlobStoreOptions implements OptionsBean {
     private final OptionSpec<String> fdsPathOption;
     private final OptionSpec<String> fakeDsPathOption;
     private final OptionSpec<Void> readWriteOption;
+    private final OptionSpec<Void> strictConfigCheckOption;
 
     private OptionSet options;
 
@@ -54,7 +55,9 @@ public class BlobStoreOptions implements OptionsBean {
         readWriteOption = parser.accepts("ds-read-write",
             "Connect to datastore in read-write mode. Use this option if only the datastore has to be opened "
                 + " in read-write mode and not the node store (i.e. --read-write not to be specified)");
-    }
+        strictConfigCheckOption = parser.accepts("strict-config-check",
+            "Fail on unknown properties in --fds config file instead of ignoring them with a warning. Disabled by default.");
+        }
 
     @Override
     public void configure(OptionSet options) {
@@ -118,5 +121,9 @@ public class BlobStoreOptions implements OptionsBean {
 
     public boolean isReadWrite(){
         return options.has(readWriteOption);
+    }
+
+    public boolean isStrictConfigCheck(){
+        return options.has(strictConfigCheckOption);
     }
 }


### PR DESCRIPTION
…y default

This change improves the usability of the oak-run `datastore` command by allowing it to tolerate unknown configuration properties in the FileDataStore config file (e.g., Sling-specific keys like `org.apache.sling.installer.configuration.persist`).

A new optional flag `--strict-config-check` was added to explicitly enforce strict validation. When enabled, oak-run will fail on unknown properties; otherwise, it logs a warning and proceeds (default behavior).

This aligns oak-run with real-world usage in Oak-based systems like AEM, where OSGi config files may include unrelated metadata keys.

Includes:
* `strictConfigCheck` flag support added to `BlobStoreFixtureProvider.populate(...)`
* CLI support for `--strict-config-check`
* Help text for the new flag
* Warning log on ignored properties