### PR TITLE
OAK-12206 Fix subtree deletion not cascading to child documents in Elastic index

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -218,6 +218,9 @@ public class ElasticIndexProviderService {
         oakRegs.add(whiteboard.register(FeatureToggle.class,
                 new FeatureToggle(FulltextIndexPlanner.FT_OAK_12171, FulltextIndexPlanner.FT_OAK_12171_DISABLE),
                 emptyMap()));
+        oakRegs.add(whiteboard.register(FeatureToggle.class,
+                new FeatureToggle(ElasticIndexEditorProvider.FT_OAK_12206, ElasticIndexEditorProvider.FT_OAK_12206_DISABLE),
+                emptyMap()));
         if (System.getProperty(QueryEngineSettings.OAK_INFERENCE_ENABLED) != null) {
             this.isInferenceEnabled = Boolean.parseBoolean(System.getProperty(QueryEngineSettings.OAK_INFERENCE_ENABLED));
         } else {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.jackrabbit.oak.commons.PathUtils.ROOT_PATH;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition.TYPE_ELASTICSEARCH;
@@ -47,6 +48,14 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
     private final ElasticRetryPolicy retryPolicy;
 
     public final static String OAK_INDEX_ELASTIC_WRITER_DISABLE_KEY = "oak.index.elastic.writer.disable";
+
+    public static final String FT_OAK_12206 = "FT_OAK-12206";
+    /**
+     * When {@code true}, the subtree deleteByQuery in {@code deleteDocuments} is skipped,
+     * reverting to the pre-fix behaviour of deleting only the exact-path document.
+     * The fix is active by default; set to {@code true} via the feature toggle to disable it.
+     */
+    public static final AtomicBoolean FT_OAK_12206_DISABLE = new AtomicBoolean(false);
 
     private final boolean OAK_INDEX_ELASTIC_WRITER_DISABLE = Boolean.getBoolean(OAK_INDEX_ELASTIC_WRITER_DISABLE_KEY);
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -41,6 +41,7 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.Inference
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceIndexConfig;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.importer.AsyncLaneSwitcher;
+import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -167,6 +168,15 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     @Override
     public void deleteDocuments(String path) throws IOException {
         retryPolicy.withRetries(() -> bulkProcessorHandler.delete(indexName, ElasticIndexUtils.idFromPath(path)));
+        // Also delete all descendants: mirrors Lucene's PrefixQuery on the path term.
+        // The :ancestors field is indexed with path_hierarchy, so a term query on `path`
+        // matches every document whose ancestor chain includes that path.
+        // The ES Bulk API does not support delete by query, so we need to issue a separate request.
+        // This is not ideal but should be ok since deletes are expected to be less frequent than updates.
+        // The alternative would be to get the list of affected documents and issue a bulk delete by id,
+        // but that would be more complex and potentially more expensive (if there are many descendants).
+        retryPolicy.withRetries(() -> elasticConnection.getClient().deleteByQuery(
+                d -> d.index(indexName).query(q -> q.term(t -> t.field(FieldNames.ANCESTORS).value(path)))));
     }
 
     @Override

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -176,8 +176,14 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
             // This is not ideal but should be ok since deletes are expected to be less frequent than updates.
             // The alternative would be to get the list of affected documents and issue a bulk delete by id,
             // but that would be more complex and potentially more expensive (if there are many descendants).
-            retryPolicy.withRetries(() -> elasticConnection.getClient().deleteByQuery(
-                    d -> d.index(indexName).query(q -> q.term(t -> t.field(FieldNames.ANCESTORS).value(path)))));
+            retryPolicy.withRetries(() -> {
+                var response = elasticConnection.getClient().deleteByQuery(
+                        d -> d.index(indexName).query(q -> q.term(t -> t.field(FieldNames.ANCESTORS).value(path))));
+                response.failures().forEach(f -> LOG.warn("Failed to delete descendants of {}: shard {} reason {}", path, f.id(), f.cause()));
+                if (response.deleted() != null && response.deleted() > 0) {
+                    LOG.info("Deleted {} descendants of {} in {} ms", response.deleted(), path, response.took());
+                }
+            });
         }
     }
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriter.java
@@ -168,15 +168,17 @@ class ElasticIndexWriter implements FulltextIndexWriter<ElasticDocument> {
     @Override
     public void deleteDocuments(String path) throws IOException {
         retryPolicy.withRetries(() -> bulkProcessorHandler.delete(indexName, ElasticIndexUtils.idFromPath(path)));
-        // Also delete all descendants: mirrors Lucene's PrefixQuery on the path term.
-        // The :ancestors field is indexed with path_hierarchy, so a term query on `path`
-        // matches every document whose ancestor chain includes that path.
-        // The ES Bulk API does not support delete by query, so we need to issue a separate request.
-        // This is not ideal but should be ok since deletes are expected to be less frequent than updates.
-        // The alternative would be to get the list of affected documents and issue a bulk delete by id,
-        // but that would be more complex and potentially more expensive (if there are many descendants).
-        retryPolicy.withRetries(() -> elasticConnection.getClient().deleteByQuery(
-                d -> d.index(indexName).query(q -> q.term(t -> t.field(FieldNames.ANCESTORS).value(path)))));
+        if (!ElasticIndexEditorProvider.FT_OAK_12206_DISABLE.get()) {
+            // Delete all descendants: mirrors Lucene's PrefixQuery on the path term.
+            // The :ancestors field is indexed with path_hierarchy, so a term query on `path`
+            // matches every document whose ancestor chain includes that path.
+            // The ES Bulk API does not support delete by query, so we need to issue a separate request.
+            // This is not ideal but should be ok since deletes are expected to be less frequent than updates.
+            // The alternative would be to get the list of affected documents and issue a bulk delete by id,
+            // but that would be more complex and potentially more expensive (if there are many descendants).
+            retryPolicy.withRetries(() -> elasticConnection.getClient().deleteByQuery(
+                    d -> d.index(indexName).query(q -> q.term(t -> t.field(FieldNames.ANCESTORS).value(path)))));
+        }
     }
 
     @Override

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
@@ -373,6 +373,30 @@ public class ElasticContentTest extends ElasticAbstractQueryTest {
     }
 
     @Test
+    public void subtreeDeletion() throws Exception {
+        IndexDefinitionBuilder builder = createIndex("a").noAsync();
+        builder.includedPaths("/content");
+        builder.indexRule("nt:base").property("a").propertyIndex();
+        Tree index = setIndex(UUID.randomUUID().toString(), builder);
+        root.commit();
+
+        Tree content = root.getTree("/").addChild("content");
+        Tree parent = content.addChild("parent");
+        parent.setProperty("a", "foo");
+        parent.addChild("child1").setProperty("a", "foo");
+        parent.addChild("child2").setProperty("a", "foo");
+        parent.addChild("child3").setProperty("a", "foo");
+        root.commit();
+
+        assertEventually(() -> assertThat(countDocuments(index), equalTo(4L)));
+
+        content.getChild("parent").remove();
+        root.commit();
+
+        assertEventually(() -> assertThat(countDocuments(index), equalTo(0L)));
+    }
+
+    @Test
     public void propertyRemoval() throws Exception {
         IndexDefinitionBuilder builder = createIndex("a", "b", "c").noAsync();
         builder.includedPaths("/content");

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticContentTest.java
@@ -386,14 +386,18 @@ public class ElasticContentTest extends ElasticAbstractQueryTest {
         parent.addChild("child1").setProperty("a", "foo");
         parent.addChild("child2").setProperty("a", "foo");
         parent.addChild("child3").setProperty("a", "foo");
+        // this node is added to check that only the subtree of the removed node gets deleted from the index
+        Tree otherParent = content.addChild("otherParent");
+        otherParent.setProperty("a", "foo");
+        otherParent.addChild("child4").setProperty("a", "foo");
         root.commit();
 
-        assertEventually(() -> assertThat(countDocuments(index), equalTo(4L)));
+        assertEventually(() -> assertThat(countDocuments(index), equalTo(6L)));
 
         content.getChild("parent").remove();
         root.commit();
 
-        assertEventually(() -> assertThat(countDocuments(index), equalTo(0L)));
+        assertEventually(() -> assertThat(countDocuments(index), equalTo(2L)));
     }
 
     @Test

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
@@ -29,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Arrays;
 
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticTestUtils.randomString;
@@ -36,6 +38,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -51,6 +54,9 @@ public class ElasticIndexWriterTest {
 
     @Mock
     private ElasticConnection elasticConnectionMock;
+
+    @Mock
+    private ElasticsearchClient elasticsearchClientMock;
 
     @Mock
     private ElasticIndexDefinition indexDefinitionMock;
@@ -69,6 +75,7 @@ public class ElasticIndexWriterTest {
         closeable = MockitoAnnotations.openMocks(this);
         when(indexDefinitionMock.getIndexAlias()).thenReturn("test-index");
         when(indexDefinitionMock.getIndexName()).thenReturn("test-index-name");
+        when(elasticConnectionMock.getClient()).thenReturn(elasticsearchClientMock);
         // In this test we are explicitly disabling inference as bulkprocessor
         // is called with update document if inference is enabled.
         InferenceConfig.reInitialize(new MemoryNodeStore(), "/oak:index/:inferenceConfig", false);
@@ -155,6 +162,14 @@ public class ElasticIndexWriterTest {
         assertEquals("[he, ll, o , wo, rl, d]",
                 Arrays.toString(ElasticIndexWriter.splitLargeString(
                         "hello world", 2)));
+    }
+
+    @Test
+    public void ft_oak_12206_toggleShouldBeRemoved() {
+        // Time-bombed: if this test fails, the feature toggle FT_OAK-12206 and its guard in
+        // ElasticIndexWriter#deleteDocuments should be removed — the fix has been in production long enough.
+        assertTrue("Feature toggle " + ElasticIndexEditorProvider.FT_OAK_12206 + " is overdue for removal",
+                LocalDate.now().isBefore(LocalDate.of(2027, 5, 6)));
     }
 
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
@@ -17,6 +17,9 @@
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.util.ObjectBuilder;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
@@ -26,12 +29,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Function;
 
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticTestUtils.randomString;
 import static org.hamcrest.CoreMatchers.not;
@@ -71,11 +77,14 @@ public class ElasticIndexWriterTest {
     private AutoCloseable closeable;
 
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         closeable = MockitoAnnotations.openMocks(this);
         when(indexDefinitionMock.getIndexAlias()).thenReturn("test-index");
         when(indexDefinitionMock.getIndexName()).thenReturn("test-index-name");
         when(elasticConnectionMock.getClient()).thenReturn(elasticsearchClientMock);
+        when(elasticConnectionMock.getClient()
+                .deleteByQuery(ArgumentMatchers.<Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>>>any()))
+                .thenReturn(DeleteByQueryResponse.of(d -> d.deleted(1L).failures(Collections.emptyList())));
         // In this test we are explicitly disabling inference as bulkprocessor
         // is called with update document if inference is enabled.
         InferenceConfig.reInitialize(new MemoryNodeStore(), "/oak:index/:inferenceConfig", false);

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
@@ -115,6 +115,9 @@ public class ElasticIndexWriterTest {
 
         ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
         verify(bulkProcessorHandlerMock).delete(eq(indexAlias), idCaptor.capture());
+        verify(elasticsearchClientMock).deleteByQuery(
+                ArgumentMatchers.<Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>>>any()
+        );
 
         String id = idCaptor.getValue();
         assertEquals("/bar", id);
@@ -129,6 +132,9 @@ public class ElasticIndexWriterTest {
 
         verify(bulkProcessorHandlerMock, times(2)).index(eq(indexAlias), anyString(), any(ElasticDocument.class));
         verify(bulkProcessorHandlerMock, times(2)).delete(eq(indexAlias), anyString());
+        verify(elasticsearchClientMock, times(2)).deleteByQuery(
+                ArgumentMatchers.<Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>>>any()
+        );
     }
 
     @Test


### PR DESCRIPTION
Summary of changes:

  - ElasticIndexWriter.java: deleteDocuments(path) now fires a deleteByQuery after the bulk delete, using a term query on the :ancestors field with the deleted path. The :ancestors field is indexed with the path_hierarchy tokenizer, so a single term query matches every document at any depth below the deleted node — mirroring what
  Lucene's PrefixQuery does on the path term.
  - ElasticContentTest.java: Added subtreeDeletion test that creates a parent with 3 children, deletes the parent, and asserts all 4 documents are removed from the index.