### PR TITLE
OAK-12036 - Expose stats in the PersistentCache

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/AbstractFileStore.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/AbstractFileStore.java
@@ -192,6 +192,11 @@ public abstract class AbstractFileStore implements SegmentStore, Closeable {
         return segmentCache.getCacheStats();
     }
 
+    @Nullable
+    public CacheStatsMBean getPersistentCacheStats() {
+        return persistentCache == null ? null : persistentCache.getCacheStats();
+    }
+
     @NotNull
     public CacheStatsMBean getStringCacheStats() {
         return segmentReader.getStringCacheStats();

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
@@ -125,6 +125,7 @@ public abstract class AbstractPersistentCache implements PersistentCache, Closea
      * @return Statistics for this cache.
      */
     @NotNull
+    @Override
     public AbstractCacheStats getCacheStats() {
         return segmentCacheStats;
     }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/DelegatingPersistentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/DelegatingPersistentCache.java
@@ -18,6 +18,7 @@
  */
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
+import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,5 +51,10 @@ public abstract class DelegatingPersistentCache implements PersistentCache {
     @Override
     public void cleanUp() {
         delegate().cleanUp();
+    }
+
+    @Override
+    public AbstractCacheStats getCacheStats() {
+        return delegate().getCacheStats();
     }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/PersistentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/PersistentCache.java
@@ -17,6 +17,7 @@
  */
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
+import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,4 +65,11 @@ public interface PersistentCache {
      * cache size, maximum number of entries, etc.)
      */
     void cleanUp();
+
+    /**
+     * Returns the cache statistics.
+     * @return the cache statistics, or {@code null} if statistics are not available
+     */
+    @Nullable
+    AbstractCacheStats getCacheStats();
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("5.1.0")
+@Version("5.2.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("5.2.0")
+@Version("6.0.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentCompactionIT.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/SegmentCompactionIT.java
@@ -278,6 +278,11 @@ public class SegmentCompactionIT {
         CacheStatsMBean segmentCacheStats = fileStore.getSegmentCacheStats();
         registrations.add(registerMBean(segmentCacheStats,
                 new ObjectName("IT:TYPE=" + segmentCacheStats.getName())));
+        CacheStatsMBean persistentCacheStats = fileStore.getPersistentCacheStats();
+        if (persistentCacheStats != null) {
+            registrations.add(registerMBean(persistentCacheStats,
+                    new ObjectName("IT:TYPE=" + persistentCacheStats.getName())));
+        }
         CacheStatsMBean stringCacheStats = fileStore.getStringCacheStats();
         registrations.add(registerMBean(stringCacheStats,
                 new ObjectName("IT:TYPE=" + stringCacheStats.getName())));

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/preloader/SegmentPreloaderTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/preloader/SegmentPreloaderTest.java
@@ -21,6 +21,7 @@ package org.apache.jackrabbit.oak.segment.file.preloader;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.apache.jackrabbit.oak.commons.Buffer;
 import org.apache.jackrabbit.oak.segment.Segment;
 import org.apache.jackrabbit.oak.segment.SegmentId;
@@ -379,6 +380,11 @@ public class SegmentPreloaderTest {
         @Override
         public void cleanUp() {
             segments.clear();
+        }
+
+        @Override
+        public @Nullable AbstractCacheStats getCacheStats() {
+            return null;
         }
     }
 


### PR DESCRIPTION
And add method to FileStore to retrieve persistent cache stats in case it is configured.