### PR TITLE
OAK-12151 : migrate oak-blob to Oak Cache API

### DIFF
--- a/oak-blob/pom.xml
+++ b/oak-blob/pom.xml
@@ -91,6 +91,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>oak-core-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
       <artifactId>oak-jackrabbit-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/oak-blob/src/main/java/org/apache/jackrabbit/oak/spi/blob/split/BlobIdSet.java
+++ b/oak-blob/src/main/java/org/apache/jackrabbit/oak/spi/blob/split/BlobIdSet.java
@@ -29,8 +29,8 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.jackrabbit.guava.common.cache.Cache;
-import org.apache.jackrabbit.guava.common.cache.CacheBuilder;
+import org.apache.jackrabbit.oak.cache.api.Cache;
+import org.apache.jackrabbit.oak.cache.api.CacheBuilder;
 import org.apache.jackrabbit.oak.commons.collections.BloomFilter;
 
 class BlobIdSet {
@@ -46,7 +46,7 @@ class BlobIdSet {
     BlobIdSet(String repositoryDir, String filename) {
         store = new File(new File(repositoryDir), filename);
         bloomFilter = BloomFilter.construct(9000000, 0.03); // 9M entries, 3% false positive rate
-        cache = CacheBuilder.newBuilder().maximumSize(1000).build();
+        cache = CacheBuilder.<String, Boolean>newBuilder().maximumSize(1000).build();
         fillBloomFilter();
     }
 


### PR DESCRIPTION
## Summary

Migrate `BlobIdSet` in `oak-blob` from the Guava-shim cache to the new Oak Cache API (`org.apache.jackrabbit.oak.cache.api`).

## Changes

- `BlobIdSet.java`: replaced `Cache`/`CacheBuilder` imports from `org.apache.jackrabbit.guava.common.cache` with `org.apache.jackrabbit.oak.cache.api`; added explicit type parameters to `CacheBuilder.<String, Boolean>newBuilder()`
- `pom.xml`: added `oak-core-spi` as a compile dependency

## Test Plan

- [x] `BlobIdSetTest` — all 10 tests pass

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-12151