### PR TITLE
OAK-11834: Add delay to getDefaultWriteConcern to avoid UNKNOWN ClusterType

### DIFF
--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConnection.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDBConnection.java
@@ -27,6 +27,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.WriteConcern;
 
 import org.apache.jackrabbit.oak.plugins.document.util.MongoConnection;
 import org.jetbrains.annotations.NotNull;
@@ -83,7 +84,10 @@ final class MongoDBConnection {
         serverMonitorListener.addListener(status);
         MongoDatabase db = client.getDatabase(name);
         if (!MongoConnection.hasWriteConcern(uri)) {
-            db = db.withWriteConcern(MongoConnection.getDefaultWriteConcern(client));
+            WriteConcern defaultWriteConcern = MongoConnection.getDefaultWriteConcern(client);
+            LOG.info("Setting default write concern: {} for cluster type: {}", 
+                    defaultWriteConcern, client.getClusterDescription().getType());
+            db = db.withWriteConcern(defaultWriteConcern);
         }
         if (status.isMajorityReadConcernSupported()
                 && status.isMajorityReadConcernEnabled()

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/MongoConnection.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/MongoConnection.java
@@ -41,10 +41,15 @@ import static java.util.Objects.requireNonNull;
 
 import org.jetbrains.annotations.NotNull;
 
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
 /**
  * The {@code MongoConnection} abstracts connection to the {@code MongoDB}.
  */
 public class MongoConnection {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoConnection.class);
 
     public static final String MONGODB_PREFIX = "mongodb://";
 
@@ -53,6 +58,12 @@ public class MongoConnection {
     private static final Set<ReadConcernLevel> REPLICA_RC = Set.of(ReadConcernLevel.MAJORITY, ReadConcernLevel.LINEARIZABLE);
     private final ConnectionString mongoURI;
     private final MongoClient mongo;
+
+    // MongoDB cluster description timeout configuration
+    private static final String PROP_CLUSTER_DESCRIPTION_TIMEOUT_MS = "oak.mongo.clusterDescriptionTimeoutMs";
+    private static final String PROP_CLUSTER_DESCRIPTION_INTERVAL_MS = "oak.mongo.clusterDescriptionIntervalMs";
+    private static final long DEFAULT_CLUSTER_DESCRIPTION_TIMEOUT_MS = 5000L;
+    private static final long DEFAULT_CLUSTER_DESCRIPTION_INTERVAL_MS = 100L;
 
     /**
      * Constructs a new connection using the specified MongoDB connection string.
@@ -227,14 +238,44 @@ public class MongoConnection {
      * @return the default write concern to use for Oak.
      */
     public static WriteConcern getDefaultWriteConcern(@NotNull MongoClient client) {
-        WriteConcern w;
-        ClusterDescription clusterDescription = client.getClusterDescription();
-        if (clusterDescription.getType() == ClusterType.REPLICA_SET) {
-            w = WriteConcern.MAJORITY;
-        } else {
-            w = WriteConcern.ACKNOWLEDGED;
+        long timeoutMs = Long.getLong(PROP_CLUSTER_DESCRIPTION_TIMEOUT_MS, DEFAULT_CLUSTER_DESCRIPTION_TIMEOUT_MS);
+        long intervalMs = Long.getLong(PROP_CLUSTER_DESCRIPTION_INTERVAL_MS, DEFAULT_CLUSTER_DESCRIPTION_INTERVAL_MS);
+        
+        // If timeout is 0, disable the retry functionality and use immediate detection
+        if (timeoutMs == 0) {
+            WriteConcern w;
+            ClusterDescription clusterDescription = client.getClusterDescription();
+            if (clusterDescription.getType() == ClusterType.REPLICA_SET) {
+                w = WriteConcern.MAJORITY;
+            } else {
+                w = WriteConcern.ACKNOWLEDGED;
+            }
+            return w;
         }
-        return w;
+        
+        long startTime = System.currentTimeMillis();
+        long endTime = startTime + timeoutMs;
+        int attempts = 0;
+        
+        while (System.currentTimeMillis() < endTime) {
+            attempts++;
+            ClusterDescription clusterDescription = client.getClusterDescription();
+            
+            if (clusterDescription.getType() == ClusterType.REPLICA_SET) {
+                return WriteConcern.MAJORITY;
+            } else if (clusterDescription.getType() == ClusterType.STANDALONE) {
+                return WriteConcern.ACKNOWLEDGED;
+            }
+            
+            try {
+                Thread.sleep(intervalMs);
+            } catch (InterruptedException e) {}
+        }
+        
+        // In case of timeout, default to ACKNOWLEDGED
+        LOG.warn("Cluster description timeout after {}ms ({} attempts). Defaulting to ACKNOWLEDGED write concern.", 
+                timeoutMs, attempts);
+        return WriteConcern.ACKNOWLEDGED;
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/MongoConnection.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/MongoConnection.java
@@ -261,7 +261,8 @@ public class MongoConnection {
             attempts++;
             ClusterDescription clusterDescription = client.getClusterDescription();
             
-            if (clusterDescription.getType() == ClusterType.REPLICA_SET) {
+            if (clusterDescription.getType() == ClusterType.REPLICA_SET || 
+                clusterDescription.getType() == ClusterType.SHARDED) {
                 return WriteConcern.MAJORITY;
             } else if (clusterDescription.getType() == ClusterType.STANDALONE) {
                 return WriteConcern.ACKNOWLEDGED;


### PR DESCRIPTION
Newer versions of Mongo Java Driver can return ClusterType.UNKNOWN while the Mongo cluster is still initializing, failing some tests since the cluster is just started immediately.

A simple solution could be to just add a delay to the test itself, but this is something that could happen in production too, meaning the WriteConcern would default to **ACKNOWLEDGED**, which would be wrong if it is actually running against a ReplicaSet.

For this reason, I'm adding a configurable delay of 5 seconds with retry to the `getDefaultWriteConcern` method. This should have no impact in most situations, since it's quite strange the Mongo cluster is not completely running when Oak tries to connect to it. 
Normal initialization time for Mongo clusters is around 3 seconds.