### PR TITLE
OAK-12005 - segment preloading graph-cache uses too much heap

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarFiles.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarFiles.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -905,10 +906,22 @@ public class TarFiles implements Closeable {
 
         for (TarReader reader : iterable(head)) {
             if (fileName.equals(reader.getFileName())) {
-                Map<UUID, Set<UUID>> result = new HashMap<>();
-                reader.getUUIDs().forEach((uuid -> result.put(uuid, emptySet())));
-                result.putAll(reader.getGraph().getEdges());
-                return result;
+                Map<String, Set<UUID>> indices = getIndices();
+                Map<UUID, UUID> uuidDeduplicationMap = indices.values().stream()
+                        .flatMap(Set::stream)
+                        .collect(Collectors.toUnmodifiableMap(Function.identity(), Function.identity()));
+                Function<UUID, UUID> uuidDeduplicator = uuid -> uuidDeduplicationMap.getOrDefault(uuid, uuid);
+                Set<UUID> uuids = indices.get(reader.getFileName());
+                Map<UUID, Set<UUID>> edges = reader.getGraph().getEdges();
+                // Create a map covering all UUIDs contained in the file's index and deduplicate
+                // all UUID instances based on the UUIDs already present in _all_ archives' indices.
+                // This helps to keep the memory overhead during the lifetime of graph-maps to a minimum.
+                return uuids.stream().collect(Collectors.toUnmodifiableMap(
+                        uuidDeduplicator,
+                        uuid -> edges.getOrDefault(uuid, emptySet()).stream()
+                                .map(uuidDeduplicator)
+                                .collect(Collectors.toUnmodifiableSet())));
+
             }
         }
         return emptyMap();

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarFiles.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarFiles.java
@@ -42,6 +42,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -910,7 +911,7 @@ public class TarFiles implements Closeable {
                 Map<UUID, UUID> uuidDeduplicationMap = indices.values().stream()
                         .flatMap(Set::stream)
                         .collect(Collectors.toUnmodifiableMap(Function.identity(), Function.identity()));
-                Function<UUID, UUID> uuidDeduplicator = uuid -> uuidDeduplicationMap.getOrDefault(uuid, uuid);
+                UnaryOperator<UUID> uuidDeduplicator = uuid -> uuidDeduplicationMap.getOrDefault(uuid, uuid);
                 Set<UUID> uuids = indices.get(reader.getFileName());
                 Map<UUID, Set<UUID>> edges = reader.getGraph().getEdges();
                 // Create a map covering all UUIDs contained in the file's index and deduplicate

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarReader.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/tar/TarReader.java
@@ -286,7 +286,7 @@ public class TarReader implements Closeable {
         this.segmentUUIDs = archive.listSegments()
                 .stream()
                 .map(e -> new UUID(e.getMsb(), e.getLsb()))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     long size() {


### PR DESCRIPTION
The segment-graph consists of a large number of UUIDs (~20 mio in a sample store I worked with). However, there are a lot of duplicate UUIDs in the graph, because segments can reference many other segments, and each segment may be referenced by many other segments.

Th proposed change eliminates duplicate UUID instances when `TarFiles#getGraph(String)`. For the deduplication, it uses the UUIDs already present in the TarReader's `segmentUUIDs` field, retrieved via `TarFiles#getIndices()`.

In my sample store, this reduced the number of UUID instances to ~1 mio.

Further memory savings come from the substitution of `HashMap` and `HashSet` instances with `java.util.ImmutableCollections.MapN` and `java.util.ImmutableCollections.SetN` respectively (via Streams).

Granted, `TarFiles#getGraph()` doesn't get much use, so this optimization may not help many cases. However, the `SegmentPreloader`, if used, caches the graphs indefinitely. At first I thought to add the deduplication in that class, but upon reflection, decided that other callers (including unsuspecting future callers) would also benefit from this enhancement.