### PR TITLE
OAK-11824 lucene analyzer factory should be able to load indirect filters

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/NodeStateAnalyzerFactory.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/NodeStateAnalyzerFactory.java
@@ -284,7 +284,12 @@ final class NodeStateAnalyzerFactory {
 
         @Override
         public <T> T newInstance(String cname, Class<T> expectedType) {
-            throw new UnsupportedOperationException();
+            try {
+                Class<? extends T> clazz = findClass(cname, expectedType);
+                return clazz.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to create instance of " + cname, e);
+            }
         }
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
@@ -235,25 +235,6 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
     }
 
     @Test
-    public void fulltextSearchWithSnowball() throws Exception {
-        setup(List.of("foo"), idx -> {
-            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild(FulltextIndexConstants.ANL_DEFAULT);
-            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
-
-            Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
-            Tree snowball = addFilter(filters, "SnowballPorter");
-            snowball.setProperty("language", "Italian");
-        });
-
-        Tree content = root.getTree("/").addChild("content");
-        content.addChild("bar").setProperty("foo", "mangio la mela");
-        content.addChild("baz").setProperty("foo", "altro testo");
-        root.commit();
-
-        assertEventually(() -> assertQuery("select * from [nt:base] where CONTAINS(*, 'mangiare')", List.of("/content/bar")));
-    }
-
-    @Test
     @Ignore("not supported in elasticsearch since hunspell resources need to be available on the server")
     @Override
     public void fullTextWithHunspell() {}

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextAnalyzerCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FullTextAnalyzerCommonTest.java
@@ -1261,6 +1261,30 @@ public abstract class FullTextAnalyzerCommonTest extends AbstractQueryTest {
         });
     }
 
+    @Test
+    public void fulltextSearchWithSnowball() throws Exception {
+        setup(List.of("foo"), idx -> {
+            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild(FulltextIndexConstants.ANL_DEFAULT);
+            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
+
+            Tree filters = anl.addChild(FulltextIndexConstants.ANL_FILTERS);
+            Tree snowball = addFilter(filters, "SnowballPorter");
+            snowball.setProperty("language", "Italian");
+        });
+
+        Tree content = root.getTree("/").addChild("content");
+        content.addChild("bar").setProperty("foo", "mangio la mela");
+        content.addChild("baz").setProperty("foo", "altro testo");
+        content.addChild("bat").setProperty("foo", "nuovo testo");
+        root.commit();
+
+        assertEventually(() -> {
+                    assertQuery("select * from [nt:base] where CONTAINS(*, 'mangiare')", List.of("/content/bar"));
+                    assertQuery("select * from [nt:base] where CONTAINS(*, 'nuova testa')", List.of("/content/bat"));
+                }
+        );
+    }
+
     protected Tree addFilter(Tree analyzer, String filterName) {
         Tree filter = analyzer.addChild(filterName);
         // mimics nodes api


### PR DESCRIPTION
This will allow the configuration of indirect filters like:

```
<SnowballPorter language="Italian">
```

which loads `org.tartarus.snowball.ext.ItalianStemmer`