### PR TITLE
OAK-12034 - CachingSegmentArchiveReader#containsSegment should not check the persistence cache for the segment

### DIFF
--- a/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCacheTest.java
+++ b/oak-segment-remote/src/test/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCacheTest.java
@@ -18,8 +18,8 @@
 package org.apache.jackrabbit.oak.segment.remote.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.Buffer;
-import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,6 +51,12 @@ public class PersistentDiskCacheTest extends AbstractPersistentCacheTest {
     @Before
     public void setUp() throws Exception {
         persistentCache = new PersistentDiskCache(temporaryFolder.newFolder(), 10 * 1024, new DiskCacheIOMonitor(StatisticsProvider.NOOP));
+    }
+
+    @After
+    public void tearDown() {
+        persistentCache.close();
+        persistentCache = null;
     }
 
     @Test

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingSegmentArchiveReader.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingSegmentArchiveReader.java
@@ -51,11 +51,7 @@ public class CachingSegmentArchiveReader implements SegmentArchiveReader {
 
     @Override
     public boolean containsSegment(long msb, long lsb) {
-        if (persistentCache.containsSegment(msb, lsb)) {
-            return true;
-        } else {
-            return delegate.containsSegment(msb, lsb);
-        }
+        return delegate.containsSegment(msb, lsb);
     }
 
     @Override

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingPersistenceTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingPersistenceTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
-import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.segment.Segment;
 import org.apache.jackrabbit.oak.segment.SegmentId;
 import org.apache.jackrabbit.oak.segment.SegmentNotFoundException;
@@ -34,10 +33,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Callable;
 
 import static org.apache.jackrabbit.oak.segment.file.FileStoreBuilder.fileStoreBuilder;
 import static org.junit.Assert.assertNotNull;
@@ -108,52 +103,5 @@ public class CachingPersistenceTest {
         SegmentNodeStorePersistence customPersistence = new CachingPersistence(new MemoryPersistentCache(repoNotReachable), new TarPersistence(getFileStoreFolder()));
         fileStoreBuilder.withCustomPersistence(customPersistence);
         return fileStoreBuilder;
-    }
-
-    class MemoryPersistentCache extends AbstractPersistentCache {
-
-        private final Map<String, Buffer> segments = Collections.synchronizedMap(new HashMap<String, Buffer>());
-
-        private boolean throwException = false;
-
-        public MemoryPersistentCache(boolean throwException) {
-            this.throwException = throwException;
-            segmentCacheStats = new SegmentCacheStats(
-                    "Memory Cache",
-                    () -> null,
-                    () -> null,
-                    () -> null,
-                    () -> null);
-        }
-
-        @Override
-        protected Buffer readSegmentInternal(long msb, long lsb) {
-            return segments.get(String.valueOf(msb) + lsb);
-        }
-
-        @Override
-        public boolean containsSegment(long msb, long lsb) {
-            return segments.containsKey(String.valueOf(msb) + lsb);
-        }
-
-        @Override
-        public void writeSegment(long msb, long lsb, Buffer buffer) {
-            segments.put(String.valueOf(msb) + lsb, buffer);
-        }
-
-        @Override
-        public Buffer readSegment(long msb, long lsb, @NotNull Callable<Buffer> loader) throws RepositoryNotReachableException {
-            return super.readSegment(msb, lsb, () -> {
-                if (throwException) {
-                    throw new RepositoryNotReachableException(null);
-                }
-                return loader.call();
-            });
-        }
-
-        @Override
-        public void cleanUp() {
-
-        }
     }
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingSegmentArchiveReaderTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingSegmentArchiveReaderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
+
+import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.file.tar.SegmentTarManager;
+import org.apache.jackrabbit.oak.segment.spi.monitor.FileStoreMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.monitor.IOMonitorAdapter;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveReader;
+import org.apache.jackrabbit.oak.segment.spi.persistence.SegmentArchiveWriter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class CachingSegmentArchiveReaderTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder(new File("target"));
+
+    @Before
+    public void setUp() throws Exception {
+        temporaryFolder.newFolder();
+    }
+
+    @Test
+    public void containsSegmentDoesNotUsePersistentDiskCache() throws IOException {
+        PersistentCache persistentCache = new CachingPersistenceTest.MemoryPersistentCache(false);
+        // Create a CachingArchiveManager with 2 tar files and a shared persistence disk cache. Each tar file contains a
+        // single segment. When looking up for a segment in a particular tar file, we should not find segments that are
+        // present in the other tar files. That is, the shared cache should not expose segments from other tar files.
+        SegmentTarManager archiveManager = new SegmentTarManager(temporaryFolder.newFolder(),
+                new FileStoreMonitorAdapter(), new IOMonitorAdapter(), false, false);
+        CachingArchiveManager cachingArchiveManager = new CachingArchiveManager(persistentCache, archiveManager);
+
+        long msb1 = 1L;
+        long lsb1 = 1L;
+        byte[] data1 = "data1".getBytes(StandardCharsets.UTF_8);
+        String archive1Name = "data0000a.tar";
+
+        long msb2 = 2L;
+        long lsb2 = 2L;
+        byte[] data2 = "data2".getBytes(StandardCharsets.UTF_8);
+        String archive2Name = "data0000b.tar";
+
+        SegmentArchiveWriter archive1 = cachingArchiveManager.create(archive1Name);
+        archive1.writeSegment(msb1, lsb1, data1, 0, data1.length, 0, 0, true);
+        archive1.close();
+
+        SegmentArchiveWriter archive2 = cachingArchiveManager.create(archive2Name);
+        archive2.writeSegment(msb2, lsb2, data2, 0, data2.length, 0, 0, true);
+        archive2.close();
+
+        // Open the archives and read the segment. This will trigger caching of the segments.
+        SegmentArchiveReader tar1 = cachingArchiveManager.open(archive1Name);
+        assertEquals(Buffer.wrap(data1), tar1.readSegment(msb1, lsb1));
+
+        SegmentArchiveReader tar2 = cachingArchiveManager.open(archive2Name);
+        assertEquals(Buffer.wrap(data2), tar2.readSegment(msb2, lsb2));
+
+        assertTrue(tar1.containsSegment(msb1, lsb1));
+        assertFalse(tar1.containsSegment(msb2, lsb2));
+        assertFalse(tar2.containsSegment(msb1, lsb1));
+        assertTrue(tar2.containsSegment(msb2, lsb2));
+    }
+}

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingSegmentArchiveReaderTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/CachingSegmentArchiveReaderTest.java
@@ -46,7 +46,7 @@ public class CachingSegmentArchiveReaderTest {
 
     @Test
     public void containsSegmentDoesNotUsePersistentDiskCache() throws IOException {
-        PersistentCache persistentCache = new CachingPersistenceTest.MemoryPersistentCache(false);
+        PersistentCache persistentCache = new MemoryPersistentCache(false);
         // Create a CachingArchiveManager with 2 tar files and a shared persistence disk cache. Each tar file contains a
         // single segment. When looking up for a segment in a particular tar file, we should not find segments that are
         // present in the other tar files. That is, the shared cache should not expose segments from other tar files.

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/MemoryPersistentCache.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/MemoryPersistentCache.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
+
+import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.segment.spi.RepositoryNotReachableException;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
+class MemoryPersistentCache extends AbstractPersistentCache {
+
+    private final Map<String, Buffer> segments = new ConcurrentHashMap<>();
+
+    private boolean throwException = false;
+
+    public MemoryPersistentCache(boolean throwException) {
+        this.throwException = throwException;
+        segmentCacheStats = new SegmentCacheStats(
+                "Memory Cache",
+                () -> null,
+                () -> null,
+                () -> null,
+                () -> null);
+    }
+
+    @Override
+    protected Buffer readSegmentInternal(long msb, long lsb) {
+        return segments.get(String.valueOf(msb) + lsb);
+    }
+
+    @Override
+    public boolean containsSegment(long msb, long lsb) {
+        return segments.containsKey(String.valueOf(msb) + lsb);
+    }
+
+    @Override
+    public void writeSegment(long msb, long lsb, Buffer buffer) {
+        segments.put(String.valueOf(msb) + lsb, buffer);
+    }
+
+    @Override
+    public Buffer readSegment(long msb, long lsb, @NotNull Callable<Buffer> loader) throws RepositoryNotReachableException {
+        return super.readSegment(msb, lsb, () -> {
+            if (throwException) {
+                throw new RepositoryNotReachableException(null);
+            }
+            return loader.call();
+        });
+    }
+
+    @Override
+    public void cleanUp() {
+
+    }
+}


### PR DESCRIPTION
`CachingSegmentArchiveReader#containsSegment` should not check in the persistent cache for the presence of the segment, because the cache is shared with other instances of this class, so the segment may be in the cache but not in the archive of this reader.

Additionally, the current implementation of `containsSegment` in the `PersistenceDiskCache` checks for the presence of a file on disk, which is a slow operation. The `SegmentArchiveReader` implementations all keep an index in memory, so they should be much faster.

Minor refactoring:
- Extract MemoryPersistentCache from CachingPersistenceTest to allow reuse in other tests.