### PR TITLE
OAK-12174 Offload Elastic async response processing from I/O thread to avoid inflated query time metrics

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -344,7 +344,8 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
             ongoingRequest = indexNode.getConnection().getAsyncClient()
                     .search(searchRequest, ObjectNode.class)
-                    .whenComplete((this::handleResponse));
+                    .whenCompleteAsync((response, throwable) ->
+                            handleResponse(response, throwable, System.currentTimeMillis()));
             metricHandler.markQuery(indexNode.getDefinition().getIndexPath(), true);
         }
 
@@ -355,8 +356,8 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
          * Some code in this method relies on structure that are not thread safe. We need to make sure
          * these data structures are modified before releasing the semaphore.
          */
-        private void onSuccess(@NotNull SearchResponse<ObjectNode> searchResponse) {
-            long searchTotalTime = System.currentTimeMillis() - searchStartTime;
+        private void onSuccess(@NotNull SearchResponse<ObjectNode> searchResponse, long responseTimeMs) {
+            long searchTotalTime = responseTimeMs - searchStartTime;
             List<Hit<ObjectNode>> searchHits = searchResponse.hits().hits();
             int hitsSize = searchHits != null ? searchHits.size() : 0;
             metricHandler.measureQuery(indexNode.getDefinition().getIndexPath(), hitsSize, searchResponse.took(),
@@ -416,9 +417,9 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
             }
         }
 
-        private void onFailure(@NotNull Throwable t) {
+        private void onFailure(@NotNull Throwable t, long responseTimeMs) {
             metricHandler.measureFailedQuery(indexNode.getDefinition().getIndexPath(),
-                    System.currentTimeMillis() - searchStartTime);
+                    responseTimeMs - searchStartTime);
             // Check in case errorRef is already set - this seems unlikely since we close the scanner once we hit failure.
             // But still, in case this do happen, we will log a warning.
             Throwable error = queryErrorRef.getAndSet(t);
@@ -463,14 +464,15 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                 searchStartTime = System.currentTimeMillis();
                 ongoingRequest = indexNode.getConnection().getAsyncClient()
                         .search(searchReq, ObjectNode.class)
-                        .whenComplete(this::handleResponse);
+                        .whenCompleteAsync((response, throwable) ->
+                                handleResponse(response, throwable, System.currentTimeMillis()));
                 metricHandler.markQuery(indexNode.getDefinition().getIndexPath(), false);
             } else {
                 LOG.trace("Scanner is closing or still processing data from the previous scan");
             }
         }
 
-        private void handleResponse(SearchResponse<ObjectNode> searchResponse, Throwable throwable) {
+        private void handleResponse(SearchResponse<ObjectNode> searchResponse, Throwable throwable, long responseTimeMs) {
             ongoingRequest = null;
             if (isClosed.get()) {
                 LOG.info("Scanner is closed, not processing search response");
@@ -478,9 +480,9 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
             }
             try {
                 if (throwable == null) {
-                    onSuccess(searchResponse);
+                    onSuccess(searchResponse, responseTimeMs);
                 } else {
-                    onFailure(throwable);
+                    onFailure(throwable, responseTimeMs);
                 }
             } catch (Throwable t) {
                 LOG.warn("Error processing search response", t);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -344,8 +344,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
             ongoingRequest = indexNode.getConnection().getAsyncClient()
                     .search(searchRequest, ObjectNode.class)
-                    .whenCompleteAsync((response, throwable) ->
-                            handleResponse(response, throwable, System.currentTimeMillis()));
+                    .whenCompleteAsync(this::handleResponse);
             metricHandler.markQuery(indexNode.getDefinition().getIndexPath(), true);
         }
 
@@ -356,8 +355,8 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
          * Some code in this method relies on structure that are not thread safe. We need to make sure
          * these data structures are modified before releasing the semaphore.
          */
-        private void onSuccess(@NotNull SearchResponse<ObjectNode> searchResponse, long responseTimeMs) {
-            long searchTotalTime = responseTimeMs - searchStartTime;
+        private void onSuccess(@NotNull SearchResponse<ObjectNode> searchResponse) {
+            long searchTotalTime = System.currentTimeMillis() - searchStartTime;
             List<Hit<ObjectNode>> searchHits = searchResponse.hits().hits();
             int hitsSize = searchHits != null ? searchHits.size() : 0;
             metricHandler.measureQuery(indexNode.getDefinition().getIndexPath(), hitsSize, searchResponse.took(),
@@ -417,9 +416,9 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
             }
         }
 
-        private void onFailure(@NotNull Throwable t, long responseTimeMs) {
+        private void onFailure(@NotNull Throwable t) {
             metricHandler.measureFailedQuery(indexNode.getDefinition().getIndexPath(),
-                    responseTimeMs - searchStartTime);
+                    System.currentTimeMillis() - searchStartTime);
             // Check in case errorRef is already set - this seems unlikely since we close the scanner once we hit failure.
             // But still, in case this do happen, we will log a warning.
             Throwable error = queryErrorRef.getAndSet(t);
@@ -464,15 +463,14 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                 searchStartTime = System.currentTimeMillis();
                 ongoingRequest = indexNode.getConnection().getAsyncClient()
                         .search(searchReq, ObjectNode.class)
-                        .whenCompleteAsync((response, throwable) ->
-                                handleResponse(response, throwable, System.currentTimeMillis()));
+                        .whenCompleteAsync(this::handleResponse);
                 metricHandler.markQuery(indexNode.getDefinition().getIndexPath(), false);
             } else {
                 LOG.trace("Scanner is closing or still processing data from the previous scan");
             }
         }
 
-        private void handleResponse(SearchResponse<ObjectNode> searchResponse, Throwable throwable, long responseTimeMs) {
+        private void handleResponse(SearchResponse<ObjectNode> searchResponse, Throwable throwable) {
             ongoingRequest = null;
             if (isClosed.get()) {
                 LOG.info("Scanner is closed, not processing search response");
@@ -480,9 +478,9 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
             }
             try {
                 if (throwable == null) {
-                    onSuccess(searchResponse, responseTimeMs);
+                    onSuccess(searchResponse);
                 } else {
-                    onFailure(throwable, responseTimeMs);
+                    onFailure(throwable);
                 }
             } catch (Throwable t) {
                 LOG.warn("Error processing search response", t);


### PR DESCRIPTION
- Offload Elasticsearch async response processing from the HTTP I/O thread to `ForkJoinPool.commonPool()` by replacing `whenComplete` with `whenCompleteAsync`
### Problem

 The `CompletableFuture` returned by the Elasticsearch async client completes on the `elasticsearch-rest-client` I/O thread (Apache HttpAsyncClient I/O dispatcher). With `whenComplete`, the `handleResponse` callback — including `onSuccess` and its hit processing loop — runs inline on that same thread.

During hit processing, `onSuccess` iterates over search hits and calls `SearchHitListener.on(hit)` for each result. In `ElasticResultRowAsyncIterator.on()`, two operations can block the I/O thread:

1. `rowInclusionPredicate.test(path)` — evaluates ACLs, which may require remote calls to the underlying persistence layer (e.g. MongoDB, segment store)
2. `queue.offer(resultRow, enqueueTimeoutMs, TimeUnit.MILLISECONDS)` — blocks when the bounded result queue is full and the consumer is slow to drain it

Since the I/O dispatcher threads are shared across all HTTP connections, blocking one thread delays response reading and `CompletableFuture` completion for other concurrent Elasticsearch queries.
This causes `ELASTIC_QUERY_TOTAL_TIME` to include not just the actual query round-trip (ES server processing + network), but also the I/O thread scheduling delay caused by other queries' blocked callbacks.

Evidence: Adding `LOG.info("handleResponse running on thread: {}", Thread.currentThread().getName())` to `handleResponse` confirmed the callback runs on `elasticsearch-rest-client-1-thread-N`, the I/O dispatcher threads.

### Relevant documentation:
- https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CompletableFuture.html: "Actions supplied for dependent completions of non-async methods may be performed by the thread that completes the current CompletableFuture"
- https://issues.apache.org/jira/browse/HTTPCLIENT-1805: Apache HttpClient lead warns to "keep code executed in callbacks as light as possible given the same I/O dispatch thread has to handle I/O events of multiple connections"

### Fix

`whenComplete` → `whenCompleteAsync`: Response processing now runs on `ForkJoinPool.commonPool()` instead of the I/O dispatcher thread. This frees the I/O thread immediately after the future completes, preventing cross-query interference.

### Risk assessment

- Thread safety: The semaphore already ensures at most one in-flight request per scanner. `searchStartTime` is written before the async call and read in the callback; the `CompletableFuture` chain guarantees happens-before. No new thread-safety concerns.
- `ForkJoinPool` blocking: `queue.offer` and `rowInclusionPredicate.test` can block, but `queue.offer` is bounded by `enqueueTimeoutMs` and the common pool can compensate with additional threads. This is far better than blocking the I/O dispatcher threads which also prevents socket reads for other connections.
- Cancellation: `ongoingRequest.cancel(true)` behaves the same — it cancels the `whenCompleteAsync` stage. The `isClosed` check in `handleResponse` guards against processing after close, same as before.