### PR TITLE
OAK-11946 : migrate cache APIs to Caffeine

### DIFF
--- a/oak-benchmarks/pom.xml
+++ b/oak-benchmarks/pom.xml
@@ -83,6 +83,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-api</artifactId>
             <version>${project.version}</version>

--- a/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/PersistentCacheTest.java
+++ b/oak-benchmarks/src/main/java/org/apache/jackrabbit/oak/benchmark/PersistentCacheTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.jcr.Repository;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.fixture.OakFixture;
 import org.apache.jackrabbit.oak.fixture.OakRepositoryFixture;

--- a/oak-blob-cloud-azure/pom.xml
+++ b/oak-blob-cloud-azure/pom.xml
@@ -172,6 +172,10 @@
             <artifactId>oak-shaded-guava</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <!-- Dependencies to other Oak components -->
         <dependency>

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -38,8 +38,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStoreException;
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.spi.blob.AbstractDataRecord;
@@ -767,7 +767,7 @@ public class AzureBlobStoreBackend extends AbstractAzureBlobStoreBackend {
         // max size 0 or smaller is used to turn off the cache
         if (maxSize > 0) {
             LOG.info("presigned GET URI cache enabled, maxSize = {} items, expiry = {} seconds", maxSize, httpDownloadURIExpirySeconds / 2);
-            httpDownloadURICache = CacheBuilder.newBuilder()
+            httpDownloadURICache = Caffeine.newBuilder()
                     .maximumSize(maxSize)
                     .expireAfterWrite(httpDownloadURIExpirySeconds / 2, TimeUnit.SECONDS)
                     .build();

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/v8/AzureBlobStoreBackendV8.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/v8/AzureBlobStoreBackendV8.java
@@ -62,8 +62,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.jackrabbit.oak.commons.collections.AbstractIterator;
 import org.apache.jackrabbit.oak.commons.time.Stopwatch;
 
@@ -731,7 +731,7 @@ public class AzureBlobStoreBackendV8 extends AbstractAzureBlobStoreBackend {
         // max size 0 or smaller is used to turn off the cache
         if (maxSize > 0) {
             LOG.info("presigned GET URI cache enabled, maxSize = {} items, expiry = {} seconds", maxSize, httpDownloadURIExpirySeconds / 2);
-            httpDownloadURICache = CacheBuilder.newBuilder()
+            httpDownloadURICache = Caffeine.newBuilder()
                     .maximumSize(maxSize)
                     .expireAfterWrite(httpDownloadURIExpirySeconds / 2, TimeUnit.SECONDS)
                     .build();

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStoreException;
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.api.blob.BlobDownloadOptions;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordDownloadOptions;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordUpload;

--- a/oak-blob-cloud/pom.xml
+++ b/oak-blob-cloud/pom.xml
@@ -46,7 +46,6 @@
 
                             <!-- Jackrabbit/Oak -->
                             org.apache.jackrabbit.core.data,
-                            org.apache.jackrabbit.guava.common.cache,
                             org.apache.jackrabbit.oak.commons.*,
                             org.apache.jackrabbit.oak.plugins.blob.*,
                             org.apache.jackrabbit.oak.spi.blob,

--- a/oak-blob-cloud/pom.xml
+++ b/oak-blob-cloud/pom.xml
@@ -431,6 +431,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
+++ b/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
@@ -63,8 +63,8 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -812,7 +812,7 @@ public class S3Backend extends AbstractSharedBackend {
         // max size 0 or smaller is used to turn off the cache
         if (maxSize > 0) {
             LOG.info("presigned GET URI cache enabled, maxSize = {} items, expiry = {} seconds", maxSize, httpDownloadURIExpirySeconds / 2);
-            httpDownloadURICache = CacheBuilder.newBuilder()
+            httpDownloadURICache = Caffeine.newBuilder()
                     .maximumSize(maxSize)
                     // cache for half the expiry time of the URIs before giving out new ones
                     .expireAfterWrite(httpDownloadURIExpirySeconds / 2, TimeUnit.SECONDS)

--- a/oak-blob-plugins/pom.xml
+++ b/oak-blob-plugins/pom.xml
@@ -132,6 +132,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/AbstractSharedCachingDataStore.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/AbstractSharedCachingDataStore.java
@@ -46,7 +46,7 @@ import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStoreException;
 import org.apache.jackrabbit.core.data.MultiDataStoreAware;
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.TypedDataStore;
 import org.apache.jackrabbit.oak.spi.blob.AbstractDataRecord;
 import org.apache.jackrabbit.oak.spi.blob.AbstractSharedBackend;

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/CachingBlobStore.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/CachingBlobStore.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.blob;
 
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.StringUtils;

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/CompositeDataStoreCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/CompositeDataStoreCache.java
@@ -27,8 +27,7 @@ import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.jackrabbit.guava.common.cache.AbstractCache;
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import org.apache.jackrabbit.oak.commons.IOUtils;
 import org.apache.jackrabbit.oak.stats.StatisticsProvider;
 import org.jetbrains.annotations.Nullable;
@@ -37,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  */
-public class CompositeDataStoreCache extends AbstractCache<String, File> implements Closeable {
+public class CompositeDataStoreCache implements Closeable {
     /**
      * Logger instance.
      */
@@ -96,7 +95,6 @@ public class CompositeDataStoreCache extends AbstractCache<String, File> impleme
     }
 
     @Nullable
-    @Override
     public File getIfPresent(Object key) {
         return getIfPresent((String) key);
     }
@@ -116,7 +114,6 @@ public class CompositeDataStoreCache extends AbstractCache<String, File> impleme
         }
     }
 
-    @Override
     public void invalidate(Object key) {
         stagingCache.invalidate((String) key);
         downloadCache.invalidate(key);

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/FileCache.java
@@ -35,10 +35,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.StringUtils;
@@ -49,11 +49,9 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.cache.AbstractCache;
-
 /**
  */
-public class FileCache extends AbstractCache<String, File> implements Closeable {
+public class FileCache implements Closeable {
     /**
      * Logger instance.
      */
@@ -201,7 +199,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
      * Get the current entry count (number of files).
      */
     public long getEntryCount() {
-        return cache.size();
+        return cache.estimatedSize();
     }
 
     private FileCache() {
@@ -257,7 +255,6 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
      * @param key of the file
      * @param file to put into cache
      */
-    @Override
     public void put(String key, File file) {
         adjustSize();
         put(key, file, true);
@@ -302,7 +299,6 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     }
 
     @Nullable
-    @Override
     public File getIfPresent(Object key) {
         return getIfPresent((String) key);
     }
@@ -320,7 +316,7 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
     }
 
     private void adjustSize() {
-        long currentSize = cache.size();
+        long currentSize = cache.estimatedSize();
         if (currentSize > highWaterMark) {
             highWaterMark = currentSize;
             // low for each additional 50'000 entries
@@ -362,11 +358,10 @@ public class FileCache extends AbstractCache<String, File> implements Closeable 
         // never grow larger than the configured size
         currentBlockLimit = Math.min(currentBlockLimit, maxBlocks);
         LOG.info("Shrinking the file cache size to {} because there are {} files (limit: {})",
-                currentBlockLimit, cache.size(), maxEntryCount);
+                currentBlockLimit, cache.estimatedSize(), maxEntryCount);
         cache.setMaxMemory(currentBlockLimit);
     }
 
-    @Override
     public void invalidate(Object key) {
         cache.invalidate(key);
     }

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/UploadStagingCache.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/UploadStagingCache.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.core.data.DataStoreException;
 import org.apache.jackrabbit.oak.commons.StringUtils;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;

--- a/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStore.java
+++ b/oak-blob-plugins/src/main/java/org/apache/jackrabbit/oak/plugins/blob/datastore/DataStoreBlobStore.java
@@ -34,8 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import javax.jcr.RepositoryException;
@@ -47,8 +46,8 @@ import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStore;
 import org.apache.jackrabbit.core.data.DataStoreException;
 import org.apache.jackrabbit.core.data.MultiDataStoreAware;
-import org.apache.jackrabbit.guava.common.cache.LoadingCache;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.blob.BlobAccessProvider;
 import org.apache.jackrabbit.oak.api.blob.BlobDownloadOptions;
@@ -420,19 +419,16 @@ public class DataStoreBlobStore
                 && blobId.hasLengthInfo()
                 && blobId.length <= maxCachedBinarySize) {
             try {
-                byte[] content = cache.get(blobId.blobId, new Callable<byte[]>() {
-                    @Override
-                    public byte[] call() throws Exception {
-                        boolean threw = true;
-                        try (InputStream stream = getStream(blobId.blobId)) {
-                            byte[] result = IOUtils.toByteArray(stream);
-                            return result;
-                        }
+                byte[] content = cache.get(blobId.blobId, key -> {
+                    try (InputStream stream = getStream(key)) {
+                        return IOUtils.toByteArray(stream);
+                    } catch (IOException e) {
+                        throw new CompletionException(e);
                     }
                 });
 
                 return new ByteArrayInputStream(content);
-            } catch (ExecutionException e) {
+            } catch (CompletionException e) {
                 log.warn("Error occurred while loading bytes from steam while fetching for id {}", encodedBlobId, e);
             }
         }

--- a/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/AbstractDataStoreCacheTest.java
+++ b/oak-blob-plugins/src/test/java/org/apache/jackrabbit/oak/plugins/blob/AbstractDataStoreCacheTest.java
@@ -55,7 +55,7 @@ import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.jackrabbit.core.data.DataIdentifier;
 import org.apache.jackrabbit.core.data.DataRecord;
 import org.apache.jackrabbit.core.data.DataStoreException;
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import org.apache.jackrabbit.oak.commons.FileIOUtils;
 import org.apache.jackrabbit.oak.spi.blob.AbstractDataRecord;
 import org.apache.jackrabbit.oak.spi.blob.AbstractSharedBackend;
@@ -112,7 +112,7 @@ public class AbstractDataStoreCacheTest {
     }
 
 
-    static class TestCacheLoader extends CacheLoader<String, InputStream> {
+    static class TestCacheLoader implements CacheLoader<String, InputStream> {
         protected File root;
 
         public TestCacheLoader(File dir) {

--- a/oak-blob/pom.xml
+++ b/oak-blob/pom.xml
@@ -100,6 +100,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/oak-blob/src/main/java/org/apache/jackrabbit/oak/spi/blob/split/BlobIdSet.java
+++ b/oak-blob/src/main/java/org/apache/jackrabbit/oak/spi/blob/split/BlobIdSet.java
@@ -29,8 +29,8 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.jackrabbit.oak.commons.collections.BloomFilter;
 
 class BlobIdSet {
@@ -46,7 +46,7 @@ class BlobIdSet {
     BlobIdSet(String repositoryDir, String filename) {
         store = new File(new File(repositoryDir), filename);
         bloomFilter = BloomFilter.construct(9000000, 0.03); // 9M entries, 3% false positive rate
-        cache = CacheBuilder.newBuilder().maximumSize(1000).build();
+        cache = Caffeine.newBuilder().maximumSize(1000).build();
         fillBloomFilter();
     }
 

--- a/oak-core-spi/pom.xml
+++ b/oak-core-spi/pom.xml
@@ -124,6 +124,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Caffeine cache -->
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/AbstractCacheStats.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/AbstractCacheStats.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.jackrabbit.oak.api.jmx.CacheStatsMBean;
 import org.apache.jackrabbit.oak.commons.jmx.AnnotatedStandardMBean;
 import org.jetbrains.annotations.NotNull;
@@ -38,8 +38,7 @@ public abstract class AbstractCacheStats extends AnnotatedStandardMBean implemen
     @NotNull
     private final String name;
 
-    private CacheStats lastSnapshot =
-            new CacheStats(0, 0, 0, 0, 0, 0);
+    private CacheStats lastSnapshot = CacheStats.empty();
 
     /**
      * Create a new {@code CacheStatsMBean} for a cache with the given {@code name}.
@@ -62,7 +61,7 @@ public abstract class AbstractCacheStats extends AnnotatedStandardMBean implemen
 
     @Override
     public synchronized void resetStats() {
-        // Cache stats cannot be rest at Guava level. Instead we
+        // Cache stats cannot be reset directly. Instead we
         // take a snapshot and then subtract it from future stats calls
         lastSnapshot = getCurrentStats();
     }
@@ -110,12 +109,12 @@ public abstract class AbstractCacheStats extends AnnotatedStandardMBean implemen
 
     @Override
     public long getLoadExceptionCount() {
-        return stats().loadExceptionCount();
+        return stats().loadFailureCount();
     }
 
     @Override
     public double getLoadExceptionRate() {
-        return stats().loadExceptionRate();
+        return stats().loadFailureRate();
     }
 
     @Override

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
@@ -16,32 +16,31 @@
  */
 package org.apache.jackrabbit.oak.cache;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
-
-import com.github.benmanes.caffeine.cache.CacheLoader;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.github.benmanes.caffeine.cache.Policy;
-import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.Weigher;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.function.Function;
 import org.apache.jackrabbit.oak.commons.annotations.Internal;
 import org.jetbrains.annotations.NotNull;
@@ -743,7 +742,6 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
                     }
                     @Override public long getMaximum() { return self.getMaxMemory(); }
                     @Override public void setMaximum(long maximum) { self.setMaxMemory(maximum); }
-                    // TODO: return actual LIRS hot/cold segment data instead of empty maps
                     @Override public Map<K, V> coldest(int limit) { return Collections.emptyMap(); }
                     @Override public Map<K, V> coldestWeighted(long weightLimit) { return Collections.emptyMap(); }
                     @Override public Map<K, V> hottest(int limit) { return Collections.emptyMap(); }

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
@@ -31,13 +31,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
-import org.apache.jackrabbit.guava.common.cache.LoadingCache;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
-import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 import org.apache.jackrabbit.oak.commons.annotations.Internal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -284,6 +289,19 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
     }
 
     @Override
+    public V get(K key, Function<? super K, ? extends V> mappingFunction) {
+        int hash = getHash(key);
+        try {
+            return getSegment(hash).get(key, hash, () -> mappingFunction.apply(key));
+        } catch (ExecutionException e) {
+            throw new CompletionException(e.getCause());
+        }
+    }
+
+    /**
+     * @deprecated use {@link #get(Object, Function)} instead
+     */
+    @Deprecated
     public V get(K key, Callable<? extends V> valueLoader)
             throws ExecutionException {
         int hash = getHash(key);
@@ -293,33 +311,31 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
     /**
      * Get the value, loading it if needed.
      * <p>
-     * If there is an exception loading, an RuntimeException is
-     * thrown.
+     * If there is an exception loading, a RuntimeException is thrown.
      *
      * @param key the key
      * @return the value
-     * @throws RuntimeException
      */
-    @Override
     public V getUnchecked(K key) {
-        try {
-            return get(key);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
-        }
+        return get(key);
     }
 
     /**
      * Get the value, loading it if needed.
+     * <p>
+     * Throws {@link CompletionException} (unchecked) if loading fails.
      *
      * @param key the key
      * @return the value
-     * @throws ExecutionException
      */
     @Override
-    public V get(K key) throws ExecutionException {
+    public V get(K key) {
         int hash = getHash(key);
-        return getSegment(hash).get(key, hash, loader);
+        try {
+            return getSegment(hash).get(key, hash, loader);
+        } catch (ExecutionException e) {
+            throw new CompletionException(e.getCause());
+        }
     }
 
     /**
@@ -327,18 +343,39 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
      * <p>
      * If there is an exception while loading, it is logged and ignored. This
      * method calls CacheLoader.reload, but synchronously replaces the old
-     * value.
+     * value. Returns a completed future with the refreshed value.
      *
      * @param key the key
+     * @return a completed future with the value after refresh
      */
     @Override
-    public void refresh(K key) {
+    public CompletableFuture<V> refresh(K key) {
         int hash = getHash(key);
         try {
             getSegment(hash).refresh(key, hash, loader);
         } catch (ExecutionException e) {
             LOG.warn("Could not refresh value for key " + key, e);
         }
+        return CompletableFuture.completedFuture(getIfPresent(key));
+    }
+
+    /**
+     * Re-load the values for the given keys.
+     *
+     * @param keys the keys to refresh
+     * @return a completed future with a map of key-value pairs after refresh
+     */
+    @Override
+    public CompletableFuture<Map<K, V>> refreshAll(Iterable<? extends K> keys) {
+        Map<K, V> result = new HashMap<>();
+        for (K key : keys) {
+            refresh(key);
+            V v = getIfPresent(key);
+            if (v != null) {
+                result.put(key, v);
+            }
+        }
+        return CompletableFuture.completedFuture(result);
     }
 
     V replace(K key, V value) {
@@ -415,10 +452,9 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
         return getSegment(hash).remove(key, hash);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public void invalidateAll(Iterable<?> keys) {
-        for (K k : (Iterable<K>) keys) {
+    public void invalidateAll(Iterable<? extends K> keys) {
+        for (K k : keys) {
             invalidate(k);
         }
     }
@@ -621,7 +657,6 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
      *
      * @return the number of entries
      */
-    @Override
     public long size() {
         int x = 0;
         for (Segment<K, V> s : segments) {
@@ -658,7 +693,12 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
     }
 
     @Override
-    public CacheStats stats() {
+    public long estimatedSize() {
+        return size();
+    }
+
+    @Override
+    public com.github.benmanes.caffeine.cache.stats.CacheStats stats() {
         long hitCount = 0;
         long missCount = 0;
         long loadSuccessCount = 0;
@@ -673,9 +713,52 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
             totalLoadTime += s.totalLoadTime.longValue();
             evictionCount += s.evictionCount.longValue();
         }
-        CacheStats stats = new CacheStats(hitCount, missCount, loadSuccessCount,
-                loadExceptionCount, totalLoadTime, evictionCount);
-        return stats;
+        return com.github.benmanes.caffeine.cache.stats.CacheStats.of(hitCount, missCount,
+                loadSuccessCount, loadExceptionCount, totalLoadTime, evictionCount, 0);
+    }
+
+    @Override
+    public Policy<K, V> policy() {
+        CacheLIRS<K, V> self = this;
+        return new Policy<K, V>() {
+            @Override
+            public boolean isRecordingStats() {
+                return true;
+            }
+            @Override
+            public V getIfPresentQuietly(K key) {
+                return self.peek(key);
+            }
+            @Override
+            public Optional<Policy.Eviction<K, V>> eviction() {
+                return Optional.of(new Policy.Eviction<K, V>() {
+                    @Override public boolean isWeighted() { return true; }
+                    @Override public OptionalLong weightedSize() {
+                        return OptionalLong.of(self.getUsedMemory());
+                    }
+                    @Override public OptionalInt weightOf(K key) {
+                        int mem = self.getMemory(key);
+                        return mem > 0 ? OptionalInt.of(mem) : OptionalInt.empty();
+                    }
+                    @Override public long getMaximum() { return self.getMaxMemory(); }
+                    @Override public void setMaximum(long maximum) { self.setMaxMemory(maximum); }
+                    @Override public Map<K, V> coldest(int limit) { return Collections.emptyMap(); }
+                    @Override public Map<K, V> coldestWeighted(long weightLimit) { return Collections.emptyMap(); }
+                    @Override public Map<K, V> hottest(int limit) { return Collections.emptyMap(); }
+                    @Override public Map<K, V> hottestWeighted(long weightLimit) { return Collections.emptyMap(); }
+                });
+            }
+            @Override
+            public Optional<Policy.FixedExpiration<K, V>> expireAfterAccess() { return Optional.empty(); }
+            @Override
+            public Optional<Policy.FixedExpiration<K, V>> expireAfterWrite() { return Optional.empty(); }
+            @Override
+            public Optional<Policy.FixedRefresh<K, V>> refreshAfterWrite() { return Optional.empty(); }
+            @Override
+            public Map<K, CompletableFuture<V>> refreshes() { return Collections.emptyMap(); }
+            @Override
+            public Optional<Policy.VarExpiration<K, V>> expireVariably() { return Optional.empty(); }
+        };
     }
 
     /**
@@ -1111,8 +1194,7 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
                 if (old == null) {
                     value = loader.load(key);
                 } else {
-                    ListenableFuture<V> future = loader.reload(key, old);
-                    value = future.get();
+                    value = loader.reload(key, old);
                 }
                 loadSuccessCount.increment();
             } catch (Exception e) {
@@ -1649,7 +1731,7 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
     }
 
     @Override
-    public ImmutableMap<K, V> getAllPresent(Iterable<?> keys) {
+    public Map<K, V> getAllPresent(Iterable<? extends K> keys) {
         throw new UnsupportedOperationException();
     }
 
@@ -1760,14 +1842,18 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
     }
 
     @Override
-    public ImmutableMap<K, V> getAll(Iterable<? extends K> keys)
-            throws ExecutionException {
+    public Map<K, V> getAll(Iterable<? extends K> keys) {
         throw new UnsupportedOperationException();
     }
 
     @Override
+    public Map<K, V> getAll(Iterable<? extends K> keys,
+            Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction) {
+        throw new UnsupportedOperationException();
+    }
+
     public V apply(K key) {
-        throw new UnsupportedOperationException();        
+        throw new UnsupportedOperationException();
     }
 
     public boolean isEmpty() {

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheLIRS.java
@@ -343,10 +343,11 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
      * <p>
      * If there is an exception while loading, it is logged and ignored. This
      * method calls CacheLoader.reload, but synchronously replaces the old
-     * value. Returns a completed future with the refreshed value.
+     * value. Returns a completed future with the refreshed value, or a
+     * completed future with {@code null} if refresh failed.
      *
      * @param key the key
-     * @return a completed future with the value after refresh
+     * @return a completed future with the value after refresh, or {@code null} on failure
      */
     @Override
     public CompletableFuture<V> refresh(K key) {
@@ -742,6 +743,7 @@ public class CacheLIRS<K, V> implements LoadingCache<K, V> {
                     }
                     @Override public long getMaximum() { return self.getMaxMemory(); }
                     @Override public void setMaximum(long maximum) { self.setMaxMemory(maximum); }
+                    // TODO: return actual LIRS hot/cold segment data instead of empty maps
                     @Override public Map<K, V> coldest(int limit) { return Collections.emptyMap(); }
                     @Override public Map<K, V> coldestWeighted(long weightLimit) { return Collections.emptyMap(); }
                     @Override public Map<K, V> hottest(int limit) { return Collections.emptyMap(); }

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheStats.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/CacheStats.java
@@ -21,8 +21,8 @@ package org.apache.jackrabbit.oak.cache;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Weigher;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,13 +56,13 @@ public class CacheStats extends AbstractCacheStats {
     }
 
     @Override
-    protected org.apache.jackrabbit.guava.common.cache.CacheStats getCurrentStats() {
+    protected com.github.benmanes.caffeine.cache.stats.CacheStats getCurrentStats() {
         return cache.stats();
     }
 
     @Override
     public long getElementCount() {
-        return cache.size();
+        return cache.estimatedSize();
     }
 
     @Override

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/EmpiricalWeigher.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/EmpiricalWeigher.java
@@ -18,7 +18,7 @@
  */
 package org.apache.jackrabbit.oak.cache;
 
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/package-info.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/package-info.java
@@ -19,7 +19,7 @@
  * <em>For Oak internal use only. Do not use outside Oak components.</em>
  */
 @Internal(since = "1.1.1")
-@Version("2.0")
+@Version("3.0")
 package org.apache.jackrabbit.oak.cache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/package-info.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/package-info.java
@@ -19,7 +19,7 @@
  * <em>For Oak internal use only. Do not use outside Oak components.</em>
  */
 @Internal(since = "1.1.1")
-@Version("3.0")
+@Version("3.0.0")
 package org.apache.jackrabbit.oak.cache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheSizeTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheSizeTest.java
@@ -23,9 +23,9 @@ import java.util.concurrent.ExecutionException;
 import org.apache.jackrabbit.oak.cache.CacheLIRS.EvictionCallback;
 import org.junit.Test;
 
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
 
 /**
  * Test the maximum cache size (for the FileCache).

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheStatsTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheStatsTest.java
@@ -21,13 +21,9 @@ package org.apache.jackrabbit.oak.cache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
-import org.jetbrains.annotations.NotNull;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,14 +31,9 @@ public class CacheStatsTest {
     private static final String NAME = "cache stats";
     private static final int KEYS = 100;
 
-    private final Weigher<Integer, Integer> weigher = new Weigher<Integer, Integer>() {
-        @Override
-        public int weigh(@NotNull Integer key, @NotNull Integer value) {
-            return 1;
-        }
-    };
+    private final Weigher<Integer, Integer> weigher = (key, value) -> 1;
 
-    private final Cache<Integer, Integer> cache = CacheBuilder.newBuilder()
+    private final Cache<Integer, Integer> cache = Caffeine.newBuilder()
                 .recordStats()
                 .maximumWeight(Long.MAX_VALUE)
                 .weigher(weigher)
@@ -64,25 +55,21 @@ public class CacheStatsTest {
         for (int k = 0; k < 100; k++) {
             final int key = 4 * k;
             try {
-                cache.get(key, new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws Exception {
-                        long t0 = System.nanoTime();
-                        try {
-                            if (key % 10 == 0) {
-                                fails++;
-                                throw new Exception("simulated load failure");
-                            } else {
-                                misses++;
-                                return key;
-                            }
-                        } finally {
-                            loadTime += System.nanoTime() - t0;
+                cache.get(key, ignored -> {
+                    long t0 = System.nanoTime();
+                    try {
+                        if (key % 10 == 0) {
+                            fails++;
+                            throw new RuntimeException("simulated load failure");
+                        } else {
+                            misses++;
+                            return key;
                         }
-
+                    } finally {
+                        loadTime += System.nanoTime() - t0;
                     }
                 });
-            } catch (ExecutionException ignore) { }
+            } catch (Exception ignore) { }
         }
     }
 

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheStatsTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheStatsTest.java
@@ -21,7 +21,8 @@ package org.apache.jackrabbit.oak.cache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
 import org.junit.Before;
@@ -33,18 +34,35 @@ public class CacheStatsTest {
 
     private final Weigher<Integer, Integer> weigher = (key, value) -> 1;
 
-    private final Cache<Integer, Integer> cache = Caffeine.newBuilder()
-                .recordStats()
-                .maximumWeight(Long.MAX_VALUE)
-                .weigher(weigher)
-                .build();
-
-    private final CacheStats cacheStats =
-            new CacheStats(cache, NAME, weigher, Long.MAX_VALUE);
-
     private int misses;
     private int fails;
     private long loadTime;
+
+    // Use LoadingCache so that load successes and failures are tracked in stats.
+    // Cache.get(K, Function) does not record load stats in Caffeine.
+    private final LoadingCache<Integer, Integer> cache = Caffeine.newBuilder()
+                .recordStats()
+                .maximumWeight(Long.MAX_VALUE)
+                .weigher(weigher)
+                .build(new CacheLoader<Integer, Integer>() {
+                    @Override
+                    public Integer load(Integer key) {
+                        long t0 = System.nanoTime();
+                        try {
+                            if (key % 10 == 0) {
+                                fails++;
+                                throw new RuntimeException("simulated load failure");
+                            }
+                            misses++;
+                            return key;
+                        } finally {
+                            loadTime += System.nanoTime() - t0;
+                        }
+                    }
+                });
+
+    private final CacheStats cacheStats =
+            new CacheStats(cache, NAME, weigher, Long.MAX_VALUE);
 
     @Before
     public void setup() {
@@ -55,20 +73,7 @@ public class CacheStatsTest {
         for (int k = 0; k < 100; k++) {
             final int key = 4 * k;
             try {
-                cache.get(key, ignored -> {
-                    long t0 = System.nanoTime();
-                    try {
-                        if (key % 10 == 0) {
-                            fails++;
-                            throw new RuntimeException("simulated load failure");
-                        } else {
-                            misses++;
-                            return key;
-                        }
-                    } finally {
-                        loadTime += System.nanoTime() - t0;
-                    }
-                });
+                cache.get(key);
             } catch (Exception ignore) { }
         }
     }

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheTest.java
@@ -596,6 +596,7 @@ public class CacheTest {
     public void testBadLoader() {
         CacheLIRS<Integer, String> cache = createCache(10, 1);
         try {
+            // CacheLIRS rejects null values, so a mapping function returning null triggers NullPointerException
             cache.get(1, k -> null);
             fail();
         } catch (Exception e) {

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/CacheTest.java
@@ -33,19 +33,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS.EvictionCallback;
-import org.apache.jackrabbit.oak.commons.internal.concurrent.FutureConverter;
 import org.junit.Test;
-
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
-import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
 
 /**
  * Tests the LIRS cache.
@@ -356,7 +350,7 @@ public class CacheTest {
     }
     
     @Test
-    public void testNonResidentBecomeHot() throws ExecutionException {
+    public void testNonResidentBecomeHot() {
         CacheLIRS<Integer, Integer> test = createCache(4);
         for (int i = 0; i < 20; i++) {
             test.put(i, 1);
@@ -602,14 +596,7 @@ public class CacheTest {
     public void testBadLoader() {
         CacheLIRS<Integer, String> cache = createCache(10, 1);
         try {
-            cache.get(1, new Callable<String>() {
-
-                @Override
-                public String call() throws Exception {
-                    return null;
-                }
-                
-            });
+            cache.get(1, k -> null);
             fail();
         } catch (Exception e) {
             // expected
@@ -660,7 +647,7 @@ public class CacheTest {
     }
     
     @Test
-    public void testRefresh() throws ExecutionException {
+    public void testRefresh() {
         CacheLIRS<Integer, String> cache = new CacheLIRS.Builder<Integer, String>().
                 maximumWeight(100).
                 weigher(new Weigher<Integer, String>() {
@@ -669,7 +656,7 @@ public class CacheTest {
                     public int weigh(Integer key, String value) {
                         return key + value.length();
                     }
-                    
+
                 }).
                 build(new CacheLoader<Integer, String>() {
 
@@ -679,13 +666,6 @@ public class CacheTest {
                             throw new Exception("Out of range");
                         }
                         return "n" + key;
-                    }
-
-                    @Override
-                    public ListenableFuture<String> reload(Integer key, String oldValue) {
-                        assertTrue(oldValue != null);
-                        CompletableFuture<String> f = CompletableFuture.completedFuture(oldValue);
-                        return FutureConverter.toListenableFuture(f);
                     }
 
                 });
@@ -703,7 +683,7 @@ public class CacheTest {
     }
 
     @Test
-    public void evictionCallback() throws ExecutionException {
+    public void evictionCallback() {
         final Set<String> evictedKeys = new HashSet<>();
         final Set<Integer> evictedValues = new HashSet<>();
         CacheLIRS<String, Integer> cache = CacheLIRS.<String, Integer>newBuilder()
@@ -799,7 +779,7 @@ public class CacheTest {
     }
 
     @Test
-    public void evictionCallbackRandomized() throws ExecutionException {
+    public void evictionCallbackRandomized() {
         final HashMap<Integer, Integer> evictedMap = new HashMap<Integer, Integer>();
         final HashSet<Integer> evictedNonResidentSet = new HashSet<Integer>();
         CacheLIRS<Integer, Integer> cache = CacheLIRS.<Integer, Integer>newBuilder()

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/ConcurrentPerformanceTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/ConcurrentPerformanceTest.java
@@ -21,16 +21,13 @@ package org.apache.jackrabbit.oak.cache;
 import static org.junit.Assert.assertFalse;
 
 import java.util.Random;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
 
 /**
  * Compares the LIRS cache by concurrently reading.
@@ -43,8 +40,7 @@ public class ConcurrentPerformanceTest {
             return new CacheLIRS.Builder<Integer, Integer>()
                     .segmentCount(concurrencyLevel).maximumSize(1000).build();
         }
-        return CacheBuilder.newBuilder().concurrencyLevel(concurrencyLevel)
-                .maximumSize(1000).build();
+        return Caffeine.newBuilder().maximumSize(1000).build();
     }
 
     @Test
@@ -81,19 +77,7 @@ public class ConcurrentPerformanceTest {
                     Random r = new Random();
                     while (!stop.get()) {
                         final int key = r.nextInt(20000);
-                        try {
-                            cache.get(key, new Callable<Integer>() {
-
-                                @Override
-                                public Integer call() throws Exception {
-                                    return key;
-                                }
-
-                            });
-                        } catch (ExecutionException e) {
-                            count.set(Integer.MIN_VALUE);
-                            stop.set(true);
-                        }
+                        cache.get(key, k -> k);
                         count.incrementAndGet();
                     }
                 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/cache/impl/CacheStatsMetricsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/cache/impl/CacheStatsMetricsTest.java
@@ -94,9 +94,9 @@ public class CacheStatsMetricsTest {
         }
 
         @Override
-        protected org.apache.jackrabbit.guava.common.cache.CacheStats getCurrentStats() {
-            return new org.apache.jackrabbit.guava.common.cache.CacheStats(
-                    HIT_COUNT, MISS_COUNT, MISS_COUNT, 0, LOAD_TIME, EVICTION_COUNT);
+        protected com.github.benmanes.caffeine.cache.stats.CacheStats getCurrentStats() {
+            return com.github.benmanes.caffeine.cache.stats.CacheStats.of(
+                    HIT_COUNT, MISS_COUNT, MISS_COUNT, 0, LOAD_TIME, EVICTION_COUNT, 0);
         }
 
         @Override

--- a/oak-it-osgi/src/test/java/org/apache/jackrabbit/oak/osgi/OSGiIT.java
+++ b/oak-it-osgi/src/test/java/org/apache/jackrabbit/oak/osgi/OSGiIT.java
@@ -75,6 +75,7 @@ public class OSGiIT {
                 mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-core").version("2.17.2"),
                 mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-annotations").version("2.17.2"),
                 mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-databind").version("2.17.2"),
+                mavenBundle().groupId("com.github.ben-manes.caffeine").artifactId("caffeine").version("3.1.8"),
 
                 frameworkProperty("repository.home").value("target"),
                 systemProperties(new SystemPropertyOption("felix.fileinstall.dir").value(getConfigDir())),

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -945,6 +945,11 @@
         <version>1.19.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>3.1.8</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/oak-run-commons/pom.xml
+++ b/oak-run-commons/pom.xml
@@ -55,6 +55,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-core</artifactId>
             <version>${project.version}</version>

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 
-import org.apache.commons.io.FileUtils;
 import com.github.benmanes.caffeine.cache.Cache;
+import org.apache.commons.io.FileUtils;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreHelper.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Type;

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -34,6 +34,7 @@
     <jetty.version>9.4.53.v20231009</jetty.version>
     <!--
       Size History:
+      + 88 MB (Caffenine-Banes, OAK-11946)
       + 87 MB (Aws Sdk 2.x, OAK-11935)
       + 84 MB (RDB/Tomcat, OAK-10752)
       + 80 MB (Java 17, OAK-10638)
@@ -52,7 +53,7 @@
       + 41 MB build failing on the release profile (OAK-6250)
       + 38 MB. Initial value. Current 35MB plus a 10%
     -->
-    <max.jar.size>91226112</max.jar.size>
+    <max.jar.size>92093202</max.jar.size>
   </properties>
 
   <build>

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -100,6 +100,10 @@
   </build>
 
   <dependencies>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
     <!-- Optional OSGi dependencies, used only when running within OSGi -->
     <dependency>
       <groupId>org.osgi</groupId>

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -27,19 +27,16 @@ import java.util.concurrent.TimeUnit;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
-import org.apache.jackrabbit.guava.common.base.Ticker;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.apache.jackrabbit.oak.commons.internal.concurrent.ExecutorHelper;
-import org.apache.jackrabbit.oak.commons.internal.concurrent.FutureConverter;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexStatistics;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
-
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
-import org.apache.jackrabbit.guava.common.cache.CacheLoader;
-import org.apache.jackrabbit.guava.common.cache.LoadingCache;
-import org.apache.jackrabbit.guava.common.util.concurrent.ListenableFuture;
 
 import co.elastic.clients.elasticsearch._types.Bytes;
 import co.elastic.clients.elasticsearch.cat.indices.IndicesRecord;
@@ -100,7 +97,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      */
     @Override
     public int numDocs() {
-        return countCache.getUnchecked(new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias()));
+        return countCache.get(new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias()));
     }
 
     /**
@@ -110,7 +107,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
     @Override
     public int getDocCountFor(String field) {
         String elasticField = ElasticIndexUtils.fieldName(field);
-        return countCache.getUnchecked(
+        return countCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias(), elasticField, null)
         );
     }
@@ -120,7 +117,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      * {@code ElasticIndexDefinition}.
      */
     public int getDocCountFor(Query query) {
-        return countCache.getUnchecked(
+        return countCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias(), null, query)
         );
     }
@@ -130,7 +127,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      * {@code ElasticIndexDefinition}.
      */
     public long primaryStoreSize() {
-        return statsCache.getUnchecked(
+        return statsCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias())
         ).primaryStoreSize;
     }
@@ -140,7 +137,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      * primary shards and replica shards.
      */
     public long storeSize() {
-        return statsCache.getUnchecked(
+        return statsCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias())
         ).storeSize;
     }
@@ -149,7 +146,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      * Returns the creation date for the remote index bound to the {@code ElasticIndexDefinition}.
      */
     public long creationDate() {
-        return statsCache.getUnchecked(
+        return statsCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias())
         ).creationDate;
     }
@@ -159,7 +156,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      * {@code ElasticIndexDefinition}. This document count includes hidden nested documents.
      */
     public int luceneNumDocs() {
-        return statsCache.getUnchecked(
+        return statsCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias())
         ).luceneDocsCount;
     }
@@ -169,7 +166,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
      * {@code ElasticIndexDefinition}. This document count includes hidden nested documents.
      */
     public int luceneNumDeletedDocs() {
-        return statsCache.getUnchecked(
+        return statsCache.get(
                 new StatsRequestDescriptor(elasticConnection, indexDefinition.getIndexAlias())
         ).luceneDocsDeleted;
     }
@@ -178,22 +175,18 @@ public class ElasticIndexStatistics implements IndexStatistics {
         return setupCache(maxSize, expireSeconds, refreshSeconds, new CountCacheLoader(), clock);
     }
 
+    @SuppressWarnings("unchecked")
     static <K, V> LoadingCache<K, V> setupCache(long maxSize, long expireSeconds, long refreshSeconds,
                                                 @NotNull CacheLoader<K, V> cacheLoader, @Nullable Clock clock) {
-        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+        Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder()
                 .maximumSize(maxSize)
                 .expireAfterWrite(expireSeconds, TimeUnit.SECONDS)
                 // https://github.com/google/guava/wiki/CachesExplained#refresh
                 .refreshAfterWrite(refreshSeconds, TimeUnit.SECONDS);
         if (clock != null) {
-            cacheBuilder.ticker(new Ticker() {
-                @Override
-                public long read() {
-                    return TimeUnit.MILLISECONDS.toNanos(clock.millis());
-                }
-            });
+            cacheBuilder.ticker(() -> TimeUnit.MILLISECONDS.toNanos(clock.millis()));
         }
-        return cacheBuilder.build(cacheLoader);
+        return ((Caffeine<K, V>) cacheBuilder).build(cacheLoader);
     }
 
     private Long getCacheMaxSize() {
@@ -208,7 +201,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
         return Long.getLong(REFRESH_SECONDS, REFRESH_SECONDS_DEFAULT);
     }
 
-    static class CountCacheLoader extends CacheLoader<StatsRequestDescriptor, Integer> {
+    static class CountCacheLoader implements CacheLoader<StatsRequestDescriptor, Integer> {
 
         @Override
         public @NotNull Integer load(@NotNull StatsRequestDescriptor countRequestDescriptor) throws IOException {
@@ -216,15 +209,15 @@ public class ElasticIndexStatistics implements IndexStatistics {
         }
 
         @Override
-        public @NotNull ListenableFuture<Integer> reload(@NotNull StatsRequestDescriptor crd, @NotNull Integer oldValue) {
-            CompletableFuture<Integer> task = CompletableFuture.supplyAsync(() -> {
+        public @NotNull CompletableFuture<Integer> asyncReload(@NotNull StatsRequestDescriptor crd, @NotNull Integer oldValue,
+                                                               @NotNull java.util.concurrent.Executor executor) {
+            return CompletableFuture.supplyAsync(() -> {
                 try {
                     return count(crd);
                 } catch (IOException e) {
                     throw new CompletionException(e);
                 }
             }, REFRESH_EXECUTOR);
-            return FutureConverter.toListenableFuture(task);
         }
 
         private int count(StatsRequestDescriptor crd) throws IOException {
@@ -241,7 +234,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
         }
     }
 
-    static class StatsCacheLoader extends CacheLoader<StatsRequestDescriptor, StatsResponse> {
+    static class StatsCacheLoader implements CacheLoader<StatsRequestDescriptor, StatsResponse> {
 
         @Override
         public @NotNull StatsResponse load(@NotNull StatsRequestDescriptor countRequestDescriptor) throws IOException {
@@ -249,15 +242,15 @@ public class ElasticIndexStatistics implements IndexStatistics {
         }
 
         @Override
-        public @NotNull ListenableFuture<StatsResponse> reload(@NotNull StatsRequestDescriptor crd, @NotNull StatsResponse oldValue) {
-            CompletableFuture<StatsResponse> task = CompletableFuture.supplyAsync(() -> {
+        public @NotNull CompletableFuture<StatsResponse> asyncReload(@NotNull StatsRequestDescriptor crd, @NotNull StatsResponse oldValue,
+                                                                     @NotNull java.util.concurrent.Executor executor) {
+            return CompletableFuture.supplyAsync(() -> {
                 try {
                     return stats(crd);
                 } catch (IOException e) {
                     throw new CompletionException(e);
                 }
             }, REFRESH_EXECUTOR);
-            return FutureConverter.toListenableFuture(task);
         }
 
         private StatsResponse stats(StatsRequestDescriptor crd) throws IOException {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatistics.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
@@ -31,7 +30,6 @@ import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Ticker;
-import org.apache.jackrabbit.oak.commons.internal.concurrent.ExecutorHelper;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexStatistics;
 import org.jetbrains.annotations.NotNull;
@@ -64,10 +62,6 @@ public class ElasticIndexStatistics implements IndexStatistics {
     private static final String REFRESH_SECONDS = "oak.elastic.statsRefreshSeconds";
     private static final Long REFRESH_SECONDS_DEFAULT = 60L;
 
-    private static final int REFRESH_POOL_SIZE = 4;
-
-    private static final ExecutorService REFRESH_EXECUTOR = ExecutorHelper.linkedQueueExecutor(
-            REFRESH_POOL_SIZE, "elastic-statistics-cache-refresh-%d");
     private final ElasticConnection elasticConnection;
     private final ElasticIndexDefinition indexDefinition;
     private final LoadingCache<StatsRequestDescriptor, Integer> countCache;
@@ -217,7 +211,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
                 } catch (IOException e) {
                     throw new CompletionException(e);
                 }
-            }, REFRESH_EXECUTOR);
+            }, executor);
         }
 
         private int count(StatsRequestDescriptor crd) throws IOException {
@@ -250,7 +244,7 @@ public class ElasticIndexStatistics implements IndexStatistics {
                 } catch (IOException e) {
                     throw new CompletionException(e);
                 }
-            }, REFRESH_EXECUTOR);
+            }, executor);
         }
 
         private StatsResponse stats(StatsRequestDescriptor crd) throws IOException {

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatisticsTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexStatisticsTest.java
@@ -20,7 +20,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.CountResponse;
-import org.apache.jackrabbit.guava.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.apache.jackrabbit.oak.stats.Clock;
 import org.junit.After;
 import org.junit.Before;

--- a/oak-search/pom.xml
+++ b/oak-search/pom.xml
@@ -76,6 +76,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-commons</artifactId>
             <version>${project.version}</version>

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/ExtractedTextCache.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/ExtractedTextCache.java
@@ -36,9 +36,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.IOUtils;
@@ -103,7 +103,7 @@ public class ExtractedTextCache {
     public ExtractedTextCache(long maxWeight, long expiryTimeInSecs, boolean alwaysUsePreExtractedCache,
                               File indexDir, StatisticsProvider statisticsProvider) {
         if (maxWeight > 0) {
-            cache = CacheBuilder.newBuilder()
+            cache = Caffeine.newBuilder()
                     .weigher(EmpiricalWeigher.INSTANCE)
                     .maximumWeight(maxWeight)
                     .expireAfterAccess(expiryTimeInSecs, TimeUnit.SECONDS)

--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -176,6 +176,10 @@
             <artifactId>oak-shaded-guava</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <!-- Dependencies on Oak modules -->
         <dependency>

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CacheWeights.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/CacheWeights.java
@@ -20,7 +20,7 @@ package org.apache.jackrabbit.oak.segment;
 
 import static org.apache.jackrabbit.oak.commons.StringUtils.estimateMemoryUsage;
 
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.segment.ReaderCache.CacheKey;
 import org.jetbrains.annotations.NotNull;
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/ReaderCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/ReaderCache.java
@@ -25,7 +25,7 @@ import static org.apache.jackrabbit.oak.segment.CacheWeights.OBJECT_HEADER_SIZE;
 import java.util.Arrays;
 import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.jetbrains.annotations.NotNull;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordCache.java
@@ -23,10 +23,10 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
-import org.apache.jackrabbit.guava.common.cache.RemovalListener;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Weigher;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -112,7 +112,7 @@ public abstract class RecordCache<K> implements Cache<K, RecordId> {
 
         @Override
         public @NotNull CacheStats getStats() {
-            return new CacheStats(0, missCount.sum(), 0, 0, 0, 0);
+            return CacheStats.of(0, missCount.sum(), 0, 0, 0, 0, 0);
         }
 
         @Override
@@ -137,7 +137,7 @@ public abstract class RecordCache<K> implements Cache<K, RecordId> {
 
     private static class Default<K> extends RecordCache<K> {
         @NotNull
-        private final org.apache.jackrabbit.guava.common.cache.Cache<K, RecordId> cache;
+        private final com.github.benmanes.caffeine.cache.Cache<K, RecordId> cache;
 
         @NotNull
         private final Weigher<K, RecordId> weigher;
@@ -150,8 +150,8 @@ public abstract class RecordCache<K> implements Cache<K, RecordId> {
         public @NotNull CacheStats getStats() {
             CacheStats internalStats = cache.stats();
             // any addition to the cache counts as load by our definition
-            return new CacheStats(internalStats.hitCount(), internalStats.missCount(),
-                    loadCount.sum(), 0, 0,  internalStats.evictionCount());
+            return CacheStats.of(internalStats.hitCount(), internalStats.missCount(),
+                    loadCount.sum(), 0, 0, internalStats.evictionCount(), 0);
         }
 
         static <K> Supplier<RecordCache<K>> defaultFactory(final int size, @NotNull final Weigher<K, RecordId> weigher) {
@@ -159,14 +159,14 @@ public abstract class RecordCache<K> implements Cache<K, RecordId> {
         }
 
         Default(final int size, @NotNull final Weigher<K, RecordId> weigher) {
-            this.cache = CacheBuilder.newBuilder()
+            this.cache = Caffeine.newBuilder()
                     .maximumSize(size * 4L / 3)
                     .initialCapacity(size)
-                    .concurrencyLevel(4)
                     .recordStats()
-                    .removalListener((RemovalListener<K, RecordId>) removal -> {
-                        int removedWeight = weigher.weigh(removal.getKey(), removal.getValue());
-                        weight.add(-removedWeight);
+                    .removalListener((K key, RecordId value, RemovalCause cause) -> {
+                        if (key != null && value != null) {
+                            weight.add(-weigher.weigh(key, value));
+                        }
                     })
                     .build();
             this.weigher = weigher;
@@ -186,7 +186,7 @@ public abstract class RecordCache<K> implements Cache<K, RecordId> {
 
         @Override
         public long size() {
-            return cache.size();
+            return cache.estimatedSize();
         }
 
         @Override

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordCacheStats.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/RecordCacheStats.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.jetbrains.annotations.NotNull;
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/SegmentCache.java
@@ -23,15 +23,16 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.jackrabbit.oak.segment.CacheWeights.segmentWeight;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
-import org.apache.jackrabbit.guava.common.cache.RemovalNotification;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.apache.jackrabbit.oak.segment.CacheWeights.SegmentCacheWeigher;
 import org.jetbrains.annotations.NotNull;
@@ -131,25 +132,27 @@ public abstract class SegmentCache {
          */
         private NonEmptyCache(long cacheSizeMB) {
             long maximumWeight = cacheSizeMB * 1024 * 1024;
-            this.cache = CacheBuilder.newBuilder()
-                    .concurrencyLevel(16)
+            this.cache = Caffeine.newBuilder()
                     .maximumWeight(maximumWeight)
                     .weigher(new SegmentCacheWeigher())
+                    // Use inline executor so removal listeners fire synchronously,
+                    // matching Guava's behaviour (needed for id.unloaded() timing).
+                    .executor(Runnable::run)
                     .removalListener(this::onRemove)
                     .build();
-            this.stats = new Stats(NAME, maximumWeight, cache::size);
+            this.stats = new Stats(NAME, maximumWeight, cache::estimatedSize);
         }
 
         /**
          * Removal handler called whenever an item is evicted from the cache.
          */
-        private void onRemove(@NotNull RemovalNotification<SegmentId, Segment> notification) {
+        private void onRemove(SegmentId key, Segment value, RemovalCause cause) {
             stats.evictionCount.incrementAndGet();
-            if (notification.getValue() != null) {
-                stats.currentWeight.addAndGet(-segmentWeight(notification.getValue()));
+            if (value != null) {
+                stats.currentWeight.addAndGet(-segmentWeight(value));
             }
-            if (notification.getKey() != null) {
-                notification.getKey().unloaded();
+            if (key != null) {
+                key.unloaded();
             }
         }
 
@@ -157,21 +160,31 @@ public abstract class SegmentCache {
         @NotNull
         public Segment getSegment(@NotNull SegmentId id, @NotNull Callable<Segment> loader) throws ExecutionException {
             if (id.isDataSegmentId()) {
-                return cache.get(id, () -> {
-                    try {
-                        long t0 = System.nanoTime();
-                        Segment segment = loader.call();
-                        stats.loadSuccessCount.incrementAndGet();
-                        stats.loadTime.addAndGet(System.nanoTime() - t0);
-                        stats.missCount.incrementAndGet();
-                        stats.currentWeight.addAndGet(segmentWeight(segment));
-                        id.loaded(segment);
-                        return segment;
-                    } catch (Exception e) {
-                        stats.loadExceptionCount.incrementAndGet();
-                        throw e;
-                    }
-                });
+                try {
+                    return cache.get(id, segmentId -> {
+                        try {
+                            long t0 = System.nanoTime();
+                            Segment segment = loader.call();
+                            stats.loadSuccessCount.incrementAndGet();
+                            stats.loadTime.addAndGet(System.nanoTime() - t0);
+                            stats.missCount.incrementAndGet();
+                            stats.currentWeight.addAndGet(segmentWeight(segment));
+                            id.loaded(segment);
+                            return segment;
+                        } catch (Exception e) {
+                            stats.loadExceptionCount.incrementAndGet();
+                            if (e instanceof RuntimeException) {
+                                throw (RuntimeException) e;
+                            }
+                            throw new RuntimeException(e);
+                        }
+                    });
+                } catch (CompletionException e) {
+                    Throwable cause = e.getCause();
+                    throw new ExecutionException(
+                            cause instanceof RuntimeException && cause.getCause() != null
+                                    ? cause.getCause() : cause);
+                }
             } else {
                 try {
                     return loader.call();
@@ -195,12 +208,17 @@ public abstract class SegmentCache {
                 id.loaded(segment);
                 stats.currentWeight.addAndGet(segmentWeight(segment));
                 cache.put(id, segment);
+                // Force Caffeine to process pending evictions synchronously,
+                // so the removal listener fires before returning to the caller.
+                cache.cleanUp();
             }
         }
 
         @Override
         public void clear() {
             cache.invalidateAll();
+            // Force removal listener notifications to fire synchronously.
+            cache.cleanUp();
         }
 
         @Override
@@ -297,13 +315,14 @@ public abstract class SegmentCache {
 
         @Override
         protected CacheStats getCurrentStats() {
-            return new CacheStats(
+            return CacheStats.of(
                     hitCount.get(),
                     missCount.get(),
                     loadSuccessCount.get(),
                     loadExceptionCount.get(),
                     loadTime.get(),
-                    evictionCount.get()
+                    evictionCount.get(),
+                    0
             );
         }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriterCacheManager.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/WriterCacheManager.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.jackrabbit.oak.api.jmx.CacheStatsMBean;
 import org.apache.jackrabbit.oak.commons.collections.IteratorUtils;
 import org.apache.jackrabbit.oak.segment.file.PriorityCache;
@@ -356,7 +356,7 @@ public abstract class WriterCacheManager {
             return new Supplier<CacheStats>() {
                 @Override
                 public CacheStats get() {
-                    CacheStats stats = new CacheStats(0, 0, 0, 0, 0, 0);
+                    CacheStats stats = CacheStats.empty();
                     for (RecordCache<?> cache : caches) {
                         stats = stats.plus(cache.getStats());
                     }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/PriorityCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/PriorityCache.java
@@ -37,8 +37,8 @@ import org.apache.jackrabbit.oak.segment.CacheWeights;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.Weigher;
 
 /**
  * {@code PriorityCache} implements a partial mapping from keys of type {@code K} to values
@@ -401,8 +401,8 @@ public class PriorityCache<K, V> {
      */
     @NotNull
     public CacheStats getStats() {
-        return new CacheStats(hitCount.sum(), missCount.sum(), loadCount.sum(),
-                loadExceptionCount.sum(), 0, evictionCount.sum());
+        return CacheStats.of(hitCount.sum(), missCount.sum(), loadCount.sum(),
+                loadExceptionCount.sum(), 0, evictionCount.sum(), 0);
     }
 
     public long estimateCurrentWeight() {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/SegmentCacheStats.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/SegmentCacheStats.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.jetbrains.annotations.NotNull;
 
@@ -68,13 +68,14 @@ public class SegmentCacheStats extends AbstractCacheStats {
 
     @Override
     protected CacheStats getCurrentStats() {
-        return new CacheStats(
+        return CacheStats.of(
                 hitCount.get(),
                 missCount.get(),
                 loadSuccessCount.get(),
                 loadExceptionCount.get(),
                 loadTime.get(),
-                evictionCount.get()
+                evictionCount.get(),
+                0
         );
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("6.1.0")
+@Version("7.0.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/ConcurrentPriorityCacheTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/ConcurrentPriorityCacheTest.java
@@ -230,7 +230,7 @@ public class ConcurrentPriorityCacheTest {
 
         assertEquals(0, cache.getStats().evictionCount());
         assertEquals(success, cache.size());
-        assertEquals(failure, cache.getStats().loadExceptionCount());
+        assertEquals(failure, cache.getStats().loadFailureCount());
     }
 
 }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/PriorityCacheTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/PriorityCacheTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assume.assumeTrue;
 
 import java.util.Random;
 
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.segment.CacheWeights;
 import org.junit.Test;
 
@@ -191,7 +191,7 @@ public class PriorityCacheTest {
 
         assertEquals(0, cache.getStats().evictionCount());
         assertEquals(success, cache.size());
-        assertEquals(failure, cache.getStats().loadExceptionCount());
+        assertEquals(failure, cache.getStats().loadFailureCount());
     }
 
 }

--- a/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/CompositeTestSupport.java
+++ b/oak-store-composite/src/test/java/org/apache/jackrabbit/oak/composite/it/CompositeTestSupport.java
@@ -100,7 +100,8 @@ public abstract class CompositeTestSupport extends TestSupport {
             mavenBundle().groupId("org.apache.commons").artifactId("commons-text").versionAsInProject(),
             mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-core").versionAsInProject(),
             mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-annotations").versionAsInProject(),
-            mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-databind").versionAsInProject()
+            mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-databind").versionAsInProject(),
+            mavenBundle().groupId("com.github.ben-manes.caffeine").artifactId("caffeine").versionAsInProject()
         );
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CachingCommitValueResolver.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/CachingCommitValueResolver.java
@@ -19,7 +19,8 @@ package org.apache.jackrabbit.oak.plugins.document;
 import java.util.List;
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.stats.Clock;
@@ -27,7 +28,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.jackrabbit.guava.common.cache.CacheBuilder.newBuilder;
 
 /**
  * Resolves the commit value for a given change revision on a document.
@@ -44,7 +44,7 @@ final class CachingCommitValueResolver implements CommitValueResolver {
     private final Supplier<RevisionVector> sweepRevisions;
 
     CachingCommitValueResolver(int cacheSize, Supplier<RevisionVector> sweepRevisions) {
-        this.commitValueCache = newBuilder().maximumSize(cacheSize).build();
+        this.commitValueCache = Caffeine.newBuilder().maximumSize(cacheSize).build();
         this.cacheSize = cacheSize;
         this.sweepRevisions = sweepRevisions;
     }
@@ -56,7 +56,7 @@ final class CachingCommitValueResolver implements CommitValueResolver {
             return new CommitValueResolver() {
 
                 private final Cache<Revision, String> emptyCommitValueCache
-                        = newBuilder().maximumSize(cacheSize).build();
+                        = Caffeine.newBuilder().maximumSize(cacheSize).build();
 
                 @Override
                 public String resolve(@NotNull Revision changeRevision,

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -1408,7 +1408,7 @@ public final class DocumentNodeStore
             PERFLOG.end(start, 1, "getNode: path={}, rev={}", path, rev);
             return result;
         } catch (RuntimeException e) {
-            throw DocumentStoreException.convert(e.getCause());
+            throw DocumentStoreException.convert(cacheFailure(e));
         }
     }
 
@@ -1462,10 +1462,14 @@ public final class DocumentNodeStore
             }
             return children;
         } catch (RuntimeException e) {
-            throw DocumentStoreException.convert(e.getCause(),
+            throw DocumentStoreException.convert(cacheFailure(e),
                     "Error occurred while fetching children for path "
                             + path);
         }
+    }
+
+    private static Throwable cacheFailure(RuntimeException e) {
+        return e.getCause() != null ? e.getCause() : e;
     }
 
     /**

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -56,10 +56,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -74,7 +72,7 @@ import java.util.function.Supplier;
 import javax.jcr.PropertyType;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -1394,25 +1392,22 @@ public final class DocumentNodeStore
         final long start = PERFLOG.start();
         try {
             PathRev key = new PathRev(path, rev);
-            DocumentNodeState node = nodeCache.get(key, new Callable<DocumentNodeState>() {
-                @Override
-                public DocumentNodeState call() throws Exception {
-                    boolean nodeDoesNotExist = checkNodeNotExistsFromChildrenCache(path, rev);
-                    if (nodeDoesNotExist){
-                        return missing;
-                    }
-                    DocumentNodeState n = readNode(path, rev);
-                    if (n == null) {
-                        n = missing;
-                    }
-                    return n;
+            DocumentNodeState node = nodeCache.get(key, k -> {
+                boolean nodeDoesNotExist = checkNodeNotExistsFromChildrenCache(path, rev);
+                if (nodeDoesNotExist){
+                    return missing;
                 }
+                DocumentNodeState n = readNode(path, rev);
+                if (n == null) {
+                    n = missing;
+                }
+                return n;
             });
             final DocumentNodeState result = node == missing
                     || node.equals(missing) ? null : node;
             PERFLOG.end(start, 1, "getNode: path={}, rev={}", path, rev);
             return result;
-        } catch (RuntimeException | ExecutionException e) {
+        } catch (RuntimeException e) {
             throw DocumentStoreException.convert(e.getCause());
         }
     }
@@ -1456,12 +1451,7 @@ public final class DocumentNodeStore
         final RevisionVector readRevision = parent.getLastRevision();
         try {
             NamePathRev key = childNodeCacheKey(path, readRevision, name);
-            DocumentNodeState.Children children = nodeChildrenCache.get(key, new Callable<DocumentNodeState.Children>() {
-                @Override
-                public DocumentNodeState.Children call() throws Exception {
-                    return readChildren(parent, name, limit);
-                }
-            });
+            DocumentNodeState.Children children = nodeChildrenCache.get(key, k -> readChildren(parent, name, limit));
             if (children.children.size() < limit && children.hasMore) {
                 // not enough children loaded - load more,
                 // and put that in the cache
@@ -1471,7 +1461,7 @@ public final class DocumentNodeStore
                 nodeChildrenCache.put(key, children);
             }
             return children;
-        } catch (RuntimeException | ExecutionException e) {
+        } catch (RuntimeException e) {
             throw DocumentStoreException.convert(e.getCause(),
                     "Error occurred while fetching children for path "
                             + path);

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -105,9 +105,28 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
             "oak.documentMK.manyChildren", 50);
 
     /**
-     * Whether to use the CacheLIRS (default) or the Guava cache implementation.
+     * @deprecated Use {@code oak.documentMK.lirsCache=false} to disable the LIRS cache.
+     *             The Guava cache implementation has been removed; this property now has no
+     *             effect other than emitting a deprecation warning. Will be removed in a future release.
      */
-    private static final boolean LIRS_CACHE = !Boolean.getBoolean("oak.documentMK.guavaCache");
+    @Deprecated(since = "2.0.0")
+    private static final String GUAVA_CACHE_PROPERTY = "oak.documentMK.guavaCache";
+
+    /**
+     * Whether to use the CacheLIRS (default) or direct Caffeine cache implementation.
+     * Set {@code -Doak.documentMK.lirsCache=false} to disable the LIRS cache.
+     */
+    private static final boolean LIRS_CACHE = resolveLirsCache();
+
+    private static boolean resolveLirsCache() {
+        if (Boolean.getBoolean(GUAVA_CACHE_PROPERTY)) {
+            LOG.warn("System property '{}' is deprecated and will be removed in a future release. "
+                    + "The Guava cache implementation has been removed; Caffeine is now always used. "
+                    + "To disable the LIRS cache, use '-Doak.documentMK.lirsCache=false' instead.",
+                    GUAVA_CACHE_PROPERTY);
+        }
+        return Boolean.parseBoolean(System.getProperty("oak.documentMK.lirsCache", "true"));
+    }
 
     /**
      * Number of content updates that need to happen before the updates

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -1157,6 +1157,7 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
             }
         };
         return Caffeine.newBuilder().
+                executor(Runnable::run).
                 weigher(typedWeigher).
                 maximumWeight(maxWeight).
                 recordStats().

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -35,12 +35,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
-import org.apache.jackrabbit.guava.common.cache.RemovalListener;
-import org.apache.jackrabbit.guava.common.cache.RemovalNotification;
-import org.apache.jackrabbit.guava.common.cache.Weigher;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.cache.CacheValue;
@@ -1151,19 +1150,17 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
                     }).
                     build();
         }
-        return CacheBuilder.newBuilder().
-                concurrencyLevel(cacheSegmentCount).
-                weigher(weigher).
+        Weigher<K, V> typedWeigher = (key, value) -> weigher.weigh(key, value);
+        RemovalListener<K, V> typedListener = (key, value, cause) -> {
+            for (EvictionListener<K, V> l : listeners) {
+                l.evicted(key, value, cause);
+            }
+        };
+        return Caffeine.newBuilder().
+                weigher(typedWeigher).
                 maximumWeight(maxWeight).
                 recordStats().
-                removalListener(new RemovalListener<K, V>() {
-                    @Override
-                    public void onRemoval(RemovalNotification<K, V> notification) {
-                        for (EvictionListener<K, V> l : listeners) {
-                            l.evicted(notification.getKey(), notification.getValue(), notification.getCause());
-                        }
-                    }
-                }).
+                removalListener(typedListener).
                 build();
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LocalDiffCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/LocalDiffCache.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.commons.json.JsopBuilder;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/MemoryDiffCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/MemoryDiffCache.java
@@ -17,10 +17,8 @@
 package org.apache.jackrabbit.oak.plugins.document;
 
 import java.util.Collections;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.plugins.document.util.StringValue;
@@ -75,21 +73,13 @@ public class MemoryDiffCache extends DiffCache {
                 diff = StringValue.EMPTY;
             }
         } else {
-            try {
-                diff = diffCache.get(key, new Callable<StringValue>() {
-                    @Override
-                    public StringValue call() throws Exception {
-                        if (isUnchanged(from, to, path)) {
-                            return StringValue.EMPTY;
-                        } else {
-                            return new StringValue(loader.call());
-                        }
-                    }
-                });
-            } catch (ExecutionException e) {
-                // try again with loader directly
-                diff = new StringValue(loader.call());
-            }
+            diff = diffCache.get(key, k -> {
+                if (isUnchanged(from, to, path)) {
+                    return StringValue.EMPTY;
+                } else {
+                    return new StringValue(loader.call());
+                }
+            });
         }
         return diff != null ? diff.toString() : null;
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/NodeDocument.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.commons.collections.AbstractIterator;
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.PathUtils;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/TieredDiffCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/TieredDiffCache.java
@@ -16,8 +16,8 @@
  */
 package org.apache.jackrabbit.oak.plugins.document;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
@@ -38,7 +38,7 @@ class TieredDiffCache extends DiffCache {
      * the same revision vector range.
      */
     private Cache<RevisionsKey, RevisionsKey> localDiffMisses
-            = CacheBuilder.newBuilder().maximumSize(128).build();
+            = Caffeine.newBuilder().maximumSize(128).build();
 
     private final int clusterId;
     private final DiffCache localCache;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/cache/ForwardingListener.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/cache/ForwardingListener.java
@@ -19,8 +19,8 @@
 
 package org.apache.jackrabbit.oak.plugins.document.cache;
 
-import org.apache.jackrabbit.guava.common.cache.RemovalListener;
-import org.apache.jackrabbit.guava.common.cache.RemovalNotification;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 
 /**
  * Listener which forwards the notifications to a delegate. It is used to bridge
@@ -39,9 +39,9 @@ public class ForwardingListener<K, V>
     }
 
     @Override
-    public void onRemoval(RemovalNotification<K, V> notification) {
+    public void onRemoval(K key, V value, RemovalCause cause) {
         if (delegate != null) {
-            delegate.onRemoval(notification);
+            delegate.onRemoval(key, value, cause);
         }
     }
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/cache/NodeDocumentCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/cache/NodeDocumentCache.java
@@ -28,12 +28,13 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Predicate;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
@@ -161,7 +162,6 @@ public class NodeDocumentCache implements Closeable {
      * is not synchronized and will be faster if you need to get the cached value
      * outside the critical section.
      *
-     * @see Cache#get(Object, Callable)
      * @param key document key
      * @param valueLoader object used to retrieve the document
      * @return document matching given key
@@ -169,21 +169,26 @@ public class NodeDocumentCache implements Closeable {
     @NotNull
     public NodeDocument get(@NotNull final String key, @NotNull final Callable<NodeDocument> valueLoader)
             throws ExecutionException {
-        Callable<NodeDocument> wrappedLoader = new Callable<NodeDocument>() {
-            @Override
-            public NodeDocument call() throws Exception {
-                for (CacheChangesTracker tracker : changeTrackers) {
-                    tracker.invalidateDocument(key);
-                }
-                return valueLoader.call();
-            }
-        };
         Lock lock = locks.acquire(key);
         try {
-            if (isLeafPreviousDocId(key)) {
-                return prevDocumentsCache.get(new StringValue(key), wrappedLoader);
-            } else {
-                return nodeDocumentsCache.get(new StringValue(key), wrappedLoader);
+            @SuppressWarnings("unchecked")
+            Cache<CacheValue, NodeDocument> targetCache =
+                    isLeafPreviousDocId(key)
+                            ? (Cache<CacheValue, NodeDocument>)(Cache<?,?>) prevDocumentsCache
+                            : nodeDocumentsCache;
+            try {
+                return targetCache.get(new StringValue(key), k -> {
+                    try {
+                        for (CacheChangesTracker tracker : changeTrackers) {
+                            tracker.invalidateDocument(key);
+                        }
+                        return valueLoader.call();
+                    } catch (Exception e) {
+                        throw new CompletionException(e);
+                    }
+                });
+            } catch (CompletionException e) {
+                throw new ExecutionException(e.getCause());
             }
         } finally {
             lock.unlock();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentStore.java
@@ -630,7 +630,7 @@ public class MongoDocumentStore implements DocumentStore {
                 invalidateCache(collection, key);
                 doc = nodesCache.get(key, new Callable<NodeDocument>() {
                     @Override
-                    public NodeDocument call() throws Exception {
+                    public NodeDocument call() {
                         return d == null ? NodeDocument.NULL : d;
                     }
                 });
@@ -1829,7 +1829,12 @@ public class MongoDocumentStore implements DocumentStore {
                         // load NULL document into cache unless it may have
                         // been affected by another concurrent operation
                         if (!tracker.mightBeenAffected(id)) {
-                            nodesCache.get(id, () -> NULL);
+                            nodesCache.get(id, new Callable<NodeDocument>() {
+                                @Override
+                                public NodeDocument call() {
+                                    return NULL;
+                                }
+                            });
                         }
                     } finally {
                         lock.unlock();

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/EvictionListener.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/EvictionListener.java
@@ -16,7 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.document.persistentCache;
 
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 
 /**
  * A listener that gets notified of entries that were removed from the cache.

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCache.java
@@ -17,23 +17,22 @@
 package org.apache.jackrabbit.oak.plugins.document.persistentCache;
 
 import static java.util.Collections.singleton;
-import static org.apache.jackrabbit.guava.common.cache.RemovalCause.COLLECTED;
-import static org.apache.jackrabbit.guava.common.cache.RemovalCause.EXPIRED;
-import static org.apache.jackrabbit.guava.common.cache.RemovalCause.SIZE;
+import static com.github.benmanes.caffeine.cache.RemovalCause.COLLECTED;
+import static com.github.benmanes.caffeine.cache.RemovalCause.EXPIRED;
+import static com.github.benmanes.caffeine.cache.RemovalCause.SIZE;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheStats;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
-import org.apache.jackrabbit.guava.common.collect.ImmutableMap;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
@@ -187,11 +186,10 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     @Nullable
-    public V getIfPresent(Object key) {
-        memCacheMetadata.increment((K) key);
+    public V getIfPresent(K key) {
+        memCacheMetadata.increment(key);
         V value = memCache.getIfPresent(key);
         if (value == null) {
             memCacheMetadata.remove(key);
@@ -208,19 +206,16 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
         stats.markRequest();
 
         // it takes care of updating memCacheMetadata
-        value = readIfPresent((K) key);
+        value = readIfPresent(key);
         if (value != null) {
-            memCache.put((K) key, value);
+            memCache.put(key, value);
             stats.markHit();
         }
         return value;
     }
 
     @Override
-    public V get(K key,
-            Callable<? extends V> valueLoader)
-            throws ExecutionException {
-
+    public V get(K key, Function<? super K, ? extends V> mappingFunction) {
         // Get stats covered in getIfPresent
         V value = getIfPresent(key);
         if (value != null) {
@@ -231,27 +226,33 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
         TimerStats.Context ctx = stats.startLoaderTimer();
         try {
             memCacheMetadata.increment(key);
-            value = memCache.get(key, valueLoader);
+            value = memCache.get(key, mappingFunction);
             ctx.stop();
             if (!async) {
                 write((K) key, value);
             }
             broadcast(key, value);
             return value;
-        } catch (ExecutionException e) {
+        } catch (RuntimeException e) {
             stats.markException();
             throw e;
-         }
+        }
     }
 
     @Override
-    public ImmutableMap<K, V> getAllPresent(
-            Iterable<?> keys) {
+    @SuppressWarnings("unchecked")
+    public Map<K, V> getAllPresent(Iterable<? extends K> keys) {
         Iterable<K> typedKeys = (Iterable<K>) keys;
         memCacheMetadata.incrementAll(keys);
-        ImmutableMap<K, V> result = memCache.getAllPresent(keys);
+        Map<K, V> result = memCache.getAllPresent(keys);
         memCacheMetadata.removeAll(IterableUtils.filter(typedKeys, x -> !result.keySet().contains(x)));
         return result;
+    }
+
+    @Override
+    public Map<K, V> getAll(Iterable<? extends K> keys,
+            Function<? super Set<? extends K>, ? extends Map<? extends K, ? extends V>> mappingFunction) {
+        return memCache.getAll(keys, mappingFunction);
     }
 
     @Override
@@ -264,17 +265,16 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
         broadcast(key, value);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public void invalidate(Object key) {
+    public void invalidate(K key) {
         memCache.invalidate(key);
         memCacheMetadata.remove(key);
         if (async) {
-            writeQueue.addInvalidate(singleton((K) key));
+            writeQueue.addInvalidate(singleton(key));
         } else {
-            write((K) key, null);
+            write(key, null);
         }
-        broadcast((K) key, null);
+        broadcast(key, null);
         stats.markInvalidateOne();
     }
 
@@ -285,7 +285,8 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
     }
 
     @Override
-    public void invalidateAll(Iterable<?> keys) {
+    @SuppressWarnings("unchecked")
+    public void invalidateAll(Iterable<? extends K> keys) {
         memCache.invalidateAll(keys);
         memCacheMetadata.removeAll(keys);
     }
@@ -299,13 +300,18 @@ class NodeCache<K extends CacheValue, V extends  CacheValue>
     }
 
     @Override
-    public long size() {
-        return memCache.size();
+    public long estimatedSize() {
+        return memCache.estimatedSize();
     }
 
     @Override
     public CacheStats stats() {
         return memCache.stats();
+    }
+
+    @Override
+    public Policy<K, V> policy() {
+        return memCache.policy();
     }
 
     @Override

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/PersistentCache.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/PersistentCache.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.DocumentStore;

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentStore.java
@@ -1524,11 +1524,11 @@ public class RDBDocumentStore implements DocumentStore {
                     doc = nodesCache.get(id, new Callable<NodeDocument>() {
                         @Override
                         public NodeDocument call() throws Exception {
-                            NodeDocument doc = (NodeDocument) readDocumentUncached(collection, id, cachedDoc);
-                            if (doc != null) {
-                                doc.seal();
+                            NodeDocument uncached = (NodeDocument) readDocumentUncached(collection, id, cachedDoc);
+                            if (uncached != null) {
+                                uncached.seal();
                             }
-                            return wrap(doc);
+                            return wrap(uncached);
                         }
                     });
                     // inspect the doc whether it can be used

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/AsyncCacheTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/AsyncCacheTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertNull;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BranchTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/BranchTest.java
@@ -19,7 +19,7 @@ package org.apache.jackrabbit.oak.plugins.document;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 
 import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.commons.collections.SetUtils;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DisableCacheTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/DisableCacheTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -50,6 +50,6 @@ public class DisableCacheTest {
                 DEFAULT_PREV_NO_PROP_CACHE_PERCENTAGE);
         DocumentNodeStore nodeStore = builder.getNodeStore();
         Cache<PathRev, DocumentNodeState> cache = nodeStore.getNodeCache();
-        assertEquals(0, cache.size());
+        assertEquals(0, cache.estimatedSize());
     }
 }

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/Sweep2Test.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/Sweep2Test.java
@@ -47,7 +47,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 
 import junitx.util.PrivateAccessor;
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/VersionGarbageCollectorIT.java
@@ -101,7 +101,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.commons.collections.AbstractIterator;
 import com.mongodb.ReadPreference;
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/cache/CacheChangesTrackerTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/cache/CacheChangesTrackerTest.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.cache.CacheValue;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/AsyncQueueTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/AsyncQueueTest.java
@@ -19,7 +19,7 @@
 package org.apache.jackrabbit.oak.plugins.document.persistentCache;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.commons.collections.ListUtils;
 import org.apache.jackrabbit.oak.plugins.document.DocumentMKBuilderProvider;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/BroadcastTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/BroadcastTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.plugins.document.MemoryDiffCache.Key;
 import org.apache.jackrabbit.oak.plugins.document.Path;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/CacheTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/CacheTest.java
@@ -26,7 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.guava.common.cache.Cache;
+import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.jackrabbit.oak.cache.CacheLIRS;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.document.Path;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCacheTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/persistentCache/NodeCacheTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
-import org.apache.jackrabbit.guava.common.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import org.apache.jackrabbit.oak.cache.CacheValue;
 import org.apache.jackrabbit.oak.commons.concurrent.ExecutorCloser;
 import org.apache.jackrabbit.oak.json.JsopDiff;


### PR DESCRIPTION
## Summary

Migrates all Guava cache API usages to Caffeine (`com.github.benmanes.caffeine`) across the Oak codebase.

## Changes

- **oak-core-spi**: `CacheLIRS`, `CacheStats`, `AbstractCacheStats`, `EmpiricalWeigher` — replace Guava `Cache`/`CacheBuilder`/`Weigher`/`CacheStats`; bump `package-info.java` version
- **oak-store-document**: `DocumentNodeStore`, `DocumentNodeStoreBuilder`, `NodeDocumentCache`, `NodeCache`, `PersistentCache`, `CachingCommitValueResolver`, `LocalDiffCache`, `MemoryDiffCache`, `TieredDiffCache`, `NodeDocument`, `ForwardingListener`, `EvictionListener` — replace Guava cache imports; adapt `Callable` → `Function`, `reload()` → `asyncReload()`
- **oak-segment-tar**: `SegmentCache`, `ReaderCache`, `RecordCache`, `WriterCacheManager`, `PriorityCache`, `CacheWeights`, `RecordCacheStats`, `SegmentCacheStats` — replace Guava cache imports; add `.executor(Runnable::run)` and `cleanUp()` for synchronous eviction
- **oak-blob-plugins**: `FileCache`, `CompositeDataStoreCache`, `UploadStagingCache`, `CachingBlobStore`, `AbstractSharedCachingDataStore`, `DataStoreBlobStore` — replace Guava `Cache`/`CacheBuilder`/`CacheLoader`/`AbstractCache`/`Weigher`/`RemovalCause`
- **oak-blob**: `BlobIdSet` — replace `CacheBuilder` with `Caffeine`
- **oak-blob-cloud**: `S3Backend` — replace `CacheBuilder` with `Caffeine`
- **oak-blob-cloud-azure**: `AzureBlobStoreBackend`, `AzureBlobStoreBackendV8` — replace `CacheBuilder` with `Caffeine`
- **oak-search**: `ExtractedTextCache` — replace Guava `Cache`/`CacheBuilder`/`Weigher` with Caffeine
- **oak-search-elastic**: `ElasticIndexStatistics` — replace `CacheBuilder`/`CacheLoader`/`LoadingCache`/`Ticker`; `reload()` → `asyncReload()` returning `CompletableFuture`; `getUnchecked()` → `get()`
- **oak-run-commons**: `DocumentNodeStoreHelper` — replace Guava `Cache` import
- **oak-benchmarks**: `PersistentCacheTest` — replace Guava `Cache` import
- **oak-core**: `CacheStatsMetricsTest` — adapt to Caffeine `CacheStats.of()`
- **pom.xml** (oak-blob, oak-blob-cloud, oak-blob-cloud-azure, oak-search, oak-search-elastic, oak-run-commons, oak-benchmarks) — add Caffeine dependency

## Test Plan

- [ ] `mvn test -pl oak-core-spi` — CacheLIRS, CacheStats tests
- [ ] `mvn test -pl oak-store-document` — NodeCache, DocumentNodeStore, persistent cache tests
- [ ] `mvn test -pl oak-segment-tar` — SegmentCache, PriorityCache tests
- [ ] `mvn test -pl oak-blob-plugins` — FileCache, CompositeDataStoreCache tests
- [ ] `mvn test -pl oak-search-elastic` — ElasticIndexStatistics tests

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-11946
- Parent: https://issues.apache.org/jira/browse/OAK-11685