### PR TITLE
OAK-11899 - use default value in case config value can not be parsed

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
@@ -133,10 +133,10 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         this.root = root;
         this.options = options;
         this.credentialsSupport = credentialsSupport;
-        this.tokenExpiration = getConfigValueOrDefault(PARAM_TOKEN_EXPIRATION, DEFAULT_TOKEN_EXPIRATION);
+        this.tokenExpiration = options.getConfigValueOrDefault(PARAM_TOKEN_EXPIRATION, DEFAULT_TOKEN_EXPIRATION);
         this.userManager = userConfiguration.getUserManager(root, NamePathMapper.DEFAULT);
         this.identifierManager = new IdentifierManager(root);
-        this.cleanupThreshold = getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_THRESHOLD, NO_TOKEN_CLEANUP);
+        this.cleanupThreshold = options.getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_THRESHOLD, NO_TOKEN_CLEANUP);
     }
 
     //------------------------------------------------------< TokenProvider >---
@@ -298,15 +298,6 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         tree.setProperty(TOKEN_ATTRIBUTE_EXPIRY, ISO8601.format(calendar), DATE);
     }
 
-    private <T> T getConfigValueOrDefault(@NotNull String configName, final T defaultValue) {
-        try {
-            return options.getConfigValue(configName, defaultValue);
-        } catch (IllegalArgumentException e) {
-            log.warn("Invalid config value for '{}': {}. Returning default value {}", configName, e.getMessage(), defaultValue);
-            return defaultValue;
-        }
-    }
-
     @Nullable
     private Credentials extractCredentials(@NotNull Credentials credentials) {
         Credentials creds = credentials;
@@ -441,7 +432,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         Tree tokenNode = TreeUtil.addChild(parent, tokenName, TOKEN_NT_NAME);
         tokenNode.setProperty(JcrConstants.JCR_UUID, uuid);
 
-        String key = generateKey(getConfigValueOrDefault(PARAM_TOKEN_LENGTH, DEFAULT_KEY_SIZE));
+        String key = generateKey(options.getConfigValueOrDefault(PARAM_TOKEN_LENGTH, DEFAULT_KEY_SIZE));
         String nodeId = getIdentifier(tokenNode);
         String token = nodeId + DELIM + key;
 
@@ -584,7 +575,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         @Override
         public boolean resetExpiration(long loginTime) {
             // for backwards compatibility use true as default value for the 'tokenRefresh' configuration
-            if (getConfigValueOrDefault(PARAM_TOKEN_REFRESH, true)) {
+            if (options.getConfigValueOrDefault(PARAM_TOKEN_REFRESH, true)) {
                 Tree tokenTree = getTokenTree(this);
                 if (tokenTree.exists()) {
                     if (isExpired(loginTime)) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
@@ -133,11 +133,10 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         this.root = root;
         this.options = options;
         this.credentialsSupport = credentialsSupport;
-
-        this.tokenExpiration = options.getConfigValue(PARAM_TOKEN_EXPIRATION, DEFAULT_TOKEN_EXPIRATION);
+        this.tokenExpiration = getConfigValueOrDefault(PARAM_TOKEN_EXPIRATION, DEFAULT_TOKEN_EXPIRATION);
         this.userManager = userConfiguration.getUserManager(root, NamePathMapper.DEFAULT);
         this.identifierManager = new IdentifierManager(root);
-        this.cleanupThreshold = options.getConfigValue(PARAM_TOKEN_CLEANUP_THRESHOLD, NO_TOKEN_CLEANUP);
+        this.cleanupThreshold = getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_THRESHOLD, NO_TOKEN_CLEANUP);
     }
 
     //------------------------------------------------------< TokenProvider >---
@@ -299,6 +298,15 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         tree.setProperty(TOKEN_ATTRIBUTE_EXPIRY, ISO8601.format(calendar), DATE);
     }
 
+    private <T> T getConfigValueOrDefault(@NotNull String configName, final T defaultValue) {
+        try {
+            return options.getConfigValue(configName, defaultValue);
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid config value for '{}': {}. Returning default value {}", configName, e.getMessage(), defaultValue);
+            return defaultValue;
+        }
+    }
+
     @Nullable
     private Credentials extractCredentials(@NotNull Credentials credentials) {
         Credentials creds = credentials;
@@ -433,7 +441,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         Tree tokenNode = TreeUtil.addChild(parent, tokenName, TOKEN_NT_NAME);
         tokenNode.setProperty(JcrConstants.JCR_UUID, uuid);
 
-        String key = generateKey(options.getConfigValue(PARAM_TOKEN_LENGTH, DEFAULT_KEY_SIZE));
+        String key = generateKey(getConfigValueOrDefault(PARAM_TOKEN_LENGTH, DEFAULT_KEY_SIZE));
         String nodeId = getIdentifier(tokenNode);
         String token = nodeId + DELIM + key;
 
@@ -576,7 +584,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         @Override
         public boolean resetExpiration(long loginTime) {
             // for backwards compatibility use true as default value for the 'tokenRefresh' configuration
-            if (options.getConfigValue(PARAM_TOKEN_REFRESH, true)) {
+            if (getConfigValueOrDefault(PARAM_TOKEN_REFRESH, true)) {
                 Tree tokenTree = getTokenTree(this);
                 if (tokenTree.exists()) {
                     if (isExpired(loginTime)) {

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/ConfigurationParameters.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/ConfigurationParameters.java
@@ -245,6 +245,33 @@ public final class ConfigurationParameters implements Map<String, Object> {
         }
     }
 
+    /**
+     * Returns the value of the configuration entry with the given {@code key}
+     * applying the following rules:
+     *
+     * <ul>
+     *     <li>If this instance doesn't contain a configuration entry with that
+     *     key, or if the entry is {@code null}, the specified {@code defaultValue} will be returned.</li>
+     *     <li>If the configured value is not {@code null} an attempt is made to convert the configured value to
+     *     match the type of the default value.</li>
+     *     <li>If the configured value can not be converted to the default value type the default value is returned.</li>
+     * </ul>
+     *
+     * @param key The name of the configuration option.
+     * @param defaultValue The default value to return if no such entry exists
+     * or to use for conversion.
+     * @return The original or converted configuration value or {@code defaultValue} if no entry for the given key exists
+     * or if a conversion error occurred.
+     */
+    @NotNull
+    public <T> T getConfigValueOrDefault(@NotNull String key, @NotNull T defaultValue) {
+        try {
+            return getConfigValue(key, defaultValue);
+        } catch (IllegalArgumentException e) {
+            return defaultValue;
+        }
+    }
+
     //--------------------------------------------------------< private >---
     @NotNull
     private static Class<?>  getTargetClass(@NotNull Object configProperty, @Nullable Object defaultValue, @Nullable Class<?> targetClass) {

--- a/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/package-info.java
+++ b/oak-security-spi/src/main/java/org/apache/jackrabbit/oak/spi/security/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("2.3.0")
+@Version("2.4.0")
 package org.apache.jackrabbit.oak.spi.security;
 
 import org.osgi.annotation.versioning.Version;

--- a/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/ConfigurationParametersTest.java
+++ b/oak-security-spi/src/test/java/org/apache/jackrabbit/oak/spi/security/ConfigurationParametersTest.java
@@ -601,6 +601,49 @@ public class ConfigurationParametersTest {
         options.clear();
     }
 
+    @Test
+    public void testConfigValueOrDefault() {
+        ConfigurationParameters options = ConfigurationParameters.of(Collections.singletonMap("test", null));
+        Object defaultObject = new TestObject("t");
+        String defaultValue = "defaultValue";
+
+        assertEquals(defaultValue, options.getConfigValueOrDefault("test", defaultValue));
+        assertEquals(1L, options.getConfigValueOrDefault("test", 1L).longValue());
+        assertEquals(1.1f, options.getConfigValueOrDefault("test", 1.1f), 0.01);
+        assertEquals(1.1d, options.getConfigValueOrDefault("test", 1.1d), 0.01);
+        assertEquals(1, options.getConfigValueOrDefault("test", 1).intValue());
+        assertEquals(defaultObject, options.getConfigValueOrDefault("test", defaultObject));
+        assertFalse(options.getConfigValueOrDefault("test", false));
+    }
+
+    @Test
+    public void testConfigValueOrDefault1() {
+        ConfigurationParameters options = ConfigurationParameters.of(Collections.singletonMap("test", ""));
+        Object defaultObject = new TestObject("t");
+
+        assertEquals("", options.getConfigValueOrDefault("test", "value"));
+        assertEquals(1L, options.getConfigValueOrDefault("test", 1L).longValue());
+        assertEquals(1.1f, options.getConfigValueOrDefault("test", 1.1f), 0.01);
+        assertEquals(1.1d, options.getConfigValueOrDefault("test", 1.1d), 0.01);
+        assertEquals(1, options.getConfigValueOrDefault("test", 1).intValue());
+        assertEquals(defaultObject, options.getConfigValueOrDefault("test", defaultObject));
+        assertFalse(options.getConfigValueOrDefault("test", false));
+    }
+
+    @Test
+    public void testConfigValueOrDefault2() {
+        ConfigurationParameters options = ConfigurationParameters.of(Collections.singletonMap("test", " "));
+        Object defaultObject = new TestObject("t");
+
+        assertEquals(" ", options.getConfigValueOrDefault("test", "value"));
+        assertEquals(1L, options.getConfigValueOrDefault("test", 1L).longValue());
+        assertEquals(1.1f, options.getConfigValueOrDefault("test", 1.1f), 0.01);
+        assertEquals(1.1d, options.getConfigValueOrDefault("test", 1.1d), 0.01);
+        assertEquals(1, options.getConfigValueOrDefault("test", 1).intValue());
+        assertEquals(defaultObject, options.getConfigValueOrDefault("test", defaultObject));
+        assertFalse(options.getConfigValueOrDefault("test", false));
+    }
+
     private static class TestObject {
 
         private final String name;


### PR DESCRIPTION
If the value in the OSGi console is cleared out, the value in the configuration file is stored with empty value :
propName=""
This makes issue that the empty string is not a null (then the default value would be used) and throws an parse exception which causes that the token is not correctly generated. 
The default value is used only when the propName is not present.  