### PR TITLE
OAK-12147 : introduce Oak cache API interfaces

### DIFF
--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCache.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCache.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * A size-bounded, thread-safe cache.
+ *
+ * <p>Implementations may use different eviction strategies (LIRS, W-TinyLFU/Caffeine,
+ * etc.) but callers see only this interface. Obtain instances via OakCacheBuilder.</p>
+ *
+ * <!-- TODO OAK-TASK2: replace plain-text OakCacheBuilder reference above with
+ *      {@link OakCacheBuilder} once OakCacheBuilder is introduced in TASK-2. -->
+ *
+ * <p>The {@link #get(Object, Function)} signature matches Caffeine's
+ * {@code Cache.get(K, Function)} contract exactly: the loader is key-aware and any
+ * exception thrown by the mapping function propagates as an unchecked
+ * {@code RuntimeException} (or {@code CompletionException}).</p>
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ */
+@ProviderType
+public interface OakCache<K, V> {
+
+    /**
+     * Returns the value associated with {@code key} if it is currently in the
+     * cache, otherwise {@code null}.
+     *
+     * @param key the key to look up (must not be null)
+     * @return the cached value, or {@code null} if not present
+     */
+    @Nullable
+    V getIfPresent(@NotNull K key);
+
+    /**
+     * Returns the value associated with {@code key}, computing it via
+     * {@code mappingFunction} and caching the result if it was absent.
+     *
+     * <p>Matches Caffeine's {@code Cache.get(K, Function)} contract: any exception
+     * thrown by the mapping function propagates as an unchecked
+     * {@code RuntimeException} or {@code CompletionException}. Implementations
+     * backed by CacheLIRS bridge internally by wrapping any checked
+     * {@code ExecutionException} into {@code CompletionException}.</p>
+     *
+     * @param key             the key whose associated value is to be returned (must not be null)
+     * @param mappingFunction the function to compute a value if the key is absent (must not be null)
+     * @return the current (existing or computed) value, or {@code null} if the
+     *         mapping function returns {@code null}
+     */
+    @Nullable
+    V get(@NotNull K key, @NotNull Function<? super K, ? extends V> mappingFunction);
+
+    /**
+     * Associates {@code value} with {@code key} in the cache. If the cache
+     * previously contained a value for {@code key} it is replaced.
+     *
+     * @param key   the key (must not be null)
+     * @param value the value (must not be null)
+     */
+    void put(@NotNull K key, @NotNull V value);
+
+    /**
+     * Discards any cached value for {@code key}.
+     *
+     * @param key the key to invalidate (must not be null)
+     */
+    void invalidate(@NotNull K key);
+
+    /**
+     * Discards all entries in the cache.
+     */
+    void invalidateAll();
+
+    /**
+     * Discards any cached values for the given keys.
+     *
+     * <p><em>Note: no Oak module currently calls this method. It may be removed
+     * from the interface in a future release if it remains unused.</em></p>
+     *
+     * @param keys the keys to invalidate (must not be null)
+     */
+    void invalidateAll(@NotNull Iterable<? extends K> keys);
+
+    /**
+     * Returns the approximate number of entries in the cache.
+     *
+     * <p><em>Note: no Oak module currently calls this method directly;
+     * {@code asMap().size()} is used instead. It may be removed from the
+     * interface in a future release if it remains unused.</em></p>
+     *
+     * @return the approximate entry count
+     */
+    long estimatedSize();
+
+    /**
+     * Returns a snapshot of this cache's cumulative statistics. If statistics
+     * collection was not enabled via {@code OakCacheBuilder.recordStats()}, all
+     * <!-- TODO OAK-TASK2: restore {@link OakCacheBuilder#recordStats()} once TASK-2 is merged. -->
+     * counters will be zero.
+     *
+     * @return a stats snapshot (never null)
+     */
+    @NotNull
+    OakCacheStats stats();
+
+    /**
+     * Returns a view of the entries stored in this cache as a thread-safe map.
+     * Modifications to the map directly affect the cache.
+     *
+     * @return a live concurrent map view of the cache entries (never null)
+     */
+    @NotNull
+    ConcurrentMap<K, V> asMap();
+
+    /**
+     * Returns a map of the values currently present in the cache for the given
+     * keys. The returned map contains only keys that were present at the time
+     * of the call.
+     *
+     * <p><em>Note: no Oak module currently calls this method (CacheLIRS throws
+     * {@code UnsupportedOperationException} for it). It may be removed from the
+     * interface in a future release if it remains unused.</em></p>
+     *
+     * @param keys the keys to look up (must not be null)
+     * @return a map of keys to cached values for those keys that were present (never null)
+     */
+    @NotNull
+    Map<K, V> getAllPresent(@NotNull Iterable<? extends K> keys);
+
+    /**
+     * Performs any pending maintenance operations needed by the cache.
+     *
+     * <p><em>Note: no Oak module currently calls this method; the CacheLIRS
+     * implementation is a no-op. It may be removed from the interface in a
+     * future release if it remains unused.</em></p>
+     */
+    void cleanUp();
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCacheLoader.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCacheLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Computes or loads a value for a missing cache entry.
+ *
+ * <p>Used with {@code OakCacheBuilder.build(OakCacheLoader)} to create an
+ * {@link OakLoadingCache}. The loader is key-aware (receives the lookup key)
+ * and may throw a checked exception.</p>
+ *
+ * <!-- TODO OAK-TASK2: restore {@link OakCacheBuilder#build(OakCacheLoader)} once TASK-2 is merged. -->
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ */
+@FunctionalInterface
+public interface OakCacheLoader<K, V> {
+
+    /**
+     * Computes the value for the given key.
+     *
+     * @param key the key whose value should be loaded (never null)
+     * @return the loaded value (never null)
+     * @throws Exception if the value cannot be loaded
+     */
+    @NotNull
+    V load(@NotNull K key) throws Exception;
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCacheStats.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCacheStats.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An immutable snapshot of cache statistics at a point in time.
+ *
+ * <p>Returned by {@link OakCache#stats()}. All counters are cumulative since
+ * the cache was created. Use {@link #minus(OakCacheStats)} to compute a delta
+ * between two snapshots.</p>
+ */
+public final class OakCacheStats {
+
+    private final long hitCount;
+    private final long missCount;
+    private final long loadSuccessCount;
+    private final long loadFailureCount;
+    private final long totalLoadTime;
+    private final long evictionCount;
+
+    /**
+     * Creates a new stats snapshot.
+     *
+     * @param hitCount         number of cache hits
+     * @param missCount        number of cache misses
+     * @param loadSuccessCount number of successful cache loads
+     * @param loadFailureCount number of failed cache loads
+     * @param totalLoadTime    total time spent loading values, in nanoseconds
+     * @param evictionCount    number of entries evicted
+     */
+    public OakCacheStats(long hitCount, long missCount, long loadSuccessCount,
+                         long loadFailureCount, long totalLoadTime, long evictionCount) {
+        this.hitCount = hitCount;
+        this.missCount = missCount;
+        this.loadSuccessCount = loadSuccessCount;
+        this.loadFailureCount = loadFailureCount;
+        this.totalLoadTime = totalLoadTime;
+        this.evictionCount = evictionCount;
+    }
+
+    /**
+     * Returns the number of times a requested key was found in the cache.
+     *
+     * @return hit count
+     */
+    public long hitCount() {
+        return hitCount;
+    }
+
+    /**
+     * Returns the number of times a requested key was not found in the cache.
+     *
+     * @return miss count
+     */
+    public long missCount() {
+        return missCount;
+    }
+
+    /**
+     * Returns the number of times a new value was successfully loaded.
+     *
+     * @return load success count
+     */
+    public long loadSuccessCount() {
+        return loadSuccessCount;
+    }
+
+    /**
+     * Returns the number of times a value load attempt threw an exception.
+     *
+     * @return load failure count
+     */
+    public long loadFailureCount() {
+        return loadFailureCount;
+    }
+
+    /**
+     * Returns the total time spent loading new values, in nanoseconds.
+     *
+     * @return total load time in nanoseconds
+     */
+    public long totalLoadTime() {
+        return totalLoadTime;
+    }
+
+    /**
+     * Returns the number of entries evicted from the cache.
+     *
+     * @return eviction count
+     */
+    public long evictionCount() {
+        return evictionCount;
+    }
+
+    /**
+     * Returns the total number of requests (hits + misses).
+     *
+     * @return request count
+     */
+    public long requestCount() {
+        return hitCount + missCount;
+    }
+
+    /**
+     * Returns the ratio of cache requests that were hits, or {@code 1.0} if no
+     * requests have been made.
+     *
+     * @return hit rate between 0.0 and 1.0
+     */
+    public double hitRate() {
+        long requests = requestCount();
+        return requests == 0 ? 1.0 : (double) hitCount / requests;
+    }
+
+    /**
+     * Returns the ratio of cache requests that were misses, or {@code 0.0} if
+     * no requests have been made.
+     *
+     * @return miss rate between 0.0 and 1.0
+     */
+    public double missRate() {
+        long requests = requestCount();
+        return requests == 0 ? 0.0 : (double) missCount / requests;
+    }
+
+    /**
+     * Returns the difference between this snapshot and an earlier {@code other}
+     * snapshot, useful for computing per-interval deltas.
+     *
+     * @param other the earlier snapshot to subtract (must not be null)
+     * @return a new snapshot representing the delta
+     */
+    @NotNull
+    public OakCacheStats minus(@NotNull OakCacheStats other) {
+        return new OakCacheStats(
+                Math.max(0, hitCount - other.hitCount),
+                Math.max(0, missCount - other.missCount),
+                Math.max(0, loadSuccessCount - other.loadSuccessCount),
+                Math.max(0, loadFailureCount - other.loadFailureCount),
+                Math.max(0, totalLoadTime - other.totalLoadTime),
+                Math.max(0, evictionCount - other.evictionCount)
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "OakCacheStats{hitCount=" + hitCount
+                + ", missCount=" + missCount
+                + ", loadSuccessCount=" + loadSuccessCount
+                + ", loadFailureCount=" + loadFailureCount
+                + ", totalLoadTime=" + totalLoadTime
+                + ", evictionCount=" + evictionCount + "}";
+    }
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCacheStats.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakCacheStats.java
@@ -24,89 +24,21 @@ import org.jetbrains.annotations.NotNull;
  * <p>Returned by {@link OakCache#stats()}. All counters are cumulative since
  * the cache was created. Use {@link #minus(OakCacheStats)} to compute a delta
  * between two snapshots.</p>
+ *
+ * @param hitCount         number of times a requested key was found in the cache
+ * @param missCount        number of times a requested key was not found in the cache
+ * @param loadSuccessCount number of times a new value was successfully loaded
+ * @param loadFailureCount number of times a value load attempt threw an exception
+ * @param totalLoadTime    total time spent loading new values, in nanoseconds
+ * @param evictionCount    number of entries evicted from the cache
  */
-public final class OakCacheStats {
-
-    private final long hitCount;
-    private final long missCount;
-    private final long loadSuccessCount;
-    private final long loadFailureCount;
-    private final long totalLoadTime;
-    private final long evictionCount;
-
-    /**
-     * Creates a new stats snapshot.
-     *
-     * @param hitCount         number of cache hits
-     * @param missCount        number of cache misses
-     * @param loadSuccessCount number of successful cache loads
-     * @param loadFailureCount number of failed cache loads
-     * @param totalLoadTime    total time spent loading values, in nanoseconds
-     * @param evictionCount    number of entries evicted
-     */
-    public OakCacheStats(long hitCount, long missCount, long loadSuccessCount,
-                         long loadFailureCount, long totalLoadTime, long evictionCount) {
-        this.hitCount = hitCount;
-        this.missCount = missCount;
-        this.loadSuccessCount = loadSuccessCount;
-        this.loadFailureCount = loadFailureCount;
-        this.totalLoadTime = totalLoadTime;
-        this.evictionCount = evictionCount;
-    }
-
-    /**
-     * Returns the number of times a requested key was found in the cache.
-     *
-     * @return hit count
-     */
-    public long hitCount() {
-        return hitCount;
-    }
-
-    /**
-     * Returns the number of times a requested key was not found in the cache.
-     *
-     * @return miss count
-     */
-    public long missCount() {
-        return missCount;
-    }
-
-    /**
-     * Returns the number of times a new value was successfully loaded.
-     *
-     * @return load success count
-     */
-    public long loadSuccessCount() {
-        return loadSuccessCount;
-    }
-
-    /**
-     * Returns the number of times a value load attempt threw an exception.
-     *
-     * @return load failure count
-     */
-    public long loadFailureCount() {
-        return loadFailureCount;
-    }
-
-    /**
-     * Returns the total time spent loading new values, in nanoseconds.
-     *
-     * @return total load time in nanoseconds
-     */
-    public long totalLoadTime() {
-        return totalLoadTime;
-    }
-
-    /**
-     * Returns the number of entries evicted from the cache.
-     *
-     * @return eviction count
-     */
-    public long evictionCount() {
-        return evictionCount;
-    }
+public record OakCacheStats(
+        long hitCount,
+        long missCount,
+        long loadSuccessCount,
+        long loadFailureCount,
+        long totalLoadTime,
+        long evictionCount) {
 
     /**
      * Returns the total number of requests (hits + misses).
@@ -156,15 +88,5 @@ public final class OakCacheStats {
                 Math.max(0, totalLoadTime - other.totalLoadTime),
                 Math.max(0, evictionCount - other.evictionCount)
         );
-    }
-
-    @Override
-    public String toString() {
-        return "OakCacheStats{hitCount=" + hitCount
-                + ", missCount=" + missCount
-                + ", loadSuccessCount=" + loadSuccessCount
-                + ", loadFailureCount=" + loadFailureCount
-                + ", totalLoadTime=" + totalLoadTime
-                + ", evictionCount=" + evictionCount + "}";
     }
 }

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakLoadingCache.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakLoadingCache.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import java.util.concurrent.CompletionException;
+
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * A cache that automatically loads absent entries from a pre-configured
+ * {@link OakCacheLoader}.
+ *
+ * <p>Obtain instances via {@code OakCacheBuilder.build(OakCacheLoader)}.
+ * <!-- TODO OAK-TASK2: restore {@link OakCacheBuilder#build(OakCacheLoader)} once TASK-2 is merged. -->
+ * Matches Caffeine's {@code LoadingCache} contract: {@link #get(Object)} throws
+ * an unchecked {@link CompletionException} on loader failure. Implementations
+ * backed by CacheLIRS bridge the checked {@code ExecutionException} by wrapping
+ * it into {@code CompletionException}.</p>
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ */
+@ProviderType
+public interface OakLoadingCache<K, V> extends OakCache<K, V> {
+
+    /**
+     * Returns the value associated with {@code key}, loading it via the
+     * pre-configured {@link OakCacheLoader} if absent.
+     *
+     * @param key the key whose value should be returned or loaded (must not be null)
+     * @return the current or newly loaded value (never null)
+     * @throws CompletionException wrapping the loader's exception if loading fails,
+     *         matching Caffeine's {@code LoadingCache.get(K)} contract
+     */
+    @NotNull
+    V get(@NotNull K key);
+
+    /**
+     * Triggers a reload of the value for {@code key}. The stale value remains
+     * available until the reload completes (Caffeine's {@code refreshAfterWrite}
+     * semantics; best-effort for the CacheLIRS implementation).
+     *
+     * @param key the key whose value should be refreshed (must not be null)
+     */
+    void refresh(@NotNull K key);
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakRemovalCause.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakRemovalCause.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+/**
+ * The reason an entry was removed from the cache.
+ *
+ * <p>Passed to {@link OakRemovalListener#onRemoval(Object, Object, OakRemovalCause)}
+ * when an entry is evicted or invalidated. Covers the common subset of removal
+ * causes across CacheLIRS and Caffeine without exposing either.</p>
+ */
+public enum OakRemovalCause {
+
+    /** The entry was manually removed via {@code invalidate}. */
+    EXPLICIT,
+
+    /** The entry was replaced by a new value for the same key. */
+    REPLACED,
+
+    /** The entry was evicted due to a size or weight constraint. */
+    SIZE,
+
+    /** The entry expired. */
+    EXPIRED,
+
+    /** The entry was collected by the garbage collector (weak/soft reference). */
+    COLLECTED
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakRemovalListener.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakRemovalListener.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Callback invoked when an entry is removed from the cache.
+ *
+ * <p>Register via {@code OakCacheBuilder.removalListener(OakRemovalListener)}.
+ * <!-- TODO OAK-TASK2: restore {@link OakCacheBuilder#removalListener(OakRemovalListener)} once TASK-2 is merged. -->
+ * The callback is invoked synchronously during cache operations that trigger
+ * removal (eviction, invalidation, replacement).</p>
+ *
+ * <p><b>Warning:</b> it is unsafe to call cache methods from within the listener.
+ * Some implementations hold internal locks during the callback.</p>
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ */
+@FunctionalInterface
+public interface OakRemovalListener<K, V> {
+
+    /**
+     * Notifies the listener that an entry was removed.
+     *
+     * @param key   the key of the removed entry (never null)
+     * @param value the value of the removed entry (may be null if collected)
+     * @param cause the reason the entry was removed (never null)
+     */
+    void onRemoval(@NotNull K key, @Nullable V value, @NotNull OakRemovalCause cause);
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakWeigher.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/OakWeigher.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Determines the weight of a cache entry.
+ *
+ * <p>Used with {@code OakCacheBuilder.weigher(OakWeigher)} in combination with
+ * {@code OakCacheBuilder.maximumWeight(long)} to create weight-bounded caches.
+ * The unit is typically bytes but is cache-specific. The returned weight must
+ * be non-negative.</p>
+ *
+ * <!-- TODO OAK-TASK2: restore {@link OakCacheBuilder#weigher(OakWeigher)} and
+ *      {@link OakCacheBuilder#maximumWeight(long)} once TASK-2 is merged. -->
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ */
+@FunctionalInterface
+public interface OakWeigher<K, V> {
+
+    /**
+     * Returns the weight of the given cache entry.
+     *
+     * @param key   the cache key (never null)
+     * @param value the cache value (never null)
+     * @return the weight of the entry; must be non-negative
+     */
+    int weigh(@NotNull K key, @NotNull V value);
+}

--- a/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/package-info.java
+++ b/oak-core-spi/src/main/java/org/apache/jackrabbit/oak/cache/package-info.java
@@ -19,7 +19,7 @@
  * <em>For Oak internal use only. Do not use outside Oak components.</em>
  */
 @Internal(since = "1.1.1")
-@Version("2.0")
+@Version("2.1")
 package org.apache.jackrabbit.oak.cache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/OakCacheStatsTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/OakCacheStatsTest.java
@@ -19,6 +19,7 @@ package org.apache.jackrabbit.oak.cache;
 import org.junit.Assert;
 import org.junit.Test;
 
+/** Tests for {@link OakCacheStats}. */
 public class OakCacheStatsTest {
 
     private OakCacheStats stats(long hits, long misses, long loadSuccess, long loadFail,
@@ -26,36 +27,42 @@ public class OakCacheStatsTest {
         return new OakCacheStats(hits, misses, loadSuccess, loadFail, loadTime, evictions);
     }
 
+    /** Verifies that {@code requestCount()} returns the sum of hits and misses. */
     @Test
     public void requestCountIsHitsPlusMisses() {
         OakCacheStats s = stats(3, 7, 0, 0, 0, 0);
         Assert.assertEquals(10, s.requestCount());
     }
 
+    /** Verifies that {@code hitRate()} returns hits divided by total requests. */
     @Test
     public void hitRateWithRequests() {
         OakCacheStats s = stats(3, 7, 0, 0, 0, 0);
         Assert.assertEquals(0.3, s.hitRate(), 0.001);
     }
 
+    /** Verifies that {@code hitRate()} returns {@code 1.0} when no requests have been made. */
     @Test
     public void hitRateWithNoRequestsReturnsOne() {
         OakCacheStats s = stats(0, 0, 0, 0, 0, 0);
         Assert.assertEquals(1.0, s.hitRate(), 0.0);
     }
 
+    /** Verifies that {@code missRate()} returns misses divided by total requests. */
     @Test
     public void missRateWithRequests() {
         OakCacheStats s = stats(3, 7, 0, 0, 0, 0);
         Assert.assertEquals(0.7, s.missRate(), 0.001);
     }
 
+    /** Verifies that {@code missRate()} returns {@code 0.0} when no requests have been made. */
     @Test
     public void missRateWithNoRequestsReturnsZero() {
         OakCacheStats s = stats(0, 0, 0, 0, 0, 0);
         Assert.assertEquals(0.0, s.missRate(), 0.0);
     }
 
+    /** Verifies that {@code minus()} produces the correct per-field delta between two snapshots. */
     @Test
     public void minusProducesDelta() {
         OakCacheStats later  = stats(10, 5, 4, 1, 1000, 3);
@@ -70,6 +77,7 @@ public class OakCacheStatsTest {
         Assert.assertEquals(2,   delta.evictionCount());
     }
 
+    /** Verifies that {@code minus()} clamps negative deltas to zero when the earlier snapshot has larger values. */
     @Test
     public void minusClampsNegativeValuesToZero() {
         OakCacheStats later   = stats(5, 2, 1, 0, 100, 1);
@@ -84,6 +92,7 @@ public class OakCacheStatsTest {
         Assert.assertEquals(0, delta.evictionCount());
     }
 
+    /** Verifies that all record accessors return the values supplied to the canonical constructor. */
     @Test
     public void accessorsReturnConstructorValues() {
         OakCacheStats s = stats(1, 2, 3, 4, 5, 6);
@@ -95,6 +104,7 @@ public class OakCacheStatsTest {
         Assert.assertEquals(6, s.evictionCount());
     }
 
+    /** Verifies that {@code toString()} includes every field name and its value. */
     @Test
     public void toStringContainsAllFields() {
         OakCacheStats s = stats(1, 2, 3, 4, 5, 6);

--- a/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/OakCacheStatsTest.java
+++ b/oak-core-spi/src/test/java/org/apache/jackrabbit/oak/cache/OakCacheStatsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.cache;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OakCacheStatsTest {
+
+    private OakCacheStats stats(long hits, long misses, long loadSuccess, long loadFail,
+                                long loadTime, long evictions) {
+        return new OakCacheStats(hits, misses, loadSuccess, loadFail, loadTime, evictions);
+    }
+
+    @Test
+    public void requestCountIsHitsPlusMisses() {
+        OakCacheStats s = stats(3, 7, 0, 0, 0, 0);
+        Assert.assertEquals(10, s.requestCount());
+    }
+
+    @Test
+    public void hitRateWithRequests() {
+        OakCacheStats s = stats(3, 7, 0, 0, 0, 0);
+        Assert.assertEquals(0.3, s.hitRate(), 0.001);
+    }
+
+    @Test
+    public void hitRateWithNoRequestsReturnsOne() {
+        OakCacheStats s = stats(0, 0, 0, 0, 0, 0);
+        Assert.assertEquals(1.0, s.hitRate(), 0.0);
+    }
+
+    @Test
+    public void missRateWithRequests() {
+        OakCacheStats s = stats(3, 7, 0, 0, 0, 0);
+        Assert.assertEquals(0.7, s.missRate(), 0.001);
+    }
+
+    @Test
+    public void missRateWithNoRequestsReturnsZero() {
+        OakCacheStats s = stats(0, 0, 0, 0, 0, 0);
+        Assert.assertEquals(0.0, s.missRate(), 0.0);
+    }
+
+    @Test
+    public void minusProducesDelta() {
+        OakCacheStats later  = stats(10, 5, 4, 1, 1000, 3);
+        OakCacheStats earlier = stats(6,  3, 2, 0,  400, 1);
+        OakCacheStats delta  = later.minus(earlier);
+
+        Assert.assertEquals(4,   delta.hitCount());
+        Assert.assertEquals(2,   delta.missCount());
+        Assert.assertEquals(2,   delta.loadSuccessCount());
+        Assert.assertEquals(1,   delta.loadFailureCount());
+        Assert.assertEquals(600, delta.totalLoadTime());
+        Assert.assertEquals(2,   delta.evictionCount());
+    }
+
+    @Test
+    public void minusClampsNegativeValuesToZero() {
+        OakCacheStats later   = stats(5, 2, 1, 0, 100, 1);
+        OakCacheStats earlier = stats(9, 3, 2, 1, 200, 2);
+        OakCacheStats delta   = later.minus(earlier);
+
+        Assert.assertEquals(0, delta.hitCount());
+        Assert.assertEquals(0, delta.missCount());
+        Assert.assertEquals(0, delta.loadSuccessCount());
+        Assert.assertEquals(0, delta.loadFailureCount());
+        Assert.assertEquals(0, delta.totalLoadTime());
+        Assert.assertEquals(0, delta.evictionCount());
+    }
+
+    @Test
+    public void accessorsReturnConstructorValues() {
+        OakCacheStats s = stats(1, 2, 3, 4, 5, 6);
+        Assert.assertEquals(1, s.hitCount());
+        Assert.assertEquals(2, s.missCount());
+        Assert.assertEquals(3, s.loadSuccessCount());
+        Assert.assertEquals(4, s.loadFailureCount());
+        Assert.assertEquals(5, s.totalLoadTime());
+        Assert.assertEquals(6, s.evictionCount());
+    }
+
+    @Test
+    public void toStringContainsAllFields() {
+        OakCacheStats s = stats(1, 2, 3, 4, 5, 6);
+        String str = s.toString();
+        Assert.assertTrue(str.contains("hitCount=1"));
+        Assert.assertTrue(str.contains("missCount=2"));
+        Assert.assertTrue(str.contains("loadSuccessCount=3"));
+        Assert.assertTrue(str.contains("loadFailureCount=4"));
+        Assert.assertTrue(str.contains("totalLoadTime=5"));
+        Assert.assertTrue(str.contains("evictionCount=6"));
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the Oak-owned cache API in `oak-core-spi` (`org.apache.jackrabbit.oak.cache`), decoupling callers from CacheLIRS and Guava implementation details. This is TASK-1 of the Caffeine migration (OAK-11300).

## Changes

- `OakCache<K,V>` — size-bounded thread-safe cache interface (`@ProviderType`)
- `OakLoadingCache<K,V>` — extends `OakCache`, adds auto-loading `get(K)` and `refresh(K)` (`@ProviderType`)
- `OakCacheLoader<K,V>` — `@FunctionalInterface` loader supplied to `OakCacheBuilder.build()`
- `OakWeigher<K,V>` — `@FunctionalInterface` weigher for weight-based eviction
- `OakRemovalListener<K,V>` — `@FunctionalInterface` eviction/invalidation callback
- `OakRemovalCause` — enum (`EXPLICIT`, `REPLACED`, `SIZE`, `EXPIRED`, `COLLECTED`)
- `OakCacheStats` — immutable value object with hit/miss/load/eviction counters and `minus()` delta support
- `package-info.java` — bumped `@Version` from `2.0` to `2.1` (OSGi minor bump for new public types)
- `OakCacheStatsTest` — 9 JUnit 4 tests covering all methods and edge cases

No production call sites are changed in this task. `OakCacheBuilder` (TASK-2) will wire these interfaces to CacheLIRS and Caffeine adapters.

## Test Plan

- [x] `OakCacheStatsTest` — 9 tests, all passing
- [x] `mvn test -pl oak-core-spi` — BUILD SUCCESS

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-12147
- Parent: https://issues.apache.org/jira/browse/OAK-11300