### PR TITLE
OAK-12128: Fail earlier (and add more diags) when detecting late writes

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -63,7 +63,7 @@
     <logback.version>1.2.13</logback.version>
     <h2.version>2.1.214</h2.version>
     <tika.version>1.28.5</tika.version>
-    <derby.version>10.15.2.0</derby.version>
+    <derby.version>10.16.1.1</derby.version>
     <jackson.version>2.17.3</jackson.version>
     <testcontainers.version>1.21.4</testcontainers.version>
     <pax-exam.version>4.14.0</pax-exam.version>

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -27,7 +27,6 @@ import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.Document;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
-import org.apache.jackrabbit.oak.plugins.document.DocumentStoreException;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.apache.jackrabbit.oak.plugins.document.Throttler;
 import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
@@ -119,10 +118,9 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
 
     @Override
     public <T extends Document> int remove(Collection<T> collection,
-                                           String indexedProperty, long startValue, long endValue)
-            throws DocumentStoreException {
+                                           String indexedProperty, long startValue, long endValue) {
         return leaseChecking(() ->
-            delegate.remove(collection, indexedProperty, startValue, endValue));
+                delegate.remove(collection, indexedProperty, startValue, endValue));
     }
 
     @Override
@@ -258,20 +256,18 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
         return delegate.throttler();
     }
 
+    // invoke operation with lease check before/after
     private <T> T leaseChecking(Supplier<T> operation) {
         performLeaseCheck();
-        try {
-            return operation.get();
-        } finally {
-            performLeaseCheck();
-        }
+        T result = operation.get();
+        performLeaseCheck();
+        return result;
     }
+
+    // invoke operation with lease check before/after
     private void leaseChecking(Runnable operation) {
         performLeaseCheck();
-        try {
-            operation.run();
-        } finally {
-            performLeaseCheck();
-        }
+        operation.run();
+        performLeaseCheck();
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -32,7 +32,6 @@ import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.apache.jackrabbit.oak.plugins.document.Throttler;
 import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
 import org.jetbrains.annotations.NotNull;
-import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,14 +84,14 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
     }
 
     @Override
-    public <T extends Document> @NonNull List<T> query(Collection<T> collection,
+    public <T extends Document> @NotNull List<T> query(Collection<T> collection,
                                                        String fromKey, String toKey, int limit) {
         return leaseChecking(() ->
                 delegate.query(collection, fromKey, toKey, limit));
     }
 
     @Override
-    public <T extends Document> @NonNull List<T> query(Collection<T> collection,
+    public <T extends Document> @NotNull List<T> query(Collection<T> collection,
                                                        String fromKey, String toKey, String indexedProperty,
                                                        long startValue, int limit) {
         return leaseChecking(() ->
@@ -100,10 +99,9 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
     }
 
     @Override
-    @NotNull
-    public <T extends Document> List<T> query(final Collection<T> collection, final String fromKey, final String toKey,
-                                              final String indexedProperty, final long startValue, final int limit,
-                                              final List<String> projection) {
+    public <T extends Document> @NotNull List<T> query(final Collection<T> collection, final String fromKey, final String toKey,
+                                                       final String indexedProperty, final long startValue, final int limit,
+                                                       final List<String> projection) {
         return leaseChecking(() ->
                 delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit, projection));
     }
@@ -164,8 +162,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
     }
 
     @Override
-    @NotNull
-    public <T extends Document> List<T> findAndUpdate(@NotNull Collection<T> collection, @NotNull List<UpdateOp> updateOps) {
+    public <T extends Document> @NotNull List<T> findAndUpdate(@NotNull Collection<T> collection, @NotNull List<UpdateOp> updateOps) {
         return leaseChecking(() ->
                 delegate.findAndUpdate(collection, updateOps));
     }
@@ -225,9 +222,8 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
         return leaseChecking(delegate::getMetadata);
     }
 
-    @NotNull
     @Override
-    public Map<String, String> getStats() {
+    public @NotNull Map<String, String> getStats() {
         return leaseChecking(delegate::getStats);
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -20,6 +20,7 @@ package org.apache.jackrabbit.oak.plugins.document.util;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo;
@@ -52,38 +53,39 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
         this.clusterNodeInfo = clusterNodeInfo;
     }
 
-    private final void performLeaseCheck() {
+    private void performLeaseCheck() {
         if (clusterNodeInfo != null) {
             clusterNodeInfo.performLeaseCheck();
         }
     }
 
     @Override
-    public final <T extends Document> T find(Collection<T> collection, String key) {
-        performLeaseCheck();
-        return delegate.find(collection, key);
+    public <T extends Document> T find(Collection<T> collection, String key) {
+        return leaseChecking(() ->
+                delegate.find(collection, key));
     }
 
     @Override
-    public final <T extends Document> T find(Collection<T> collection, String key,
-            int maxCacheAge) {
-        performLeaseCheck();
-        return delegate.find(collection, key, maxCacheAge);
+    public <T extends Document> T find(Collection<T> collection, String key,
+                                       int maxCacheAge) {
+        return leaseChecking(() ->
+                delegate.find(collection, key, maxCacheAge));
+
     }
 
     @Override
-    public final <T extends Document> List<T> query(Collection<T> collection,
-            String fromKey, String toKey, int limit) {
-        performLeaseCheck();
-        return delegate.query(collection, fromKey, toKey, limit);
+    public <T extends Document> List<T> query(Collection<T> collection,
+                                              String fromKey, String toKey, int limit) {
+        return leaseChecking(() ->
+                delegate.query(collection, fromKey, toKey, limit));
     }
 
     @Override
-    public final <T extends Document> List<T> query(Collection<T> collection,
-            String fromKey, String toKey, String indexedProperty,
-            long startValue, int limit) {
-        performLeaseCheck();
-        return delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit);
+    public <T extends Document> List<T> query(Collection<T> collection,
+                                              String fromKey, String toKey, String indexedProperty,
+                                              long startValue, int limit) {
+        return leaseChecking(() ->
+                delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit));
     }
 
     @Override
@@ -91,94 +93,94 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
     public <T extends Document> List<T> query(final Collection<T> collection, final String fromKey, final String toKey,
                                               final String indexedProperty, final long startValue, final int limit,
                                               final List<String> projection) {
-        performLeaseCheck();
-        return delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit, projection);
+        return leaseChecking(() ->
+                delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit, projection));
     }
 
     @Override
-    public final <T extends Document> void remove(Collection<T> collection, String key) {
-        performLeaseCheck();
-        delegate.remove(collection, key);
+    public <T extends Document> void remove(Collection<T> collection, String key) {
+        leaseChecking(() ->
+                delegate.remove(collection, key));
     }
 
     @Override
-    public final <T extends Document> void remove(Collection<T> collection,
-            List<String> keys) {
-        performLeaseCheck();
-        delegate.remove(collection, keys);
+    public <T extends Document> void remove(Collection<T> collection,
+                                            List<String> keys) {
+        leaseChecking(() ->
+                delegate.remove(collection, keys));
     }
 
     @Override
-    public final <T extends Document> int remove(Collection<T> collection,
-            Map<String, Long> toRemove) {
-        performLeaseCheck();
-        return delegate.remove(collection, toRemove);
+    public <T extends Document> int remove(Collection<T> collection,
+                                           Map<String, Long> toRemove) {
+        return leaseChecking(() ->
+                delegate.remove(collection, toRemove));
     }
 
     @Override
-    public<T extends Document> int remove(Collection<T> collection,
-                                          String indexedProperty, long startValue, long endValue)
+    public <T extends Document> int remove(Collection<T> collection,
+                                           String indexedProperty, long startValue, long endValue)
             throws DocumentStoreException {
-        performLeaseCheck();
-        return delegate.remove(collection, indexedProperty, startValue, endValue);
+        return leaseChecking(() ->
+            delegate.remove(collection, indexedProperty, startValue, endValue));
     }
 
     @Override
-    public final <T extends Document> boolean create(Collection<T> collection,
-            List<UpdateOp> updateOps) {
-        performLeaseCheck();
-        return delegate.create(collection, updateOps);
+    public <T extends Document> boolean create(Collection<T> collection,
+                                               List<UpdateOp> updateOps) {
+        return leaseChecking(() ->
+                delegate.create(collection, updateOps));
     }
 
     @Override
-    public final <T extends Document> T createOrUpdate(Collection<T> collection,
-            UpdateOp update) {
-        performLeaseCheck();
-        return delegate.createOrUpdate(collection, update);
+    public <T extends Document> T createOrUpdate(Collection<T> collection,
+                                                 UpdateOp update) {
+        return leaseChecking(() ->
+                delegate.createOrUpdate(collection, update));
     }
 
     @Override
     public <T extends Document> List<T> createOrUpdate(Collection<T> collection,
-            List<UpdateOp> updateOps) {
-        performLeaseCheck();
-        return delegate.createOrUpdate(collection, updateOps);
+                                                       List<UpdateOp> updateOps) {
+        return leaseChecking(() ->
+                delegate.createOrUpdate(collection, updateOps));
     }
 
     @Override
-    public final <T extends Document> T findAndUpdate(Collection<T> collection,
-            UpdateOp update) {
-        performLeaseCheck();
-        return delegate.findAndUpdate(collection, update);
+    public <T extends Document> T findAndUpdate(Collection<T> collection,
+                                                UpdateOp update) {
+        return leaseChecking(() ->
+                delegate.findAndUpdate(collection, update));
     }
 
     @Override
     @NotNull
     public <T extends Document> List<T> findAndUpdate(@NotNull Collection<T> collection, @NotNull List<UpdateOp> updateOps) {
-        performLeaseCheck();
-        return delegate.findAndUpdate(collection, updateOps);
+        return leaseChecking(() ->
+                delegate.findAndUpdate(collection, updateOps));
     }
 
     @Override
-    public final CacheInvalidationStats invalidateCache() {
-        performLeaseCheck();
-        return delegate.invalidateCache();
+    public CacheInvalidationStats invalidateCache() {
+        return leaseChecking(() ->
+                delegate.invalidateCache());
     }
 
     @Override
-    public final CacheInvalidationStats invalidateCache(Iterable<String> keys) {
-        performLeaseCheck();
-        return delegate.invalidateCache(keys);
+    public CacheInvalidationStats invalidateCache(Iterable<String> keys) {
+        return leaseChecking(() ->
+                delegate.invalidateCache(keys));
     }
 
     @Override
-    public final <T extends Document> void invalidateCache(Collection<T> collection,
-            String key) {
-        performLeaseCheck();
-        delegate.invalidateCache(collection, key);
+    public <T extends Document> void invalidateCache(Collection<T> collection,
+                                                     String key) {
+        leaseChecking(() ->
+            delegate.invalidateCache(collection, key));
     }
 
     @Override
-    public final void dispose() {
+    public void dispose() {
         // this is debatable whether or not a lease check should be done on dispose.
         // I'd say the lease must still be valid as on dispose there could be
         // stuff written to the document store which should only be done
@@ -191,48 +193,48 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
     }
 
     @Override
-    public final <T extends Document> T getIfCached(Collection<T> collection,
-            String key) {
-        performLeaseCheck();
-        return delegate.getIfCached(collection, key);
+    public <T extends Document> T getIfCached(Collection<T> collection,
+                                              String key) {
+        return leaseChecking(() ->
+                delegate.getIfCached(collection, key));
     }
 
     @Override
-    public final void setReadWriteMode(String readWriteMode) {
-        performLeaseCheck();
-        delegate.setReadWriteMode(readWriteMode);
+    public void setReadWriteMode(String readWriteMode) {
+        leaseChecking(() ->
+            delegate.setReadWriteMode(readWriteMode));
     }
 
     @Override
-    public final Iterable<CacheStats> getCacheStats() {
-        performLeaseCheck();
-        return delegate.getCacheStats();
+    public Iterable<CacheStats> getCacheStats() {
+        return leaseChecking(() ->
+            delegate.getCacheStats());
     }
 
     @Override
-    public final Map<String, String> getMetadata() {
-        performLeaseCheck();
-        return delegate.getMetadata();
+    public Map<String, String> getMetadata() {
+        return leaseChecking(() ->
+                delegate.getMetadata());
     }
 
     @NotNull
     @Override
     public Map<String, String> getStats() {
-        performLeaseCheck();
-        return delegate.getStats();
+        return leaseChecking(() ->
+                delegate.getStats());
     }
 
     @Override
     public long determineServerTimeDifferenceMillis() {
-        performLeaseCheck();
-        return delegate.determineServerTimeDifferenceMillis();
+        return leaseChecking(() ->
+                delegate.determineServerTimeDifferenceMillis());
     }
 
     @Override
     public <T extends Document> void prefetch(Collection<T> collection,
-            Iterable<String> keys) {
-        performLeaseCheck();
-        delegate.prefetch(collection, keys);
+                                              Iterable<String> keys) {
+        leaseChecking(() ->
+                delegate.prefetch(collection, keys));
     }
 
     /**
@@ -242,7 +244,8 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
      */
     @Override
     public int getNodeNameLimit() {
-        return delegate.getNodeNameLimit();
+        return leaseChecking(() ->
+                delegate.getNodeNameLimit());
     }
 
     /**
@@ -253,6 +256,24 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
      */
     @Override
     public Throttler throttler() {
-        return delegate.throttler();
+        return leaseChecking(() ->
+                delegate.throttler());
+    }
+
+    private <T> T leaseChecking(Supplier<T> operation) {
+        performLeaseCheck();
+        try {
+            return operation.get();
+        } finally {
+            performLeaseCheck();
+        }
+    }
+    private void leaseChecking(Runnable operation) {
+        performLeaseCheck();
+        try {
+            operation.run();
+        } finally {
+            performLeaseCheck();
+        }
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -62,7 +62,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
                 clusterNodeInfo.performLeaseCheck();
             } catch (DocumentStoreException ex) {
                 if (after) {
-                    LOG.error("Potential late write operation detected", new Exception("call stack"));
+                    LOG.error("Potential late write operation detected", ex);
                 }
                 throw ex;
             }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -27,10 +27,13 @@ import org.apache.jackrabbit.oak.plugins.document.ClusterNodeInfo;
 import org.apache.jackrabbit.oak.plugins.document.Collection;
 import org.apache.jackrabbit.oak.plugins.document.Document;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;
+import org.apache.jackrabbit.oak.plugins.document.DocumentStoreException;
 import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.apache.jackrabbit.oak.plugins.document.Throttler;
 import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper of another DocumentStore that does a lease check on any method
@@ -42,6 +45,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
 
     private final DocumentStore delegate;
     private final ClusterNodeInfo clusterNodeInfo;
+    private final Logger LOG = LoggerFactory.getLogger(LeaseCheckDocumentStoreWrapper.class);
 
     public LeaseCheckDocumentStoreWrapper(final DocumentStore delegate, final ClusterNodeInfo clusterNodeInfo) {
         if (delegate == null) {
@@ -52,9 +56,16 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
         this.clusterNodeInfo = clusterNodeInfo;
     }
 
-    private void performLeaseCheck() {
+    private void performLeaseCheck(boolean after) {
         if (clusterNodeInfo != null) {
-            clusterNodeInfo.performLeaseCheck();
+            try {
+                clusterNodeInfo.performLeaseCheck();
+            } catch (DocumentStoreException ex) {
+                if (after) {
+                    LOG.error("Potential late write operation detected", new Exception("call stack"));
+                }
+                throw ex;
+            }
         }
     }
 
@@ -258,16 +269,16 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
 
     // invoke operation with lease check before/after
     private <T> T leaseChecking(Supplier<T> operation) {
-        performLeaseCheck();
+        performLeaseCheck(false);
         T result = operation.get();
-        performLeaseCheck();
+        performLeaseCheck(true);
         return result;
     }
 
     // invoke operation with lease check before/after
     private void leaseChecking(Runnable operation) {
-        performLeaseCheck();
+        performLeaseCheck(false);
         operation.run();
-        performLeaseCheck();
+        performLeaseCheck(true);
     }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -256,8 +256,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
      */
     @Override
     public Throttler throttler() {
-        return leaseChecking(() ->
-                delegate.throttler());
+        return delegate.throttler();
     }
 
     private <T> T leaseChecking(Supplier<T> operation) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -32,6 +32,7 @@ import org.apache.jackrabbit.oak.plugins.document.UpdateOp;
 import org.apache.jackrabbit.oak.plugins.document.Throttler;
 import org.apache.jackrabbit.oak.plugins.document.cache.CacheInvalidationStats;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
             throw new IllegalArgumentException("delegate must not be null");
         }
         this.delegate = delegate;
-        // clusterNodeInfo is allowed to be null - eg for testing
+        // clusterNodeInfo is allowed to be null - e.g. for testing
         this.clusterNodeInfo = clusterNodeInfo;
     }
 
@@ -84,16 +85,16 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
     }
 
     @Override
-    public <T extends Document> List<T> query(Collection<T> collection,
-                                              String fromKey, String toKey, int limit) {
+    public <T extends Document> @NonNull List<T> query(Collection<T> collection,
+                                                       String fromKey, String toKey, int limit) {
         return leaseChecking(() ->
                 delegate.query(collection, fromKey, toKey, limit));
     }
 
     @Override
-    public <T extends Document> List<T> query(Collection<T> collection,
-                                              String fromKey, String toKey, String indexedProperty,
-                                              long startValue, int limit) {
+    public <T extends Document> @NonNull List<T> query(Collection<T> collection,
+                                                       String fromKey, String toKey, String indexedProperty,
+                                                       long startValue, int limit) {
         return leaseChecking(() ->
                 delegate.query(collection, fromKey, toKey, indexedProperty, startValue, limit));
     }
@@ -190,7 +191,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
 
     @Override
     public void dispose() {
-        // this is debatable whether or not a lease check should be done on dispose.
+        // this is debatable whether a lease check should be done on dispose.
         // I'd say the lease must still be valid as on dispose there could be
         // stuff written to the document store which should only be done
         // when the lease is valid.
@@ -216,27 +217,23 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
 
     @Override
     public Iterable<CacheStats> getCacheStats() {
-        return leaseChecking(() ->
-            delegate.getCacheStats());
+        return leaseChecking(delegate::getCacheStats);
     }
 
     @Override
     public Map<String, String> getMetadata() {
-        return leaseChecking(() ->
-                delegate.getMetadata());
+        return leaseChecking(delegate::getMetadata);
     }
 
     @NotNull
     @Override
     public Map<String, String> getStats() {
-        return leaseChecking(() ->
-                delegate.getStats());
+        return leaseChecking(delegate::getStats);
     }
 
     @Override
     public long determineServerTimeDifferenceMillis() {
-        return leaseChecking(() ->
-                delegate.determineServerTimeDifferenceMillis());
+        return leaseChecking(delegate::determineServerTimeDifferenceMillis);
     }
 
     @Override

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/LeaseCheckDocumentStoreWrapper.java
@@ -244,8 +244,7 @@ public final class LeaseCheckDocumentStoreWrapper implements DocumentStore {
      */
     @Override
     public int getNodeNameLimit() {
-        return leaseChecking(() ->
-                delegate.getNodeNameLimit());
+        return delegate.getNodeNameLimit();
     }
 
     /**

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBackgroundUpdateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBackgroundUpdateTest.java
@@ -36,10 +36,8 @@ import org.junit.Test;
 
 import static org.apache.jackrabbit.oak.plugins.document.Collection.NODES;
 import static org.apache.jackrabbit.oak.plugins.document.TestUtils.merge;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBackgroundUpdateTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBackgroundUpdateTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DocumentNodeStoreBackgroundUpdateTest {
@@ -109,7 +110,9 @@ public class DocumentNodeStoreBackgroundUpdateTest {
                         ns.runBackgroundOperations();
                         fail("background operations must fail because of lease failure");
                     } catch (Exception ex) {
-                        assertThat(ex.getMessage(), containsString("concurrent update"));
+                        // OAK-12128, LeaseCheckDocumentStoreWrapper will check immediately when method call is done
+                        assertTrue(ex.getMessage(), ex.getMessage().contains("concurrent update") ||
+                                ex.getMessage().contains("failed to update the lease"));
                     }
                 } catch (Throwable t) {
                     exceptions.add(t);


### PR DESCRIPTION
test failures: see https://issues.apache.org/jira/browse/OAK-12128?focusedCommentId=18063476&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18063476