### PR TITLE
OAK-12131 : Remove Guava references from FutureUtilsTest

### DIFF
--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/internal/concurrent/FutureUtilsTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/internal/concurrent/FutureUtilsTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.jackrabbit.oak.commons.internal.concurrent;
 
-import org.apache.jackrabbit.guava.common.util.concurrent.Futures;
-import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
-import org.apache.jackrabbit.guava.common.util.concurrent.SettableFuture;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,21 +35,11 @@ public class FutureUtilsTest {
     public void successfulAsListAllSuccessful() throws Exception {
         CompletableFuture<String> cf1 = CompletableFuture.completedFuture("a");
         CompletableFuture<String> cf2 = CompletableFuture.completedFuture("b");
-        List<CompletableFuture<String>> jdkFutures = Arrays.asList(cf1, cf2);
+        List<CompletableFuture<String>> futures = Arrays.asList(cf1, cf2);
 
-        SettableFuture<String> lf1 = SettableFuture.create();
-        SettableFuture<String> lf2 = SettableFuture.create();
-        lf1.set("a");
-        lf2.set("b");
-        List<ListenableFuture<String>> guavaFutures = Arrays.asList(lf1, lf2);
+        List<String> result = FutureUtils.successfulAsList(futures).get();
 
-        // Native JDK method
-        List<String> jdkResults = FutureUtils.successfulAsList(jdkFutures).get();
-
-        // Guava method (blocking)
-        List<String> guavaResults = Futures.successfulAsList(guavaFutures).get();
-
-        Assert.assertEquals(guavaResults, jdkResults);
+        Assert.assertEquals(Arrays.asList("a", "b"), result);
     }
 
     @Test
@@ -60,21 +47,11 @@ public class FutureUtilsTest {
         CompletableFuture<String> cf1 = CompletableFuture.completedFuture("a");
         CompletableFuture<String> cf2 = new CompletableFuture<>();
         cf2.completeExceptionally(new RuntimeException("fail"));
-        List<CompletableFuture<String>> jdkFutures = Arrays.asList(cf1, cf2);
+        List<CompletableFuture<String>> futures = Arrays.asList(cf1, cf2);
 
-        SettableFuture<String> lf1 = SettableFuture.create();
-        SettableFuture<String> lf2 = SettableFuture.create();
-        lf1.set("a");
-        lf2.setException(new RuntimeException("fail"));
-        List<ListenableFuture<String>> guavaFutures = Arrays.asList(lf1, lf2);
+        List<String> result = FutureUtils.successfulAsList(futures).get();
 
-        // Native JDK method
-        List<String> jdkResults = FutureUtils.successfulAsList(jdkFutures).get();
-
-        // Guava method (blocking)
-        List<String> guavaResults = Futures.successfulAsList(guavaFutures).get();
-
-        Assert.assertEquals(guavaResults, jdkResults);
+        Assert.assertEquals(Arrays.asList("a", null), result);
     }
 
     @Test
@@ -83,54 +60,29 @@ public class FutureUtilsTest {
         cf1.completeExceptionally(new RuntimeException("fail A"));
         CompletableFuture<String> cf2 = new CompletableFuture<>();
         cf2.completeExceptionally(new RuntimeException("fail B"));
-        List<CompletableFuture<String>> jdkFutures = Arrays.asList(cf1, cf2);
+        List<CompletableFuture<String>> futures = Arrays.asList(cf1, cf2);
 
-        SettableFuture<String> lf1 = SettableFuture.create();
-        SettableFuture<String> lf2 = SettableFuture.create();
-        lf1.setException(new RuntimeException("fail A"));
-        lf2.setException(new RuntimeException("fail B"));
-        List<ListenableFuture<String>> guavaFutures = Arrays.asList(lf1, lf2);
+        List<String> result = FutureUtils.successfulAsList(futures).get();
 
-        // Native JDK method
-        List<String> jdkResults = FutureUtils.successfulAsList(jdkFutures).get();
-
-        // Guava method (blocking)
-        List<String> guavaResults = Futures.successfulAsList(guavaFutures).get();
-
-        Assert.assertEquals(guavaResults, jdkResults);
+        Assert.assertEquals(Arrays.asList(null, null), result);
     }
 
     @Test
     public void successfulAsListEmptyList() throws Exception {
-        List<CompletableFuture<String>> jdkFutures = List.of();
-        List<ListenableFuture<String>> guavaFutures = List.of();
+        List<Object> result = FutureUtils.successfulAsList(List.of()).get();
 
-        List<String> jdkResult = FutureUtils.successfulAsList(jdkFutures).get();
-        List<String> guavaResult = Futures.successfulAsList(guavaFutures).get();
-
-        Assert.assertEquals(guavaResult, jdkResult);
-        Assert.assertTrue(jdkResult.isEmpty());
+        Assert.assertTrue(result.isEmpty());
     }
 
     @Test
     public void allAsListAllSuccessful() throws Exception {
         CompletableFuture<String> cf1 = CompletableFuture.completedFuture("foo");
         CompletableFuture<String> cf2 = CompletableFuture.completedFuture("bar");
-        List<CompletableFuture<String>> jdkFutures = Arrays.asList(cf1, cf2);
+        List<CompletableFuture<String>> futures = Arrays.asList(cf1, cf2);
 
-        SettableFuture<String> lf1 = SettableFuture.create();
-        SettableFuture<String> lf2 = SettableFuture.create();
-        lf1.set("foo");
-        lf2.set("bar");
-        List<ListenableFuture<String>> guavaFutures = Arrays.asList(lf1, lf2);
+        List<String> result = FutureUtils.allAsList(futures).get();
 
-        // Native JDK method
-        List<String> jdkResults = FutureUtils.allAsList(jdkFutures).get();
-
-        // Guava method (blocking)
-        List<String> guavaResults = Futures.allAsList(guavaFutures).get();
-
-        Assert.assertEquals(guavaResults, jdkResults);
+        Assert.assertEquals(Arrays.asList("foo", "bar"), result);
     }
 
     @Test
@@ -138,32 +90,17 @@ public class FutureUtilsTest {
         CompletableFuture<String> cf1 = CompletableFuture.completedFuture("ok");
         CompletableFuture<String> cf2 = new CompletableFuture<>();
         cf2.completeExceptionally(new IllegalStateException("fail"));
-        List<CompletableFuture<String>> jdkFutures = Arrays.asList(cf1, cf2);
+        List<CompletableFuture<String>> futures = Arrays.asList(cf1, cf2);
 
-        SettableFuture<String> lf1 = SettableFuture.create();
-        SettableFuture<String> lf2 = SettableFuture.create();
-        lf1.set("ok");
-        lf2.setException(new IllegalStateException("fail"));
-        List<ListenableFuture<String>> guavaFutures = Arrays.asList(lf1, lf2);
-
-        boolean jdkFailed;
+        boolean failed;
         try {
-            FutureUtils.allAsList(jdkFutures).get();
-            jdkFailed = false;
+            FutureUtils.allAsList(futures).get();
+            failed = false;
         } catch (ExecutionException e) {
-            jdkFailed = true;
+            failed = true;
         }
 
-        boolean guavaFailed;
-        try {
-            Futures.allAsList(guavaFutures).get();
-            guavaFailed = false;
-        } catch (ExecutionException e) {
-            guavaFailed = true;
-        }
-
-        Assert.assertTrue(jdkFailed);
-        Assert.assertTrue(guavaFailed);
+        Assert.assertTrue(failed);
     }
 
     @Test
@@ -172,44 +109,24 @@ public class FutureUtilsTest {
         cf1.completeExceptionally(new RuntimeException("f1 failed"));
         CompletableFuture<String> cf2 = new CompletableFuture<>();
         cf2.completeExceptionally(new RuntimeException("f2 failed"));
-        List<CompletableFuture<String>> jdkFutures = Arrays.asList(cf1, cf2);
+        List<CompletableFuture<String>> futures = Arrays.asList(cf1, cf2);
 
-        SettableFuture<String> lf1 = SettableFuture.create();
-        SettableFuture<String> lf2 = SettableFuture.create();
-        lf1.setException(new RuntimeException("f1 failed"));
-        lf2.setException(new RuntimeException("f2 failed"));
-        List<ListenableFuture<String>> guavaFutures = Arrays.asList(lf1, lf2);
-
-        boolean jdkFailed;
+        boolean failed;
         try {
-            FutureUtils.allAsList(jdkFutures).get();
-            jdkFailed = false;
+            FutureUtils.allAsList(futures).get();
+            failed = false;
         } catch (ExecutionException e) {
-            jdkFailed = true;
+            failed = true;
         }
 
-        boolean guavaFailed;
-        try {
-            Futures.allAsList(guavaFutures).get();
-            guavaFailed = false;
-        } catch (ExecutionException e) {
-            guavaFailed = true;
-        }
-
-        Assert.assertTrue(jdkFailed);
-        Assert.assertTrue(guavaFailed);
+        Assert.assertTrue(failed);
     }
 
     @Test
     public void allAsListEmptyList() throws Exception {
-        List<CompletableFuture<String>> jdkFutures = List.of();
-        List<ListenableFuture<String>> guavaFutures = List.of();
+        List<Object> result = FutureUtils.allAsList(List.of()).get();
 
-        List<String> jdkResult = FutureUtils.allAsList(jdkFutures).get();
-        List<String> guavaResult = Futures.allAsList(guavaFutures).get();
-
-        Assert.assertTrue(jdkResult.isEmpty());
-        Assert.assertTrue(guavaResult.isEmpty());
+        Assert.assertTrue(result.isEmpty());
     }
 
 }


### PR DESCRIPTION
## Summary

Removes all Guava `SettableFuture`, `ListenableFuture`, and `Futures` usages from `FutureUtilsTest`. Tests previously compared JDK results against Guava results to verify parity; they now assert directly against known expected values.

## Changes

- `FutureUtilsTest.java`:
  - Removed imports: `Futures`, `ListenableFuture`, `SettableFuture`
  - Rewrote all 8 tests to assert against explicit expected values instead of comparing with Guava equivalents
  - `successfulAsList` tests assert `null` for failed futures (matching documented behaviour)
  - `allAsList` failure tests assert that `ExecutionException` is thrown

## Test Plan

- [ ] All 8 `FutureUtilsTest` tests pass
- [ ] No Guava imports remain in the file

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-12131