### PR TITLE
OAK-11930 prevent binaries from being read and returned as string

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -107,7 +107,7 @@ public class EventFactory {
                 return Collections.unmodifiableMap(builder);
             }
             @Override
-            public Map<?,?> getInfoToString() {
+            public Map<?, ?> getInfoToString() {
                 if (!after.getType().equals(Type.BINARY)) {
                     return getInfo();
                 }
@@ -138,7 +138,7 @@ public class EventFactory {
                 return Collections.unmodifiableMap(builder);
             }
             @Override
-            public Map<?,?> getInfoToString() {
+            public Map<?, ?> getInfoToString() {
                 if (!before.getType().equals(Type.BINARY)) {
                     return getInfo();
                 }
@@ -168,7 +168,7 @@ public class EventFactory {
                 return Collections.unmodifiableMap(builder);
             }
             @Override
-            public Map<?,?> getInfoToString() {
+            public Map<?, ?> getInfoToString() {
                 if (!before.getType().equals(Type.BINARY)) {
                     return getInfo();
                 }
@@ -344,7 +344,7 @@ public class EventFactory {
          * 
          * @return a serialized version of getInfo
          */
-        public Map<?,?> getInfoToString() {
+        public Map<?, ?> getInfoToString() {
             return getInfo();
         }
 

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -103,18 +103,18 @@ public class EventFactory {
             public Map<?, ?> getInfo() {
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("afterValue", createValue(after));
+                builder.put(AFTERVALUE, createValue(after));
                 return Collections.unmodifiableMap(builder);
             }
             @Override
-            public Map<?,?> getInfo_ToString() {
+            public Map<?,?> getInfoToString() {
                 if (!after.getType().equals(Type.BINARY)) {
                     return getInfo();
                 }
                 // for binary values just the binary information is logged
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("afterValue", getSimpleBinaryReference(after));
+                builder.put(AFTERVALUE, getSimpleBinaryReference(after));
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -133,20 +133,20 @@ public class EventFactory {
             public Map<?, ?> getInfo() {
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("beforeValue", createValue(before));
-                builder.put("afterValue", createValue(after));
+                builder.put(BEFOREVALUE, createValue(before));
+                builder.put(AFTERVALUE, createValue(after));
                 return Collections.unmodifiableMap(builder);
             }
             @Override
-            public Map<?,?> getInfo_ToString() {
+            public Map<?,?> getInfoToString() {
                 if (!before.getType().equals(Type.BINARY)) {
                     return getInfo();
                 }
                 // for binary values just the binary information is logged
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("beforeValue", getSimpleBinaryReference(before));
-                builder.put("afterValue", getSimpleBinaryReference(after));
+                builder.put(BEFOREVALUE, getSimpleBinaryReference(before));
+                builder.put(AFTERVALUE, getSimpleBinaryReference(after));
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -164,18 +164,18 @@ public class EventFactory {
             public Map<?, ?> getInfo() {
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("beforeValue", createValue(before));
+                builder.put(BEFOREVALUE, createValue(before));
                 return Collections.unmodifiableMap(builder);
             }
             @Override
-            public Map<?,?> getInfo_ToString() {
+            public Map<?,?> getInfoToString() {
                 if (!before.getType().equals(Type.BINARY)) {
                     return getInfo();
                 }
                 // for binary values just the binary information is logged
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("beforeValue", getSimpleBinaryReference(before));
+                builder.put(BEFOREVALUE, getSimpleBinaryReference(before));
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -344,7 +344,7 @@ public class EventFactory {
          * 
          * @return a serialized version of getInfo
          */
-        public Map<?,?> getInfo_ToString() {
+        public Map<?,?> getInfoToString() {
             return getInfo();
         }
 
@@ -380,7 +380,7 @@ public class EventFactory {
                     .add("type=" + getType())
                     .add("path=" + getPath())
                     .add("identifier=" + getIdentifier())
-                    .add("info=" + getInfo_ToString())
+                    .add("info=" + getInfoToString())
                     .add("userID=" + getUserID())
                     .add("userData=" + getUserData())
                     .add("date=" + getDate())

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -56,6 +56,9 @@ import org.jetbrains.annotations.NotNull;
  */
 public class EventFactory {
     public static final String USER_DATA = "user-data";
+    
+    public static final String BEFOREVALUE = "beforeValue";
+    public static final String AFTERVALUE = "afterValue";
 
     private final NamePathMapper mapper;
 

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -41,7 +41,6 @@ import org.apache.jackrabbit.oak.api.blob.BlobAccessProvider;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
-import org.apache.jackrabbit.oak.plugins.memory.BinaryPropertyState;
 import org.apache.jackrabbit.oak.plugins.value.jcr.PartialValueFactory;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.jetbrains.annotations.NotNull;

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -339,7 +339,7 @@ public class EventFactory {
 
         /** A custom version of getInfo(), which is only used
          * for the toString() implementation; the goal is to limit the amount
-         * of data, which is returned, no binary data should be logged
+         * of data that is returned; no binary data should be logged.
          * This is not included in hash calculation and equality checks.
          * 
          * @return

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -342,7 +342,7 @@ public class EventFactory {
          * of data that is returned; no binary data should be logged.
          * This is not included in hash calculation and equality checks.
          * 
-         * @return
+         * @return a serialized version of getInfo
          */
         public Map<?,?> getInfo_ToString() {
             return getInfo();

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -35,6 +35,7 @@ import javax.jcr.observation.Event;
 
 import org.apache.jackrabbit.api.observation.JackrabbitEvent;
 import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.api.blob.BlobAccessProvider;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
@@ -101,6 +102,17 @@ public class EventFactory {
                 builder.put("afterValue", createValue(after));
                 return Collections.unmodifiableMap(builder);
             }
+            @Override
+            public Map<?,?> getInfo_ToString() {
+                if (!after.getType().equals(Type.BINARY)) {
+                    return getInfo();
+                }
+                // for binary values just the binary information is logged
+                Map<Object, Object> builder = new HashMap<>();
+                builder.putAll(createInfoMap(primaryType, mixinTypes));
+                builder.put("afterValue", "<binary>");
+                return Collections.unmodifiableMap(builder);
+            }
         };
     }
 
@@ -121,6 +133,18 @@ public class EventFactory {
                 builder.put("afterValue", createValue(after));
                 return Collections.unmodifiableMap(builder);
             }
+            @Override
+            public Map<?,?> getInfo_ToString() {
+                if (!before.getType().equals(Type.BINARY)) {
+                    return getInfo();
+                }
+                // for binary values just the binary information is logged
+                Map<Object, Object> builder = new HashMap<>();
+                builder.putAll(createInfoMap(primaryType, mixinTypes));
+                builder.put("beforeValue", "<binary>");
+                builder.put("afterValue", "<binary>");
+                return Collections.unmodifiableMap(builder);
+            }
         };
     }
 
@@ -137,6 +161,17 @@ public class EventFactory {
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
                 builder.put("beforeValue", createValue(before));
+                return Collections.unmodifiableMap(builder);
+            }
+            @Override
+            public Map<?,?> getInfo_ToString() {
+                if (!before.getType().equals(Type.BINARY)) {
+                    return getInfo();
+                }
+                // for binary values just the binary information is logged
+                Map<Object, Object> builder = new HashMap<>();
+                builder.putAll(createInfoMap(primaryType, mixinTypes));
+                builder.put("beforeValue", "<binary>");
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -298,6 +333,17 @@ public class EventFactory {
 
         //--------------------------------------------------------< Object >--
 
+        /** A custom version of getInfo(), which is only used
+         * for the toString() implementation; the goal is to limit the amount
+         * of data, which is returned, no binary data should be logged
+         * This is not included in hash calculation and equality checks.
+         * 
+         * @return
+         */
+        public Map<?,?> getInfo_ToString() {
+            return getInfo();
+        }
+        
         @Override
         public boolean equals(Object object) {
             if (this == object) {
@@ -330,7 +376,7 @@ public class EventFactory {
                     .add("type=" + getType())
                     .add("path=" + getPath())
                     .add("identifier=" + getIdentifier())
-                    .add("info=" + getInfo())
+                    .add("info=" + getInfo_ToString())
                     .add("userID=" + getUserID())
                     .add("userData=" + getUserData())
                     .add("date=" + getDate())

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/observation/EventFactory.java
@@ -34,12 +34,14 @@ import javax.jcr.Value;
 import javax.jcr.observation.Event;
 
 import org.apache.jackrabbit.api.observation.JackrabbitEvent;
+import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.api.blob.BlobAccessProvider;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.namepath.NamePathMapper;
+import org.apache.jackrabbit.oak.plugins.memory.BinaryPropertyState;
 import org.apache.jackrabbit.oak.plugins.value.jcr.PartialValueFactory;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.jetbrains.annotations.NotNull;
@@ -69,8 +71,8 @@ public class EventFactory {
     private final boolean external;
 
     EventFactory(@NotNull NamePathMapper mapper,
-                 @NotNull BlobAccessProvider blobAccessProvider,
-                 @NotNull CommitInfo commitInfo) {
+            @NotNull BlobAccessProvider blobAccessProvider,
+            @NotNull CommitInfo commitInfo) {
         this.mapper = mapper;
         this.valueFactory = new PartialValueFactory(mapper, blobAccessProvider);
         if (!commitInfo.isExternal()) {
@@ -110,7 +112,7 @@ public class EventFactory {
                 // for binary values just the binary information is logged
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("afterValue", "<binary>");
+                builder.put("afterValue", getSimpleBinaryReference(after));
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -141,8 +143,8 @@ public class EventFactory {
                 // for binary values just the binary information is logged
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("beforeValue", "<binary>");
-                builder.put("afterValue", "<binary>");
+                builder.put("beforeValue", getSimpleBinaryReference(before));
+                builder.put("afterValue", getSimpleBinaryReference(after));
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -171,7 +173,7 @@ public class EventFactory {
                 // for binary values just the binary information is logged
                 Map<Object, Object> builder = new HashMap<>();
                 builder.putAll(createInfoMap(primaryType, mixinTypes));
-                builder.put("beforeValue", "<binary>");
+                builder.put("beforeValue", getSimpleBinaryReference(before));
                 return Collections.unmodifiableMap(builder);
             }
         };
@@ -343,7 +345,7 @@ public class EventFactory {
         public Map<?,?> getInfo_ToString() {
             return getInfo();
         }
-        
+
         @Override
         public boolean equals(Object object) {
             if (this == object) {
@@ -384,6 +386,19 @@ public class EventFactory {
                     .toString();
         }
 
+        /**
+         * Return a brief string which references a binary.
+         * @param property a binary property
+         * @return a string representation 
+         */
+        protected @NotNull String getSimpleBinaryReference(@NotNull PropertyState property) {
+            // property must be a binary property
+            if (property.getType().equals(Type.BINARY)) {
+                Blob b = property.getValue(Type.BINARY);
+                return String.format("Binary (reference=%s, length=%s bytes)", b.getReference(), b.length());
+            }
+            return "Not a binary, but " + property.getClass(); // should never happen
+        }
     }
 
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/EventSerializationTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/EventSerializationTest.java
@@ -26,7 +26,6 @@ import static javax.jcr.observation.Event.PROPERTY_ADDED;
 import static javax.jcr.observation.Event.PROPERTY_CHANGED;
 import static javax.jcr.observation.Event.PROPERTY_REMOVED;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -114,12 +113,11 @@ public class EventSerializationTest extends AbstractRepositoryTest {
 
             listener.expectEvent("check for added binary property",e -> {
                 try {
-                    assertEquals("/" + TEST_NODE+"/binary", e.getPath());
-                    assertEquals(Event.PROPERTY_ADDED, e.getType());
-                    assertEquals(BINARY_1, e.getInfo().get("afterValue").toString());
-                    assertFalse("Binary value should not be contained in the .toString() output", e.toString().contains(BINARY_1));
-                    return true;
-                } catch (Exception|AssertionError ex) {
+                    return isEqual("/" + TEST_NODE+"/binary", e.getPath())
+                           && isEqual(Event.PROPERTY_ADDED, e.getType()) 
+                           && isEqual(BINARY_1, e.getInfo().get("afterValue").toString())
+                           && isFalse(e.toString().contains(BINARY_1));
+                } catch (Exception ex) {
                     return false;
                 }
             });
@@ -130,14 +128,13 @@ public class EventSerializationTest extends AbstractRepositoryTest {
             // modify the property
             listener.expectEvent("check for modified binary property",e -> {
                 try {
-                    assertEquals("/" + TEST_NODE+"/binary", e.getPath());
-                    assertEquals(Event.PROPERTY_CHANGED, e.getType());
-                    assertEquals(BINARY_1, e.getInfo().get("beforeValue").toString());
-                    assertEquals(BINARY_2, e.getInfo().get("afterValue").toString());
-                    assertFalse("before binary value should not be contained in the .toString() output", e.toString().contains(BINARY_1));
-                    assertFalse("after binary value should not be contained in the .toString() output", e.toString().contains(BINARY_2));
-                    return true;
-                } catch (Exception|AssertionError ex) {
+                    return isEqual("/" + TEST_NODE+"/binary", e.getPath())
+                           && isEqual(Event.PROPERTY_CHANGED, e.getType())
+                           && isEqual(BINARY_1, e.getInfo().get("beforeValue").toString())
+                           && isEqual(BINARY_2, e.getInfo().get("afterValue").toString())
+                           && isFalse(e.toString().contains(BINARY_1))
+                           && isFalse(e.toString().contains(BINARY_2));
+                } catch (Exception ex) {
                     return false;
                 }
             });
@@ -148,11 +145,10 @@ public class EventSerializationTest extends AbstractRepositoryTest {
             // remove the property
             listener.expectEvent("check for removed binary property",e -> {
                 try {
-                    assertEquals("/" + TEST_NODE+"/binary", e.getPath());
-                    assertEquals(Event.PROPERTY_REMOVED, e.getType());
-                    assertEquals(BINARY_2, e.getInfo().get("beforeValue").toString());
-                    assertFalse("before binary value should not be contained in the .toString() output", e.toString().contains(BINARY_2));
-                    return true;
+                    return isEqual("/" + TEST_NODE+"/binary", e.getPath())
+                           && isEqual(Event.PROPERTY_REMOVED, e.getType())
+                           && isEqual(BINARY_2, e.getInfo().get("beforeValue").toString())
+                           && isFalse(e.toString().contains(BINARY_2));
                 } catch (Exception|AssertionError ex) {
                     return false;
                 }
@@ -210,6 +206,11 @@ public class EventSerializationTest extends AbstractRepositoryTest {
         }
     }
 
+    private static boolean isEqual(Object o1, Object o2) {
+        return o1.equals(o2);
+    }
 
-
+    private static boolean isFalse(boolean b) {
+        return b == false;
+    }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/EventSerializationTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/EventSerializationTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.jcr.observation;
+
+import static javax.jcr.observation.Event.NODE_ADDED;
+import static javax.jcr.observation.Event.NODE_MOVED;
+import static javax.jcr.observation.Event.NODE_REMOVED;
+import static javax.jcr.observation.Event.PERSIST;
+import static javax.jcr.observation.Event.PROPERTY_ADDED;
+import static javax.jcr.observation.Event.PROPERTY_CHANGED;
+import static javax.jcr.observation.Event.PROPERTY_REMOVED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.jcr.Binary;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.nodetype.NodeTypeManager;
+import javax.jcr.nodetype.NodeTypeTemplate;
+import javax.jcr.observation.Event;
+import javax.jcr.observation.ObservationManager;
+
+import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
+import org.apache.jackrabbit.oak.jcr.AbstractRepositoryTest;
+import org.apache.jackrabbit.oak.jcr.observation.ExpectationListener.Expectation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class EventSerializationTest extends AbstractRepositoryTest {
+
+    public static final int ALL_EVENTS = NODE_ADDED | NODE_REMOVED | NODE_MOVED | PROPERTY_ADDED |
+            PROPERTY_REMOVED | PROPERTY_CHANGED | PERSIST;
+    public static final String TEST_NODE= "testnode";
+    public static final int TIME_OUT = 12;
+    public static final String TEST_TYPE="mix:test";
+
+    public static final String BINARY_1 = "binary_String_1";
+    public static final Binary BINARY_VALUE_1 = binaryForString(BINARY_1);
+    public static final String BINARY_2 = "binary_string_2_";
+    public static final Binary BINARY_VALUE_2 = binaryForString(BINARY_2);
+
+
+    Session observingSession;
+    ObservationManager observationManager;
+
+    public EventSerializationTest(NodeStoreFixture fixture) {
+        super(fixture);
+    }
+
+    @Before
+    public void setup() throws RepositoryException {
+        Session session = getAdminSession();
+
+        NodeTypeManager ntMgr = session.getWorkspace().getNodeTypeManager();
+        NodeTypeTemplate mixTest = ntMgr.createNodeTypeTemplate();
+        mixTest.setName(TEST_TYPE);
+        mixTest.setMixin(true);
+        ntMgr.registerNodeType(mixTest, false);
+
+        Node n = session.getRootNode().addNode(TEST_NODE);
+        n.addMixin(TEST_TYPE);
+        n.setProperty("test_property1", 42);
+        n.setProperty("test_property2", "forty_two");
+        session.save();
+
+        observingSession = createAdminSession();
+        observationManager = observingSession.getWorkspace().getObservationManager();
+    }
+
+    @After
+    public void tearDown() {
+        if (observingSession != null) {
+            observingSession.logout();
+        }
+    }
+
+    @Test
+    public void checkSerializationOfBinaryProperties() throws RepositoryException, ExecutionException, InterruptedException {
+        ExpectationListener listener = new ExpectationListener();
+        observationManager.addEventListener(listener, ALL_EVENTS, "/", true, null, null, false);
+        Session adminSession = getAdminSession();
+        try {
+            Node n = adminSession.getNode("/" + TEST_NODE);
+
+            listener.expectEvent("check for added binary property",e -> {
+                try {
+                    assertEquals("/" + TEST_NODE+"/binary", e.getPath());
+                    assertEquals(Event.PROPERTY_ADDED, e.getType());
+                    assertEquals(BINARY_1, e.getInfo().get("afterValue").toString());
+                    assertFalse("Binary value should not be contained in the .toString() output", e.toString().contains(BINARY_1));
+                    return true;
+                } catch (Exception|AssertionError ex) {
+                    return false;
+                }
+            });
+            Property binary = n.setProperty("binary", BINARY_VALUE_1);
+            adminSession.save();
+            assertEquals(BINARY_1,binary.getString());
+
+            // modify the property
+            listener.expectEvent("check for modified binary property",e -> {
+                try {
+                    assertEquals("/" + TEST_NODE+"/binary", e.getPath());
+                    assertEquals(Event.PROPERTY_CHANGED, e.getType());
+                    assertEquals(BINARY_1, e.getInfo().get("beforeValue").toString());
+                    assertEquals(BINARY_2, e.getInfo().get("afterValue").toString());
+                    assertFalse("before binary value should not be contained in the .toString() output", e.toString().contains(BINARY_1));
+                    assertFalse("after binary value should not be contained in the .toString() output", e.toString().contains(BINARY_2));
+                    return true;
+                } catch (Exception|AssertionError ex) {
+                    return false;
+                }
+            });
+            Property binary2 = n.setProperty("binary", BINARY_VALUE_2);
+            adminSession.save();
+            assertEquals(BINARY_2, binary2.getString());
+
+            // remove the property
+            listener.expectEvent("check for removed binary property",e -> {
+                try {
+                    assertEquals("/" + TEST_NODE+"/binary", e.getPath());
+                    assertEquals(Event.PROPERTY_REMOVED, e.getType());
+                    assertEquals(BINARY_2, e.getInfo().get("beforeValue").toString());
+                    assertFalse("before binary value should not be contained in the .toString() output", e.toString().contains(BINARY_2));
+                    return true;
+                } catch (Exception|AssertionError ex) {
+                    return false;
+                }
+            });
+            binary2.remove();
+            adminSession.save();
+
+            List<Expectation> missing = listener.getMissing(TIME_OUT, TimeUnit.SECONDS);
+            assertTrue("Missing events: " + missing, missing.isEmpty());
+            List<Event> unexpected = listener.getUnexpected();
+            assertTrue("Unexpected events: " + unexpected, unexpected.isEmpty());
+        }
+        finally {
+            observationManager.removeEventListener(listener);
+        }
+    }
+
+    private static Binary binaryForString(String s) {
+        return new BinaryImpl(s);
+    }
+
+    // A very simple memory-based implementation of a binary property
+    private static class BinaryImpl implements Binary {
+
+        byte[] buffer;
+
+        public BinaryImpl(String s) {
+            buffer = s.getBytes();
+        }
+
+        @Override
+        public InputStream getStream() throws RepositoryException {
+            return new ByteArrayInputStream(buffer);
+        }
+
+        @Override
+        public int read(byte[] b, long position) throws IOException, RepositoryException {
+            int length = Math.min(b.length, buffer.length - (int) position);
+            if (length > 0) {
+                System.arraycopy(buffer, (int) position, b, 0, length);
+                return length;
+            } else {
+                return -1;
+            }
+        }
+
+        @Override
+        public long getSize() throws RepositoryException {
+            return buffer.length;
+        }
+
+        @Override
+        public void dispose() {
+            // nothing to do
+        }
+    }
+
+
+
+}

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ExpectationListener.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ExpectationListener.java
@@ -19,6 +19,7 @@
 package org.apache.jackrabbit.oak.jcr.observation;
 
 import static java.util.Collections.synchronizedList;
+
 import static java.util.Collections.synchronizedSet;
 import static javax.jcr.observation.Event.NODE_ADDED;
 import static javax.jcr.observation.Event.NODE_MOVED;
@@ -52,6 +53,9 @@ import org.apache.jackrabbit.guava.common.util.concurrent.ForwardingListenableFu
 import org.apache.jackrabbit.guava.common.util.concurrent.Futures;
 import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
 import org.apache.jackrabbit.guava.common.util.concurrent.SettableFuture;
+
+import static org.apache.jackrabbit.oak.jcr.observation.EventFactory.AFTERVALUE;
+import static org.apache.jackrabbit.oak.jcr.observation.EventFactory.BEFOREVALUE;
 
 
 public class ExpectationListener implements EventListener {
@@ -138,8 +142,8 @@ public class ExpectationListener implements EventListener {
         expect(new Expectation("Before value " + before + " after value " + after) {
             @Override
             public boolean onEvent(Event event) throws Exception {
-                return Objects.equals(before, event.getInfo().get("beforeValue")) &&
-                        Objects.equals(after, event.getInfo().get("afterValue"));
+                return Objects.equals(before, event.getInfo().get(BEFOREVALUE)) &&
+                        Objects.equals(after, event.getInfo().get(AFTERVALUE));
             }
         });
     }
@@ -148,8 +152,8 @@ public class ExpectationListener implements EventListener {
         expect(new Expectation("Before valuse " + before + " after values " + after) {
             @Override
             public boolean onEvent(Event event) throws Exception {
-                return Arrays.equals(before, (Object[])event.getInfo().get("beforeValue")) &&
-                        Arrays.equals(after, (Object[]) event.getInfo().get("afterValue"));
+                return Arrays.equals(before, (Object[])event.getInfo().get(BEFOREVALUE)) &&
+                        Arrays.equals(after, (Object[]) event.getInfo().get(AFTERVALUE));
             }
         });
     }
@@ -167,7 +171,10 @@ public class ExpectationListener implements EventListener {
         return expect(new Expectation("path = " + path + ", type = " + type + ", beforeValue = " + beforeValue) {
             @Override
             public boolean onEvent(Event event) throws RepositoryException {
-                return type == event.getType() && Objects.equals(path, event.getPath()) && event.getInfo().containsKey("beforeValue") && beforeValue.equals(((Value)event.getInfo().get("beforeValue")).getString());
+                return type == event.getType() 
+                        && Objects.equals(path, event.getPath()) 
+                        && event.getInfo().containsKey(BEFOREVALUE) 
+                        && beforeValue.equals(((Value)event.getInfo().get(BEFOREVALUE)).getString());
             }
         });
     }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ExpectationListener.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ExpectationListener.java
@@ -280,6 +280,12 @@ public class ExpectationListener implements EventListener {
             }
         }
 
+        /**
+         * Handle the event
+         * @param event the event
+         * @return if the event should be handled
+         * @throws Exception
+         */
         public boolean onEvent(Event event) throws Exception {
             return true;
         }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ExpectationListener.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ExpectationListener.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.jcr.observation;
+
+import static java.util.Collections.synchronizedList;
+import static java.util.Collections.synchronizedSet;
+import static javax.jcr.observation.Event.NODE_ADDED;
+import static javax.jcr.observation.Event.NODE_MOVED;
+import static javax.jcr.observation.Event.NODE_REMOVED;
+import static javax.jcr.observation.Event.PROPERTY_ADDED;
+import static javax.jcr.observation.Event.PROPERTY_CHANGED;
+import static javax.jcr.observation.Event.PROPERTY_REMOVED;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.observation.Event;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+
+import org.apache.jackrabbit.guava.common.util.concurrent.ForwardingListenableFuture;
+import org.apache.jackrabbit.guava.common.util.concurrent.Futures;
+import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
+import org.apache.jackrabbit.guava.common.util.concurrent.SettableFuture;
+
+
+public class ExpectationListener implements EventListener {
+    private final Set<Expectation> expected = synchronizedSet(new CopyOnWriteArraySet<>());
+    private final Set<Expectation> optional = synchronizedSet(new CopyOnWriteArraySet<>());
+    private final List<Event> unexpected = synchronizedList(new CopyOnWriteArrayList<>());
+
+    private volatile Exception failed;
+
+    public Expectation expect(Expectation expectation) {
+        if (failed != null) {
+            expectation.fail(failed);
+        }
+        expected.add(expectation);
+        return expectation;
+    }
+
+    public Expectation optional(Expectation expectation) {
+        if (failed != null) {
+            expectation.fail(failed);
+        }
+        optional.add(expectation);
+        return expectation;
+    }
+
+    public Future<Event> expect(final String path, final int type) {
+        return expect(new Expectation("path = " + path + ", type = " + type) {
+            @Override
+            public boolean onEvent(Event event) throws RepositoryException {
+                return type == event.getType() && Objects.equals(path, event.getPath());
+            }
+        });
+    }
+
+    public Future<Event> expect(final String path, final String identifier, final int type) {
+        return expect(new Expectation("path = " + path + ", identifier = " + identifier + ", type = " + type) {
+            @Override
+            public boolean onEvent(Event event) throws RepositoryException {
+                return type == event.getType() && Objects.equals(path, event.getPath()) && Objects.equals(identifier, event.getIdentifier());
+            }
+        });
+    }
+
+    public Node expectAdd(Node node) throws RepositoryException {
+        expect(node.getPath(), NODE_ADDED);
+        expect(node.getPath() + "/jcr:primaryType", PROPERTY_ADDED);
+        return node;
+    }
+
+    public Node expectRemove(Node node) throws RepositoryException {
+        expect(node.getPath(), NODE_REMOVED);
+        expect(node.getPath() + "/jcr:primaryType", PROPERTY_REMOVED);
+        return node;
+    }
+
+    public Property expectAdd(Property property) throws RepositoryException {
+        expect(property.getPath(), PROPERTY_ADDED);
+        return property;
+    }
+
+    public Property expectRemove(Property property) throws RepositoryException {
+        expect(property.getPath(), PROPERTY_REMOVED);
+        return property;
+    }
+
+    public Property expectChange(Property property) throws RepositoryException {
+        expect(property.getPath(), PROPERTY_CHANGED);
+        return property;
+    }
+
+    public void expectMove(final String src, final String dst) {
+        expect(new Expectation('>' + src + ':' + dst){
+            @Override
+            public boolean onEvent(Event event) throws Exception {
+                return event.getType() == NODE_MOVED &&
+                        Objects.equals(dst, event.getPath()) &&
+                        Objects.equals(src, event.getInfo().get("srcAbsPath")) &&
+                        Objects.equals(dst, event.getInfo().get("destAbsPath"));
+            }
+        });
+    }
+
+    public void expectValue(final Value before, final Value after) {
+        expect(new Expectation("Before value " + before + " after value " + after) {
+            @Override
+            public boolean onEvent(Event event) throws Exception {
+                return Objects.equals(before, event.getInfo().get("beforeValue")) &&
+                        Objects.equals(after, event.getInfo().get("afterValue"));
+            }
+        });
+    }
+
+    public void expectValues(final Value[] before, final Value[] after) {
+        expect(new Expectation("Before valuse " + before + " after values " + after) {
+            @Override
+            public boolean onEvent(Event event) throws Exception {
+                return Arrays.equals(before, (Object[])event.getInfo().get("beforeValue")) &&
+                        Arrays.equals(after, (Object[]) event.getInfo().get("afterValue"));
+            }
+        });
+    }
+
+    public void expectEvent(String name, Function<Event,Boolean> validation) {
+        expect(new Expectation(name) {
+            @Override
+            public boolean onEvent(Event event) throws Exception {
+                return validation.apply(event);
+            }
+        });
+    }
+
+    public Future<Event> expectBeforeValue(final String path, final int type, final String beforeValue) {
+        return expect(new Expectation("path = " + path + ", type = " + type + ", beforeValue = " + beforeValue) {
+            @Override
+            public boolean onEvent(Event event) throws RepositoryException {
+                return type == event.getType() && Objects.equals(path, event.getPath()) && event.getInfo().containsKey("beforeValue") && beforeValue.equals(((Value)event.getInfo().get("beforeValue")).getString());
+            }
+        });
+    }
+
+    public List<Expectation> getMissing(int time, TimeUnit timeUnit)
+            throws ExecutionException, InterruptedException {
+        List<Expectation> missing = new ArrayList<>();
+        try {
+            Futures.allAsList(expected).get(time, timeUnit);
+        }
+        catch (TimeoutException e) {
+            for (Expectation exp : expected) {
+                if (!exp.isDone()) {
+                    missing.add(exp);
+                }
+            }
+        }
+        return missing;
+    }
+
+    public List<Event> getUnexpected() {
+        return new ArrayList<>(unexpected);
+    }
+
+    @Override
+    public void onEvent(EventIterator events) {
+        try {
+            while (events.hasNext() && failed == null) {
+                Event event = events.nextEvent();
+                boolean found = false;
+                for (Expectation exp : expected) {
+                    if (exp.isEnabled() && !exp.isComplete() && exp.onEvent(event)) {
+                        found = true;
+                        exp.complete(event);
+                    }
+                }
+                for (Expectation opt : optional) {
+                    if (opt.isEnabled() && !opt.isComplete() && opt.onEvent(event)) {
+                        found = true;
+                        opt.complete(event);
+                    }
+                }
+                if (!found) {
+                    unexpected.add(event);
+                }
+
+            }
+        } catch (Exception e) {
+            for (Expectation exp : expected) {
+                exp.fail(e);
+            }
+            failed = e;
+        }
+    }
+
+    public static class Expectation extends ForwardingListenableFuture<Event> {
+        private final SettableFuture<Event> future = SettableFuture.create();
+        private final String name;
+
+        private volatile boolean enabled = true;
+
+        Expectation(String name, boolean enabled) {
+            this.name = name;
+            this.enabled = enabled;
+        }
+
+        Expectation(String name) {
+            this(name, true);
+        }
+
+        @Override
+        protected ListenableFuture<Event> delegate() {
+            return future;
+        }
+
+        public void enable(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void complete(Event event) {
+            future.set(event);
+        }
+
+        public boolean isComplete() {
+            return future.isDone();
+        }
+
+        public void fail(Exception e) {
+            future.setException(e);
+        }
+
+        public boolean wait(long timeout, TimeUnit unit) {
+            try {
+                future.get(timeout, unit);
+                return true;
+            }
+            catch (Exception e) {
+                return false;
+            }
+        }
+
+        public boolean onEvent(Event event) throws Exception {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+
+}

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ObservationTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/observation/ObservationTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.jackrabbit.oak.jcr.observation;
 
-import static java.util.Collections.synchronizedList;
-import static java.util.Collections.synchronizedSet;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static javax.jcr.observation.Event.NODE_ADDED;
 import static javax.jcr.observation.Event.NODE_MOVED;
@@ -42,19 +40,12 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -85,11 +76,6 @@ import javax.jcr.observation.EventListener;
 import javax.jcr.observation.ObservationManager;
 import javax.jcr.version.VersionException;
 
-import org.apache.jackrabbit.guava.common.util.concurrent.ForwardingListenableFuture;
-import org.apache.jackrabbit.guava.common.util.concurrent.Futures;
-import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
-import org.apache.jackrabbit.guava.common.util.concurrent.SettableFuture;
-
 import junitx.util.PrivateAccessor;
 
 import org.apache.jackrabbit.JcrConstants;
@@ -102,6 +88,7 @@ import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
 import org.apache.jackrabbit.oak.jcr.AbstractRepositoryTest;
+import org.apache.jackrabbit.oak.jcr.observation.ExpectationListener.Expectation;
 import org.apache.jackrabbit.oak.jcr.observation.filter.FilterFactory;
 import org.apache.jackrabbit.oak.jcr.observation.filter.OakEventFilter;
 import org.apache.jackrabbit.oak.plugins.observation.filter.ChangeSetFilterImpl;
@@ -722,6 +709,7 @@ public class ObservationTest extends AbstractRepositoryTest {
         getAdminSession().save();
 
         List<Expectation> missing = listener.getMissing(TIME_OUT, TimeUnit.SECONDS);
+        System.out.println("finisehd");
         assertTrue("Missing events: " + missing, missing.isEmpty());
         List<Event> unexpected = listener.getUnexpected();
         assertTrue("Unexpected events: " + unexpected, unexpected.isEmpty());
@@ -1178,234 +1166,7 @@ public class ObservationTest extends AbstractRepositoryTest {
     private Node getNode(String path) throws RepositoryException {
         return getAdminSession().getNode(path);
     }
-
-    //------------------------------------------------------------< ExpectationListener >---
-
-    private static class Expectation extends ForwardingListenableFuture<Event> {
-        private final SettableFuture<Event> future = SettableFuture.create();
-        private final String name;
-
-        private volatile boolean enabled = true;
-
-        Expectation(String name, boolean enabled) {
-            this.name = name;
-            this.enabled = enabled;
-        }
-
-        Expectation(String name) {
-            this(name, true);
-        }
-
-        @Override
-        protected ListenableFuture<Event> delegate() {
-            return future;
-        }
-
-        public void enable(boolean enabled) {
-            this.enabled = enabled;
-        }
-
-        public boolean isEnabled() {
-            return enabled;
-        }
-
-        public void complete(Event event) {
-            future.set(event);
-        }
-
-        public boolean isComplete() {
-            return future.isDone();
-        }
-
-        public void fail(Exception e) {
-            future.setException(e);
-        }
-
-        public boolean wait(long timeout, TimeUnit unit) {
-            try {
-                future.get(timeout, unit);
-                return true;
-            }
-            catch (Exception e) {
-                return false;
-            }
-        }
-
-        public boolean onEvent(Event event) throws Exception {
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            return name;
-        }
-    }
-
-    private static class ExpectationListener implements EventListener {
-        private final Set<Expectation> expected = synchronizedSet(new CopyOnWriteArraySet<>());
-        private final Set<Expectation> optional = synchronizedSet(new CopyOnWriteArraySet<>());
-        private final List<Event> unexpected = synchronizedList(new CopyOnWriteArrayList<>());
-
-        private volatile Exception failed;
-
-        public Expectation expect(Expectation expectation) {
-            if (failed != null) {
-                expectation.fail(failed);
-            }
-            expected.add(expectation);
-            return expectation;
-        }
-
-        public Expectation optional(Expectation expectation) {
-            if (failed != null) {
-                expectation.fail(failed);
-            }
-            optional.add(expectation);
-            return expectation;
-        }
-
-        public Future<Event> expect(final String path, final int type) {
-            return expect(new Expectation("path = " + path + ", type = " + type) {
-                @Override
-                public boolean onEvent(Event event) throws RepositoryException {
-                    return type == event.getType() && Objects.equals(path, event.getPath());
-                }
-            });
-        }
-
-        public Future<Event> expect(final String path, final String identifier, final int type) {
-            return expect(new Expectation("path = " + path + ", identifier = " + identifier + ", type = " + type) {
-                @Override
-                public boolean onEvent(Event event) throws RepositoryException {
-                    return type == event.getType() && Objects.equals(path, event.getPath()) && Objects.equals(identifier, event.getIdentifier());
-                }
-            });
-        }
-
-        public Node expectAdd(Node node) throws RepositoryException {
-            expect(node.getPath(), NODE_ADDED);
-            expect(node.getPath() + "/jcr:primaryType", PROPERTY_ADDED);
-            return node;
-        }
-
-        public Node expectRemove(Node node) throws RepositoryException {
-            expect(node.getPath(), NODE_REMOVED);
-            expect(node.getPath() + "/jcr:primaryType", PROPERTY_REMOVED);
-            return node;
-        }
-
-        public Property expectAdd(Property property) throws RepositoryException {
-            expect(property.getPath(), PROPERTY_ADDED);
-            return property;
-        }
-
-        public Property expectRemove(Property property) throws RepositoryException {
-            expect(property.getPath(), PROPERTY_REMOVED);
-            return property;
-        }
-
-        public Property expectChange(Property property) throws RepositoryException {
-            expect(property.getPath(), PROPERTY_CHANGED);
-            return property;
-        }
-
-        public void expectMove(final String src, final String dst) {
-            expect(new Expectation('>' + src + ':' + dst){
-                @Override
-                public boolean onEvent(Event event) throws Exception {
-                    return event.getType() == NODE_MOVED &&
-                            Objects.equals(dst, event.getPath()) &&
-                            Objects.equals(src, event.getInfo().get("srcAbsPath")) &&
-                            Objects.equals(dst, event.getInfo().get("destAbsPath"));
-                }
-            });
-        }
-
-        public void expectValue(final Value before, final Value after) {
-            expect(new Expectation("Before value " + before + " after value " + after) {
-                @Override
-                public boolean onEvent(Event event) throws Exception {
-                    return Objects.equals(before, event.getInfo().get("beforeValue")) &&
-                            Objects.equals(after, event.getInfo().get("afterValue"));
-                }
-            });
-        }
-
-        public void expectValues(final Value[] before, final Value[] after) {
-            expect(new Expectation("Before valuse " + before + " after values " + after) {
-                @Override
-                public boolean onEvent(Event event) throws Exception {
-                    return Arrays.equals(before, (Object[])event.getInfo().get("beforeValue")) &&
-                           Arrays.equals(after, (Object[]) event.getInfo().get("afterValue"));
-                }
-            });
-        }
-
-        public Future<Event> expectBeforeValue(final String path, final int type, final String beforeValue) {
-            return expect(new Expectation("path = " + path + ", type = " + type + ", beforeValue = " + beforeValue) {
-                @Override
-                public boolean onEvent(Event event) throws RepositoryException {
-                    return type == event.getType() && Objects.equals(path, event.getPath()) && event.getInfo().containsKey("beforeValue") && beforeValue.equals(((Value)event.getInfo().get("beforeValue")).getString());
-                }
-            });
-        }
-
-        public List<Expectation> getMissing(int time, TimeUnit timeUnit)
-                throws ExecutionException, InterruptedException {
-            List<Expectation> missing = new ArrayList<>();
-            long t0 = System.nanoTime();
-            try {
-                Futures.allAsList(expected).get(time, timeUnit);
-            }
-            catch (TimeoutException e) {
-                for (Expectation exp : expected) {
-                    if (!exp.isDone()) {
-                        missing.add(exp);
-                    }
-                }
-            }
-            return missing;
-        }
-
-        public List<Event> getUnexpected() {
-            return new ArrayList<>(unexpected);
-        }
-
-        @Override
-        public void onEvent(EventIterator events) {
-            try {
-                while (events.hasNext() && failed == null) {
-                    Event event = events.nextEvent();
-                    boolean found = false;
-                    for (Expectation exp : expected) {
-                        if (exp.isEnabled() && !exp.isComplete() && exp.onEvent(event)) {
-                            found = true;
-                            exp.complete(event);
-                        }
-                    }
-                    for (Expectation opt : optional) {
-                        if (opt.isEnabled() && !opt.isComplete() && opt.onEvent(event)) {
-                            found = true;
-                            opt.complete(event);
-                        }
-                    }
-                    if (!found) {
-                        unexpected.add(event);
-                    }
-
-                }
-            } catch (Exception e) {
-                for (Expectation exp : expected) {
-                    exp.fail(e);
-                }
-                failed = e;
-            }
-        }
-
-        private static String key(String path, int type) {
-            return path + ':' + type;
-        }
-    }
+    
     
     //------------------------------------------------------------< OakEventFilter tests >---
 


### PR DESCRIPTION
if ``event.toString()`` is invoked (e.g. during logging), do not serialize the binary values as part of the returned string, but use something less memory-intensive.

The question remains if ``event.getInfo().get("beforeValue")`` or ``event.getInfo().get("afterValue")`` is used and useful as it is implemented today ... but at least that won't happen accidentally.