### PR TITLE
OAK-11989 Fixed the nondeterminism of testTraceLoggingForBulkUpdates() caused by order-specific assertion

### DIFF
--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MultiDocumentStoreTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/MultiDocumentStoreTest.java
@@ -414,7 +414,10 @@ public class MultiDocumentStoreTest extends AbstractMultiDocumentStoreTest {
                 ds.createOrUpdate(NODES, ops);
 
                 assertTrue(logCustomizer.getLogs().size() == 1);
-                assertTrue(logCustomizer.getLogs().get(0).contains("failure for [" + modifiedRow + ", " + deletedRow + "]"));
+                String bulkUpdateLog = logCustomizer.getLogs().get(0);
+                assertTrue(bulkUpdateLog.contains("failure for"));
+                assertTrue(bulkUpdateLog.contains(modifiedRow));
+                assertTrue(bulkUpdateLog.contains(deletedRow));
                 // System.out.println(logCustomizer.getLogs());
                 assertTrue(logCustomizerJDBC.getLogs().size() == 1);
                 assertTrue(logCustomizerJDBC.getLogs().get(0).contains("0 (for " + modifiedRow + " (1)"));


### PR DESCRIPTION
## Problem
When the execution order is changed, the test function `testTraceLoggingForBulkUpdates()` in MultiDocumentStoreTest.java shows a non-deterministic behavior, where the test sometimes fails with AssertionError.
```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.57 s <<< FAILURE! - in org.apache.jackrabbit.oak.plugins.document.MultiDocumentStoreTest
[ERROR] testTraceLoggingForBulkUpdates[RDBFixture: RDB-H2(file)](org.apache.jackrabbit.oak.plugins.document.MultiDocumentStoreTest)  Time elapsed: 0.279 s  <<< FAILURE!
java.lang.AssertionError

[ERROR] Failures: 
[ERROR]   MultiDocumentStoreTest.testTraceLoggingForBulkUpdates:417
[INFO] 
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
```
The root cause of this issue is that failedUpdates is returned as a set by SetUtils.difference. When it is converted to a string for logging in the TRACE log, the order of elements is non-deterministic. But the test expects a specific order `"failure for [" + modifiedRow + ", " + deletedRow + "]"`, resulting in a mismatch.

Command to reproduce the output:
```
mvn -pl oak-store-document -Dcheckstyle.skip=true -Drat.skip=true \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=org.apache.jackrabbit.oak.plugins.document.MultiDocumentStoreTest#testTraceLoggingForBulkUpdates* \
    -DnondexRuns=10 |& tee nondex-$(date +%s).log
```

## Proposed Fix
Instead of checking for an exact string match with a specific order, the test should check for the presence of the target strings in the log message, regardless of string order. The proposed fix splits the original assertion into small parts to check for the presence of different elements separately. With this fix, the non-deterministic behavior would be resolved.

