### PR TITLE
Remove indexes with selectionPolicy=tag when finding a matching index with no tags

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/DiffIndex.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/DiffIndex.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -34,11 +35,13 @@ import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexName;
+import org.apache.jackrabbit.oak.plugins.index.IndexSelectionPolicy;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdateProvider;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.diff.predicates.IncludedPathsPredicate;
 import org.apache.jackrabbit.oak.plugins.index.diff.predicates.NoTagsPredicate;
 import org.apache.jackrabbit.oak.plugins.index.diff.predicates.NodeTypesPredicate;
+import org.apache.jackrabbit.oak.plugins.index.diff.predicates.TagSelectionPolicyPredicate;
 import org.apache.jackrabbit.oak.plugins.index.diff.predicates.TagsPredicate;
 import org.apache.jackrabbit.oak.plugins.index.optimizer.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexEditorProvider;
@@ -131,7 +134,10 @@ public class DiffIndex {
         Set<String> tags = getTagsForIndex(index);
 
         if (tags.isEmpty()) {
-            return candidateIndexes;
+            // Filter indexes with a selection policy
+            return candidateIndexes.stream()
+                .filter(entry -> Predicate.not(TagSelectionPolicyPredicate.INSTANCE).test(entry.getValue()))
+                .collect(Collectors.toSet());
         } else {
             // Need to find an index with either a matching tag, or an index with no tags
             Set<Map.Entry<String, JsonObject>> matchingIndexes = candidateIndexes.stream()

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/DiffIndex.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/DiffIndex.java
@@ -35,7 +35,6 @@ import org.apache.jackrabbit.oak.plugins.index.CompositeIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.IndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.IndexName;
-import org.apache.jackrabbit.oak.plugins.index.IndexSelectionPolicy;
 import org.apache.jackrabbit.oak.plugins.index.IndexUpdateProvider;
 import org.apache.jackrabbit.oak.plugins.index.counter.NodeCounterEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.diff.predicates.IncludedPathsPredicate;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/JsonNodeBuilder.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/JsonNodeBuilder.java
@@ -187,7 +187,7 @@ public class JsonNodeBuilder {
         }
     }
 
-    static String oakStringValue(JsonObject json, String propertyName) {
+    public static String oakStringValue(JsonObject json, String propertyName) {
         String value = json.getProperties().get(propertyName);
         if (value == null) {
             return null;

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/predicates/TagSelectionPolicyPredicate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/diff/predicates/TagSelectionPolicyPredicate.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.diff.predicates;
+
+import java.util.function.Predicate;
+
+import org.apache.jackrabbit.oak.commons.json.JsonObject;
+import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.IndexSelectionPolicy;
+import org.apache.jackrabbit.oak.plugins.index.diff.JsonNodeBuilder;
+
+/**
+ * Predicate for filtering indexes with <code>selectionPolicy=tag</code>.
+ */
+public final class TagSelectionPolicyPredicate implements Predicate<JsonObject> {
+
+    /** Singleton instance of this predicate. */
+    public static final Predicate<JsonObject> INSTANCE = new TagSelectionPolicyPredicate();
+
+    @Override
+    public boolean test(final JsonObject indexJson) {
+        final String selectionPolicy = JsonNodeBuilder.oakStringValue(indexJson, IndexConstants.INDEX_SELECTION_POLICY);
+
+        return IndexSelectionPolicy.TAG.equals(selectionPolicy);
+    }
+}


### PR DESCRIPTION
When matching an index with no tags, remove any indexes with `selectionPolicy=tag` from the set of candidate indexes.