### PR TITLE
OAK-11975: Use Mockito as an agent in Oak

### DIFF
--- a/oak-api/pom.xml
+++ b/oak-api/pom.xml
@@ -84,5 +84,10 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/oak-benchmarks/pom.xml
+++ b/oak-benchmarks/pom.xml
@@ -222,6 +222,10 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/oak-blob/pom.xml
+++ b/oak-blob/pom.xml
@@ -150,6 +150,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/oak-http/pom.xml
+++ b/oak-http/pom.xml
@@ -89,5 +89,10 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/oak-it-osgi/pom.xml
+++ b/oak-it-osgi/pom.xml
@@ -300,6 +300,11 @@
       <artifactId>metrics-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -262,9 +262,19 @@
           </configuration>
         </plugin>
         <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <execution>
+              <goals>
+                <goal>properties</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <argLine>${test.opts}</argLine>
+            <argLine>${test.opts} -javaagent:${org.mockito:mockito-core:jar}</argLine>
             <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
               <!-- evaluated in oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/util/KnownIssuesIgnoreRule.java (JUnit4) and
@@ -287,7 +297,7 @@
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
-            <argLine>${test.opts}</argLine>
+            <argLine>${test.opts} -javaagent:${org.mockito:mockito-core:jar}</argLine>
             <trimStackTrace>false</trimStackTrace>
             <systemPropertyVariables>
               <!-- evaluated in oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/util/KnownIssuesIgnoreRule.java (JUnit4) and
@@ -359,6 +369,9 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -124,6 +124,12 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>properties</id>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <phase>pre-integration-test</phase>
                         <goals><goal>copy</goal></goals>
                         <configuration>

--- a/oak-upgrade/pom.xml
+++ b/oak-upgrade/pom.xml
@@ -242,6 +242,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- test dependency of classic Jackrabbit -->
     <dependency>


### PR DESCRIPTION
Replaced the dynamic inline mocking with a static agent dependency.