### PR TITLE
OAK-12093: Rationalize dependency management

### DIFF
--- a/oak-benchmarks/pom.xml
+++ b/oak-benchmarks/pom.xml
@@ -203,7 +203,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/oak-blob-cloud-azure/pom.xml
+++ b/oak-blob-cloud-azure/pom.xml
@@ -204,57 +204,46 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
@@ -290,7 +279,6 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/oak-blob-plugins/pom.xml
+++ b/oak-blob-plugins/pom.xml
@@ -168,8 +168,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-commons/pom.xml
+++ b/oak-commons/pom.xml
@@ -116,7 +116,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-jcr-commons</artifactId>
-      <version>${jackrabbit.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>

--- a/oak-core-spi/pom.xml
+++ b/oak-core-spi/pom.xml
@@ -161,8 +161,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-core/pom.xml
+++ b/oak-core/pom.xml
@@ -330,8 +330,7 @@
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-examples/standalone/pom.xml
+++ b/oak-examples/standalone/pom.xml
@@ -130,7 +130,6 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>${tika.version}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -187,6 +186,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Required for Felix WebConsole -->

--- a/oak-examples/webapp/pom.xml
+++ b/oak-examples/webapp/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>

--- a/oak-lucene/pom.xml
+++ b/oak-lucene/pom.xml
@@ -213,7 +213,6 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>${tika.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
@@ -361,7 +360,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-jcr-tests</artifactId>
-      <version>${jackrabbit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -374,7 +372,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-core</artifactId>
-      <version>${jackrabbit.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
       <exclusions>
@@ -387,7 +384,6 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>${tika.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -417,8 +413,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -434,7 +429,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
-      <version>1.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -450,7 +444,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${h2.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -54,11 +54,8 @@
     <mongo.db>MongoMKDB</mongo.db>
     <mongo.db2>MongoMKDB2</mongo.db2>
     <mongo.url />
-    <mongo.version>3.6</mongo.version>
     <segment.db>SegmentMK</segment.db>
     <lucene.version>4.7.2</lucene.version>
-    <mongo.driver.version>5.2.1</mongo.driver.version>
-    <slf4j.api.version>1.7.36</slf4j.api.version>
     <slf4j.version>1.7.36</slf4j.version> <!-- sync with logback version -->
     <logback.version>1.2.13</logback.version>
     <h2.version>2.1.214</h2.version>
@@ -71,6 +68,9 @@
     <groovy.version>3.0.25</groovy.version>
     <netty.version>4.1.135.Final</netty.version>
     <aws.sdk.version>2.34.9</aws.sdk.version>
+    <jna.version>5.13.0</jna.version>
+    <mockito.version>5.20.0</mockito.version>
+
     <!-- determines the bytecode version (i.e. the minimum JRE required to run the build artifact) -->
     <javaTargetVersion>17</javaTargetVersion>
     <maven.compiler.release>${javaTargetVersion}</maven.compiler.release>
@@ -514,16 +514,6 @@
         <artifactId>org.osgi.service.cm</artifactId>
         <version>1.6.1</version>
       </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.log</artifactId>
-        <version>1.4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.service.event</artifactId>
-        <version>1.4.1</version>
-      </dependency>
       <!-- OSGi R7 annotations -->
       <dependency>
         <groupId>org.osgi</groupId>
@@ -566,41 +556,11 @@
       <dependency>
         <groupId>org.mongodb</groupId>
         <artifactId>mongodb-driver-sync</artifactId>
-        <version>${mongo.driver.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>5.6.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>5.20.0</version>
+        <version>5.2.1</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
@@ -617,18 +577,6 @@
         <groupId>org.apache.jclouds.provider</groupId>
         <artifactId>aws-s3</artifactId>
         <version>2.0.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.sling</groupId>
-        <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
-        <version>2.4.18</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.sling</groupId>
-        <artifactId>org.apache.sling.testing.osgi-mock.core</artifactId>
-        <version>2.4.18</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -664,6 +612,16 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.19.0</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.28.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -750,13 +708,7 @@
         <artifactId>httpmime</artifactId>
         <version>4.5.14</version>
       </dependency>
-      <!-- Testcontainers dependency -->
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
-        <version>${testcontainers.version}</version>
-        <scope>test</scope>
-      </dependency>
+
       <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-storage</artifactId>
@@ -857,6 +809,319 @@
         <scope>import</scope>
       </dependency>
 
+      <!-- Jackrabbit dependencies -->
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-commons</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-data</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-aws-ext</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-server</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-jcr-tests</artifactId>
+        <version>${jackrabbit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>jackrabbit-core</artifactId>
+        <version>${jackrabbit.version}</version>
+        <classifier>tests</classifier>
+      </dependency>
+
+      <!-- Tika -->
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-core</artifactId>
+        <version>${tika.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-parsers</artifactId>
+        <version>${tika.version}</version>
+      </dependency>
+
+      <!-- Databases -->
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>${h2.version}</version>
+      </dependency>
+
+      <!-- Quartz scheduler -->
+      <dependency>
+        <groupId>org.quartz-scheduler</groupId>
+        <artifactId>quartz</artifactId>
+        <version>2.3.2</version>
+      </dependency>
+
+      <!-- Felix -->
+      <dependency>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>org.apache.felix.inventory</artifactId>
+        <version>1.0.4</version>
+      </dependency>
+      <dependency>
+        <groupId>com.googlecode.json-simple</groupId>
+        <artifactId>json-simple</artifactId>
+        <version>1.1.1</version>
+      </dependency>
+
+      <!-- Azure storage -->
+      <dependency>
+        <groupId>org.codehaus.woodstox</groupId>
+        <artifactId>stax2-api</artifactId>
+        <version>4.2.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>6.7.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-storage-blob</artifactId>
+        <version>12.25.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-storage-common</artifactId>
+        <version>12.24.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-storage-internal-avro</artifactId>
+        <version>12.10.3</version>
+      </dependency>
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-xml</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+
+      <!-- Netty (used by azure-storage-blob) -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-epoll</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <!-- Transitive version alignment -->
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>${jna.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>${jna.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.17.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.8</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.41.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>3.42.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.17.2</version>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.12.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.function</artifactId>
+        <version>1.2.0</version>
+      </dependency>
+
+      <!-- Pax OSGi transitive alignment -->
+      <dependency>
+        <groupId>org.ops4j.base</groupId>
+        <artifactId>ops4j-base-lang</artifactId>
+        <version>1.5.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.base</groupId>
+        <artifactId>ops4j-base-util-property</artifactId>
+        <version>1.5.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.swissbox</groupId>
+        <artifactId>pax-swissbox-tracker</artifactId>
+        <version>1.9.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.tinybundles</groupId>
+        <artifactId>tinybundles</artifactId>
+        <version>4.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-commons</artifactId>
+        <version>${pax-url.version}</version>
+      </dependency>
+
+      <!-- Test-scoped dependencies -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.log</artifactId>
+        <version>1.4.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.event</artifactId>
+        <version>1.4.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.easymock</groupId>
+        <artifactId>easymock</artifactId>
+        <version>5.6.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+        <version>2.4.18</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.testing.osgi-mock.core</artifactId>
+        <version>2.4.18</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- Pax Exam Integration Test Dependencies -->
       <dependency>
         <groupId>org.apache.sling</groupId>
@@ -928,6 +1193,80 @@
         <groupId>com.github.stefanbirkner</groupId>
         <artifactId>system-rules</artifactId>
         <version>1.19.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Test infrastructure -->
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Hamcrest / JUnit extras -->
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>2.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit-addons</groupId>
+        <artifactId>junit-addons</artifactId>
+        <version>1.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>de.flapdoodle.embed</groupId>
+        <artifactId>de.flapdoodle.embed.mongo</artifactId>
+        <version>3.2.6</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-exec</artifactId>
+        <version>1.4.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Reactor test -->
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-test</artifactId>
+        <version>3.6.10</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Miscellaneous test deps -->
+      <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>javax.activation-api</artifactId>
+        <version>1.2.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.converter</artifactId>
+        <version>1.0.9</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
+        <version>5.14.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>3.9.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>4.2.1</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/oak-run-commons/pom.xml
+++ b/oak-run-commons/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-core</artifactId>
             <version>${project.version}</version>
@@ -202,8 +206,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -248,7 +248,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-aws-ext</artifactId>
-      <version>${jackrabbit.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -265,7 +264,6 @@
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-jcr-server</artifactId>
-      <version>${jackrabbit.version}</version>
     </dependency>
 
     <dependency>
@@ -350,7 +348,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${h2.version}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
@@ -366,12 +363,10 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>${tika.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>${tika.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
@@ -497,8 +492,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -516,44 +510,16 @@
 
   <profiles>
     <profile>
-      <!--
-         oak-lucene embeds the Lucene jar. However when running in IDE
-         the IDE use the module classpath. So need to explicitly list the
-         lucene jars
-        -->
       <id>ide</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <dependencies>
+        <!-- oak-lucene embeds lucene-* but NOT lucene-core (forked from source).
+             Declare it explicitly so the IDE module classpath includes it. -->
         <dependency>
           <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-core</artifactId>
-          <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>lucene-analyzers-common</artifactId>
-          <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>lucene-queryparser</artifactId>
-          <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>lucene-queries</artifactId>
-          <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>lucene-suggest</artifactId>
-          <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>lucene-facet</artifactId>
           <version>${lucene.version}</version>
         </dependency>
         <dependency>

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -273,8 +273,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-search/pom.xml
+++ b/oak-search/pom.xml
@@ -143,8 +143,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/oak-segment-azure/pom.xml
+++ b/oak-segment-azure/pom.xml
@@ -181,29 +181,24 @@
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>
-            <version>4.2.2</version>
         </dependency>
 
         <!-- Azure Blob Storage v12 dependencies -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.25.3</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-common</artifactId>
-            <version>12.24.3</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-internal-avro</artifactId>
-            <version>12.10.3</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-xml</artifactId>
-            <version>1.0.0</version>
         </dependency>
 
         <!-- Azure Identity Client for Microsoft Entra ID dependency -->
@@ -244,57 +239,46 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
@@ -335,7 +319,6 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -390,7 +373,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>3.6.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -401,7 +383,6 @@
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
-            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -422,13 +403,11 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.converter</artifactId>
-            <version>1.0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
-            <version>5.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -454,13 +433,11 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -297,43 +297,36 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/oak-store-composite/pom.xml
+++ b/oak-store-composite/pom.xml
@@ -150,8 +150,7 @@
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-store-document/pom.xml
+++ b/oak-store-document/pom.xml
@@ -164,7 +164,6 @@
     <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
-      <version>2.3.2</version>
       <scope>provided</scope>
     </dependency>
 
@@ -179,7 +178,6 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.inventory</artifactId>
-      <version>1.0.4</version>
       <optional>true</optional>
     </dependency>
 
@@ -195,7 +193,6 @@
     <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
@@ -218,8 +215,7 @@
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -230,7 +226,6 @@
     <dependency>
       <groupId>junit-addons</groupId>
       <artifactId>junit-addons</artifactId>
-      <version>1.4</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -327,13 +322,11 @@
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>3.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-upgrade/pom.xml
+++ b/oak-upgrade/pom.xml
@@ -236,8 +236,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR reduces the number of dependencies with duplicates from 37 down to 3 (see below).

Centralization required some minor adjustments:
- hamcrest dependencies: removed the old hamcrest-all in favor of hamcrest. (There still remains a hamcrest-core which is in fact empty with only a class stating core is deprecated, can be managed separately later if need be).

All test scoped dependencies grouped at the bottom of the parent pom.xml

## Artifacts where modules resolve to DIFFERENT versions (37 artifacts) (on trunk)

| Artifact | Version | Modules |
|---|---|---|
| `com.azure:azure-xml` | 1.0.0 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
|  | 1.2.0 | `oak-blob-cloud-azure` |
| `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` | 2.13.5 | `oak-standalone` |
|  | 2.17.2 | `oak-search-elastic` |
|  | 2.18.4 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `com.fasterxml.woodstox:woodstox-core` | 6.3.1 | `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 7.1.1 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `com.google.errorprone:error_prone_annotations` | 2.21.1 | `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-plugins`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-it-osgi`, `oak-jcr`, `oak-query-spi`, `oak-run-elastic`, `oak-search`, `oak-security-spi`, `oak-segment-aws`, `oak-store-composite`, `oak-store-document`, `oak-store-spi` |
|  | 2.26.1 | `oak-blob-cloud-azure`, `oak-it`, `oak-run-commons`, `oak-segment-azure`, `oak-upgrade` |
|  | 2.41.0 | `oak-commons`, `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-segment-remote`, `oak-segment-tar`, `oak-shaded-guava`, `oak-standalone`, `oak-webapp` |
| `com.google.guava:guava` | 15.0 | `oak-run`, `oak-run-elastic` |
|  | 21.0 | `oak-segment-aws` |
|  | 31.1-jre | `oak-lucene`, `oak-pojosr`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 33.1.0-jre | `oak-benchmarks`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run-commons`, `oak-segment-azure`, `oak-upgrade` |
|  | 33.5.0-jre | `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-plugins`, `oak-commons`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-query-spi`, `oak-search`, `oak-security-spi`, `oak-segment-remote`, `oak-segment-tar`, `oak-shaded-guava`, `oak-store-composite`, `oak-store-document`, `oak-store-spi` |
| `com.googlecode.json-simple:json-simple` | 1.1 | `oak-webapp` |
|  | 1.1.1 | `oak-core`, `oak-it`, `oak-jcr`, `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-store-document` |
| `commons-logging:commons-logging` | 1.2 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run-commons`, `oak-run-elastic`, `oak-search-elastic`, `oak-segment-aws`, `oak-upgrade` |
|  | 1.3.4 | `oak-run` |
|  | 1.3.5 | `oak-webapp` |
| `io.netty:netty-buffer` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `io.netty:netty-codec` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `io.netty:netty-codec-http` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `io.netty:netty-codec-http2` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `io.netty:netty-common` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `io.netty:netty-handler` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `io.netty:netty-resolver` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `io.netty:netty-transport` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `io.netty:netty-transport-classes-epoll` | 4.1.101.Final | `oak-blob-cloud-azure`, `oak-segment-azure` |
|  | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-upgrade` |
| `io.netty:netty-transport-native-unix-common` | 4.1.126.Final | `oak-segment-aws` |
|  | 4.1.133.Final | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-segment-tar`, `oak-upgrade` |
| `joda-time:joda-time` | 2.12.7 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-it`, `oak-jcr`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-aws` |
|  | 2.2 | `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
| `net.bytebuddy:byte-buddy` | 1.12.23 | `oak-standalone` |
|  | 1.17.5 | `oak-segment-tar` |
|  | 1.17.7 | `oak-api`, `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-blob-plugins`, `oak-commons`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-it`, `oak-it-osgi`, `oak-jackrabbit-api`, `oak-jcr`, `oak-lucene`, `oak-pojosr`, `oak-query-spi`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-search`, `oak-search-elastic`, `oak-security-spi`, `oak-segment-aws`, `oak-segment-azure`, `oak-segment-remote`, `oak-store-composite`, `oak-store-document`, `oak-store-spi`, `oak-upgrade` |
| `net.java.dev.jna:jna` | 5.10.0 | `oak-store-document` |
|  | 5.12.1 | `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 5.13.0 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `net.java.dev.jna:jna-platform` | 5.10.0 | `oak-store-document` |
|  | 5.6.0 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `org.apache.commons:commons-compress` | 1.21 | `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 1.24.0 | `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-store-document`, `oak-upgrade` |
|  | 1.28.0 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene` |
| `org.apache.commons:commons-exec` | 1.3 | `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 1.4.0 | `oak-lucene` |
| `org.apache.logging.log4j:log4j-api` | 2.17.2 | `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 2.6.2 | `oak-segment-aws` |
| `org.apache.lucene:lucene-core` | 3.6.0 | `oak-upgrade` |
|  | 3.6.2 | `oak-jcr` |
|  | 4.7.2 | `oak-benchmarks-lucene`, `oak-it-osgi`, `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-standalone`, `oak-webapp` |
|  | 9.12.2 | `oak-benchmarks-elastic`, `oak-run-elastic`, `oak-search-elastic` |
| `org.apache.tika:tika-core` | 1.28.5 | `oak-benchmarks-lucene`, `oak-http`, `oak-it-osgi`, `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-run-elastic`, `oak-search`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 2.4.1 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-jcr`, `oak-run-commons`, `oak-upgrade` |
| `org.checkerframework:checker-qual` | 3.12.0 | `oak-pojosr`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 3.37.0 | `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-plugins`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-it-osgi`, `oak-jcr`, `oak-lucene`, `oak-query-spi`, `oak-run`, `oak-run-elastic`, `oak-search`, `oak-security-spi`, `oak-segment-aws`, `oak-segment-remote`, `oak-segment-tar`, `oak-store-composite`, `oak-store-document`, `oak-store-spi` |
|  | 3.42.0 | `oak-blob-cloud-azure`, `oak-it`, `oak-run-commons`, `oak-segment-azure`, `oak-upgrade` |
| `org.codehaus.woodstox:stax2-api` | 4.2.1 | `oak-lucene`, `oak-pojosr`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 4.2.2 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `org.hamcrest:hamcrest-core` | 1.3 | `oak-api`, `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-blob-plugins`, `oak-commons`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-it`, `oak-it-osgi`, `oak-jackrabbit-api`, `oak-jcr`, `oak-lucene`, `oak-pojosr`, `oak-query-spi`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-search`, `oak-security-spi`, `oak-segment-aws`, `oak-segment-azure`, `oak-segment-remote`, `oak-segment-tar`, `oak-store-composite`, `oak-store-document`, `oak-store-spi`, `oak-upgrade`, `oak-webapp` |
|  | 2.2 | `oak-search-elastic`, `oak-standalone` |
| `org.objenesis:objenesis` | 3.3 | `oak-api`, `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-cloud-azure`, `oak-blob-plugins`, `oak-commons`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-it`, `oak-it-osgi`, `oak-jackrabbit-api`, `oak-jcr`, `oak-lucene`, `oak-pojosr`, `oak-query-spi`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-search`, `oak-search-elastic`, `oak-security-spi`, `oak-segment-aws`, `oak-segment-azure`, `oak-segment-remote`, `oak-standalone`, `oak-store-composite`, `oak-store-document`, `oak-store-spi`, `oak-upgrade` |
|  | 3.4 | `oak-segment-tar` |
| `org.ops4j.base:ops4j-base-lang` | 1.5.0 | `oak-store-composite` |
|  | 1.5.1 | `oak-it-osgi` |
| `org.ops4j.base:ops4j-base-util-property` | 1.5.0 | `oak-store-composite` |
|  | 1.5.1 | `oak-it-osgi` |
| `org.ops4j.pax.swissbox:pax-swissbox-tracker` | 1.8.2 | `oak-store-composite` |
|  | 1.9.0 | `oak-it-osgi` |
| `org.ops4j.pax.tinybundles:tinybundles` | 3.0.0 | `oak-store-composite` |
|  | 4.0.0 | `oak-it-osgi` |
| `org.ops4j.pax.url:pax-url-commons` | 2.4.5 | `oak-store-composite` |
|  | 2.6.17 | `oak-it-osgi` |
| `org.osgi:org.osgi.util.function` | 1.0.0 | `oak-segment-azure` |
|  | 1.2.0 | `oak-it-osgi` |
| `org.ow2.asm:asm` | 9.3 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-search-elastic`, `oak-segment-azure`, `oak-standalone`, `oak-upgrade`, `oak-webapp` |
|  | 9.8 | `oak-core`, `oak-segment-tar` |]()



## Artifacts where modules resolve to DIFFERENT versions (3 artifacts) (this pr branch)

| Artifact | Version | Modules |
|---|---|---|
| `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` | 2.13.5 | `oak-standalone` |
|  | 2.17.2 | `oak-search-elastic` |
|  | 2.18.4 | `oak-benchmarks`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run`, `oak-run-commons`, `oak-run-elastic`, `oak-segment-azure`, `oak-upgrade` |
| `com.google.guava:guava` | 15.0 | `oak-run`, `oak-run-elastic` |
|  | 21.0 | `oak-segment-aws` |
|  | 31.1-jre | `oak-lucene`, `oak-pojosr`, `oak-search-elastic`, `oak-standalone`, `oak-webapp` |
|  | 33.1.0-jre | `oak-benchmarks`, `oak-blob-cloud-azure`, `oak-it`, `oak-it-osgi`, `oak-jcr`, `oak-run-commons`, `oak-segment-azure`, `oak-upgrade` |
|  | 33.5.0-jre | `oak-auth-external`, `oak-auth-ldap`, `oak-authorization-cug`, `oak-authorization-principalbased`, `oak-benchmarks-elastic`, `oak-benchmarks-lucene`, `oak-blob`, `oak-blob-cloud`, `oak-blob-plugins`, `oak-commons`, `oak-core`, `oak-core-spi`, `oak-exercise`, `oak-http`, `oak-query-spi`, `oak-search`, `oak-security-spi`, `oak-segment-remote`, `oak-segment-tar`, `oak-shaded-guava`, `oak-store-composite`, `oak-store-document`, `oak-store-spi` |
| `org.apache.lucene:lucene-core` | 3.6.0 | `oak-upgrade` |
|  | 3.6.2 | `oak-jcr` |
|  | 4.7.2 | `oak-benchmarks-lucene`, `oak-it-osgi`, `oak-lucene`, `oak-pojosr`, `oak-run`, `oak-standalone`, `oak-webapp` |
|  | 9.12.2 | `oak-benchmarks-elastic`, `oak-run-elastic`, `oak-search-elastic` |
