### PR TITLE
OAK-12203: Updated mina-core version

### DIFF
--- a/oak-auth-ldap/pom.xml
+++ b/oak-auth-ldap/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.1.10</version>
+            <version>2.1.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
Updating mina-core version dependency as current version used is affected by CVE-2026-41635 