### PR TITLE
OAK-11969 do not check the existence of the tree twice

### DIFF
--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/NodeDelegate.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/NodeDelegate.java
@@ -339,8 +339,7 @@ public class NodeDelegate extends ItemDelegate {
     @NotNull
     public Iterator<NodeDelegate> getChildren() throws InvalidItemStateException {
         Iterator<Tree> iterator = getTree().getChildren().iterator();
-        return IteratorUtils.transform(
-                IteratorUtils.filter(iterator, tree -> tree.exists()),
+        return IteratorUtils.transform(iterator, 
                 tree -> new NodeDelegate(sessionDelegate, tree));
     }
 


### PR DESCRIPTION
``tree.getChildren()`` returns only accessible tree objects, for that these tree objects always exist, and there is no need to check for their existence here as well.

on the implementation side ``AbstractTree.getChildren()`` already performs these checks for existence of the child nodes, so this check is really redundant.