### PR TITLE
OAK-12180 - AzureRepositoryLock renewal thread should not terminate

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureRepositoryLock.java
@@ -167,10 +167,7 @@ public class AzureRepositoryLock implements RepositoryLock {
                     } else if (isTransientClientSideException(e)) {
                         log.warn("Could not renew the lease due to transient client-side error. Retry in progress ...", e);
                     } else {
-                        log.error("Can't renew the lease", e);
-                        shutdownHook.run();
-                        doUpdate = false;
-                        return;
+                        log.warn("Could not renew lease due to exception. Retry in progress ... ", e);
                     }
                 }
                 waitABit(100);

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/v8/AzureRepositoryLockV8.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/v8/AzureRepositoryLockV8.java
@@ -170,10 +170,7 @@ public class AzureRepositoryLockV8 implements RepositoryLock {
                             log.warn("Could not renew lease due to storage exception. Retry in progress ... ", e);
                         }
                     } else {
-                        log.error("Can't renew the lease", e);
-                        shutdownHook.run();
-                        doUpdate = false;
-                        return;
+                        log.warn("Could not renew lease due to exception. Retry in progress ... ", e);
                     }
                 }
                 waitABit(100);


### PR DESCRIPTION
There are still situations where an exception occurs in lease renewal and the thread exits, meaning it will block writes forever and never recover, even if the cause of the exception is temporary.