### PR TITLE
OAK-11847 - AzureJournalFile fails to rotate journal

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFile.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFile.java
@@ -33,7 +33,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Iterator;
+import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -245,7 +250,7 @@ public class AzureJournalFile implements JournalFile {
         }
 
         private int parseCurrentSuffix() {
-            String name = AzureUtilities.getName(currentBlob);
+            String name = currentBlob.getBlobName();
             Pattern pattern = Pattern.compile(Pattern.quote(journalNamePrefix) + "\\.(\\d+)");
             Matcher matcher = pattern.matcher(name);
             int parsedSuffix;

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFile.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFile.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Map;
 import java.util.Iterator;
 import java.util.HashMap;
@@ -59,11 +60,11 @@ public class AzureJournalFile implements JournalFile {
 
     private final WriteAccessController writeAccessController;
 
-    AzureJournalFile(BlobContainerClient readBlobContainerClient, BlobContainerClient writeBlobContainerClient, String journalNamePrefix, WriteAccessController writeAccessController, int lineLimit) {
+    AzureJournalFile(BlobContainerClient readBlobContainerClient, BlobContainerClient writeBlobContainerClient, String journalNamePrefix, WriteAccessController writeAccessController, Integer lineLimit) {
         this.readBlobContainerClient = readBlobContainerClient;
         this.writeBlobContainerClient = writeBlobContainerClient;
         this.journalNamePrefix = journalNamePrefix;
-        this.lineLimit = lineLimit;
+        this.lineLimit = Objects.requireNonNullElse(lineLimit, JOURNAL_LINE_LIMIT);
         this.writeAccessController = writeAccessController;
     }
 

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistence.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistence.java
@@ -53,20 +53,23 @@ public class AzurePersistence implements SegmentNodeStorePersistence {
 
     protected WriteAccessController writeAccessController = new WriteAccessController();
 
+    private final Integer journalLineLimit;
+
     public AzurePersistence(BlobContainerClient blobContainerClient, String rootPrefix) {
         this(blobContainerClient, blobContainerClient, blobContainerClient, rootPrefix);
     }
 
     public AzurePersistence(BlobContainerClient readBlobContainerClient, BlobContainerClient writeBlobContainerClient, BlobContainerClient noRetryBlobContainerClient, String rootPrefix) {
-        this(readBlobContainerClient, writeBlobContainerClient, noRetryBlobContainerClient, rootPrefix, null);
+        this(readBlobContainerClient, writeBlobContainerClient, noRetryBlobContainerClient, rootPrefix, null, null);
     }
 
-    public AzurePersistence(BlobContainerClient readBlobContainerClient, BlobContainerClient writeBlobContainerClient, BlobContainerClient noRetryBlobContainerClient, String rootPrefix, AzureHttpRequestLoggingPolicy azureHttpRequestLoggingPolicy) {
+    public AzurePersistence(BlobContainerClient readBlobContainerClient, BlobContainerClient writeBlobContainerClient, BlobContainerClient noRetryBlobContainerClient, String rootPrefix, AzureHttpRequestLoggingPolicy azureHttpRequestLoggingPolicy, Integer journalLineLimit) {
         this.readBlobContainerClient = readBlobContainerClient;
         this.writeBlobContainerClient = writeBlobContainerClient;
         this.noRetryBlobContainerClient = noRetryBlobContainerClient;
         this.azureHttpRequestLoggingPolicy = azureHttpRequestLoggingPolicy;
         this.rootPrefix = rootPrefix;
+        this.journalLineLimit = journalLineLimit;
     }
 
     @Override
@@ -89,7 +92,7 @@ public class AzurePersistence implements SegmentNodeStorePersistence {
 
     @Override
     public JournalFile getJournalFile() {
-        return new AzureJournalFile(readBlobContainerClient, writeBlobContainerClient, rootPrefix + "/journal.log", writeAccessController);
+        return new AzureJournalFile(readBlobContainerClient, writeBlobContainerClient, rootPrefix + "/journal.log", writeAccessController, journalLineLimit);
     }
 
     @Override

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistenceManager.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistenceManager.java
@@ -196,7 +196,7 @@ public class AzurePersistenceManager {
 
         final String rootPrefixNormalized = normalizePath(rootPrefix);
 
-        return new AzurePersistence(blobContainerClient, writeContainerClient, noRetryBlobContainerClient, rootPrefixNormalized, azureHttpRequestLoggingPolicy);
+        return new AzurePersistence(blobContainerClient, writeContainerClient, noRetryBlobContainerClient, rootPrefixNormalized, azureHttpRequestLoggingPolicy, null);
     }
 
     private static BlobContainerClient getBlobContainerClientWithSas(String accountName, String containerName, RequestRetryOptions requestRetryOptions, AzureHttpRequestLoggingPolicy azureHttpRequestLoggingPolicy, String sasToken) {

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFileTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFileTest.java
@@ -26,6 +26,7 @@ import com.azure.storage.blob.models.ListBlobsOptions;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.jackrabbit.oak.commons.collections.ListUtils;
 import org.apache.jackrabbit.oak.segment.remote.WriteAccessController;
+import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFileReader;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFileWriter;
 import org.jetbrains.annotations.NotNull;
@@ -51,17 +52,21 @@ public class AzureJournalFileTest {
 
     private BlobContainerClient writeBlobContainerClient;
 
-    private AzureJournalFile journal;
+    private JournalFile journal;
 
     private final String rootPrefix = "oak";
 
     @Before
-    public void setup() throws BlobStorageException {
+    public void setup() throws BlobStorageException, IOException {
         readBlobContainerClient = azurite.getReadBlobContainerClient("oak-test");
         writeBlobContainerClient = azurite.getWriteBlobContainerClient("oak-test");
+        BlobContainerClient noRetryBlobContainerClient = azurite.getNoRetryBlobContainerClient("oak-test");
+
         WriteAccessController writeAccessController = new WriteAccessController();
         writeAccessController.enableWriting();
-        journal = new AzureJournalFile(readBlobContainerClient, writeBlobContainerClient, rootPrefix + "journal.log", writeAccessController, 50);
+        AzurePersistence azurePersistence = new AzurePersistence(readBlobContainerClient, writeBlobContainerClient, noRetryBlobContainerClient, rootPrefix, null, 50);
+        azurePersistence.lockRepository();
+        journal = azurePersistence.getJournalFile();
     }
 
     @Test
@@ -87,7 +92,7 @@ public class AzureJournalFileTest {
 
     private int countJournalBlobs() {
         ListBlobsOptions listBlobsOptions = new ListBlobsOptions();
-        listBlobsOptions.setPrefix(rootPrefix + "journal.log");
+        listBlobsOptions.setPrefix(rootPrefix + "/journal.log");
 
         List<BlobItem> result  = readBlobContainerClient.listBlobs(listBlobsOptions, null).stream().collect(Collectors.toList());
         return result.size();

--- a/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFileTest.java
+++ b/oak-segment-azure/src/test/java/org/apache/jackrabbit/oak/segment/azure/AzureJournalFileTest.java
@@ -53,13 +53,15 @@ public class AzureJournalFileTest {
 
     private AzureJournalFile journal;
 
+    private final String rootPrefix = "oak";
+
     @Before
     public void setup() throws BlobStorageException {
         readBlobContainerClient = azurite.getReadBlobContainerClient("oak-test");
         writeBlobContainerClient = azurite.getWriteBlobContainerClient("oak-test");
         WriteAccessController writeAccessController = new WriteAccessController();
         writeAccessController.enableWriting();
-        journal = new AzureJournalFile(readBlobContainerClient, writeBlobContainerClient, "journal.log", writeAccessController, 50);
+        journal = new AzureJournalFile(readBlobContainerClient, writeBlobContainerClient, rootPrefix + "journal.log", writeAccessController, 50);
     }
 
     @Test
@@ -85,7 +87,7 @@ public class AzureJournalFileTest {
 
     private int countJournalBlobs() {
         ListBlobsOptions listBlobsOptions = new ListBlobsOptions();
-        listBlobsOptions.setPrefix("journal.log");
+        listBlobsOptions.setPrefix(rootPrefix + "journal.log");
 
         List<BlobItem> result  = readBlobContainerClient.listBlobs(listBlobsOptions, null).stream().collect(Collectors.toList());
         return result.size();


### PR DESCRIPTION
The issue was introduced because when [AzureJournalFile](https://github.com/apache/jackrabbit-oak/blob/trunk/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzurePersistence.java#L92) is created the `journalNamePrefix` is set to `rootPrefix + "/journal.log"` and `AzureUtilities.getName(currentBlob)` is returning `journal.log`. The result is taht `matcher.find()` will always return false since `journalNamePrefix` = `rootPrefix + "/journal.log"` and `name` = `journal.log`