### PR TITLE
OAK-11731: expose NodeCounter (getEstimatedChildNodeCounts) in Jackra…

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -773,13 +773,9 @@ public class Oak {
             regs.add(registerMBean(whiteboard, NodeCounterMBean.class,
                     new NodeCounterOld(store), NodeCounterMBean.TYPE, "nodeCounter"));
         } else {
-            NodeCounter nc = new NodeCounter(store);
-            // register both backwards-compatibly
-            regs.add(registerMBean(whiteboard, NodeCounterMBean.class,
-                    nc, NodeCounterMBean.TYPE, "nodeCounter"));
-            // and using org.apache.jackrabbit.oak.api.jmx.NodeCounterMBean, with a different name
+            // new NodeCounterMBean (moved) is compatible
             regs.add(registerMBean(whiteboard, org.apache.jackrabbit.oak.api.jmx.NodeCounterMBean.class,
-                    nc, NodeCounterMBean.TYPE, "nodeCounter2"));
+                    new NodeCounter(store), NodeCounterMBean.TYPE, "nodeCounter"));
         }
 
         regs.add(registerMBean(whiteboard, QueryEngineSettingsMBean.class,


### PR DESCRIPTION
…bbitNode - register bean just once with the compatible interface