### PR TITLE
OAK-11873 also log the caller for Fulltext searches

### DIFF
--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndex.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.commons.json.JsopBuilder;
 import org.apache.jackrabbit.oak.commons.json.JsopWriter;
 import org.apache.jackrabbit.oak.plugins.index.IndexName;
+import org.apache.jackrabbit.oak.plugins.index.IndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.cursor.Cursors;
 import org.apache.jackrabbit.oak.plugins.index.cursor.PathCursor;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexLookup;
@@ -432,8 +433,9 @@ public abstract class FulltextIndex implements AdvancedQueryIndex, QueryIndex, N
                     if (readCount % TRAVERSING_WARNING == 0) {
                         Cursors.checkReadLimit(readCount, settings);
                         if (readCount == 2 * TRAVERSING_WARNING) {
-                            log.warn("Index-Traversed {} nodes with filter {}", readCount, plan.getFilter(),
-                                    new Exception("call stack"));
+                            String caller = IndexUtils.getCaller(settings.getIgnoredClassNamesInCallTrace());
+                            log.warn("Index-Traversed {} nodes with filter {} called by {}", readCount, plan.getFilter(),
+                                    caller);
                         } else {
                             log.warn("Index-Traversed {} nodes with filter {}", readCount, plan.getFilter());
                         }


### PR DESCRIPTION
(see also OAK-9624, where I added this for other queries in Oak)