### PR TITLE
OAK-12149 : migrate oak-blob-cloud S3Backend to Oak Cache API

### DIFF
--- a/oak-blob-cloud/pom.xml
+++ b/oak-blob-cloud/pom.xml
@@ -46,7 +46,7 @@
 
                             <!-- Jackrabbit/Oak -->
                             org.apache.jackrabbit.core.data,
-                            org.apache.jackrabbit.guava.common.cache,
+                            org.apache.jackrabbit.oak.cache.api,
                             org.apache.jackrabbit.oak.commons.*,
                             org.apache.jackrabbit.oak.plugins.blob.*,
                             org.apache.jackrabbit.oak.spi.blob,

--- a/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
+++ b/oak-blob-cloud/src/main/java/org/apache/jackrabbit/oak/blob/cloud/s3/S3Backend.java
@@ -63,8 +63,8 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import org.apache.jackrabbit.oak.cache.api.Cache;
+import org.apache.jackrabbit.oak.cache.api.CacheBuilder;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -812,10 +812,10 @@ public class S3Backend extends AbstractSharedBackend {
         // max size 0 or smaller is used to turn off the cache
         if (maxSize > 0) {
             LOG.info("presigned GET URI cache enabled, maxSize = {} items, expiry = {} seconds", maxSize, httpDownloadURIExpirySeconds / 2);
-            httpDownloadURICache = CacheBuilder.newBuilder()
+            httpDownloadURICache = CacheBuilder.<DataIdentifier, URI>newBuilder()
                     .maximumSize(maxSize)
                     // cache for half the expiry time of the URIs before giving out new ones
-                    .expireAfterWrite(httpDownloadURIExpirySeconds / 2, TimeUnit.SECONDS)
+                    .expireAfterWrite(Duration.ofSeconds(httpDownloadURIExpirySeconds / 2))
                     .build();
         } else {
             LOG.info("presigned GET URI cache disabled");


### PR DESCRIPTION
## Summary

Migrate `S3Backend` in `oak-blob-cloud` from the Guava-shim cache (`org.apache.jackrabbit.guava.common.cache`) to the new Oak Cache API (`org.apache.jackrabbit.oak.cache.api`).

## Changes

- `S3Backend.java`: replaced `Cache`/`CacheBuilder` imports from `org.apache.jackrabbit.guava.common.cache` with `org.apache.jackrabbit.oak.cache.api`; updated `.expireAfterWrite(long, TimeUnit)` to `.expireAfterWrite(Duration)`
- `pom.xml`: replaced `org.apache.jackrabbit.guava.common.cache` OSGi `Import-Package` entry with `org.apache.jackrabbit.oak.cache.api`

## Test Plan

- [x] `S3BackendCompatibilityTest` — all 6 tests pass

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-12149