### PR TITLE
OAK-11862: missing facets for multi-valued fields

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticSecureFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticSecureFacetAsyncProvider.java
@@ -18,6 +18,7 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.query.async.facets;
 
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticRequestHandler;
@@ -48,7 +49,7 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider, ElasticRe
 
     private final Set<String> facetFields;
     private final long facetsEvaluationTimeoutMs;
-    private final Map<String, Map<String, MutableInt>> accessibleFacetCounts = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, MutableInt>> accessibleFacets = new ConcurrentHashMap<>();
     private final ElasticResponseHandler elasticResponseHandler;
     private final Predicate<String> isAccessible;
     private final CountDownLatch latch = new CountDownLatch(1);
@@ -81,30 +82,44 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider, ElasticRe
     public boolean on(Hit<ObjectNode> searchHit) {
         final String path = elasticResponseHandler.getPath(searchHit);
         if (path != null && isAccessible.test(path)) {
-            for (String field: facetFields) {
-                JsonNode value = searchHit.source().get(field);
-                if (value != null) {
-                    accessibleFacetCounts.compute(field, (column, facetValues) -> {
-                        if (facetValues == null) {
-                            Map<String, MutableInt> values = new HashMap<>();
-                            values.put(value.asText(), new MutableInt(1));
-                            return values;
+            ObjectNode source = searchHit.source();
+            for (String field : facetFields) {
+                JsonNode value;
+                if (source != null) {
+                    value = source.get(field);
+                    if (value != null) {
+                        if (value.getNodeType() == JsonNodeType.ARRAY) {
+                            for (JsonNode item : value) {
+                                updateAccessibleFacets(field, item.asText());
+                            }
                         } else {
-                            facetValues.compute(value.asText(), (k, v) -> {
-                                if (v == null) {
-                                    return new MutableInt(1);
-                                } else {
-                                    v.increment();
-                                    return v;
-                                }
-                            });
-                            return facetValues;
+                            updateAccessibleFacets(field, value.asText());
                         }
-                    });
+                    }
                 }
             }
         }
         return true;
+    }
+
+    private void updateAccessibleFacets(String field, String value) {
+        accessibleFacets.compute(field, (column, facetValues) -> {
+            if (facetValues == null) {
+                Map<String, MutableInt> values = new HashMap<>();
+                values.put(value, new MutableInt(1));
+                return values;
+            } else {
+                facetValues.compute(value, (k, v) -> {
+                    if (v == null) {
+                        return new MutableInt(1);
+                    } else {
+                        v.increment();
+                        return v;
+                    }
+                });
+                return facetValues;
+            }
+        });
     }
 
     @Override
@@ -114,7 +129,7 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider, ElasticRe
                 .comparing(FulltextIndex.Facet::getCount).reversed()
                 .thenComparing(FulltextIndex.Facet::getLabel);
         // create Facet objects, order by count (desc) and then by label (asc)
-        facets = accessibleFacetCounts.entrySet()
+        facets = accessibleFacets.entrySet()
                 .stream()
                 .collect(Collectors.toMap
                         (Map.Entry::getKey, x -> x.getValue().entrySet()

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
@@ -25,6 +25,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceConfig;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
@@ -146,14 +147,14 @@ public class ElasticStatisticalFacetAsyncProvider implements ElasticFacetProvide
         List<Hit<ObjectNode>> searchHits = searchResponse.hits().hits();
         this.sampled = searchHits != null ? searchHits.size() : 0;
         if (sampled > 0) {
-            this.totalHits = searchResponse.hits().total().value();
+            this.totalHits = searchResponse.hits().total() != null ? searchResponse.hits().total().value() : 0;
             Map<String, List<FulltextIndex.Facet>> allFacets = processAggregations(searchResponse.aggregations());
-            Map<String, Map<String, MutableInt>> accessibleFacetCounts = new HashMap<>();
+            Map<String, Map<String, MutableInt>> accessibleFacets = new HashMap<>();
             searchResponse.hits().hits().stream()
                     // Possible candidate for parallelization using parallel streams
                     .filter(this::isAccessible)
-                    .forEach(hit -> processFilteredHit(hit, accessibleFacetCounts));
-            Map<String, List<FulltextIndex.Facet>> facets = computeStatisticalFacets(allFacets, accessibleFacetCounts);
+                    .forEach(hit -> processFilteredHit(hit, accessibleFacets));
+            Map<String, List<FulltextIndex.Facet>> facets = computeStatisticalFacets(allFacets, accessibleFacets);
             if (LOG.isDebugEnabled()) {
                 LOG.debug(timingsToString());
             }
@@ -163,32 +164,45 @@ public class ElasticStatisticalFacetAsyncProvider implements ElasticFacetProvide
         }
     }
 
-    private void processFilteredHit(Hit<ObjectNode> searchHit, Map<String, Map<String, MutableInt>> accessibleFacetCounts) {
+    private void processFilteredHit(Hit<ObjectNode> searchHit, Map<String, Map<String, MutableInt>> accessibleFacets) {
         long start = System.nanoTime();
         ObjectNode source = searchHit.source();
         for (String field : facetFields) {
-            JsonNode value = source.get(field);
-            if (value != null) {
-                accessibleFacetCounts.compute(field, (column, facetValues) -> {
-                    if (facetValues == null) {
-                        Map<String, MutableInt> values = new HashMap<>();
-                        values.put(value.asText(), new MutableInt(1));
-                        return values;
+            JsonNode value;
+            if (source != null) {
+                value = source.get(field);
+                if (value != null) {
+                    if (value.getNodeType() == JsonNodeType.ARRAY) {
+                        for (JsonNode item : value) {
+                            updateAccessibleFacets(accessibleFacets, field, item.asText());
+                        }
                     } else {
-                        facetValues.compute(value.asText(), (k, v) -> {
-                            if (v == null) {
-                                return new MutableInt(1);
-                            } else {
-                                v.increment();
-                                return v;
-                            }
-                        });
-                        return facetValues;
+                        updateAccessibleFacets(accessibleFacets, field, value.asText());
                     }
-                });
+                }
             }
         }
         this.processHitsTimeNanos += System.nanoTime() - start;
+    }
+
+    private void updateAccessibleFacets(Map<String, Map<String, MutableInt>> accessibleFacets, String field, String value) {
+        accessibleFacets.compute(field, (column, facetValues) -> {
+            if (facetValues == null) {
+                Map<String, MutableInt> values = new HashMap<>();
+                values.put(value, new MutableInt(1));
+                return values;
+            } else {
+                facetValues.compute(value, (k, v) -> {
+                    if (v == null) {
+                        return new MutableInt(1);
+                    } else {
+                        v.increment();
+                        return v;
+                    }
+                });
+                return facetValues;
+            }
+        });
     }
 
     private boolean isAccessible(Hit<ObjectNode> searchHit) {

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FacetCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FacetCommonTest.java
@@ -46,6 +46,7 @@ import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConsta
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_REFRESH_DEFN;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_SECURE_FACETS;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_SECURE_FACETS_VALUE_INSECURE;
+import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_SECURE_FACETS_VALUE_SECURE;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_SECURE_FACETS_VALUE_STATISTICAL;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_STATISTICAL_FACET_SAMPLE_SIZE;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.STATISTICAL_FACET_SAMPLE_SIZE_DEFAULT;
@@ -92,15 +93,15 @@ public abstract class FacetCommonTest extends AbstractJcrTest {
     }
 
     private void createDataset(int numberOfLeafNodes) throws RepositoryException {
-        Random rGen = new Random(42);
-        Random rGen1 = new Random(42);
-        int[] foolabelCount = new int[NUM_LABELS];
-        int[] fooaclLabelCount = new int[NUM_LABELS];
-        int[] fooaclPar1LabelCount = new int[NUM_LABELS];
+        Random fooGen = new Random(42);
+        Random barGen = new Random(42);
+        int[] fooLabelCount = new int[NUM_LABELS];
+        int[] fooAclLabelCount = new int[NUM_LABELS];
+        int[] fooAclPar1LabelCount = new int[NUM_LABELS];
 
-        int[] barlabelCount = new int[NUM_LABELS];
-        int[] baraclLabelCount = new int[NUM_LABELS];
-        int[] baraclPar1LabelCount = new int[NUM_LABELS];
+        int[] barLabelCount = new int[NUM_LABELS];
+        int[] barAclLabelCount = new int[NUM_LABELS];
+        int[] barAclPar1LabelCount = new int[NUM_LABELS];
 
         Node par = allow(getOrCreateByPath("/parent", "oak:Unstructured", adminSession));
 
@@ -110,20 +111,20 @@ public abstract class FacetCommonTest extends AbstractJcrTest {
                 Node child = subPar.addNode("c" + j);
                 child.setProperty("cons", "val");
                 // Add a random label out of "l0", "l1", "l2", "l3"
-                int foolabelNum = rGen.nextInt(NUM_LABELS);
-                int barlabelNum = rGen1.nextInt(NUM_LABELS);
-                child.setProperty("foo", "l" + foolabelNum);
-                child.setProperty("bar", "m" + barlabelNum);
+                int fooLabelNum = fooGen.nextInt(NUM_LABELS);
+                int barLabelNum = barGen.nextInt(NUM_LABELS);
+                child.setProperty("foo", "l" + fooLabelNum);
+                child.setProperty("bar", "m" + barLabelNum);
 
-                foolabelCount[foolabelNum]++;
-                barlabelCount[barlabelNum]++;
+                fooLabelCount[fooLabelNum]++;
+                barLabelCount[barLabelNum]++;
                 if (i != 0) {
-                    fooaclLabelCount[foolabelNum]++;
-                    baraclLabelCount[barlabelNum]++;
+                    fooAclLabelCount[fooLabelNum]++;
+                    barAclLabelCount[barLabelNum]++;
                 }
                 if (i == 1) {
-                    fooaclPar1LabelCount[foolabelNum]++;
-                    baraclPar1LabelCount[barlabelNum]++;
+                    fooAclPar1LabelCount[fooLabelNum]++;
+                    barAclPar1LabelCount[barLabelNum]++;
                 }
             }
 
@@ -133,13 +134,13 @@ public abstract class FacetCommonTest extends AbstractJcrTest {
             }
         }
         adminSession.save();
-        for (int i = 0; i < foolabelCount.length; i++) {
-            actualLabelCount.put("l" + i, foolabelCount[i]);
-            actualLabelCount.put("m" + i, barlabelCount[i]);
-            actualAclLabelCount.put("l" + i, fooaclLabelCount[i]);
-            actualAclLabelCount.put("m" + i, baraclLabelCount[i]);
-            actualAclPar1LabelCount.put("l" + i, fooaclPar1LabelCount[i]);
-            actualAclPar1LabelCount.put("m" + i, baraclPar1LabelCount[i]);
+        for (int i = 0; i < fooLabelCount.length; i++) {
+            actualLabelCount.put("l" + i, fooLabelCount[i]);
+            actualLabelCount.put("m" + i, barLabelCount[i]);
+            actualAclLabelCount.put("l" + i, fooAclLabelCount[i]);
+            actualAclLabelCount.put("m" + i, barAclLabelCount[i]);
+            actualAclPar1LabelCount.put("l" + i, fooAclPar1LabelCount[i]);
+            actualAclPar1LabelCount.put("m" + i, barAclPar1LabelCount[i]);
         }
         assertNotEquals("Acl-ed and actual counts mustn't be same", actualLabelCount, actualAclLabelCount);
     }
@@ -310,6 +311,46 @@ public abstract class FacetCommonTest extends AbstractJcrTest {
                                 "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
                         Math.abs(ratio - 1) < 0.05);
             }
+        });
+    }
+
+    @Test
+    public void secureFacetsWithMultiValueProperty() throws Exception {
+        facetsWithMultiValueProperty(PROP_SECURE_FACETS_VALUE_SECURE);
+    }
+
+    @Test
+    public void insecureFacetsWithMultiValueProperty() throws Exception {
+        facetsWithMultiValueProperty(PROP_SECURE_FACETS_VALUE_INSECURE);
+    }
+
+    @Test
+    public void statisticalFacetsWithMultiValueProperty() throws Exception {
+        facetsWithMultiValueProperty(PROP_SECURE_FACETS_VALUE_STATISTICAL);
+    }
+
+    public void facetsWithMultiValueProperty(String facetType) throws Exception {
+        Node facetConfig = getOrCreateByPath(indexNode.getPath() + "/" + FACETS, "nt:unstructured", adminSession);
+        facetConfig.setProperty(PROP_SECURE_FACETS, facetType);
+        indexNode.setProperty(PROP_REFRESH_DEFN, true);
+        adminSession.save();
+
+        Node par = allow(getOrCreateByPath("/parent", "oak:Unstructured", adminSession));
+        Node subPar = par.addNode("par");
+        Node child = subPar.addNode("c");
+        child.setProperty("cons", "val");
+        child.setProperty("foo", new String[] { "l0", "l1", "l2", "l3" });
+        child.setProperty("bar", "m0");
+        adminSession.save();
+
+        assertEventually(() -> {
+            Map<String, Integer> facets = getFacets();
+            assertEquals("Unexpected number of facets", 5, facets.size()); // l0, l1, l2, l3, m0
+            assertEquals(1, (int) facets.get("l0"));
+            assertEquals(1, (int) facets.get("l1"));
+            assertEquals(1, (int) facets.get("l2"));
+            assertEquals(1, (int) facets.get("l3"));
+            assertEquals(1, (int) facets.get("m0"));
         });
     }
 


### PR DESCRIPTION
Facets over multi-value fields are not correctly computed for secure and statistical facets.

Logic to update accessible facets is duplicated on secure and statistical. This will be improved in a separate PR to decouple secure facets from the async iterator.