### PR TITLE
OAK-12134 - compaction with concurrent writes can increase segmentstore size

### DIFF
--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/test/FileStoreParameterResolver.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/test/FileStoreParameterResolver.java
@@ -116,12 +116,12 @@ public class FileStoreParameterResolver implements ParameterResolver {
     @SuppressWarnings("unchecked")
     private <T extends AbstractFileStore> T getOrCreateFileStore(ExtensionContext ctx, Class<T> type) {
         ExtensionContext.Store store = ctx.getStore(NAMESPACE);
+        CloseablePath segmentstoreDir = store.getOrComputeIfAbsent("tempdir-for-" + FileStore.class.getSimpleName(),
+                key -> new CloseablePath(computePathForTest(ctx)),
+                CloseablePath.class
+        );
         return store.getOrComputeIfAbsent(type.getName(), k -> {
             try {
-                CloseablePath segmentstoreDir = store.getOrComputeIfAbsent("tempdir-for-" + FileStore.class.getSimpleName(),
-                        key -> new CloseablePath(computePathForTest(ctx)),
-                        CloseablePath.class
-                );
                 Files.createDirectories(segmentstoreDir.path);
                 FileStoreBuilder fileStoreBuilder = FileStoreBuilder.fileStoreBuilder(segmentstoreDir.path.toFile())
                         .withStringCacheSize(0)


### PR DESCRIPTION
- fix test cleanup; data files should be deleted after FileStore is closed