### PR TITLE
OAK-12220 fix flaky test ElasticFacetTest.statisticalFacets

### DIFF
--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FacetCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/FacetCommonTest.java
@@ -187,17 +187,17 @@ public abstract class FacetCommonTest extends AbstractJcrTest {
 
             for (Map.Entry<String, Integer> facet : actualAclLabelCount.entrySet()) {
                 String facetLabel = facet.getKey();
-                assertEventually(() -> {
-                    int facetCount = facets.get(facetLabel);
-                    float ratio = ((float) facetCount) / facet.getValue();
-                    assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
-                                    "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
-                            Math.abs(ratio - 1) < 0.1);
-                });
+                int facetCount = facets.get(facetLabel);
+                float ratio = ((float) facetCount) / facet.getValue();
+                assertTrue("Facet count for label: " + facetLabel + " is outside of 10% margin of error. " +
+                                "Expected: " + facet.getValue() + "; Got: " + facetCount + "; Ratio: " + ratio,
+                        Math.abs(ratio - 1) < 0.1);
             }
+        });
 
+        // Verify that the query result is not affected by the facet sampling
+        assertEventually(() -> {
             try {
-                // Verify that the query result is not affected by the facet sampling
                 int rowCounter = 0;
                 RowIterator rows = getQueryResult(null).getRows();
                 while (rows.hasNext()) {


### PR DESCRIPTION
Fix flaky statisticalFacets test in FacetCommonTest

The test was failing intermittently in CI with the row count assertion (expected:<3000> but was:<2646>) being reached only once or twice before the outer timeout expired.