### PR TITLE
OAK-12202: add DistinctBinarySize.add(String blobId)

### DIFF
--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/analysis/modules/DistinctBinarySize.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/analysis/modules/DistinctBinarySize.java
@@ -75,6 +75,8 @@ public class DistinctBinarySize implements StatsCollector {
     private long bloomFilterIgnoredSize;
     private long referenceCount;
     private long referenceSize;
+    private long totalDistinctCount;
+    private long totalDistinctSize;
 
     public DistinctBinarySize(long largeBinariesMB, long bloomFilterMB) {
         this.largeBinariesMB = largeBinariesMB;
@@ -110,8 +112,9 @@ public class DistinctBinarySize implements StatsCollector {
     }
 
     public void add(String blobId) {
+        BinaryId id = new BinaryId(blobId);
         referenceCount++;
-        addBinaryId(new BinaryId(blobId));
+        addBinaryId(id);
     }
 
     private void addBinaryId(BinaryId id) {
@@ -188,12 +191,32 @@ public class DistinctBinarySize implements StatsCollector {
         storage.add("small binaries HLL count", smallBinariesEstimatedCountHLL);
         storage.add("small binaries size", bloomFilterEstimatedSize);
 
-        long estimatedCount = largeBinaries.size() + smallBinariesEstimatedCount;
-        storage.add("total distinct count", estimatedCount);
-        long estimatedSize = largeBinariesSize + bloomFilterEstimatedSize;
-        storage.add("total distinct size", estimatedSize);
+        totalDistinctCount = largeBinaries.size() + smallBinariesEstimatedCount;
+        storage.add("total distinct count", totalDistinctCount);
+        totalDistinctSize = largeBinariesSize + bloomFilterEstimatedSize;
+        storage.add("total distinct size", totalDistinctSize);
         storage.add("total reference count", referenceCount);
         storage.add("total reference size", referenceSize);
+    }
+
+    public long getTotalReferenceCount() {
+        return referenceCount;
+    }
+
+    public long getTotalReferenceSize() {
+        return referenceSize;
+    }
+
+    public long getTotalDistinctCount() {
+        return totalDistinctCount;
+    }
+
+    public long getTotalDistinctSize() {
+        return totalDistinctSize;
+    }
+
+    public Storage getStorage() {
+        return storage;
     }
 
     public List<String> getRecords() {

--- a/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/analysis/modules/DistinctBinarySize.java
+++ b/oak-run-commons/src/main/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/analysis/modules/DistinctBinarySize.java
@@ -105,13 +105,22 @@ public class DistinctBinarySize implements StatsCollector {
         }
         referenceCount += list.size();
         for(BinaryId id : list) {
-            referenceSize += id.getLength();
-            if (largeBinariesCountMax > 0 && id.getLength() > largeBinarySizeThreshold) {
-                largeBinaries.add(id);
-                truncateLargeBinariesSet();
-            } else {
-                addToBloomFilter(id);
-            }
+            addBinaryId(id);
+        }
+    }
+
+    public void add(String blobId) {
+        referenceCount++;
+        addBinaryId(new BinaryId(blobId));
+    }
+
+    private void addBinaryId(BinaryId id) {
+        referenceSize += id.getLength();
+        if (largeBinariesCountMax > 0 && id.getLength() > largeBinarySizeThreshold) {
+            largeBinaries.add(id);
+            truncateLargeBinariesSet();
+        } else {
+            addToBloomFilter(id);
         }
     }
 

--- a/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/analysis/modules/BinarySizeTest.java
+++ b/oak-run-commons/src/test/java/org/apache/jackrabbit/oak/index/indexer/document/flatfile/analysis/modules/BinarySizeTest.java
@@ -40,6 +40,36 @@ public class BinarySizeTest {
     }
 
     @Test
+    public void addBlobIdString() {
+        DistinctBinarySize size = new DistinctBinarySize(1, 1);
+        String id1 = "0102030405060708090a0b0c0d0e0f1011121314#1000";
+        String id2 = "1112131415161718191a1b1c1d1e1f2021222324#2000";
+        size.add(id1);
+        size.add(id2);
+        size.add(id1); // duplicate: should not increase distinct count or size
+        size.end();
+        assertEquals(
+                "DistinctBinarySize\n"
+                + "config Bloom filter memory MB: 1\n"
+                + "config large binaries set memory MB: 1\n"
+                + "large binaries count: 2\n"
+                + "large binaries count million: 0\n"
+                + "large binaries count max: 31250\n"
+                + "large binaries size: 3000\n"
+                + "large binaries size GiB: 0\n"
+                + "total distinct count: 2\n"
+                + "total distinct count million: 0\n"
+                + "total distinct size: 3000\n"
+                + "total distinct size GiB: 0\n"
+                + "total reference count: 3\n"
+                + "total reference count million: 0\n"
+                + "total reference size: 4000\n"
+                + "total reference size GiB: 0\n"
+                + "storage size: 0 MB; 16 entries\n"
+                + "", size.toString());
+    }
+
+    @Test
     public void nodeNameFilter() {
         BinarySizeHistogram histogram = new BinarySizeHistogram(1);
         NodeNameFilter filtered = new NodeNameFilter("filtered", new BinarySizeHistogram(1));


### PR DESCRIPTION
Extracts a private addBinaryId helper from `add(NodeData)` and adds a `public add(String blobId)` overload for callers that already hold a raw blob-id string (e.g. from the datastore journal), plus a unit test covering reference counting and deduplication.