### PR TITLE
OAK-12031 : added jackrabbit-jcr-commons since future stable release of jackrabbit-core is…

### DIFF
--- a/oak-upgrade/pom.xml
+++ b/oak-upgrade/pom.xml
@@ -136,6 +136,11 @@
       <artifactId>oak-security-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
+      <dependency>
+          <groupId>org.apache.jackrabbit</groupId>
+          <artifactId>jackrabbit-jcr-commons</artifactId>
+          <version>${jackrabbit.version}</version>
+      </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-core</artifactId>


### PR DESCRIPTION
… using it from its path used by oak-upgrade