### PR TITLE
OAK-12170 Invalid path: rep:facet - rename feature toggle

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -63,7 +63,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String FT_SORT_UNION_QUERY_BY_SCORE = "FT_OAK-11949";
 
-    public static final String FT_OPTIMIZE_XPATH_UNION = "FT_OAK-12007";
+    public static final String FT_OPTIMIZE_XPATH_UNION = "FT_OAK-12170";
 
     public static final int DEFAULT_PREFETCH_COUNT = Integer.getInteger(OAK_QUERY_PREFETCH_COUNT, -1);
 


### PR DESCRIPTION
Enabling FT_OAK-12007 caused a regression (do this this bug).
With the new Oak version, the bug is fixed, and the feature toggle could be safely enabled.
However, some environments are still on the old release, and so actually that's not possible.
To solve this dilemma, the feature toggle needs to be renamed.