### PR TITLE
OAK-12189: integration tests in oak-it-osgi fail due to misconfiguration of the assembly plugin

### DIFF
--- a/oak-it-osgi/test-bundles.xml
+++ b/oak-it-osgi/test-bundles.xml
@@ -67,6 +67,9 @@
         <include>org.apache.jackrabbit:oak-auth-ldap</include>
         <include>io.dropwizard.metrics:metrics-core</include>
       </includes>
+      <excludes>
+        <exclude>*:*:test-jar:*</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
Fixed by excluding all test-jars.