### PR TITLE
OAK-11987 - org.apache.jackrabbit.oak.segment.azure.tool.SegmentStoreMigrator.migrateBinaryRef is missing a null check

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/SegmentStoreMigrator.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/tool/SegmentStoreMigrator.java
@@ -214,8 +214,10 @@ public class SegmentStoreMigrator implements Closeable  {
     private void migrateBinaryRef(SegmentArchiveReader reader, SegmentArchiveWriter writer) throws IOException, ExecutionException, InterruptedException {
         Future<Buffer> future = executor.submit(() -> RETRIER.execute(reader::getBinaryReferences));
         Buffer binaryReferences = future.get();
-        byte[] array = fetchByteArray(binaryReferences);
-        RETRIER.execute(() -> writer.writeBinaryReferences(array));
+        if (binaryReferences != null) {
+            byte[] array = fetchByteArray(binaryReferences);
+            RETRIER.execute(() -> writer.writeBinaryReferences(array));
+        }
     }
 
     private void migrateGraph(SegmentArchiveReader reader, SegmentArchiveWriter writer) throws IOException, ExecutionException, InterruptedException {


### PR DESCRIPTION
Add a null check to the Azure implementation of SegmentStoreMigrator.migrateBinaryRef