### PR TITLE
OAK-12057: Add feature toggle for LIMIT-aware index selection

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -597,6 +597,10 @@ public class Oak {
             LOG.info("Registered optimize XPath union feature: " + QueryEngineSettings.FT_OPTIMIZE_XPATH_UNION);
             closer.register(optimizeXPathUnion);
             queryEngineSettings.setOptimizeXPathUnion(optimizeXPathUnion);
+            Feature ignoreLimitInIndexSelection = newFeature(QueryEngineSettings.FT_IGNORE_LIMIT_IN_INDEX_SELECTION, whiteboard);
+            LOG.info("Registered ignore limit in index selection feature: " + QueryEngineSettings.FT_IGNORE_LIMIT_IN_INDEX_SELECTION);
+            closer.register(ignoreLimitInIndexSelection);
+            queryEngineSettings.setIgnoreLimitInIndexSelectionFeature(ignoreLimitInIndexSelection);
         }
 
         return this;
@@ -1019,6 +1023,10 @@ public class Oak {
 
         public void setOptimizeXPathUnion(@Nullable Feature feature) {
             settings.setOptimizeXPathUnion(feature);
+        }
+
+        public void setIgnoreLimitInIndexSelectionFeature(@Nullable Feature feature) {
+            settings.setIgnoreLimitInIndexSelectionFeature(feature);
         }
 
         @Override

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -71,6 +71,8 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String FT_OPTIMIZE_XPATH_UNION = "FT_OAK-12007";
 
+    public static final String FT_IGNORE_LIMIT_IN_INDEX_SELECTION = "FT_OAK-12057";
+
     public static final int DEFAULT_PREFETCH_COUNT = Integer.getInteger(OAK_QUERY_PREFETCH_COUNT, -1);
 
     public static final String OAK_QUERY_FAIL_TRAVERSAL = "oak.queryFailTraversal";
@@ -130,6 +132,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private Feature optimizeInRestrictionsForFunctions;
     private Feature sortUnionQueryByScoreFeature;
     private Feature optimizeXPathUnion;
+    private Feature ignoreLimitInIndexSelectionFeature;
 
     private String autoOptionsMappingJson = "{}";
     private QueryOptions.AutomaticQueryOptionsMapping autoOptionsMapping = new QueryOptions.AutomaticQueryOptionsMapping(autoOptionsMappingJson);
@@ -270,6 +273,16 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     public boolean isOptimizeXPathUnionEnabled() {
         // disable if the feature toggle is not used
         return optimizeXPathUnion != null && optimizeXPathUnion.isEnabled();
+    }
+
+    public void setIgnoreLimitInIndexSelectionFeature(@Nullable Feature feature) {
+        this.ignoreLimitInIndexSelectionFeature = feature;
+    }
+
+    @Override
+    public boolean isIgnoreLimitInIndexSelection() {
+        // enabled if the feature toggle is not used
+        return ignoreLimitInIndexSelectionFeature == null || ignoreLimitInIndexSelectionFeature.isEnabled();
     }
 
     public String getStrictPathRestriction() {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryImpl.java
@@ -1081,6 +1081,12 @@ public class QueryImpl implements Query {
         double almostBestCost = Double.POSITIVE_INFINITY;
         IndexPlan almostBestPlan = null;
 
+        // Legacy behavior: cap entry count by offset+limit for index cost calculation
+        Long maxEntryCount = null;
+        if (!settings.isIgnoreLimitInIndexSelection()) {
+            maxEntryCount = saturatedAdd(offset.orElse(0L), limit.orElse(Long.MAX_VALUE));
+        }
+
         // Sort the indexes according to their minimum cost to be able to skip the remaining indexes if the cost of the
         // current index is below the minimum cost of the next index.
         List<? extends QueryIndex> queryIndexes = indexProvider.getQueryIndexes(rootState).stream()
@@ -1114,6 +1120,14 @@ public class QueryImpl implements Query {
                     long entryCount = p.getEstimatedEntryCount();
                     if (p.getSupportsPathRestriction()) {
                         entryCount = scaleEntryCount(rootState, filter, entryCount);
+                    }
+                    if (maxEntryCount != null) {
+                        if (sortOrder == null || p.getSortOrder() != null) {
+                            // if the query is unordered, or
+                            // if the query contains "order by" and the index can sort on that,
+                            // then we don't need to read all entries from the index
+                            entryCount = Math.min(maxEntryCount, entryCount);
+                        }
                     }
                     double c = p.getCostPerExecution() + entryCount * p.getCostPerEntry();
 

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryLimits.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/QueryLimits.java
@@ -68,4 +68,14 @@ public interface QueryLimits {
         return false;
     };
 
+    /**
+     * See OAK-12057. By default, LIMIT is ignored when selecting indexes
+     * (allowing the query engine to select based on the best plan).
+     *
+     * @return true to ignore LIMIT in index selection, false for legacy behavior
+     */
+    default boolean isIgnoreLimitInIndexSelection() {
+        return true;
+    }
+
 }

--- a/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/package-info.java
+++ b/oak-query-spi/src/main/java/org/apache/jackrabbit/oak/spi/query/package-info.java
@@ -18,7 +18,7 @@
 /**
  * This package contains oak query index related classes.
  */
-@Version("3.2.0")
+@Version("3.3.0")
 package org.apache.jackrabbit.oak.spi.query;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
## Summary

Adds a feature toggle (`FT_IGNORE_LIMIT_IN_INDEX_SELECTION`) to enable gradual rollout of OAK-12057 (wrong index selection when using LIMIT).

- **Default (ON)**: Uses the optimized behavior from PR #2724 - ignores LIMIT/OFFSET when calculating index costs
- **Toggle OFF**: Reverts to legacy behavior - caps entry counts by offset+limit

## Changes

- Added toggle constant and infrastructure in `QueryEngineSettings`
- Registered feature in `Oak.java`
- Wrapped index entry count capping logic in `QueryImpl.java` with toggle check

Allows safe gradual deployment without requiring immediate rollout to all environments.