### PR TITLE
OAK-12063: Remove obsolete feature toggles FT_NAME_IMPROVED_IS_NULL_COST, FT_OPTIMIZE_IN_RESTRICTIONS_FOR_FUNCTIONS, and FT_NAME_PREFETCH_FOR_QUERIES

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -577,22 +577,11 @@ public class Oak {
         }
 
         if (queryEngineSettings != null) {
-            Feature prefetchFeature = newFeature(QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES, whiteboard);
-            LOG.info("Registered Prefetch feature: " + QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES);
-            closer.register(prefetchFeature);
-            queryEngineSettings.setPrefetchFeature(prefetchFeature);
-            Feature improvedIsNullCostFeature = newFeature(QueryEngineSettings.FT_NAME_IMPROVED_IS_NULL_COST, whiteboard);
-            LOG.info("Registered improved cost feature: " + QueryEngineSettings.FT_NAME_IMPROVED_IS_NULL_COST);
-            closer.register(improvedIsNullCostFeature);
-            queryEngineSettings.setImprovedIsNullCostFeature(improvedIsNullCostFeature);
-            Feature optimizeInRestrictionsForFunctions = newFeature(QueryEngineSettings.FT_OPTIMIZE_IN_RESTRICTIONS_FOR_FUNCTIONS, whiteboard);
-            LOG.info("Registered optimize in restrictions for functions feature: " + QueryEngineSettings.FT_OPTIMIZE_IN_RESTRICTIONS_FOR_FUNCTIONS);
-            closer.register(optimizeInRestrictionsForFunctions);
-            queryEngineSettings.setOptimizeInRestrictionsForFunctions(optimizeInRestrictionsForFunctions);
             Feature sortUnionQueryByScoreFeature = newFeature(QueryEngineSettings.FT_SORT_UNION_QUERY_BY_SCORE, whiteboard);
             LOG.info("Registered sort union query by score feature: " + QueryEngineSettings.FT_SORT_UNION_QUERY_BY_SCORE);
             closer.register(sortUnionQueryByScoreFeature);
             queryEngineSettings.setSortUnionQueryByScoreFeature(sortUnionQueryByScoreFeature);
+
             Feature optimizeXPathUnion = newFeature(QueryEngineSettings.FT_OPTIMIZE_XPATH_UNION, whiteboard);
             LOG.info("Registered optimize XPath union feature: " + QueryEngineSettings.FT_OPTIMIZE_XPATH_UNION);
             closer.register(optimizeXPathUnion);
@@ -1003,14 +992,6 @@ public class Oak {
 
         public void setPrefetchFeature(@Nullable Feature prefetch) {
             settings.setPrefetchFeature(prefetch);
-        }
-
-        public void setImprovedIsNullCostFeature(@Nullable Feature feature) {
-            settings.setImprovedIsNullCostFeature(feature);
-        }
-
-        public void setOptimizeInRestrictionsForFunctions(@Nullable Feature feature) {
-            settings.setOptimizeInRestrictionsForFunctions(feature);
         }
 
         public void setSortUnionQueryByScoreFeature(@Nullable Feature feature) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -61,12 +61,6 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String OAK_QUERY_PREFETCH_COUNT = "oak.prefetchCount";
 
-    public static final String FT_NAME_PREFETCH_FOR_QUERIES = "FT_OAK-10490";
-
-    public static final String FT_NAME_IMPROVED_IS_NULL_COST = "FT_OAK-10532";
-
-    public static final String FT_OPTIMIZE_IN_RESTRICTIONS_FOR_FUNCTIONS = "FT_OAK-11214";
-
     public static final String FT_SORT_UNION_QUERY_BY_SCORE = "FT_OAK-11949";
 
     public static final String FT_OPTIMIZE_XPATH_UNION = "FT_OAK-12007";
@@ -126,8 +120,6 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private final long queryLengthErrorLimit = Long.getLong(OAK_QUERY_LENGTH_ERROR_LIMIT, 100 * 1024 * 1024); //100MB
 
     private Feature prefetchFeature;
-    private Feature improvedIsNullCostFeature;
-    private Feature optimizeInRestrictionsForFunctions;
     private Feature sortUnionQueryByScoreFeature;
     private Feature optimizeXPathUnion;
 
@@ -232,26 +224,6 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     public void setFastQuerySize(boolean fastQuerySize) {
         this.fastQuerySize = fastQuerySize;
         System.setProperty(OAK_FAST_QUERY_SIZE, String.valueOf(fastQuerySize));
-    }
-
-    public void setImprovedIsNullCostFeature(@Nullable Feature feature) {
-        this.improvedIsNullCostFeature = feature;
-    }
-
-    @Override
-    public boolean getImprovedIsNullCost() {
-        // enabled if the feature toggle is not used
-        return improvedIsNullCostFeature == null || improvedIsNullCostFeature.isEnabled();
-    }
-
-    public void setOptimizeInRestrictionsForFunctions(@Nullable Feature feature) {
-        this.optimizeInRestrictionsForFunctions = feature;
-    }
-
-    @Override
-    public boolean getOptimizeInRestrictionsForFunctions() {
-        // enabled if the feature toggle is not used
-        return optimizeInRestrictionsForFunctions == null || optimizeInRestrictionsForFunctions.isEnabled();
     }
 
     public void setSortUnionQueryByScoreFeature(@Nullable Feature feature) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/LowerCaseImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/LowerCaseImpl.java
@@ -105,9 +105,6 @@ public class LowerCaseImpl extends DynamicOperandImpl {
     public void restrictList(FilterImpl f, List<PropertyValue> list) {
         // "LOWER(x) IN (A, B)" implies x is not null
         operand.restrict(f, Operator.NOT_EQUAL, null);
-        if (!f.getQueryLimits().getOptimizeInRestrictionsForFunctions()) {
-            return;
-        }
         String fn = getFunction(f.getSelector());
         if (fn != null) {
             f.restrictPropertyAsList(QueryConstants.FUNCTION_RESTRICTION_PREFIX + fn, list);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/NodeLocalNameImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/NodeLocalNameImpl.java
@@ -109,9 +109,6 @@ public class NodeLocalNameImpl extends DynamicOperandImpl {
 
     @Override
     public void restrictList(FilterImpl f, List<PropertyValue> list) {
-        if (!f.getQueryLimits().getOptimizeInRestrictionsForFunctions()) {
-            return;
-        }
         String fn = getFunction(f.getSelector());
         if (fn != null) {
             f.restrictPropertyAsList(QueryConstants.FUNCTION_RESTRICTION_PREFIX + fn, list);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/NodeNameImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/NodeNameImpl.java
@@ -111,9 +111,6 @@ public class NodeNameImpl extends DynamicOperandImpl {
 
     @Override
     public void restrictList(FilterImpl f, List<PropertyValue> list) {
-        if (!f.getQueryLimits().getOptimizeInRestrictionsForFunctions()) {
-            return;
-        }
         String fn = getFunction(f.getSelector());
         if (fn != null) {
             f.restrictPropertyAsList(QueryConstants.FUNCTION_RESTRICTION_PREFIX + fn, list);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PathImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PathImpl.java
@@ -95,9 +95,6 @@ public class PathImpl extends DynamicOperandImpl {
 
     @Override
     public void restrictList(FilterImpl f, List<PropertyValue> list) {
-        if (!f.getQueryLimits().getOptimizeInRestrictionsForFunctions()) {
-            return;
-        }
         String fn = getFunction(f.getSelector());
         if (fn != null) {
             f.restrictPropertyAsList(QueryConstants.FUNCTION_RESTRICTION_PREFIX + fn, list);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/UpperCaseImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/UpperCaseImpl.java
@@ -98,9 +98,6 @@ public class UpperCaseImpl extends DynamicOperandImpl {
     public void restrictList(FilterImpl f, List<PropertyValue> list) {
         // "UPPER(x) IN (A, B)" implies x is not null
         operand.restrict(f, Operator.NOT_EQUAL, null);
-        if (!f.getQueryLimits().getOptimizeInRestrictionsForFunctions()) {
-            return;
-        }
         String fn = getFunction(f.getSelector());
         if (fn != null) {
             f.restrictPropertyAsList(QueryConstants.FUNCTION_RESTRICTION_PREFIX + fn, list);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/index/FilterImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/index/FilterImpl.java
@@ -145,12 +145,6 @@ public class FilterImpl implements Filter {
             public boolean getFailTraversal() {
                 return false;
             }
-
-            @Override
-            public boolean getImprovedIsNullCost() {
-                return true;
-            }
-            
         });
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsServiceTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsServiceTest.java
@@ -19,22 +19,16 @@
 package org.apache.jackrabbit.oak.query;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.jackrabbit.oak.api.jmx.QueryEngineSettingsMBean;
-import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
-import org.apache.jackrabbit.oak.spi.toggle.Feature;
-import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
-import org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils;
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.apache.jackrabbit.oak.spi.toggle.Feature.newFeature;
 import static org.junit.Assert.*;
 
 public class QueryEngineSettingsServiceTest {
@@ -92,26 +86,6 @@ public class QueryEngineSettingsServiceTest {
     public void prefetchDefault() {
         QueryEngineSettings settings = new QueryEngineSettings();
         assertEquals(0, settings.getPrefetchCount());
-    }
-
-    @Test
-    public void prefetchWithFeature() {
-        QueryEngineSettings settings = new QueryEngineSettings();
-        OsgiContext context = new OsgiContext();
-        OsgiWhiteboard whiteboard = new OsgiWhiteboard(context.bundleContext());
-        try (Feature feature = newFeature(QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES, whiteboard)) {
-            assertFalse(feature.isEnabled());
-            List<FeatureToggle> toggles = WhiteboardUtils.getServices(whiteboard, FeatureToggle.class);
-            assertEquals(1, toggles.size());
-            FeatureToggle toggle = toggles.get(0);
-            assertEquals(QueryEngineSettings.FT_NAME_PREFETCH_FOR_QUERIES, toggle.getName());
-            assertEquals(0, settings.getPrefetchCount());
-            toggle.setEnabled(true);
-            settings.setPrefetchFeature(feature);
-            assertEquals(20, settings.getPrefetchCount());
-            toggle.setEnabled(false);
-            assertEquals(0, settings.getPrefetchCount());
-        }
     }
 
     @Test

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/Filter.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/Filter.java
@@ -461,12 +461,6 @@ public interface Filter {
             public boolean getFailTraversal() {
                 return false;
             }
-
-            @Override
-            public boolean getImprovedIsNullCost() {
-                return true;
-            }
-
         };
 
         @Override

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryLimits.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryLimits.java
@@ -30,22 +30,24 @@ public interface QueryLimits {
     boolean getFullTextComparisonWithoutIndex();
 
     /**
-     * See OAK-10532. This method is used for backward compatibility
-     * (bug compatibility) only.
+     * See OAK-10532. This method is kept only to avoid breaking compatibility.
      *
-     * @return true, except when backward compatibility for OAK-10532 is enabled
+     * @return true
+     * @deprecated Setting is no longer used
      */
+    @Deprecated
     default boolean getImprovedIsNullCost() {
         return true;
     }
 
     /**
-     * See OAK-11214. This method is used for backward compatibility
-     * (bug compatibility) only.
+     * See OAK-11214. This method is kept only to avoid breaking compatibility.
      *
-     * @return true, except when backward compatibility for OAK-11214 is enabled
+     * @return true
+     * @deprecated Setting is no longer used
      */
-    default public boolean getOptimizeInRestrictionsForFunctions() {
+    @Deprecated
+    default boolean getOptimizeInRestrictionsForFunctions() {
         return true;
     }
 
@@ -66,6 +68,6 @@ public interface QueryLimits {
 
     default boolean isInferenceEnabled(){
         return false;
-    };
+    }
 
 }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndexPlanner.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndexPlanner.java
@@ -86,7 +86,6 @@ public class FulltextIndexPlanner {
     private final IndexNode indexNode;
     protected PlanResult result;
     protected static boolean useActualEntryCount;
-    private final boolean improvedIsNullCost;
 
     static {
         useActualEntryCount = Boolean.parseBoolean(System.getProperty(FLAG_ENTRY_COUNT, "true"));
@@ -104,7 +103,6 @@ public class FulltextIndexPlanner {
         this.definition = indexNode.getDefinition();
         this.filter = filter;
         this.sortOrder = sortOrder;
-        this.improvedIsNullCost = filter.getQueryLimits().getImprovedIsNullCost();
     }
 
     public IndexPlan getPlan() {
@@ -840,10 +838,8 @@ public class FulltextIndexPlanner {
             PropertyRestriction pr = filter.getPropertyRestriction(key);
             String fieldName = key;
             // for "is not null" we can use an asterisk query
-            if (improvedIsNullCost) {
-                if (pr != null && pr.isNullRestriction()) {
-                    fieldName = FieldNames.NULL_PROPS;
-                }
+            if (pr != null && pr.isNullRestriction()) {
+                fieldName = FieldNames.NULL_PROPS;
             }
             int docCntForField = indexStatistics.getDocCountFor(fieldName);
             if (docCntForField == -1) {
@@ -857,7 +853,7 @@ public class FulltextIndexPlanner {
                     // don't use weight for "is not null" restrictions
                     // as all documents with this field can match;
                     weight = 1;
-                } else if (improvedIsNullCost && pr.isNullRestriction()) {
+                } else if (pr.isNullRestriction()) {
                     // don't use the weight for "is null" restrictions
                     // as all documents with ":nullProps" can match
                     weight = 1;


### PR DESCRIPTION
See [OAK-12063 - Feature toggle cleanup](https://issues.apache.org/jira/browse/OAK-12063)