### PR TITLE
OAK-11909 : removed Guava's newDirectExecutorService with oak-commons…

### DIFF
--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/ActiveDeletedBlobCollectorMBeanImplTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/ActiveDeletedBlobCollectorMBeanImplTest.java
@@ -28,6 +28,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.jmx.IndexStatsMBean;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
@@ -240,7 +241,7 @@ public class ActiveDeletedBlobCollectorMBeanImplTest {
         ActiveDeletedBlobCollectorMBeanImpl bean =
                 new ActiveDeletedBlobCollectorMBeanImpl(ActiveDeletedBlobCollectorFactory.NOOP, wb, failingNodeStore,
                         indexPathService, asyncIndexInfoService,
-                        new MemoryBlobStore(), newDirectExecutorService());
+                        new MemoryBlobStore(), DirectExecutor.INSTANCE);
         bean.clock = clock;
 
         bean.flagActiveDeletionUnsafeForCurrentState();
@@ -273,7 +274,7 @@ public class ActiveDeletedBlobCollectorMBeanImplTest {
                     return null;
                 }), wb, nodeStore,
                         indexPathService, asyncIndexInfoService,
-                        new MemoryBlobStore(), newDirectExecutorService());
+                        new MemoryBlobStore(), DirectExecutor.INSTANCE);
         bean.clock = clock;
 
         bean.flagActiveDeletionUnsafeForCurrentState();
@@ -311,7 +312,7 @@ public class ActiveDeletedBlobCollectorMBeanImplTest {
         ActiveDeletedBlobCollectorMBeanImpl bean =
                 new ActiveDeletedBlobCollectorMBeanImpl(ActiveDeletedBlobCollectorFactory.NOOP, wb, dns1,
                         indexPathService, asyncIndexInfoService,
-                        new MemoryBlobStore(), newDirectExecutorService());
+                        new MemoryBlobStore(), DirectExecutor.INSTANCE);
         bean.clock = clock;
 
         bean.flagActiveDeletionUnsafeForCurrentState();

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopierCleanupTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopierCleanupTest.java
@@ -21,6 +21,7 @@ package org.apache.jackrabbit.oak.plugins.index.lucene;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.pio.Closer;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
@@ -45,7 +46,6 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.directory.CopyOnReadDirectory.DELETE_MARGIN_MILLIS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.INDEX_DATA_CHILD_NAME;
@@ -98,7 +98,7 @@ public class IndexCopierCleanupTest {
 
         localFSDir = temporaryFolder.newFolder();
 
-        copier = new RAMIndexCopier(localFSDir, newDirectExecutorService(), temporaryFolder.getRoot(), true);
+        copier = new RAMIndexCopier(localFSDir, DirectExecutor.INSTANCE, temporaryFolder.getRoot(), true);
 
         // convince copier that local FS dir is ok (avoid integrity check doing the cleanup)
         copier.getCoRDir().close();

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopierTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexCopierTest.java
@@ -49,6 +49,7 @@ import org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors;
 import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.pio.Closer;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.LocalIndexFile;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
@@ -68,7 +69,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.directory.CopyOnReadDirectory.DELETE_MARGIN_MILLIS_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.INDEX_DATA_CHILD_NAME;
@@ -123,7 +123,7 @@ public class IndexCopierTest {
     public void basicTest() throws Exception{
         Directory baseDir = new RAMDirectory();
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new RAMDirectory();
         Directory wrapped = c1.wrapForRead("/foo", defn, remote, INDEX_DATA_CHILD_NAME);
@@ -156,7 +156,7 @@ public class IndexCopierTest {
             }
         };
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir(), true);
+        IndexCopier c1 = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir(), true);
 
         Directory remote = new RAMDirectory();
 
@@ -203,7 +203,7 @@ public class IndexCopierTest {
     @Test
     public void basicTestWithFS() throws Exception{
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new IndexCopier(newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new IndexCopier(DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new RAMDirectory();
         Directory wrapped = c1.wrapForRead("/foo", defn, remote, INDEX_DATA_CHILD_NAME);
@@ -233,7 +233,7 @@ public class IndexCopierTest {
     @Test
     public void multiDirNames() throws Exception{
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new IndexCopier(newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new IndexCopier(DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new CloseSafeDir();
         byte[] t1 = writeFile(remote, "t1");
@@ -252,7 +252,7 @@ public class IndexCopierTest {
     @Test
     public void deleteOldPostReindex() throws Exception{
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new IndexCopier(newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new IndexCopier(DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new CloseSafeDir();
         Directory w1 = c1.wrapForRead(indexPath, defn, remote, INDEX_DATA_CHILD_NAME);
@@ -402,7 +402,7 @@ public class IndexCopierTest {
     public void reuseLocalDir() throws Exception{
         Directory baseDir = new RAMDirectory();
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         FileTrackingDirectory remote = new FileTrackingDirectory();
         Directory wrapped = c1.wrapForRead("/foo", defn, remote, INDEX_DATA_CHILD_NAME);
@@ -437,7 +437,7 @@ public class IndexCopierTest {
     public void deleteCorruptedFile() throws Exception{
         Directory baseDir = new RAMDirectory();
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        RAMIndexCopier c1 = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        RAMIndexCopier c1 = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new RAMDirectory(){
             @Override
@@ -467,7 +467,7 @@ public class IndexCopierTest {
 
 
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         Directory r1 = new DelayCopyingSimpleFSDirectory();
 
@@ -510,7 +510,7 @@ public class IndexCopierTest {
         };
 
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier c1 = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier c1 = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         Directory r1 = new DelayCopyingSimpleFSDirectory();
 
@@ -561,7 +561,7 @@ public class IndexCopierTest {
         Directory baseDir = new CloseSafeDir();
 
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier copier = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier copier = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         //1. Open a local and read t1 from remote
         Directory remote1 = new RAMDirectory();
@@ -588,7 +588,7 @@ public class IndexCopierTest {
     public void wrapForWriteWithoutIndexPath() throws Exception{
         Directory remote = new CloseSafeDir();
 
-        IndexCopier copier = new IndexCopier(newDirectExecutorService(), getWorkDir());
+        IndexCopier copier = new IndexCopier(DirectExecutor.INSTANCE, getWorkDir());
 
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
         Directory dir = copier.wrapForWrite(defn, remote, false, INDEX_DATA_CHILD_NAME,
@@ -607,7 +607,7 @@ public class IndexCopierTest {
     public void wrapForWriteWithIndexPath() throws Exception{
         Directory remote = new CloseSafeDir();
 
-        IndexCopier copier = new IndexCopier(newDirectExecutorService(), getWorkDir());
+        IndexCopier copier = new IndexCopier(DirectExecutor.INSTANCE, getWorkDir());
 
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
         Directory dir = copier.wrapForWrite(defn, remote, false, INDEX_DATA_CHILD_NAME,
@@ -632,7 +632,7 @@ public class IndexCopierTest {
     public void copyOnWriteBasics() throws Exception{
         Directory baseDir = new CloseSafeDir();
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier copier = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier copier = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new RAMDirectory();
         byte[] t1 = writeFile(remote, "t1");
@@ -693,7 +693,7 @@ public class IndexCopierTest {
     public void cowExistingLocalFileNotDeleted() throws Exception{
         Directory baseDir = new CloseSafeDir();
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier copier = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier copier = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         Directory remote = new CloseSafeDir();
         byte[] t1 = writeFile(remote, "t1");
@@ -738,7 +738,7 @@ public class IndexCopierTest {
             }
         };
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier copier = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir());
+        IndexCopier copier = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir());
 
         final Set<String> readRemotes = new HashSet<>();
         Directory remote = new RAMDirectory() {
@@ -1057,7 +1057,7 @@ public class IndexCopierTest {
     public void directoryContentMismatch_COR() throws Exception{
         Directory baseDir = new CloseSafeDir();
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, builder.getNodeState(), "/foo");
-        IndexCopier copier = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir(), true);
+        IndexCopier copier = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir(), true);
 
         Directory remote = new RAMDirectory();
         byte[] t1 = writeFile(remote, "t1");
@@ -1078,7 +1078,7 @@ public class IndexCopierTest {
         t1 = writeFile(remoteModified, "t1");
 
         //3. Reopen the copier
-        copier = new RAMIndexCopier(baseDir, newDirectExecutorService(), getWorkDir(), true);
+        copier = new RAMIndexCopier(baseDir, DirectExecutor.INSTANCE, getWorkDir(), true);
 
         //4. Post opening local the content should be in sync with remote
         //So t1 should be recreated matching remote

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexNodeManagerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/IndexNodeManagerTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.index.lucene.directory.OakDirectory;
 import org.apache.jackrabbit.oak.plugins.index.lucene.hybrid.NRTIndex;
 import org.apache.jackrabbit.oak.plugins.index.lucene.hybrid.NRTIndexFactory;
@@ -47,7 +48,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.api.Type.STRINGS;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.TestUtil.newDoc;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
@@ -74,7 +74,7 @@ public class IndexNodeManagerTest {
 
     @Before
     public void setUp() throws IOException {
-        indexCopier = new IndexCopier(newDirectExecutorService(), temporaryFolder.getRoot());
+        indexCopier = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.getRoot());
         nrtFactory = new NRTIndexFactory(indexCopier, StatisticsProvider.NOOP);
         readerFactory = new DefaultIndexReaderFactory(Mounts.defaultMountInfoProvider(), indexCopier);
         LuceneIndexEditorContext.configureUniqueId(builder);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Arrays.asList;
 import static javax.jcr.PropertyType.TYPENAME_STRING;
 import static org.apache.jackrabbit.JcrConstants.JCR_DATA;
@@ -69,6 +68,7 @@ import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.collections.IteratorUtils;
 import org.apache.jackrabbit.oak.commons.collections.ListUtils;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdate;
@@ -670,7 +670,7 @@ public class LuceneIndexTest {
         NodeState indexed = HOOK.processCommit(before, after,CommitInfo.EMPTY);
 
         File indexRootDir = new File(getIndexDir());
-        tracker = new IndexTracker(new IndexCopier(newDirectExecutorService(), indexRootDir));
+        tracker = new IndexTracker(new IndexCopier(DirectExecutor.INSTANCE, indexRootDir));
         tracker.update(indexed);
 
         assertQuery(tracker, indexed, "foo", "bar");
@@ -696,7 +696,7 @@ public class LuceneIndexTest {
 
         NodeState indexed = HOOK.processCommit(before, builder.getNodeState(),CommitInfo.EMPTY);
 
-        IndexCopier copier = new IndexCopier(newDirectExecutorService(), new File(getIndexDir()));
+        IndexCopier copier = new IndexCopier(DirectExecutor.INSTANCE, new File(getIndexDir()));
         tracker = new IndexTracker(copier);
         tracker.update(indexed);
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ConcurrentCopyOnReadDirectoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/ConcurrentCopyOnReadDirectoryTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.plugins.index.lucene.directory;
 import org.apache.jackrabbit.oak.InitialContentHelper;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.junit.TemporarySystemProperty;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexCopier;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
@@ -43,7 +44,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.directory.CopyOnReadDirectory.WAIT_OTHER_COPY_SYSPROP_NAME;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.INDEX_DATA_CHILD_NAME;
 import static org.junit.Assert.assertFalse;
@@ -97,7 +97,7 @@ public class ConcurrentCopyOnReadDirectoryTest {
         IndexInput remoteInput = remote.openInput("file", IOContext.READ);
         assertTrue(remoteInput.length() > 1);
 
-        copier = new IndexCopier(newDirectExecutorService(), temporaryFolder.newFolder(), true);
+        copier = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.newFolder(), true);
 
         NodeState root = InitialContentHelper.INITIAL_CONTENT;
         defn = new LuceneIndexDefinition(root, root, "/foo");

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/CopyOnReadDirectoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/directory/CopyOnReadDirectoryTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexCopier;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
@@ -30,7 +31,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.junit.Assert.assertEquals;
 
 public class CopyOnReadDirectoryTest {
@@ -41,7 +41,7 @@ public class CopyOnReadDirectoryTest {
     public void multipleCloseCalls() throws Exception{
         AtomicInteger executionCount = new AtomicInteger();
         Executor e = r -> {executionCount.incrementAndGet(); r.run();};
-        IndexCopier c = new IndexCopier(newDirectExecutorService(), temporaryFolder.newFolder(), true);
+        IndexCopier c = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.newFolder(), true);
         Directory dir = new CopyOnReadDirectory(c, new RAMDirectory(), new RAMDirectory(), false, "foo", e);
 
         dir.close();

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/DelayedFacetReadTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/DelayedFacetReadTest.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
@@ -78,7 +79,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_FACETS;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.STATISTICAL_FACET_SAMPLE_SIZE_DEFAULT;
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
@@ -138,7 +138,7 @@ public class DelayedFacetReadTest extends AbstractQueryTest {
         LuceneIndexReaderFactory indexReaderFactory = new DefaultIndexReaderFactory(mip, copier);
         IndexTracker tracker = new IndexTracker(indexReaderFactory, nrtIndexFactory);
         luceneIndexProvider = new LuceneIndexProvider(tracker);
-        queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         LuceneIndexEditorProvider editorProvider = new LuceneIndexEditorProvider(copier,
                 tracker,
                 null,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/DocumentQueueTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/DocumentQueueTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.collections4.ListValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.time.Stopwatch;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdateProvider;
@@ -60,7 +61,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.FieldFactory.newPathField;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.hybrid.LocalIndexObserverTest.NOOP_EXECUTOR;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexHelper.newLucenePropertyIndexDefinition;
@@ -112,14 +112,14 @@ public class DocumentQueueTest {
 
     @Test
     public void noIssueIfNoIndex() throws Exception{
-        DocumentQueue queue = new DocumentQueue(2, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(2, tracker, DirectExecutor.INSTANCE);
         assertTrue(queue.add(LuceneDoc.forDelete("foo", "bar")));
         assertTrue(queue.getQueuedDocs().isEmpty());
     }
 
     @Test
     public void closeQueue() throws Exception{
-        DocumentQueue queue = new DocumentQueue(2, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(2, tracker, DirectExecutor.INSTANCE);
         queue.close();
 
         try {
@@ -133,7 +133,7 @@ public class DocumentQueueTest {
     @Test
     public void noIssueIfNoWriter() throws Exception{
         NodeState indexed = createAndPopulateAsyncIndex(FulltextIndexConstants.IndexingMode.NRT);
-        DocumentQueue queue = new DocumentQueue(2, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(2, tracker, DirectExecutor.INSTANCE);
 
         tracker.update(indexed);
         assertTrue(queue.add(LuceneDoc.forDelete("/oak:index/fooIndex", "bar")));
@@ -144,7 +144,7 @@ public class DocumentQueueTest {
         IndexTracker tracker = createTracker();
         NodeState indexed = createAndPopulateAsyncIndex(FulltextIndexConstants.IndexingMode.NRT);
         tracker.update(indexed);
-        DocumentQueue queue = new DocumentQueue(2, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(2, tracker, DirectExecutor.INSTANCE);
 
         Document d1 = new Document();
         d1.add(newPathField("/a/b"));
@@ -164,7 +164,7 @@ public class DocumentQueueTest {
 
         clock.waitUntil(refreshDelta);
 
-        DocumentQueue queue = new DocumentQueue(2, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(2, tracker, DirectExecutor.INSTANCE);
 
         TopDocs td = doSearch("bar");
         assertEquals(1, td.totalHits);
@@ -225,7 +225,7 @@ public class DocumentQueueTest {
         NodeState indexed = createAndPopulateAsyncIndex(FulltextIndexConstants.IndexingMode.SYNC);
         tracker.update(indexed);
 
-        DocumentQueue queue = new DocumentQueue(2, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(2, tracker, DirectExecutor.INSTANCE);
 
         TopDocs td = doSearch("bar");
         assertEquals(1, td.totalHits);
@@ -323,7 +323,7 @@ public class DocumentQueueTest {
     }
 
     private IndexTracker createTracker() throws IOException {
-        IndexCopier indexCopier = new IndexCopier(newDirectExecutorService(), temporaryFolder.getRoot());
+        IndexCopier indexCopier = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.getRoot());
         indexFactory = new NRTIndexFactory(indexCopier, clock, TimeUnit.MILLISECONDS.toSeconds(refreshDelta), StatisticsProvider.NOOP);
         return new IndexTracker(
                 new DefaultIndexReaderFactory(defaultMountInfoProvider(), indexCopier),

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/FacetCacheTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/FacetCacheTest.java
@@ -27,6 +27,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
@@ -81,7 +82,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_FACETS;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.STATISTICAL_FACET_SAMPLE_SIZE_DEFAULT;
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
@@ -138,7 +138,7 @@ public class FacetCacheTest extends AbstractQueryTest {
         LuceneIndexReaderFactory indexReaderFactory = new DefaultIndexReaderFactory(mip, copier);
         IndexTracker tracker = new IndexTracker(indexReaderFactory, nrtIndexFactory);
         luceneIndexProvider = new LuceneIndexProvider(tracker);
-        queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         LuceneIndexEditorProvider editorProvider = new LuceneIndexEditorProvider(copier,
                 tracker,
                 null,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/HybridIndexClusterIT.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/HybridIndexClusterIT.java
@@ -36,6 +36,7 @@ import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
 
 import org.apache.jackrabbit.commons.JcrUtils;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.fixture.DocumentMemoryFixture;
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
 import org.apache.jackrabbit.oak.jcr.Jcr;
@@ -68,7 +69,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertNotNull;
@@ -100,7 +100,7 @@ public class HybridIndexClusterIT extends AbstractClusterTest {
         LuceneIndexReaderFactory indexReaderFactory = new DefaultIndexReaderFactory(mip, copier);
         IndexTracker tracker = new IndexTracker(indexReaderFactory,nrtIndexFactory);
         LuceneIndexProvider provider = new LuceneIndexProvider(tracker);
-        DocumentQueue queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         LuceneIndexEditorProvider editorProvider = new LuceneIndexEditorProvider(copier,
                 tracker,
                 null,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/HybridIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/HybridIndexTest.java
@@ -53,6 +53,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IteratorUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
@@ -98,7 +99,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.api.QueryEngine.NO_BINDINGS;
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -147,7 +147,7 @@ public class HybridIndexTest extends AbstractQueryTest {
         LuceneIndexReaderFactory indexReaderFactory = new DefaultIndexReaderFactory(mip, copier);
         IndexTracker tracker = new IndexTracker(indexReaderFactory,nrtIndexFactory);
         luceneIndexProvider = new LuceneIndexProvider(tracker);
-        queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         LuceneIndexEditorProvider editorProvider = new LuceneIndexEditorProvider(copier,
                 tracker,
                 null,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LocalIndexWriterFactoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/LocalIndexWriterFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdateProvider;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.lucene.TestUtil;
@@ -41,7 +42,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.junit.Assert.*;
@@ -59,7 +59,7 @@ public class LocalIndexWriterFactoryTest {
     @Before
     public void setUp() throws IOException {
         tracker = new IndexTracker();
-        DocumentQueue queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         editorProvider = new LuceneIndexEditorProvider(
                 null,
                 null,
@@ -147,7 +147,7 @@ public class LocalIndexWriterFactoryTest {
     public void inMemoryDocLimit() throws Exception{
         NodeState indexed = createAndPopulateAsyncIndex(FulltextIndexConstants.IndexingMode.NRT);
         editorProvider.setInMemoryDocsLimit(5);
-        editorProvider.setIndexingQueue(new DocumentQueue(1, tracker, newDirectExecutorService()));
+        editorProvider.setIndexingQueue(new DocumentQueue(1, tracker, DirectExecutor.INSTANCE));
         builder = indexed.builder();
         for (int i = 0; i < 10; i++) {
             builder.child("b" + i).setProperty("foo", "bar");

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/ManyFacetsTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/ManyFacetsTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.lucene.hybrid;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_FACETS;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.STATISTICAL_FACET_SAMPLE_SIZE_DEFAULT;
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
@@ -50,6 +49,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.commons.json.JsonObject;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
@@ -135,7 +135,7 @@ public class ManyFacetsTest extends AbstractQueryTest {
         LuceneIndexReaderFactory indexReaderFactory = new DefaultIndexReaderFactory(mip, copier);
         IndexTracker tracker = new IndexTracker(indexReaderFactory, nrtIndexFactory);
         luceneIndexProvider = new LuceneIndexProvider(tracker);
-        queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         LuceneIndexEditorProvider editorProvider = new LuceneIndexEditorProvider(copier,
                 tracker,
                 null,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/MultithreadedOldLuceneFacetProviderReadFailureTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/MultithreadedOldLuceneFacetProviderReadFailureTest.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.plugins.index.AsyncIndexUpdate;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
@@ -80,7 +81,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.PROP_FACETS;
 import static org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants.STATISTICAL_FACET_SAMPLE_SIZE_DEFAULT;
 import static org.apache.jackrabbit.oak.spi.mount.Mounts.defaultMountInfoProvider;
@@ -140,7 +140,7 @@ public class MultithreadedOldLuceneFacetProviderReadFailureTest extends Abstract
         LuceneIndexReaderFactory indexReaderFactory = new DefaultIndexReaderFactory(mip, copier);
         IndexTracker tracker = new IndexTracker(indexReaderFactory, nrtIndexFactory);
         luceneIndexProvider = new LuceneIndexProvider(tracker);
-        queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         LuceneIndexEditorProvider editorProvider = new LuceneIndexEditorProvider(copier,
                 tracker,
                 null,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/NRTIndexFactoryTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/NRTIndexFactoryTest.java
@@ -22,6 +22,7 @@ package org.apache.jackrabbit.oak.plugins.index.lucene.hybrid;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexCopier;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.lucene.TestUtil;
@@ -36,7 +37,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.FieldFactory.newPathField;
 import static org.junit.Assert.assertEquals;
@@ -57,7 +57,7 @@ public class NRTIndexFactoryTest {
 
     @Before
     public void setUp() throws IOException {
-        indexCopier = new IndexCopier(newDirectExecutorService(), temporaryFolder.getRoot());
+        indexCopier = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.getRoot());
         indexFactory = new NRTIndexFactory(indexCopier, StatisticsProvider.NOOP);
         indexFactory.setAssertAllResourcesClosed(true);
     }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/NRTIndexTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/NRTIndexTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexCopier;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.lucene.TestUtil;
@@ -40,7 +41,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.FieldFactory.newPathField;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.junit.Assert.assertEquals;
@@ -64,7 +64,7 @@ public class NRTIndexTest {
 
     @Before
     public void setUp() throws IOException {
-        indexCopier = new IndexCopier(newDirectExecutorService(), temporaryFolder.getRoot());
+        indexCopier = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.getRoot());
         indexFactory = new NRTIndexFactory(indexCopier, StatisticsProvider.NOOP);
         indexFactory.setAssertAllResourcesClosed(true);
         LuceneIndexEditorContext.configureUniqueId(builder);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/ReaderRefCountIT.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/hybrid/ReaderRefCountIT.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexCopier;
 import org.apache.jackrabbit.oak.plugins.index.lucene.IndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.lucene.LuceneIndexNode;
@@ -49,7 +50,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Collections.singletonList;
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.index.lucene.FieldFactory.newPathField;
@@ -67,7 +67,7 @@ public class ReaderRefCountIT {
 
     @Before
     public void setUp() throws IOException {
-        indexCopier = new IndexCopier(newDirectExecutorService(), temporaryFolder.getRoot());
+        indexCopier = new IndexCopier(DirectExecutor.INSTANCE, temporaryFolder.getRoot());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class ReaderRefCountIT {
             }
         };
 
-        DocumentQueue queue = new DocumentQueue(100, tracker, newDirectExecutorService());
+        DocumentQueue queue = new DocumentQueue(100, tracker, DirectExecutor.INSTANCE);
         queue.setExceptionHandler(uh);
 
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/bundlor/BundlingConfigHandlerTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/bundlor/BundlingConfigHandlerTest.java
@@ -22,13 +22,13 @@ package org.apache.jackrabbit.oak.plugins.document.bundlor;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.internal.concurrent.DirectExecutor;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.junit.Test;
 
-import static org.apache.jackrabbit.guava.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static java.util.Collections.singletonList;
 import static org.apache.jackrabbit.oak.plugins.document.bundlor.BundlingConfigHandler.BUNDLOR;
 import static org.apache.jackrabbit.oak.plugins.document.bundlor.BundlingConfigHandler.DOCUMENT_NODE_STORE;
@@ -50,7 +50,7 @@ public class BundlingConfigHandlerTest {
 
     @Test
     public void detectRegistryUpdate() throws Exception{
-        configHandler.initialize(nodeStore, newDirectExecutorService());
+        configHandler.initialize(nodeStore, DirectExecutor.INSTANCE);
         addBundlorConfigForAsset();
 
         BundledTypesRegistry registry = configHandler.getRegistry();


### PR DESCRIPTION
… implementation