### PR TITLE
OAK-12101 - Skip indexing of very long tags

### DIFF
--- a/oak-doc/src/site/markdown/query/lucene.md
+++ b/oak-doc/src/site/markdown/query/lucene.md
@@ -154,6 +154,7 @@ Below is the canonical index definition structure
       - queryPaths (string) multiple = ['/']
       - excludedPaths (string) multiple
       - maxFieldLength (long) = 10000
+      - maxTagLength (long) = 100
       - refresh (boolean)
       - useIfExists (string)
       - blobSize (long) = 32768
@@ -232,6 +233,13 @@ selectionPolicy
 
 [maxFieldLength][OAK-2469]
 : Numbers of terms indexed per field. Defaults to 10000
+
+[maxTagLength][OAK-12101]
+: Optional integer property. Defaults to 100.
+: Maximum length of similarity tag and dynamic boost tag values to be indexed.
+  Tags with values longer than this limit are skipped during indexing.
+  Set to -1 to disable the length check entirely.
+  See [Dynamic Boost](#dynamic-boost) and [Search by similar feature vectors](#similar-fv) for details.
 
 refresh
 : Optional boolean property.
@@ -1231,6 +1239,11 @@ with boost set to the confidence.
 This is a replacement for the `IndexFieldProvider`.
 See also [OAK-8971][OAK-8971].
 
+Tag values that exceed the configured `maxTagLength` (default 100) are skipped during indexing.
+This prevents unexpectedly long values from being indexed as dynamic boost tags.
+The limit can be changed by setting the `maxTagLength` property on the index definition,
+or disabled entirely by setting it to -1. See [OAK-12101][OAK-12101].
+
 
 ### <a name="native-query"></a>Native Query and Index Selection
 `@deprecated Oak 1.46`
@@ -1701,6 +1714,11 @@ improve precision (see [OAK-7824](https://issues.apache.org/jira/browse/OAK-7824
 As a further improvement for the accuracy of similarity search results if nodes having feature vectors also have properties
  holding text values that can be used as keywords or tags that well describe the feature vector contents, the
  `similarityTags` configuration can be set to _true_ for such properties (see [OAK-8118](https://issues.apache.org/jira/browse/OAK-8118)).
+
+Similarity tag values that exceed the configured `maxTagLength` (default 100) are skipped during indexing.
+This prevents unexpectedly long values from being indexed as similarity tags.
+The limit can be changed by setting the `maxTagLength` property on the index definition,
+or disabled entirely by setting it to -1. See [OAK-12101][OAK-12101].
 
 See also [OAK-7575](https://issues.apache.org/jira/browse/OAK-7575).
 
@@ -2231,6 +2249,7 @@ SELECT rep:facet(title) FROM [app:Asset] WHERE [title] IS NOT NULL
 [OAK-7739]: https://issues.apache.org/jira/browse/OAK-7739
 [OAK-8971]: https://issues.apache.org/jira/browse/OAK-8971
 [OAK-9625]: https://issues.apache.org/jira/browse/OAK-9625
+[OAK-12101]: https://issues.apache.org/jira/browse/OAK-12101
 [luke]: https://code.google.com/p/luke/
 [tika]: http://tika.apache.org/
 [oak-console]: https://github.com/apache/jackrabbit-oak/tree/trunk/oak-run#console

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -415,8 +415,8 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     }
 
     @Override
-    protected boolean indexSimilarityTag(Document doc, PropertyState property) {
-        doc.add(new TextField(FieldNames.SIMILARITY_TAGS, property.getValue(Type.STRING), Field.Store.YES));
+    protected boolean indexSimilarityTag(Document doc, String value) {
+        doc.add(new TextField(FieldNames.SIMILARITY_TAGS, value, Field.Store.YES));
         return true;
     }
 

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -77,7 +77,7 @@ public class LuceneDocumentMakerTest {
                 .property("tag")
                 .similarityTags(true);
 
-        builder.getBuilderTree().setProperty(FulltextIndexConstants.SIMILARITY_TAG_MAX_LENGTH, 10);
+        builder.getBuilderTree().setProperty(FulltextIndexConstants.MAX_TAG_LENGTH, 10);
 
         LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
         LuceneDocumentMaker docMaker = new LuceneDocumentMaker(defn,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -21,23 +21,27 @@ package org.apache.jackrabbit.oak.plugins.index.lucene;
 
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.lucene.document.Document;
 import org.junit.Test;
 
 import java.util.List;
 
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class LuceneDocumentMakerTest {
     private final NodeState root = INITIAL_CONTENT;
-    private final LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
 
     @Test
     public void excludeSingleProperty() throws Exception{
+        LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("foo")
                 .propertyIndex()
@@ -61,6 +65,42 @@ public class LuceneDocumentMakerTest {
 
         test.setProperty("foo", List.of("/jobs/a"), Type.STRINGS);
         assertNull(docMaker.makeDocument(test.getNodeState()));
+    }
+
+    @Test
+    public void similarityTagsMaxLengthFiltering() throws Exception{
+        LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
+        builder.indexRule("nt:base")
+                .property("jcr:primaryType")
+                .propertyIndex();
+        builder.indexRule("nt:base")
+                .property("tag")
+                .similarityTags(true);
+
+        builder.getBuilderTree().setProperty(FulltextIndexConstants.SIMILARITY_TAGS_MAX_LENGTH, 10);
+
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
+        LuceneDocumentMaker docMaker = new LuceneDocumentMaker(defn,
+                defn.getApplicableIndexingRule("nt:base"), "/x");
+
+        NodeBuilder test = EMPTY_NODE.builder();
+        test.setProperty("tag", "short");
+
+        Document doc = docMaker.makeDocument(test.getNodeState());
+        assertNotNull(doc);
+        assertEquals("short", doc.get(FieldNames.SIMILARITY_TAGS));
+
+        test = EMPTY_NODE.builder();
+        test.setProperty("tag", "exactly10!");
+        doc = docMaker.makeDocument(test.getNodeState());
+        assertNotNull(doc);
+        assertEquals("exactly10!", doc.get(FieldNames.SIMILARITY_TAGS));
+
+        test = EMPTY_NODE.builder();
+        test.setProperty("tag", "this is too long");
+        doc = docMaker.makeDocument(test.getNodeState());
+        assertNotNull(doc);
+        assertNull(doc.get(FieldNames.SIMILARITY_TAGS));
     }
 
 }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -68,7 +68,7 @@ public class LuceneDocumentMakerTest {
     }
 
     @Test
-    public void similarityTagsMaxLengthFiltering() throws Exception{
+    public void similarityTagMaxLengthFiltering() throws Exception{
         LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("jcr:primaryType")
@@ -77,7 +77,7 @@ public class LuceneDocumentMakerTest {
                 .property("tag")
                 .similarityTags(true);
 
-        builder.getBuilderTree().setProperty(FulltextIndexConstants.SIMILARITY_TAGS_MAX_LENGTH, 10);
+        builder.getBuilderTree().setProperty(FulltextIndexConstants.SIMILARITY_TAG_MAX_LENGTH, 10);
 
         LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
         LuceneDocumentMaker docMaker = new LuceneDocumentMaker(defn,

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -85,7 +85,6 @@ public class LuceneDocumentMakerTest {
 
         NodeBuilder test = EMPTY_NODE.builder();
         test.setProperty("tag", "short");
-
         Document doc = docMaker.makeDocument(test.getNodeState());
         assertNotNull(doc);
         assertEquals("short", doc.get(FieldNames.SIMILARITY_TAGS));

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/dynamicBoost/LuceneDynamicBoostTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/dynamicBoost/LuceneDynamicBoostTest.java
@@ -184,10 +184,37 @@ public class LuceneDynamicBoostTest extends DynamicBoostCommonTest {
                 List.of("/test/asset3", "/test/asset2"));
     }
 
+    @Test
+    public void dynamicBoostMaxLengthFiltering() throws Exception {
+        createAssetsIndexAndProperties(false, false, true, 10);
+
+        Tree testParent = createNodeWithType(root.getTree("/"), "test", JcrConstants.NT_UNSTRUCTURED, "");
+
+        Tree predicted1 = createAssetNodeWithPredicted(testParent, "asset1", "test");
+        createPredictedTag(predicted1, "short", 0.9);
+        createPredictedTag(predicted1, "exactly10!", 0.8);
+        createPredictedTag(predicted1, "this is too long", 0.7);
+
+        Tree predicted2 = createAssetNodeWithPredicted(testParent, "asset2", "test");
+        createPredictedTag(predicted2, "short", 0.9);
+        createPredictedTag(predicted2, "exactly10!", 0.8);
+
+        root.commit();
+
+        assertEventually(() -> {
+            assertQuery("select [jcr:path] from [dam:Asset] where contains(*, 'short')", SQL2,
+                    List.of("/test/asset1", "/test/asset2"));
+            assertQuery("select [jcr:path] from [dam:Asset] where contains(*, 'exactly10!')", SQL2,
+                    List.of("/test/asset1", "/test/asset2"));
+
+            assertQuery("select [jcr:path] from [dam:Asset] where contains(*, 'this is too long')", SQL2, List.of());
+        });
+    }
+
     @Override
-    protected void createAssetsIndexAndProperties(boolean lite, boolean similarityTags) throws Exception {
+    protected void createAssetsIndexAndProperties(boolean lite, boolean similarityTags, boolean useInFullTextQuery, Integer maxTagLength) throws Exception {
         factory.queryTermsProvider = new FulltextQueryTermsProviderImpl();
-        super.createAssetsIndexAndProperties(lite, similarityTags);
+        super.createAssetsIndexAndProperties(lite, similarityTags, useInFullTextQuery, maxTagLength);
     }
 
     private String runIndexingTest(Class<?> loggerClass, boolean nameProperty) throws CommitFailedException {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticDocumentMaker.java
@@ -242,10 +242,9 @@ public class ElasticDocumentMaker extends FulltextDocumentMaker<ElasticDocument>
     }
 
     @Override
-    protected boolean indexSimilarityTag(ElasticDocument doc, PropertyState property) {
-        String val = property.getValue(Type.STRING);
-        if (!val.isEmpty()) {
-            doc.addSimilarityTag(val);
+    protected boolean indexSimilarityTag(ElasticDocument doc, String value) {
+        if (!value.isEmpty()) {
+            doc.addSimilarityTag(value);
             return true;
         }
         return false;

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -252,7 +252,7 @@ public interface FulltextIndexConstants {
     String MAX_FIELD_LENGTH = "maxFieldLength";
 
     /**
-     * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped.
+     * Maximum length of similarity and dynamic boost tag values to be indexed. Tags longer than this value will be skipped.
      * Set to -1 to disable the length check entirely
      */
     String MAX_TAG_LENGTH = "maxTagLength";

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -289,7 +289,7 @@ public interface FulltextIndexConstants {
     /**
      * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped
      */
-    String SIMILARITY_TAGS_MAX_LENGTH = "similarityTagsMaxLength";
+    String SIMILARITY_TAG_MAX_LENGTH = "similarityTagMaxLength";
 
     /**
      * Property definition config indicating that null check support should be

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -252,6 +252,12 @@ public interface FulltextIndexConstants {
     String MAX_FIELD_LENGTH = "maxFieldLength";
 
     /**
+     * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped.
+     * Set to -1 to disable the length check entirely
+     */
+    String MAX_TAG_LENGTH = "maxTagLength";
+
+    /**
      * whether use this property values for suggestions
      */
     String PROP_USE_IN_SUGGEST = "useInSuggest";
@@ -285,12 +291,6 @@ public interface FulltextIndexConstants {
      * whether property values should be indexed as tags to boost similarity search results
      */
     String PROP_SIMILARITY_TAGS = "similarityTags";
-
-    /**
-     * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped.
-     * Set to -1 to disable the length check entirely
-     */
-    String SIMILARITY_TAG_MAX_LENGTH = "similarityTagMaxLength";
 
     /**
      * Property definition config indicating that null check support should be

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -287,6 +287,11 @@ public interface FulltextIndexConstants {
     String PROP_SIMILARITY_TAGS = "similarityTags";
 
     /**
+     * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped
+     */
+    String SIMILARITY_TAGS_MAX_LENGTH = "similarityTagsMaxLength";
+
+    /**
      * Property definition config indicating that null check support should be
      * enabled for this property
      */

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -287,7 +287,8 @@ public interface FulltextIndexConstants {
     String PROP_SIMILARITY_TAGS = "similarityTags";
 
     /**
-     * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped
+     * Maximum length of similarity tag values to be indexed. Tags longer than this value will be skipped.
+     * Set to -1 to disable the length check entirely
      */
     String SIMILARITY_TAG_MAX_LENGTH = "similarityTagMaxLength";
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
@@ -146,12 +146,12 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
      */
     public static final int DEFAULT_MAX_FIELD_LENGTH = 10000;
 
-    public static final int DEFAULT_MAX_EXTRACT_LENGTH = -10;
-
     /**
-     * Default maximum length to skip indexing excessively long tags.
+     * Default value for property {@link #maxTagLength}.
      */
-    public static final int DEFAULT_SIMILARITY_TAG_MAX_LENGTH = 100;
+    public static final int DEFAULT_MAX_TAG_LENGTH = 100;
+
+    public static final int DEFAULT_MAX_EXTRACT_LENGTH = -10;
 
     /**
      * System managed hidden property to record the current index version
@@ -279,9 +279,9 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
 
     private final int maxFieldLength;
 
-    private final int maxExtractLength;
+    private final int maxTagLength;
 
-    private final int similarityTagMaxLength;
+    private final int maxExtractLength;
 
     private final int suggesterUpdateFrequencyMinutes;
 
@@ -477,8 +477,7 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
             }
 
             this.maxFieldLength = getOptionalValue(defn, FulltextIndexConstants.MAX_FIELD_LENGTH, DEFAULT_MAX_FIELD_LENGTH);
-            this.similarityTagMaxLength = getOptionalValue(defn,
-                    FulltextIndexConstants.SIMILARITY_TAG_MAX_LENGTH, DEFAULT_SIMILARITY_TAG_MAX_LENGTH);
+            this.maxTagLength = getOptionalValue(defn, FulltextIndexConstants.MAX_TAG_LENGTH, DEFAULT_MAX_TAG_LENGTH);
             this.costPerEntry = getOptionalValue(defn, FulltextIndexConstants.COST_PER_ENTRY, getDefaultCostPerEntry(version));
             this.costPerExecution = getOptionalValue(defn, FulltextIndexConstants.COST_PER_EXECUTION, 1.0);
             this.hasCustomTikaConfig = getTikaConfigNode().exists();
@@ -699,12 +698,12 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
         return indexSelectionPolicy;
     }
 
-    public int getMaxExtractLength() {
-        return maxExtractLength;
+    public int getMaxTagLength() {
+        return maxTagLength;
     }
 
-    public int getSimilarityTagMaxLength() {
-        return similarityTagMaxLength;
+    public int getMaxExtractLength() {
+        return maxExtractLength;
     }
 
     public PathFilter getPathFilter() {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
@@ -151,7 +151,7 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
     /**
      * Default maximum length to skip indexing excessively long tags.
      */
-    public static final int DEFAULT_SIMILARITY_TAGS_MAX_LENGTH = 100;
+    public static final int DEFAULT_SIMILARITY_TAG_MAX_LENGTH = 100;
 
     /**
      * System managed hidden property to record the current index version
@@ -281,7 +281,7 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
 
     private final int maxExtractLength;
 
-    private final int similarityTagsMaxLength;
+    private final int similarityTagMaxLength;
 
     private final int suggesterUpdateFrequencyMinutes;
 
@@ -477,8 +477,8 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
             }
 
             this.maxFieldLength = getOptionalValue(defn, FulltextIndexConstants.MAX_FIELD_LENGTH, DEFAULT_MAX_FIELD_LENGTH);
-            this.similarityTagsMaxLength = getOptionalValue(defn,
-                    FulltextIndexConstants.SIMILARITY_TAGS_MAX_LENGTH, DEFAULT_SIMILARITY_TAGS_MAX_LENGTH);
+            this.similarityTagMaxLength = getOptionalValue(defn,
+                    FulltextIndexConstants.SIMILARITY_TAG_MAX_LENGTH, DEFAULT_SIMILARITY_TAG_MAX_LENGTH);
             this.costPerEntry = getOptionalValue(defn, FulltextIndexConstants.COST_PER_ENTRY, getDefaultCostPerEntry(version));
             this.costPerExecution = getOptionalValue(defn, FulltextIndexConstants.COST_PER_EXECUTION, 1.0);
             this.hasCustomTikaConfig = getTikaConfigNode().exists();
@@ -703,8 +703,8 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
         return maxExtractLength;
     }
 
-    public int getSimilarityTagsMaxLength() {
-        return similarityTagsMaxLength;
+    public int getSimilarityTagMaxLength() {
+        return similarityTagMaxLength;
     }
 
     public PathFilter getPathFilter() {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinition.java
@@ -149,6 +149,11 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
     public static final int DEFAULT_MAX_EXTRACT_LENGTH = -10;
 
     /**
+     * Default maximum length to skip indexing excessively long tags.
+     */
+    public static final int DEFAULT_SIMILARITY_TAGS_MAX_LENGTH = 100;
+
+    /**
      * System managed hidden property to record the current index version
      */
     public static final String INDEX_VERSION = ":version";
@@ -275,6 +280,8 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
     private final int maxFieldLength;
 
     private final int maxExtractLength;
+
+    private final int similarityTagsMaxLength;
 
     private final int suggesterUpdateFrequencyMinutes;
 
@@ -470,6 +477,8 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
             }
 
             this.maxFieldLength = getOptionalValue(defn, FulltextIndexConstants.MAX_FIELD_LENGTH, DEFAULT_MAX_FIELD_LENGTH);
+            this.similarityTagsMaxLength = getOptionalValue(defn,
+                    FulltextIndexConstants.SIMILARITY_TAGS_MAX_LENGTH, DEFAULT_SIMILARITY_TAGS_MAX_LENGTH);
             this.costPerEntry = getOptionalValue(defn, FulltextIndexConstants.COST_PER_ENTRY, getDefaultCostPerEntry(version));
             this.costPerExecution = getOptionalValue(defn, FulltextIndexConstants.COST_PER_EXECUTION, 1.0);
             this.hasCustomTikaConfig = getTikaConfigNode().exists();
@@ -692,6 +701,10 @@ public class IndexDefinition implements Aggregate.AggregateMapper {
 
     public int getMaxExtractLength() {
         return maxExtractLength;
+    }
+
+    public int getSimilarityTagsMaxLength() {
+        return similarityTagsMaxLength;
     }
 
     public PathFilter getPathFilter() {

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -749,12 +749,13 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     }
 
     private boolean isTagWithinLengthLimit(String value, String pname) {
-        if (value.length() <= definition.getSimilarityTagMaxLength()) {
+        int maxLength = definition.getSimilarityTagMaxLength();
+        if (maxLength < 0 || value.length() <= maxLength) {
             return true;
         }
         if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_TAG_SKIPPED)) {
             log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length {}",
-                    getIndexName(), pname, value.length(), definition.getSimilarityTagMaxLength());
+                    getIndexName(), pname, value.length(), maxLength);
         }
         return false;
     }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -62,7 +62,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final LogSilencer LOG_SILENCER = new LogSilencer(Duration.ofMinutes(1).toMillis(), 4);
-    private static final String LOG_KEY_SIMILARITY_TAG_SKIPPED = "Similarity tag skipped";
+    private static final String LOG_KEY_TAG_LENGTH_EXCEEDED = "Tag length exceeded";
 
     public static final String WARN_LOG_STRING_SIZE_THRESHOLD_KEY = "oak.repository.property.index.logWarnStringSizeThreshold";
     private static final int DEFAULT_WARN_LOG_STRING_SIZE_THRESHOLD_VALUE = 102400;
@@ -350,7 +350,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
             }
             if (pd.similarityTags) {
                 String value = property.getValue(Type.STRING);
-                if (isTagWithinLengthLimit(value, pname)) {
+                if (isTagWithinLengthLimit(value, pname, true)) {
                     dirty |= indexSimilarityTag(doc, value);
                 }
             }
@@ -713,7 +713,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 continue;
             }
             String dynaTagValue = p.getValue(Type.STRING);
-            if (!isTagWithinLengthLimit(dynaTagValue, p.getName())) {
+            if (!isTagWithinLengthLimit(dynaTagValue, p.getName(), false)) {
                 continue;
             }
             p = dynaTag.getProperty(DYNAMIC_BOOST_TAG_CONFIDENCE);
@@ -748,14 +748,15 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         return definition.getIndexName();
     }
 
-    private boolean isTagWithinLengthLimit(String value, String pname) {
-        int maxLength = definition.getSimilarityTagMaxLength();
+    private boolean isTagWithinLengthLimit(String value, String pname, boolean isSimilarityTag) {
+        int maxLength = definition.getMaxTagLength();
         if (maxLength < 0 || value.length() <= maxLength) {
             return true;
         }
-        if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_TAG_SKIPPED)) {
-            log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length {}",
-                    getIndexName(), pname, value.length(), maxLength);
+        if (!LOG_SILENCER.silence(LOG_KEY_TAG_LENGTH_EXCEEDED)) {
+            String tagType = isSimilarityTag ? "similarity tag" : "dynamic boost tag";
+            log.warn("[{}] Skipping {} for property {}. Value length {} exceeds maximum allowed length {}",
+                    getIndexName(), tagType, pname, value.length(), maxLength);
         }
         return false;
     }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -343,7 +343,10 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 dirty |= indexFacets(doc, property, pname, pd);
             }
             if (pd.similarityTags) {
-                dirty |= indexSimilarityTag(doc, property);
+                String value = property.getValue(Type.STRING);
+                if (value.length() <= definition.getSimilarityTagsMaxLength()) {
+                    dirty |= indexSimilarityTag(doc, value);
+                }
             }
 
         }
@@ -377,7 +380,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         return true;
     }
 
-    protected abstract boolean indexSimilarityTag(D doc, PropertyState property);
+    protected abstract boolean indexSimilarityTag(D doc, String value);
 
     protected abstract void indexSimilarityBinaries(D doc, PropertyDefinition pd, Blob blob) throws IOException;
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -749,12 +749,12 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
     }
 
     private boolean isTagWithinLengthLimit(String value, String pname) {
-        if (value.length() <= definition.getSimilarityTagsMaxLength()) {
+        if (value.length() <= definition.getSimilarityTagMaxLength()) {
             return true;
         }
         if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_TAG_SKIPPED)) {
             log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length {}",
-                    getIndexName(), pname, value.length(), definition.getSimilarityTagsMaxLength());
+                    getIndexName(), pname, value.length(), definition.getSimilarityTagMaxLength());
         }
         return false;
     }

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
+import org.apache.jackrabbit.oak.commons.log.LogSilencer;
 import org.apache.jackrabbit.oak.plugins.index.search.Aggregate;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.PropertyType;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,10 @@ import static java.util.Objects.requireNonNull;
 public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final LogSilencer LOG_SILENCER = new LogSilencer(Duration.ofMinutes(1).toMillis(), 4);
+    private static final String LOG_KEY_SIMILARITY_TAG_SKIPPED = "Similarity tag skipped";
+
     public static final String WARN_LOG_STRING_SIZE_THRESHOLD_KEY = "oak.repository.property.index.logWarnStringSizeThreshold";
     private static final int DEFAULT_WARN_LOG_STRING_SIZE_THRESHOLD_VALUE = 102400;
 
@@ -346,6 +352,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 String value = property.getValue(Type.STRING);
                 if (value.length() <= definition.getSimilarityTagsMaxLength()) {
                     dirty |= indexSimilarityTag(doc, value);
+                } else if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_TAG_SKIPPED)) {
+                    log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length {}",
+                            getIndexName(), pname, value.length(), definition.getSimilarityTagsMaxLength());
                 }
             }
 

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.PropertyType;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +60,7 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private static final LogSilencer LOG_SILENCER = new LogSilencer(Duration.ofMinutes(1).toMillis(), 4);
-    private static final String LOG_KEY_TAG_LENGTH_EXCEEDED = "Tag length exceeded";
+    private static final LogSilencer LOG_SILENCER = new LogSilencer();
 
     public static final String WARN_LOG_STRING_SIZE_THRESHOLD_KEY = "oak.repository.property.index.logWarnStringSizeThreshold";
     private static final int DEFAULT_WARN_LOG_STRING_SIZE_THRESHOLD_VALUE = 102400;
@@ -350,8 +348,11 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
             }
             if (pd.similarityTags) {
                 String value = property.getValue(Type.STRING);
-                if (isTagWithinLengthLimit(value, pname, true)) {
+                if (isTagWithinLengthLimit(value)) {
                     dirty |= indexSimilarityTag(doc, value);
+                } else if (!LOG_SILENCER.silence(pname)) {
+                    log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length",
+                            getIndexName(), pname, value.length());
                 }
             }
 
@@ -713,7 +714,11 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 continue;
             }
             String dynaTagValue = p.getValue(Type.STRING);
-            if (!isTagWithinLengthLimit(dynaTagValue, p.getName(), false)) {
+            if (!isTagWithinLengthLimit(dynaTagValue)) {
+                if (!LOG_SILENCER.silence(p.getName())) {
+                    log.warn("[{}] Skipping dynamic boost tag for property {}. Value length {} exceeds maximum allowed length",
+                            getIndexName(), p.getName(), dynaTagValue.length());
+                }
                 continue;
             }
             p = dynaTag.getProperty(DYNAMIC_BOOST_TAG_CONFIDENCE);
@@ -748,17 +753,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
         return definition.getIndexName();
     }
 
-    private boolean isTagWithinLengthLimit(String value, String pname, boolean isSimilarityTag) {
+    private boolean isTagWithinLengthLimit(String value) {
         int maxLength = definition.getMaxTagLength();
-        if (maxLength < 0 || value.length() <= maxLength) {
-            return true;
-        }
-        if (!LOG_SILENCER.silence(LOG_KEY_TAG_LENGTH_EXCEEDED)) {
-            String tagType = isSimilarityTag ? "similarity tag" : "dynamic boost tag";
-            log.warn("[{}] Skipping {} for property {}. Value length {} exceeds maximum allowed length {}",
-                    getIndexName(), tagType, pname, value.length(), maxLength);
-        }
-        return false;
+        return maxLength < 0 || value.length() <= maxLength;
     }
 
     /*

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextDocumentMaker.java
@@ -350,11 +350,8 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
             }
             if (pd.similarityTags) {
                 String value = property.getValue(Type.STRING);
-                if (value.length() <= definition.getSimilarityTagsMaxLength()) {
+                if (isTagWithinLengthLimit(value, pname)) {
                     dirty |= indexSimilarityTag(doc, value);
-                } else if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_TAG_SKIPPED)) {
-                    log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length {}",
-                            getIndexName(), pname, value.length(), definition.getSimilarityTagsMaxLength());
                 }
             }
 
@@ -716,6 +713,9 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
                 continue;
             }
             String dynaTagValue = p.getValue(Type.STRING);
+            if (!isTagWithinLengthLimit(dynaTagValue, p.getName())) {
+                continue;
+            }
             p = dynaTag.getProperty(DYNAMIC_BOOST_TAG_CONFIDENCE);
             if (p == null) {
                 // here we don't log a warning, because possibly it will be added later
@@ -746,6 +746,17 @@ public abstract class FulltextDocumentMaker<D> implements DocumentMaker<D> {
 
     protected String getIndexName() {
         return definition.getIndexName();
+    }
+
+    private boolean isTagWithinLengthLimit(String value, String pname) {
+        if (value.length() <= definition.getSimilarityTagsMaxLength()) {
+            return true;
+        }
+        if (!LOG_SILENCER.silence(LOG_KEY_SIMILARITY_TAG_SKIPPED)) {
+            log.warn("[{}] Skipping similarity tag for property {}. Value length {} exceeds maximum allowed length {}",
+                    getIndexName(), pname, value.length(), definition.getSimilarityTagsMaxLength());
+        }
+        return false;
     }
 
     /*

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/DynamicBoostCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/DynamicBoostCommonTest.java
@@ -234,6 +234,10 @@ public abstract class DynamicBoostCommonTest extends AbstractQueryTest {
     }
 
     protected void createAssetsIndexAndProperties(boolean lite, boolean similarityTags, boolean useInFullTextQuery) throws Exception {
+        createAssetsIndexAndProperties(lite, similarityTags, useInFullTextQuery, null);
+    }
+
+    protected void createAssetsIndexAndProperties(boolean lite, boolean similarityTags, boolean useInFullTextQuery, Integer maxTagLength) throws Exception {
         NodeTypeRegistry.register(root, new ByteArrayInputStream(ASSET_NODE_TYPE.getBytes()), "test nodeType");
         Tree indexRuleProps = createIndex("dam:Asset", lite);
 
@@ -248,6 +252,11 @@ public abstract class DynamicBoostCommonTest extends AbstractQueryTest {
             predictedTags.setProperty("name", "jcr:content/metadata/predictedTags/*/name");
             predictedTags.setProperty("isRegexp", true);
             predictedTags.setProperty("similarityTags", true);
+        }
+
+        if (maxTagLength != null) {
+            Tree indexDef = root.getTree("/oak:index/" + TEST_INDEX_NAME);
+            indexDef.setProperty(FulltextIndexConstants.MAX_TAG_LENGTH, maxTagLength);
         }
 
         root.commit();

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
@@ -533,12 +533,12 @@ public class IndexDefinitionTest {
         NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
                 "lucene", Set.of(TYPENAME_STRING));
         IndexDefinition defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
-        assertEquals(IndexDefinition.DEFAULT_SIMILARITY_TAG_MAX_LENGTH, defn.getSimilarityTagMaxLength());
+        assertEquals(IndexDefinition.DEFAULT_MAX_TAG_LENGTH, defn.getMaxTagLength());
 
-        defnb.setProperty(FulltextIndexConstants.SIMILARITY_TAG_MAX_LENGTH, 50);
+        defnb.setProperty(FulltextIndexConstants.MAX_TAG_LENGTH, 50);
 
         defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
-        assertEquals(50, defn.getSimilarityTagMaxLength());
+        assertEquals(50, defn.getMaxTagLength());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
@@ -528,6 +528,19 @@ public class IndexDefinitionTest {
         assertEquals(1000, defn.getMaxExtractLength());
     }
 
+    @Test
+    public void similarityTagsMaxLength() {
+        NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
+                "lucene", Set.of(TYPENAME_STRING));
+        IndexDefinition defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
+        assertEquals(IndexDefinition.DEFAULT_SIMILARITY_TAGS_MAX_LENGTH, defn.getSimilarityTagsMaxLength());
+
+        defnb.setProperty(FulltextIndexConstants.SIMILARITY_TAGS_MAX_LENGTH, 50);
+
+        defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
+        assertEquals(50, defn.getSimilarityTagsMaxLength());
+    }
+
     @Test(expected = IllegalStateException.class)
     public void nullCheckEnabledWithNtBase() {
         builder.child(PROP_NODE).child("foo").setProperty(FulltextIndexConstants.PROP_NULL_CHECK_ENABLED, true);

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
@@ -529,16 +529,16 @@ public class IndexDefinitionTest {
     }
 
     @Test
-    public void similarityTagsMaxLength() {
+    public void similarityTagMaxLength() {
         NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
                 "lucene", Set.of(TYPENAME_STRING));
         IndexDefinition defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
-        assertEquals(IndexDefinition.DEFAULT_SIMILARITY_TAGS_MAX_LENGTH, defn.getSimilarityTagsMaxLength());
+        assertEquals(IndexDefinition.DEFAULT_SIMILARITY_TAG_MAX_LENGTH, defn.getSimilarityTagMaxLength());
 
-        defnb.setProperty(FulltextIndexConstants.SIMILARITY_TAGS_MAX_LENGTH, 50);
+        defnb.setProperty(FulltextIndexConstants.SIMILARITY_TAG_MAX_LENGTH, 50);
 
         defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
-        assertEquals(50, defn.getSimilarityTagsMaxLength());
+        assertEquals(50, defn.getSimilarityTagMaxLength());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
@@ -514,6 +514,19 @@ public class IndexDefinitionTest {
     }
 
     @Test
+    public void similarityTagMaxLength() {
+        NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
+                "lucene", Set.of(TYPENAME_STRING));
+        IndexDefinition defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
+        assertEquals(IndexDefinition.DEFAULT_MAX_TAG_LENGTH, defn.getMaxTagLength());
+
+        defnb.setProperty(FulltextIndexConstants.MAX_TAG_LENGTH, 50);
+
+        defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
+        assertEquals(50, defn.getMaxTagLength());
+    }
+
+    @Test
     public void maxExtractLength() {
         NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
                 "lucene", Set.of(TYPENAME_STRING));
@@ -526,19 +539,6 @@ public class IndexDefinitionTest {
 
         defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
         assertEquals(1000, defn.getMaxExtractLength());
-    }
-
-    @Test
-    public void similarityTagMaxLength() {
-        NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
-                "lucene", Set.of(TYPENAME_STRING));
-        IndexDefinition defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
-        assertEquals(IndexDefinition.DEFAULT_MAX_TAG_LENGTH, defn.getMaxTagLength());
-
-        defnb.setProperty(FulltextIndexConstants.MAX_TAG_LENGTH, 50);
-
-        defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");
-        assertEquals(50, defn.getMaxTagLength());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/IndexDefinitionTest.java
@@ -514,7 +514,7 @@ public class IndexDefinitionTest {
     }
 
     @Test
-    public void similarityTagMaxLength() {
+    public void maxTagLength() {
         NodeBuilder defnb = newFTIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
                 "lucene", Set.of(TYPENAME_STRING));
         IndexDefinition defn = new IndexDefinition(root, defnb.getNodeState(), "/foo");


### PR DESCRIPTION
Very long tag names inflate index sizes and probably defeat the purpose of tags. This PR introduces optional configurable values per index to configure how tags should be filtered in `indexSimilarityTag` and `indexDynamicBoost`.