### PR TITLE
OAK-11827 check the permission of the mixin tree only once

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/NodeImpl.java
@@ -128,6 +128,8 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
      */
     private static final Logger LOG = LoggerFactory.getLogger(NodeImpl.class);
 
+    private static final String CACHE_KEY_MIXIN_TPYES_READABLE = NodeImpl.class.getName() + ".MIXIN_TYPES_READABLE";
+
     private final int logWarnStringSizeThreshold;
 
     @Nullable
@@ -1342,8 +1344,11 @@ public class NodeImpl<T extends NodeDelegate> extends ItemImpl<T> implements Jac
     }
 
     private boolean canReadMixinTypes(@NotNull Tree tree) {
-        return sessionContext.getAccessManager().hasPermissions(
-                tree, EMPTY_MIXIN_TYPES, Permissions.READ_PROPERTY);
+        // cache this information per SessionContext, as it is valid independent of the node
+        // it is invoked on
+        return (Boolean) sessionContext.getCache().computeIfAbsent(CACHE_KEY_MIXIN_TPYES_READABLE,
+                s -> { return sessionContext.getAccessManager().hasPermissions(
+                        tree, EMPTY_MIXIN_TYPES, Permissions.READ_PROPERTY);});
     }
 
     private EffectiveNodeType getEffectiveNodeType() throws RepositoryException {

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionContext.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionContext.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.oak.plugins.value.jcr.PartialValueFactory.DEFAULT_BLOB_ACCESS_PROVIDER;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -117,6 +118,8 @@ public class SessionContext implements NamePathMapper {
     
     private final SessionQuerySettings sessionQuerySettings;
 
+    private final Map<String,Object> cacheMap;
+
     public SessionContext(
              @NotNull Repository repository, @NotNull StatisticManager statisticManager,
              @NotNull SecurityProvider securityProvider, @NotNull Whiteboard whiteboard,
@@ -152,6 +155,7 @@ public class SessionContext implements NamePathMapper {
         this.valueFactory = new ValueFactoryImpl(
                 delegate.getRoot(), namePathMapper, this.blobAccessProvider);
         this.sessionQuerySettings = sessionQuerySettings;
+        this.cacheMap = new HashMap<>();
     }
 
     public final Map<String, Object> getAttributes() {
@@ -424,6 +428,11 @@ public class SessionContext implements NamePathMapper {
     @NotNull
     public SecurityProvider getSecurityProvider() {
         return securityProvider;
+    }
+
+    @NotNull
+    public Map<String,Object> getCache() {
+        return this.cacheMap;
     }
 
     //-----------------------------------------------------------< internal >---

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/session/SessionImpl.java
@@ -481,6 +481,8 @@ public class SessionImpl implements JackrabbitSession {
                 return true;
             }
         });
+        // clear the cache
+        sessionContext.getCache().clear();
     }
 
     @Override


### PR DESCRIPTION
Introducing a simple cache structure on a session level, which is invalidated on every session.refresh().