### PR TITLE
OAK-12051: Fix NPE when ordering union query by jcr:score

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -577,11 +577,10 @@ public class Oak {
         }
 
         if (queryEngineSettings != null) {
-            Feature sortUnionQueryByScoreFeature = newFeature(QueryEngineSettings.FT_SORT_UNION_QUERY_BY_SCORE, whiteboard);
-            LOG.info("Registered sort union query by score feature: " + QueryEngineSettings.FT_SORT_UNION_QUERY_BY_SCORE);
-            closer.register(sortUnionQueryByScoreFeature);
-            queryEngineSettings.setSortUnionQueryByScoreFeature(sortUnionQueryByScoreFeature);
-
+            Feature sortUnionQueryLegacyModeFeature = newFeature(QueryEngineSettings.FT_SORT_UNION_QUERY_LEGACY_MODE, whiteboard);
+            LOG.info("Registered sort union query legacy mode feature: " + QueryEngineSettings.FT_SORT_UNION_QUERY_LEGACY_MODE);
+            closer.register(sortUnionQueryLegacyModeFeature);
+            queryEngineSettings.setSortUnionQueryLegacyModeFeature(sortUnionQueryLegacyModeFeature);
             Feature optimizeXPathUnion = newFeature(QueryEngineSettings.FT_OPTIMIZE_XPATH_UNION, whiteboard);
             LOG.info("Registered optimize XPath union feature: " + QueryEngineSettings.FT_OPTIMIZE_XPATH_UNION);
             closer.register(optimizeXPathUnion);
@@ -994,8 +993,8 @@ public class Oak {
             settings.setPrefetchFeature(prefetch);
         }
 
-        public void setSortUnionQueryByScoreFeature(@Nullable Feature feature) {
-            settings.setSortUnionQueryByScoreFeature(feature);
+        public void setSortUnionQueryLegacyModeFeature(@Nullable Feature feature) {
+            settings.setSortUnionQueryLegacyModeFeature(feature);
         }
 
         public void setOptimizeXPathUnion(@Nullable Feature feature) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -61,7 +61,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String OAK_QUERY_PREFETCH_COUNT = "oak.prefetchCount";
 
-    public static final String FT_SORT_UNION_QUERY_BY_SCORE = "FT_OAK-11949";
+    public static final String FT_SORT_UNION_QUERY_BY_SCORE = "FT_OAK-12051";
 
     public static final String FT_OPTIMIZE_XPATH_UNION = "FT_OAK-12007";
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -61,7 +61,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String OAK_QUERY_PREFETCH_COUNT = "oak.prefetchCount";
 
-    public static final String FT_SORT_UNION_QUERY_BY_SCORE = "FT_OAK-12051";
+    public static final String FT_SORT_UNION_QUERY_LEGACY_MODE = "FT_OAK-12051";
 
     public static final String FT_OPTIMIZE_XPATH_UNION = "FT_OAK-12007";
 
@@ -120,7 +120,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private final long queryLengthErrorLimit = Long.getLong(OAK_QUERY_LENGTH_ERROR_LIMIT, 100 * 1024 * 1024); //100MB
 
     private Feature prefetchFeature;
-    private Feature sortUnionQueryByScoreFeature;
+    private Feature sortUnionQueryLegacyModeFeature;
     private Feature optimizeXPathUnion;
 
     private String autoOptionsMappingJson = "{}";
@@ -226,13 +226,13 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
         System.setProperty(OAK_FAST_QUERY_SIZE, String.valueOf(fastQuerySize));
     }
 
-    public void setSortUnionQueryByScoreFeature(@Nullable Feature feature) {
-        this.sortUnionQueryByScoreFeature = feature;
+    public void setSortUnionQueryLegacyModeFeature(@Nullable Feature feature) {
+        this.sortUnionQueryLegacyModeFeature = feature;
     }
 
-    public boolean isSortUnionQueryByScoreEnabled() {
-        // disable if the feature toggle is not used
-        return sortUnionQueryByScoreFeature != null && sortUnionQueryByScoreFeature.isEnabled();
+    public boolean isSortUnionQueryLegacyModeEnabled() {
+        // Legacy mode (concatenate) is disabled by default; score-based sorting is the default behavior
+        return sortUnionQueryLegacyModeFeature != null && sortUnionQueryLegacyModeFeature.isEnabled();
     }
 
     public void setOptimizeXPathUnion(@Nullable Feature feature) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
@@ -324,8 +324,8 @@ public class UnionQueryImpl implements Query {
             rightIter = ((MeasuringIterator) rightRows).getDelegate();
         }
         if (orderBy == null) {
-            if(!settings.isSortUnionQueryByScoreEnabled()) {
-                // Default old behavior
+            if(settings.isSortUnionQueryLegacyModeEnabled()) {
+                // Legacy mode: concatenate results without score-based merging
                 it = IteratorUtils.chainedIterator(leftIter, rightIter);
             } else {
                 boolean leftHasScore = isScorePresent(left);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/UnionQueryImpl.java
@@ -568,16 +568,16 @@ public class UnionQueryImpl implements Query {
 
     /**
      * @param row the result row
-     * @return the jcr:score as a double
-     * Precondition: {@link #isScorePresent(Query)} must be true. If the row lacks a jcr:score, 0.0 is returned and
-     * the issue is logged.
+     * @return the jcr:score as a double, or 0.0 if the row lacks a score value
      */
     private double getScoreFromRow(ResultRowImpl row) {
         try {
             PropertyValue scoreValue = row.getValue(QueryConstants.JCR_SCORE);
+            if (scoreValue == null) {
+                return 0.0;
+            }
             return scoreValue.getValue(Type.DOUBLE);
         } catch (IllegalArgumentException e) {
-            LOG.warn("Failed to get jcr:score for path={}", row.getPath(), e);
             return 0.0;
         }
     }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
@@ -69,8 +69,8 @@ public class UnionQueryTest extends AbstractQueryTest {
     protected ContentRepository createRepository() {
         store = new MemoryNodeStore();
         qeSettings = new QueryEngineSettings();
-        Feature sortFeature = createFeature(true);
-        qeSettings.setSortUnionQueryByScoreFeature(sortFeature);
+        Feature sortFeature = createFeature(false);
+        qeSettings.setSortUnionQueryLegacyModeFeature(sortFeature);
 
         return new Oak(store)
                 .with(new OpenSecurityProvider())
@@ -439,10 +439,11 @@ public class UnionQueryTest extends AbstractQueryTest {
     }
 
     @Test
-    public void testSortUnionQueryScoreFlagDisabled() throws Exception {
-        QueryEngineSettings disabledSettings = new QueryEngineSettings();
-        Feature sortFeature = createFeature(false);
-        disabledSettings.setSortUnionQueryByScoreFeature(sortFeature);
+    public void testSortUnionQueryLegacyModeEnabled() throws Exception {
+        // When legacy mode is enabled, query results should be concatenated
+        QueryEngineSettings legacySettings = new QueryEngineSettings();
+        Feature legacyModeFeature = createFeature(true);
+        legacySettings.setSortUnionQueryLegacyModeFeature(legacyModeFeature);
         MockQueryBuilder leftQuery = new MockQueryBuilder(true)
                 .addResult("/left/doc1", 0.8)
                 .addResult("/left/doc2", 0.7);
@@ -450,15 +451,15 @@ public class UnionQueryTest extends AbstractQueryTest {
                 .addResult("/right/doc1", 0.9)
                 .addResult("/right/doc2", 0.6);
 
-        UnionQueryImpl unionQuery = new UnionQueryImpl(true, leftQuery.build(), rightQuery.build(), disabledSettings);
+        UnionQueryImpl unionQuery = new UnionQueryImpl(true, leftQuery.build(), rightQuery.build(), legacySettings);
         List<ScoredResult> results = executeUnionAndGetScoredResults(unionQuery);
         assertPathOrder(results, new String[]{"/left/doc1", "/left/doc2", "/right/doc1", "/right/doc2"});
     }
 
     @Test
-    public void testSortUnionQueryScoreFlagIsNull() throws Exception {
-        QueryEngineSettings disabledSettings = new QueryEngineSettings();
-        disabledSettings.setSortUnionQueryByScoreFeature(null);
+    public void testSortUnionQueryLegacyModeNotSet() throws Exception {
+        QueryEngineSettings defaultSettings = new QueryEngineSettings();
+        defaultSettings.setSortUnionQueryLegacyModeFeature(null);
         MockQueryBuilder leftQuery = new MockQueryBuilder(true)
                 .addResult("/left/doc1", 0.8)
                 .addResult("/left/doc2", 0.7);
@@ -466,9 +467,9 @@ public class UnionQueryTest extends AbstractQueryTest {
                 .addResult("/right/doc1", 0.9)
                 .addResult("/right/doc2", 0.6);
 
-        UnionQueryImpl unionQuery = new UnionQueryImpl(true, leftQuery.build(), rightQuery.build(), disabledSettings);
+        UnionQueryImpl unionQuery = new UnionQueryImpl(true, leftQuery.build(), rightQuery.build(), defaultSettings);
         List<ScoredResult> results = executeUnionAndGetScoredResults(unionQuery);
-        assertPathOrder(results, new String[]{"/left/doc1", "/left/doc2", "/right/doc1", "/right/doc2"});
+        assertPathOrder(results, new String[]{"/right/doc1", "/left/doc1", "/left/doc2", "/right/doc2"});
     }
 
     @Test

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/UnionQueryTest.java
@@ -471,6 +471,45 @@ public class UnionQueryTest extends AbstractQueryTest {
         assertPathOrder(results, new String[]{"/left/doc1", "/left/doc2", "/right/doc1", "/right/doc2"});
     }
 
+    @Test
+    public void testUnionMergingWithNullScoreValue() throws Exception {
+        MockQueryBuilder leftQuery = new MockQueryBuilder(true)
+                .addResult("/left/doc1", 0.8)
+                .addResult("/left/docNull", (Double) null);
+        MockQueryBuilder rightQuery = new MockQueryBuilder(true)
+                .addResult("/right/doc1", 0.9)
+                .addResult("/right/doc2", 0.6);
+
+        UnionQueryImpl unionQuery = new UnionQueryImpl(true, leftQuery.build(), rightQuery.build(), qeSettings);
+        List<ScoredResult> results = executeUnionAndGetScoredResults(unionQuery);
+
+        assertPathOrder(results, new String[]{"/right/doc1", "/left/doc1", "/right/doc2", "/left/docNull"});
+    }
+
+    @Test
+    public void testNestedUnionWithMixedScores() throws Exception {
+        // Simulates scenario where score exists for some rows, and is null for others
+        MockQueryBuilder queryA = new MockQueryBuilder(true)
+                .addResult("/a/doc1", 0.9)
+                .addResult("/a/doc2", 0.5);
+        MockQueryBuilder queryB = new MockQueryBuilder(false)
+                .addResult("/b/doc1")
+                .addResult("/b/doc2");
+        MockQueryBuilder queryC = new MockQueryBuilder(true)
+                .addResult("/c/doc1", 0.8)
+                .addResult("/c/doc2", 0.3);
+
+        // Inner union: A (has score) UNION B (no score)
+        UnionQueryImpl innerUnion = new UnionQueryImpl(true, queryA.build(), queryB.build(), qeSettings);
+        // Outer union: innerUnion UNION C
+        UnionQueryImpl outerUnion = new UnionQueryImpl(true, innerUnion, queryC.build(), qeSettings);
+        List<ScoredResult> results = executeUnionAndGetScoredResults(outerUnion);
+
+        assertPathOrder(results, new String[]{
+                "/a/doc1", "/c/doc1", "/a/doc2", "/c/doc2", "/b/doc1", "/b/doc2"
+        });
+    }
+
     private QueryImpl createQuery (String statement, ConstraintImpl c, SourceImpl sImpl) throws Exception {
 
         NamePathMapper namePathMapper = new NamePathMapperImpl(new GlobalNameMapper(root));
@@ -515,9 +554,16 @@ public class UnionQueryTest extends AbstractQueryTest {
             if (!hasScore) {
                 throw new IllegalStateException("Cannot provide score");
             }
+            return addResult(path, Double.valueOf(score));
+        }
+
+        public MockQueryBuilder addResult(String path, Double score) {
+            if (!hasScore) {
+                throw new IllegalStateException("Cannot provide score");
+            }
             PropertyValue[] values = new PropertyValue[] {
                     PropertyValues.newString(path),
-                    PropertyValues.newDouble(score)
+                    score == null ? null : PropertyValues.newDouble(score)
             };
             results.add(new ResultRowImpl(mockQuery, null, values, null, null));
             return this;


### PR DESCRIPTION
Fixes the NullPointerException during UnionQuery sorting by the JCR score. The problem occurs if there is a score column, but accessing a score of that column returns Null. This can happen if, for example, there is a union between three queries, of which at least one has scores, and at least one doesn't have, and those two results are merged first. 

Issue: https://issues.apache.org/jira/browse/OAK-12051

New behavior: If null values occur in such a column, we replace it with a zero. The warning from the illegalArgumentException was removed, as returning 0 occurs frequently and is nothing to worry about.

Question:
- Should this PR first be merged to a separate branch?