### PR TITLE
OAK-12150 : migrate oak-blob-cloud-azure to Oak Cache API

### DIFF
--- a/oak-blob-cloud-azure/pom.xml
+++ b/oak-blob-cloud-azure/pom.xml
@@ -174,6 +174,11 @@
             <artifactId>oak-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>oak-core-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackend.java
@@ -38,8 +38,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.oak.spi.blob.data.DataIdentifier;
 import org.apache.jackrabbit.oak.spi.blob.data.DataRecord;
 import org.apache.jackrabbit.oak.spi.blob.data.DataStoreException;
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import org.apache.jackrabbit.oak.cache.api.Cache;
+import org.apache.jackrabbit.oak.cache.api.CacheBuilder;
 import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.apache.jackrabbit.oak.commons.conditions.Validate;
 import org.apache.jackrabbit.oak.spi.blob.AbstractDataRecord;
@@ -64,6 +64,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.InvalidKeyException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -766,9 +767,9 @@ public class AzureBlobStoreBackend extends AbstractAzureBlobStoreBackend {
         // max size 0 or smaller is used to turn off the cache
         if (maxSize > 0) {
             LOG.info("presigned GET URI cache enabled, maxSize = {} items, expiry = {} seconds", maxSize, httpDownloadURIExpirySeconds / 2);
-            httpDownloadURICache = CacheBuilder.newBuilder()
+            httpDownloadURICache = CacheBuilder.<String, URI>newBuilder()
                     .maximumSize(maxSize)
-                    .expireAfterWrite(httpDownloadURIExpirySeconds / 2, TimeUnit.SECONDS)
+                    .expireAfterWrite(Duration.ofSeconds(httpDownloadURIExpirySeconds / 2))
                     .build();
         } else {
             LOG.info("presigned GET URI cache disabled");

--- a/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/v8/AzureBlobStoreBackendV8.java
+++ b/oak-blob-cloud-azure/src/main/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/v8/AzureBlobStoreBackendV8.java
@@ -44,6 +44,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -62,8 +63,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import org.apache.jackrabbit.oak.cache.api.Cache;
+import org.apache.jackrabbit.oak.cache.api.CacheBuilder;
 import org.apache.jackrabbit.oak.commons.collections.AbstractIterator;
 import org.apache.jackrabbit.oak.commons.time.Stopwatch;
 
@@ -731,9 +732,9 @@ public class AzureBlobStoreBackendV8 extends AbstractAzureBlobStoreBackend {
         // max size 0 or smaller is used to turn off the cache
         if (maxSize > 0) {
             LOG.info("presigned GET URI cache enabled, maxSize = {} items, expiry = {} seconds", maxSize, httpDownloadURIExpirySeconds / 2);
-            httpDownloadURICache = CacheBuilder.newBuilder()
+            httpDownloadURICache = CacheBuilder.<String, URI>newBuilder()
                     .maximumSize(maxSize)
-                    .expireAfterWrite(httpDownloadURIExpirySeconds / 2, TimeUnit.SECONDS)
+                    .expireAfterWrite(Duration.ofSeconds(httpDownloadURIExpirySeconds / 2))
                     .build();
         } else {
             LOG.info("presigned GET URI cache disabled");

--- a/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
+++ b/oak-blob-cloud-azure/src/test/java/org/apache/jackrabbit/oak/blob/cloud/azure/blobstorage/AzureBlobStoreBackendTest.java
@@ -27,10 +27,10 @@ import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.jackrabbit.oak.cache.api.Cache;
 import org.apache.jackrabbit.oak.spi.blob.data.DataIdentifier;
 import org.apache.jackrabbit.oak.spi.blob.data.DataRecord;
 import org.apache.jackrabbit.oak.spi.blob.data.DataStoreException;
-import org.apache.jackrabbit.guava.common.cache.Cache;
 import org.apache.jackrabbit.oak.api.blob.BlobDownloadOptions;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordDownloadOptions;
 import org.apache.jackrabbit.oak.plugins.blob.datastore.directaccess.DataRecordUpload;

--- a/oak-core-spi/pom.xml
+++ b/oak-core-spi/pom.xml
@@ -44,6 +44,7 @@
           <instructions>
             <Export-Package>
               org.apache.jackrabbit.oak.cache,
+              org.apache.jackrabbit.oak.cache.api,
               org.apache.jackrabbit.oak.commons.jmx,
               org.apache.jackrabbit.oak.namepath,
               org.apache.jackrabbit.oak.osgi,


### PR DESCRIPTION
## Summary

Migrate `AzureBlobStoreBackend` and `AzureBlobStoreBackendV8` in `oak-blob-cloud-azure` from the Guava-shim cache to the new Oak Cache API (`org.apache.jackrabbit.oak.cache.api`).

## Changes

- `AzureBlobStoreBackend.java` / `AzureBlobStoreBackendV8.java`: replaced `Cache`/`CacheBuilder` imports from `org.apache.jackrabbit.guava.common.cache` with `org.apache.jackrabbit.oak.cache.api`; updated `.expireAfterWrite(long, TimeUnit)` to `.expireAfterWrite(Duration)`; added explicit type parameters to `CacheBuilder.<String, URI>newBuilder()`
- `pom.xml`: added `oak-core-spi` as a compile dependency

## Test Plan

- [x] `AzureBlobStoreBackendCompatibilityTest` — all 5 tests pass

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-12150