### PR TITLE
OAK-11300 : remove unused common.hash export from oak-shaded-guava

### DIFF
--- a/oak-shaded-guava/pom.xml
+++ b/oak-shaded-guava/pom.xml
@@ -64,6 +64,7 @@
                           <exclude>com/google/common/escape/**</exclude>
                           <exclude>com/google/common/eventbus/**</exclude>
                           <exclude>com/google/common/graph/**</exclude>
+                          <exclude>com/google/common/hash/**</exclude>
                           <exclude>com/google/common/html/**</exclude>
                           <exclude>com/google/common/io/**</exclude>
                           <exclude>com/google/common/net/**</exclude>
@@ -101,7 +102,6 @@
               ${pref}.common.base;version="34.0.0",
               ${pref}.common.cache;version="33.4.2";uses:="${pref}.common.base,${pref}.common.collect,${pref}.common.util.concurrent",
               ${pref}.common.collect;version="34.0.1";uses:="${pref}.common.base",
-              ${pref}.common.hash;version="33.5.0";uses:="${pref}.common.base",
               ${pref}.common.util.concurrent;version="33.5.0";uses:="${pref}.common.base,${pref}.common.collect,${pref}.common.util.concurrent.internal,${pref}.common.primitives",
             </Export-Package>
             <Import-Package>


### PR DESCRIPTION
## Summary

- Removes `common.hash` from `Export-Package` in `oak-shaded-guava/pom.xml` — no class in the codebase imports `org.apache.jackrabbit.guava.common.hash`
- Excludes `com/google/common/hash/**` from the shade plugin filter, consistent with how `common.graph` was removed in the previous commit

## Changes

- `oak-shaded-guava/pom.xml`: add `hash` to shade excludes, remove from `Export-Package`

## Test Plan

- [ ] `mvn apache-rat:check -pl oak-shaded-guava` passes
- [ ] `mvn clean install -pl oak-shaded-guava -DskipTests` passes

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-11300