### PR TITLE
OAK-12190 Add createUserWithAbsolutePath and createGroupWithAbsolutePath to UserManager API (#2910)

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserManagerImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserManagerImpl.java
@@ -183,17 +183,7 @@ public class UserManagerImpl implements UserManager {
         if (intermediatePath != null) {
             intermediatePath = namePathMapper.getOakPath(intermediatePath);
         }
-        Tree userTree = userProvider.createUser(userID, intermediatePath);
-        setPrincipal(userTree, principal);
-        if (password != null) {
-            setPassword(userTree, userID, password, false);
-        }
-
-        User user = new UserImpl(userID, userTree, this);
-        onCreate(user, password);
-
-        log.debug("User created: {}", userID);
-        return user;
+        return buildUser(userID, password, principal, userProvider.createUser(userID, intermediatePath));
     }
 
     @NotNull
@@ -241,14 +231,27 @@ public class UserManagerImpl implements UserManager {
         if (intermediatePath != null) {
             intermediatePath = namePathMapper.getOakPath(intermediatePath);
         }
-        Tree groupTree = userProvider.createGroup(groupID, intermediatePath);
-        setPrincipal(groupTree, principal);
+        return buildGroup(groupID, principal, userProvider.createGroup(groupID, intermediatePath));
+    }
 
-        Group group = new GroupImpl(groupID, groupTree, this);
-        onCreate(group);
+    @NotNull
+    @Override
+    public User createUserWithAbsolutePath(@NotNull String userID, @Nullable String password,
+                                           @NotNull Principal principal, @NotNull String absolutePath)
+            throws AuthorizableExistsException, UnsupportedRepositoryOperationException, RepositoryException {
+        checkValidId(userID);
+        checkValidPrincipal(principal, false);
+        return buildUser(userID, password, principal, userProvider.createUserAtAbsolutePath(userID, getOakPath(absolutePath)));
+    }
 
-        log.debug("Group created: {}", groupID);
-        return group;
+    @NotNull
+    @Override
+    public Group createGroupWithAbsolutePath(@NotNull String groupID, @NotNull Principal principal,
+                                             @NotNull String absolutePath)
+            throws AuthorizableExistsException, UnsupportedRepositoryOperationException, RepositoryException {
+        checkValidId(groupID);
+        checkValidPrincipal(principal, true);
+        return buildGroup(groupID, principal, userProvider.createGroupAtAbsolutePath(groupID, getOakPath(absolutePath)));
     }
 
     /**
@@ -475,6 +478,38 @@ public class UserManagerImpl implements UserManager {
     @NotNull
     ConfigurationParameters getConfig() {
         return config;
+    }
+
+    @NotNull
+    private User buildUser(@NotNull String userID, @Nullable String password,
+                           @NotNull Principal principal, @NotNull Tree userTree) throws RepositoryException {
+        setPrincipal(userTree, principal);
+        if (password != null) {
+            setPassword(userTree, userID, password, false);
+        }
+        User user = new UserImpl(userID, userTree, this);
+        onCreate(user, password);
+        log.debug("User created: {}", userID);
+        return user;
+    }
+
+    @NotNull
+    private Group buildGroup(@NotNull String groupID, @NotNull Principal principal,
+                             @NotNull Tree groupTree) throws RepositoryException {
+        setPrincipal(groupTree, principal);
+        Group group = new GroupImpl(groupID, groupTree, this);
+        onCreate(group);
+        log.debug("Group created: {}", groupID);
+        return group;
+    }
+
+    @NotNull
+    private String getOakPath(@NotNull String jcrPath) throws RepositoryException {
+        String oakPath = namePathMapper.getOakPath(jcrPath);
+        if (oakPath == null) {
+            throw new RepositoryException("Invalid path: " + jcrPath);
+        }
+        return oakPath;
     }
 
     private void checkValidId(@Nullable String id) throws RepositoryException {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserProvider.java
@@ -188,6 +188,16 @@ class UserProvider extends AuthorizableBaseProvider {
     }
 
     @NotNull
+    Tree createUserAtAbsolutePath(@NotNull String userID, @NotNull String absoluteOakPath) throws RepositoryException {
+        return createAuthorizableNodeAtAbsolutePath(userID, NT_REP_USER, absoluteOakPath);
+    }
+
+    @NotNull
+    Tree createGroupAtAbsolutePath(@NotNull String groupID, @NotNull String absoluteOakPath) throws RepositoryException {
+        return createAuthorizableNodeAtAbsolutePath(groupID, NT_REP_GROUP, absoluteOakPath);
+    }
+
+    @NotNull
     Tree createSystemUser(@NotNull String userID, @Nullable String intermediateJcrPath) throws RepositoryException {
         String relSysPath = config.getConfigValue(PARAM_SYSTEM_RELATIVE_PATH, DEFAULT_SYSTEM_RELATIVE_PATH);
         String relPath;
@@ -360,5 +370,40 @@ class UserProvider extends AuthorizableBaseProvider {
     private String getNodeName(@NotNull String authorizableId) {
         AuthorizableNodeName generator = requireNonNull(config.getConfigValue(PARAM_AUTHORIZABLE_NODE_NAME, AuthorizableNodeName.DEFAULT, AuthorizableNodeName.class));
         return generator.generateNodeName(authorizableId);
+    }
+
+    private Tree createAuthorizableNodeAtAbsolutePath(@NotNull String authorizableId,
+                                                      @NotNull String ntName,
+                                                      @NotNull String absoluteOakPath) throws RepositoryException {
+        String nodeName = PathUtils.getName(absoluteOakPath);
+        String parentPath = PathUtils.getParentPath(absoluteOakPath);
+        String authRoot = NT_REP_GROUP.equals(ntName) ? groupPath : userPath;
+
+        if (!parentPath.equals(authRoot) && !PathUtils.isAncestor(authRoot, parentPath)) {
+            throw new ConstraintViolationException("Attempt to create authorizable at '" + absoluteOakPath
+                    + "' outside of the configured root '" + authRoot + "'");
+        }
+
+        Tree tree = root.getTree(parentPath);
+        while (!tree.isRoot() && !tree.exists()) {
+            tree = tree.getParent();
+        }
+        if (!tree.exists()) {
+            throw new AccessDeniedException("Unable to retrieve authorizable parent folder.");
+        }
+        String relativePath = PathUtils.relativize(tree.getPath(), parentPath);
+        Tree folder = relativePath.isEmpty() ? tree : Utils.getOrAddTree(tree, relativePath, NT_REP_AUTHORIZABLE_FOLDER);
+
+        if (folder.hasChild(nodeName)) {
+            throw new ConstraintViolationException("Node already exists at: " + absoluteOakPath);
+        }
+
+        Tree typeRoot = root.getTree(NODE_TYPES_PATH);
+        String userId = Objects.toString(root.getContentSession().getAuthInfo().getUserID(), "");
+        Tree authorizableNode = TreeUtil.addChild(folder, nodeName, ntName, typeRoot, userId);
+        authorizableNode.setProperty(REP_AUTHORIZABLE_ID, authorizableId);
+        authorizableNode.setProperty(JcrConstants.JCR_UUID, getContentID(authorizableId));
+
+        return authorizableNode;
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/autosave/AutoSaveEnabledManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/autosave/AutoSaveEnabledManager.java
@@ -142,6 +142,28 @@ public class AutoSaveEnabledManager implements UserManager {
 
     @NotNull
     @Override
+    public User createUserWithAbsolutePath(@NotNull String userID, @Nullable String password,
+                                           @NotNull Principal principal, @NotNull String absolutePath) throws RepositoryException {
+        try {
+            return wrap(dlg.createUserWithAbsolutePath(userID, password, principal, absolutePath));
+        } finally {
+            autosave();
+        }
+    }
+
+    @NotNull
+    @Override
+    public Group createGroupWithAbsolutePath(@NotNull String groupID, @NotNull Principal principal,
+                                             @NotNull String absolutePath) throws RepositoryException {
+        try {
+            return wrap(dlg.createGroupWithAbsolutePath(groupID, principal, absolutePath));
+        } finally {
+            autosave();
+        }
+    }
+
+    @NotNull
+    @Override
     public Group createGroup(@NotNull String groupId) throws RepositoryException {
         try {
             return wrap(dlg.createGroup(groupId));

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/IntermediatePathTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/IntermediatePathTest.java
@@ -23,6 +23,9 @@ import javax.jcr.RepositoryException;
 import javax.jcr.nodetype.ConstraintViolationException;
 
 import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.AuthorizableExistsException;
+import org.apache.jackrabbit.api.security.user.Group;
+import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.oak.AbstractSecurityTest;
 import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.commons.PathUtils;
@@ -30,6 +33,7 @@ import org.apache.jackrabbit.oak.plugins.tree.TreeUtil;
 import org.apache.jackrabbit.oak.spi.nodetype.NodeTypeConstants;
 import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
@@ -203,5 +207,75 @@ public class IntermediatePathTest extends AbstractSecurityTest {
     public void testCurrentRelativePath() throws Exception {
         Authorizable authorizable = createAuthorizable(false, ".");
         assertEquals(UserConstants.DEFAULT_USER_PATH, PathUtils.getAncestorPath(authorizable.getPath(), 1));
+    }
+
+    // --- createUserWithAbsolutePath ---
+
+    private User createUserWithAbsolutePath(@NotNull String oakPath) throws RepositoryException {
+        String id = UUID.randomUUID().toString();
+        return getUserManager(root).createUserWithAbsolutePath(id, null, new PrincipalImpl(id), oakPath);
+    }
+
+    private Group createGroupWithAbsolutePath(@NotNull String oakPath) throws RepositoryException {
+        String id = UUID.randomUUID().toString();
+        return getUserManager(root).createGroupWithAbsolutePath(id, new PrincipalImpl(id), oakPath);
+    }
+
+    @Test
+    public void testCreateUserWithAbsolutePath() throws Exception {
+        String oakPath = UserConstants.DEFAULT_USER_PATH + "/a/b/c";
+        User user = createUserWithAbsolutePath(oakPath);
+        assertNotNull(user);
+        assertTrue(user.getPath().startsWith(oakPath));
+    }
+
+    @Test
+    public void testCreateGroupWithAbsolutePath() throws Exception {
+        String oakPath = UserConstants.DEFAULT_GROUP_PATH + "/a/b/c";
+        Group group = createGroupWithAbsolutePath(oakPath);
+        assertNotNull(group);
+        assertTrue(group.getPath().startsWith(oakPath));
+    }
+
+    @Test
+    public void testCreateUserWithAbsolutePathRetrievableByPath() throws Exception {
+        String oakPath = UserConstants.DEFAULT_USER_PATH + "/retrieve/test";
+        User user = createUserWithAbsolutePath(oakPath);
+        root.commit();
+        assertNotNull(getUserManager(root).getAuthorizableByPath(user.getPath()));
+    }
+
+    @Test
+    public void testCreateGroupWithAbsolutePathRetrievableByPath() throws Exception {
+        String oakPath = UserConstants.DEFAULT_GROUP_PATH + "/retrieve/test";
+        Group group = createGroupWithAbsolutePath(oakPath);
+        root.commit();
+        assertNotNull(getUserManager(root).getAuthorizableByPath(group.getPath()));
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testCreateUserWithAbsolutePathWrongRoot() throws Exception {
+        createUserWithAbsolutePath(UserConstants.DEFAULT_GROUP_PATH + "/wrong");
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testCreateGroupWithAbsolutePathWrongRoot() throws Exception {
+        createGroupWithAbsolutePath(UserConstants.DEFAULT_USER_PATH + "/wrong");
+    }
+
+    @Test(expected = AuthorizableExistsException.class)
+    public void testCreateUserWithAbsolutePathDuplicateId() throws Exception {
+        String id = UUID.randomUUID().toString();
+        String oakPath = UserConstants.DEFAULT_USER_PATH + "/dup/test";
+        getUserManager(root).createUserWithAbsolutePath(id, null, new PrincipalImpl(id), oakPath);
+        getUserManager(root).createUserWithAbsolutePath(id, null, new PrincipalImpl(id + "_2"), oakPath);
+    }
+
+    @Test(expected = AuthorizableExistsException.class)
+    public void testCreateGroupWithAbsolutePathDuplicateId() throws Exception {
+        String id = UUID.randomUUID().toString();
+        String oakPath = UserConstants.DEFAULT_GROUP_PATH + "/dup/test";
+        getUserManager(root).createGroupWithAbsolutePath(id, new PrincipalImpl(id), oakPath);
+        getUserManager(root).createGroupWithAbsolutePath(id, new PrincipalImpl(id + "_2"), oakPath);
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/UserManagerImplAbsolutePathTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/UserManagerImplAbsolutePathTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.security.user;
+
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.AuthorizableExistsException;
+import org.apache.jackrabbit.api.security.user.Group;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
+import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
+import org.junit.Test;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import java.security.Principal;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for {@link UserManagerImpl#createUserWithAbsolutePath} and
+ * {@link UserManagerImpl#createGroupWithAbsolutePath}.
+ *
+ * Verifies that the authorizable node is created exactly at the given absolute
+ * path, with the last path segment used as the node name.
+ */
+public class UserManagerImplAbsolutePathTest extends AbstractUserTest {
+
+    private static final String USER_PATH = UserConstants.DEFAULT_USER_PATH + "/test/absolute";
+    private static final String GROUP_PATH = UserConstants.DEFAULT_GROUP_PATH + "/test/absolute";
+
+    // ---- helpers ----
+
+    private User createUser(String absolutePath) throws RepositoryException {
+        String id = UUID.randomUUID().toString();
+        return getUserManager(root).createUserWithAbsolutePath(id, null, new PrincipalImpl(id), absolutePath);
+    }
+
+    private Group createGroup(String absolutePath) throws RepositoryException {
+        String id = UUID.randomUUID().toString();
+        return getUserManager(root).createGroupWithAbsolutePath(id, new PrincipalImpl(id), absolutePath);
+    }
+
+    // ---- user: exact path placement ----
+
+    @Test
+    public void testUserCreatedAtExactPath() throws Exception {
+        User user = createUser(USER_PATH);
+        assertEquals(USER_PATH, user.getPath());
+    }
+
+    @Test
+    public void testUserNodeNameIsLastPathSegment() throws Exception {
+        String expectedNodeName = "my-user-node";
+        String path = UserConstants.DEFAULT_USER_PATH + "/test/" + expectedNodeName;
+        User user = createUser(path);
+        assertEquals(expectedNodeName, PathUtils.getName(user.getPath()));
+    }
+
+    @Test
+    public void testUserIntermediateFoldersCreated() throws Exception {
+        // parent folders do not pre-exist; they must be created by the implementation
+        String deepPath = UserConstants.DEFAULT_USER_PATH + "/deep/nested/folders/myuser";
+        User user = createUser(deepPath);
+        assertEquals(deepPath, user.getPath());
+    }
+
+    @Test
+    public void testUserRetrievableByExactPath() throws Exception {
+        User user = createUser(USER_PATH);
+        root.commit();
+        Authorizable found = getUserManager(root).getAuthorizableByPath(USER_PATH);
+        assertNotNull(found);
+        assertEquals(user.getID(), found.getID());
+    }
+
+    @Test
+    public void testUserPasswordSet() throws Exception {
+        String id = UUID.randomUUID().toString();
+        User user = getUserManager(root).createUserWithAbsolutePath(id, "s3cr3t", new PrincipalImpl(id), USER_PATH);
+        assertNotNull(user);
+        assertEquals(USER_PATH, user.getPath());
+        // password authentication is validated through credentials check, not directly readable
+    }
+
+    @Test
+    public void testUserPrincipalSet() throws Exception {
+        String id = UUID.randomUUID().toString();
+        Principal principal = new PrincipalImpl("my-principal-" + id);
+        User user = getUserManager(root).createUserWithAbsolutePath(id, null, principal, USER_PATH);
+        assertEquals(principal.getName(), user.getPrincipal().getName());
+    }
+
+    // ---- user: error cases ----
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testUserOutsideUserRoot() throws Exception {
+        createUser(UserConstants.DEFAULT_GROUP_PATH + "/wrong/location");
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testUserPathCollision() throws Exception {
+        createUser(USER_PATH);
+        // different ID, same absolute path → node already exists
+        createUser(USER_PATH);
+    }
+
+    @Test(expected = AuthorizableExistsException.class)
+    public void testUserDuplicateId() throws Exception {
+        String id = UUID.randomUUID().toString();
+        String path1 = UserConstants.DEFAULT_USER_PATH + "/dup/first";
+        String path2 = UserConstants.DEFAULT_USER_PATH + "/dup/second";
+        getUserManager(root).createUserWithAbsolutePath(id, null, new PrincipalImpl(id), path1);
+        getUserManager(root).createUserWithAbsolutePath(id, null, new PrincipalImpl(id + "_2"), path2);
+    }
+
+    // ---- group: exact path placement ----
+
+    @Test
+    public void testGroupCreatedAtExactPath() throws Exception {
+        Group group = createGroup(GROUP_PATH);
+        assertEquals(GROUP_PATH, group.getPath());
+    }
+
+    @Test
+    public void testGroupNodeNameIsLastPathSegment() throws Exception {
+        String expectedNodeName = "my-group-node";
+        String path = UserConstants.DEFAULT_GROUP_PATH + "/test/" + expectedNodeName;
+        Group group = createGroup(path);
+        assertEquals(expectedNodeName, PathUtils.getName(group.getPath()));
+    }
+
+    @Test
+    public void testGroupIntermediateFoldersCreated() throws Exception {
+        String deepPath = UserConstants.DEFAULT_GROUP_PATH + "/deep/nested/folders/mygroup";
+        Group group = createGroup(deepPath);
+        assertEquals(deepPath, group.getPath());
+    }
+
+    @Test
+    public void testGroupRetrievableByExactPath() throws Exception {
+        Group group = createGroup(GROUP_PATH);
+        root.commit();
+        Authorizable found = getUserManager(root).getAuthorizableByPath(GROUP_PATH);
+        assertNotNull(found);
+        assertEquals(group.getID(), found.getID());
+    }
+
+    @Test
+    public void testGroupPrincipalSet() throws Exception {
+        String id = UUID.randomUUID().toString();
+        Principal principal = new PrincipalImpl("my-group-principal-" + id);
+        Group group = getUserManager(root).createGroupWithAbsolutePath(id, principal, GROUP_PATH);
+        assertEquals(principal.getName(), group.getPrincipal().getName());
+    }
+
+    @Test
+    public void testUserCreatedDirectlyUnderUserRoot() throws Exception {
+        String path = UserConstants.DEFAULT_USER_PATH + "/myuser";
+        User user = createUser(path);
+        assertEquals(path, user.getPath());
+    }
+
+    // ---- group: error cases ----
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testGroupOutsideGroupRoot() throws Exception {
+        createGroup(UserConstants.DEFAULT_USER_PATH + "/wrong/location");
+    }
+
+    @Test(expected = ConstraintViolationException.class)
+    public void testGroupPathCollision() throws Exception {
+        createGroup(GROUP_PATH);
+        // different ID, same absolute path → node already exists
+        createGroup(GROUP_PATH);
+    }
+
+    @Test
+    public void testGroupCreatedDirectlyUnderGroupRoot() throws Exception {
+        String path = UserConstants.DEFAULT_GROUP_PATH + "/mygroup";
+        Group group = createGroup(path);
+        assertEquals(path, group.getPath());
+    }
+
+    @Test(expected = AuthorizableExistsException.class)
+    public void testGroupDuplicateId() throws Exception {
+        String id = UUID.randomUUID().toString();
+        String path1 = UserConstants.DEFAULT_GROUP_PATH + "/dup/first";
+        String path2 = UserConstants.DEFAULT_GROUP_PATH + "/dup/second";
+        getUserManager(root).createGroupWithAbsolutePath(id, new PrincipalImpl(id), path1);
+        getUserManager(root).createGroupWithAbsolutePath(id, new PrincipalImpl(id + "_2"), path2);
+    }
+
+    // ---- buildUser / buildGroup via regular create paths ----
+
+    @Test
+    public void testRegularCreateUserPrincipalAndPathSet() throws Exception {
+        String id = UUID.randomUUID().toString();
+        Principal principal = new PrincipalImpl("regular-" + id);
+        User user = getUserManager(root).createUser(id, null, principal, null);
+        assertEquals(principal.getName(), user.getPrincipal().getName());
+        assertNotNull(user.getPath());
+    }
+
+    @Test
+    public void testRegularCreateGroupPrincipalAndPathSet() throws Exception {
+        String id = UUID.randomUUID().toString();
+        Principal principal = new PrincipalImpl("regular-group-" + id);
+        Group group = getUserManager(root).createGroup(id, principal, null);
+        assertEquals(principal.getName(), group.getPrincipal().getName());
+        assertNotNull(group.getPath());
+    }
+}

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/UserProviderTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/UserProviderTest.java
@@ -44,6 +44,7 @@ import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
 import org.apache.jackrabbit.oak.spi.security.user.AuthorizableNodeName;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.apache.jackrabbit.oak.spi.security.user.util.UserUtil;
+import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.util.Text;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -470,6 +471,107 @@ public class UserProviderTest {
     public void testAutoCreatedItemsUponGroupCreation() throws Exception {
         UserProvider up = createUserProvider();
         assertAutoCreatedItems(up.createGroup("g", null), UserConstants.NT_REP_GROUP, root);
+    }
+
+    // ---- createUserAtAbsolutePath / createGroupAtAbsolutePath ----
+
+    @Test
+    public void testCreateUserAtAbsolutePath() throws Exception {
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultUserPath + "/a/b/myuser";
+        Tree userTree = up.createUserAtAbsolutePath("myuser", absolutePath);
+        assertNotNull(userTree);
+        assertEquals(absolutePath, userTree.getPath());
+    }
+
+    @Test
+    public void testCreateGroupAtAbsolutePath() throws Exception {
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultGroupPath + "/a/b/mygroup";
+        Tree groupTree = up.createGroupAtAbsolutePath("mygroup", absolutePath);
+        assertNotNull(groupTree);
+        assertEquals(absolutePath, groupTree.getPath());
+    }
+
+    @Test
+    public void testCreateUserAtAbsolutePathDirectlyUnderUserRoot() throws Exception {
+        // parentPath equals authRoot: the relativePath.isEmpty() branch is taken
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultUserPath + "/myuser";
+        Tree userTree = up.createUserAtAbsolutePath("myuser", absolutePath);
+        assertEquals(absolutePath, userTree.getPath());
+    }
+
+    @Test
+    public void testCreateGroupAtAbsolutePathDirectlyUnderGroupRoot() throws Exception {
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultGroupPath + "/mygroup";
+        Tree groupTree = up.createGroupAtAbsolutePath("mygroup", absolutePath);
+        assertEquals(absolutePath, groupTree.getPath());
+    }
+
+    @Test
+    public void testCreateUserAtAbsolutePathIntermediateFolderType() throws Exception {
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultUserPath + "/folder/myuser";
+        up.createUserAtAbsolutePath("myuser", absolutePath);
+        String parentPath = PathUtils.getParentPath(absolutePath);
+        Tree folder = root.getTree(parentPath);
+        assertTrue(folder.exists());
+        assertEquals(NT_REP_AUTHORIZABLE_FOLDER, folder.getProperty(JCR_PRIMARYTYPE).getValue(Type.NAME));
+    }
+
+    @Test(expected = javax.jcr.nodetype.ConstraintViolationException.class)
+    public void testCreateUserAtAbsolutePathOutsideUserRoot() throws Exception {
+        UserProvider up = createUserProvider();
+        up.createUserAtAbsolutePath("uid", defaultGroupPath + "/wrong/uid");
+    }
+
+    @Test(expected = javax.jcr.nodetype.ConstraintViolationException.class)
+    public void testCreateGroupAtAbsolutePathOutsideGroupRoot() throws Exception {
+        UserProvider up = createUserProvider();
+        up.createGroupAtAbsolutePath("gid", defaultUserPath + "/wrong/gid");
+    }
+
+    @Test(expected = javax.jcr.nodetype.ConstraintViolationException.class)
+    public void testCreateUserAtAbsolutePathCollision() throws Exception {
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultUserPath + "/collision/myuser";
+        up.createUserAtAbsolutePath("user1", absolutePath);
+        up.createUserAtAbsolutePath("user2", absolutePath);
+    }
+
+    @Test(expected = javax.jcr.nodetype.ConstraintViolationException.class)
+    public void testCreateGroupAtAbsolutePathCollision() throws Exception {
+        UserProvider up = createUserProvider();
+        String absolutePath = defaultGroupPath + "/collision/mygroup";
+        up.createGroupAtAbsolutePath("group1", absolutePath);
+        up.createGroupAtAbsolutePath("group2", absolutePath);
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    public void testCreateUserAtAbsolutePathMissingAccess() throws RepositoryException {
+        Tree t = mock(Tree.class);
+        when(t.getParent()).thenReturn(t);
+        when(t.exists()).thenReturn(false);
+        when(t.isRoot()).thenReturn(false, false, true);
+        Root r = when(mock(Root.class).getTree(anyString())).thenReturn(t).getMock();
+
+        UserProvider up = new UserProvider(r, ConfigurationParameters.EMPTY);
+        up.createUserAtAbsolutePath("uid", UserConstants.DEFAULT_USER_PATH + "/parent/uid");
+    }
+
+    @Test(expected = javax.jcr.nodetype.ConstraintViolationException.class)
+    public void testCreateUserAtAbsolutePathSiblingOfUserRoot() throws Exception {
+        // path shares a string prefix with userPath but is a sibling, not a descendant
+        UserProvider up = createUserProvider();
+        up.createUserAtAbsolutePath("uid", defaultUserPath + "-sibling/uid");
+    }
+
+    @Test(expected = javax.jcr.nodetype.ConstraintViolationException.class)
+    public void testCreateGroupAtAbsolutePathSiblingOfGroupRoot() throws Exception {
+        UserProvider up = createUserProvider();
+        up.createGroupAtAbsolutePath("gid", defaultGroupPath + "-sibling/gid");
     }
 
     private static void assertAutoCreatedItems(@NotNull Tree authorizableTree, @NotNull String ntName, @NotNull Root root) throws Exception {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/autosave/AutoSaveEnabledManagerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/autosave/AutoSaveEnabledManagerTest.java
@@ -355,6 +355,26 @@ public class AutoSaveEnabledManagerTest extends AbstractAutoSaveTest {
     }
 
     @Test
+    public void testCreateUserWithAbsolutePath() throws Exception {
+        Principal principal = new PrincipalImpl("u");
+        autosaveMgr.createUserWithAbsolutePath("u", null, principal, UserConstants.DEFAULT_USER_PATH + "/absolute/u");
+        assertFalse(root.hasPendingChanges());
+
+        verify(mgrDlg, times(1)).createUserWithAbsolutePath("u", null, principal, UserConstants.DEFAULT_USER_PATH + "/absolute/u");
+        verify(autosaveMgr, times(1)).autosave();
+    }
+
+    @Test
+    public void testCreateGroupWithAbsolutePath() throws Exception {
+        Principal principal = new PrincipalImpl("g");
+        autosaveMgr.createGroupWithAbsolutePath("g", principal, UserConstants.DEFAULT_GROUP_PATH + "/absolute/g");
+        assertFalse(root.hasPendingChanges());
+
+        verify(mgrDlg, times(1)).createGroupWithAbsolutePath("g", principal, UserConstants.DEFAULT_GROUP_PATH + "/absolute/g");
+        verify(autosaveMgr, times(1)).autosave();
+    }
+
+    @Test
     public void testUnwrap() {
         assertSame(mgrDlg, autosaveMgr.unwrap());
     }

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/UserManager.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/UserManager.java
@@ -214,6 +214,35 @@ public interface UserManager {
 
 
     /**
+     * Creates a new {@code User} for the given parameters at the specified absolute JCR path.
+     * Unlike {@link #createUser(String, String, Principal, String)} where the
+     * {@code intermediatePath} is a relative hint, this method accepts an absolute
+     * JCR repository path that precisely determines the location of the new user node.
+     * The path must be within the configured user root.
+     * <p>
+     * Implementations that do not support creation with at an absolute path
+     * must throw {@link UnsupportedRepositoryOperationException}.
+     *
+     * @param userID       The ID of the new user.
+     * @param password     The initial password of the new user, may be {@code null}.
+     * @param principal    The principal of the new user.
+     * @param absolutePath The absolute JCR repository path at which the user node
+     *                     must be created. Must not be {@code null}.
+     * @return The new {@code User}.
+     * @throws AuthorizableExistsException             if an authorizable with the given
+     *                                                 userID or principal already exists.
+     * @throws UnsupportedRepositoryOperationException if the implementation does not
+     *                                                 support creation at an absolute path.
+     * @throws RepositoryException                     If another error occurs.
+     */
+    @NotNull
+    default User createUserWithAbsolutePath(@NotNull String userID, @Nullable String password,
+                                            @NotNull Principal principal, @NotNull String absolutePath)
+            throws AuthorizableExistsException, UnsupportedRepositoryOperationException, RepositoryException {
+        throw new UnsupportedRepositoryOperationException("Creating user with absolutePath not supported");
+    }
+
+    /**
      * Create a new system user for the specified {@code userID}. The new authorizable
      * is required to have the following characteristics:
      *
@@ -304,6 +333,35 @@ public interface UserManager {
      */
     @NotNull
     Group createGroup(@NotNull String groupID, @NotNull Principal principal, @Nullable String intermediatePath) throws AuthorizableExistsException, RepositoryException;
+
+    /**
+     * Creates a new {@code Group} at the specified absolute JCR repository path.
+     * <p>
+     * Unlike {@link #createGroup(String, Principal, String)} where the
+     * {@code intermediatePath} is a relative hint, this method accepts an absolute
+     * JCR repository path that precisely determines the location of the new group node.
+     * The path must be within the configured group root.
+     * <p>
+     * Implementations that do not support creation with at an absolute path
+     * must throw {@link UnsupportedRepositoryOperationException}.
+     *
+     * @param groupID      The ID of the new group.
+     * @param principal    The principal of the new group.
+     * @param absolutePath The absolute JCR repository path at which the group node
+     *                     must be created. Must not be {@code null}.
+     * @return The new {@code Group}.
+     * @throws AuthorizableExistsException             if an authorizable with the given
+     *                                                 groupID or principal already exists.
+     * @throws UnsupportedRepositoryOperationException if the implementation does not
+     *                                                 support creation at an absolute path.
+     * @throws RepositoryException                     If another error occurs.
+     */
+    @NotNull
+    default Group createGroupWithAbsolutePath(@NotNull String groupID, @NotNull Principal principal,
+                                              @NotNull String absolutePath)
+            throws AuthorizableExistsException, UnsupportedRepositoryOperationException, RepositoryException {
+        throw new UnsupportedRepositoryOperationException("Creating group with absolutePath not supported");
+    }
 
     /**
      * If any write operations executed through the User API are automatically

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/package-info.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/package-info.java
@@ -18,5 +18,5 @@
 /**
  * Jackrabbit extensions for user management.
  */
-@org.osgi.annotation.versioning.Version("2.4.5")
+@org.osgi.annotation.versioning.Version("2.5.0")
 package org.apache.jackrabbit.api.security.user;

--- a/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/UserManagerDelegator.java
+++ b/oak-jcr/src/main/java/org/apache/jackrabbit/oak/jcr/delegate/UserManagerDelegator.java
@@ -170,6 +170,21 @@ public class UserManagerDelegator implements UserManager {
 
     @NotNull
     @Override
+    public User createUserWithAbsolutePath(@NotNull final String userID, @Nullable final String password,
+                                           @NotNull final Principal principal, @NotNull final String absolutePath)
+            throws RepositoryException {
+        return sessionDelegate.perform(new UserManagerOperation<User>(sessionDelegate, "createUserWithAbsolutePath", true) {
+            @NotNull
+            @Override
+            public User perform() throws RepositoryException {
+                User user = userManagerDelegate.createUserWithAbsolutePath(userID, password, principal, absolutePath);
+                return UserDelegator.wrap(sessionDelegate, user);
+            }
+        });
+    }
+
+    @NotNull
+    @Override
     public User createSystemUser(@NotNull final String userID, @Nullable final String intermediatePath) throws RepositoryException {
         return sessionDelegate.perform(new UserManagerOperation<User>(sessionDelegate, "createUser", true) {
             @NotNull
@@ -228,6 +243,21 @@ public class UserManagerDelegator implements UserManager {
             @Override
             public Group perform() throws RepositoryException {
                 Group group = userManagerDelegate.createGroup(groupID, principal, intermediatePath);
+                return GroupDelegator.wrap(sessionDelegate, group);
+            }
+        });
+    }
+
+    @NotNull
+    @Override
+    public Group createGroupWithAbsolutePath(@NotNull final String groupID, @NotNull final Principal principal,
+                                             @NotNull final String absolutePath)
+            throws RepositoryException {
+        return sessionDelegate.perform(new UserManagerOperation<Group>(sessionDelegate, "createGroupWithAbsolutePath", true) {
+            @NotNull
+            @Override
+            public Group perform() throws RepositoryException {
+                Group group = userManagerDelegate.createGroupWithAbsolutePath(groupID, principal, absolutePath);
                 return GroupDelegator.wrap(sessionDelegate, group);
             }
         });

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/delegate/UserManagerDelegatorTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/delegate/UserManagerDelegatorTest.java
@@ -139,17 +139,31 @@ public class UserManagerDelegatorTest extends AbstractDelegatorTest {
     public void testCreateUser() throws Exception {
         doReturn(user).when(um).createUser(anyString(), anyString());
         doReturn(user).when(um).createUser(anyString(), anyString(), any(Principal.class), anyString());
-        
+
         Principal p = mock(Principal.class);
         User u1 = delegator.createUser("uid", "pw");
         User u2 = delegator.createUser("uid", "pw", p, "rel/path");
         assertTrue(u1 instanceof UserDelegator);
         assertTrue(u2 instanceof UserDelegator);
-        
+
         verify(um).createUser("uid", "pw");
         verify(um).createUser("uid", "pw", p, "rel/path");
 
         verifySessionDelegatePerform(sessionDelegate, 2);
+        verifyNoMoreInteractions(um, sessionDelegate);
+        verifyNoInteractions(user);
+    }
+
+    @Test
+    public void testCreateUserWithAbsolutePath() throws Exception {
+        doReturn(user).when(um).createUserWithAbsolutePath(anyString(), anyString(), any(Principal.class), anyString());
+
+        Principal p = mock(Principal.class);
+        User u = delegator.createUserWithAbsolutePath("uid", "pw", p, "/home/users/a/b");
+        assertTrue(u instanceof UserDelegator);
+
+        verify(um).createUserWithAbsolutePath("uid", "pw", p, "/home/users/a/b");
+        verifySessionDelegatePerform(sessionDelegate, 1);
         verifyNoMoreInteractions(um, sessionDelegate);
         verifyNoInteractions(user);
     }
@@ -179,13 +193,26 @@ public class UserManagerDelegatorTest extends AbstractDelegatorTest {
         assertTrue(delegator.createGroup("groupId", p, "rel/path") instanceof GroupDelegator);
         assertTrue(delegator.createGroup(p) instanceof GroupDelegator);
         assertTrue(delegator.createGroup(p, "rel/path") instanceof GroupDelegator);
-        
+
         verify(um).createGroup("groupId");
         verify(um).createGroup("groupId", p, "rel/path");
         verify(um).createGroup(p);
         verify(um).createGroup(p, "rel/path");
-        
+
         verifySessionDelegatePerform(sessionDelegate, 4);
+        verifyNoMoreInteractions(um, sessionDelegate);
+        verifyNoInteractions(group);
+    }
+
+    @Test
+    public void testCreateGroupWithAbsolutePath() throws Exception {
+        doReturn(group).when(um).createGroupWithAbsolutePath(anyString(), any(Principal.class), anyString());
+
+        Principal p = mock(Principal.class);
+        assertTrue(delegator.createGroupWithAbsolutePath("groupId", p, "/home/groups/a/b") instanceof GroupDelegator);
+
+        verify(um).createGroupWithAbsolutePath("groupId", p, "/home/groups/a/b");
+        verifySessionDelegatePerform(sessionDelegate, 1);
         verifyNoMoreInteractions(um, sessionDelegate);
         verifyNoInteractions(group);
     }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/security/user/RemappingTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/security/user/RemappingTest.java
@@ -25,8 +25,10 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 
 import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.Query;
 import org.apache.jackrabbit.api.security.user.QueryBuilder;
+import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.spi.namespace.NamespaceConstants;
 import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
@@ -277,6 +279,69 @@ public class RemappingTest extends AbstractUserTest {
             } catch (RepositoryException e) {
                 // success
             }
+        }
+    }
+
+    @Test
+    public void testCreateUserWithAbsolutePath() throws Exception {
+        // Path uses session-local namespace prefixes: myRep: for rep:, my: for uTest:
+        String jcrPath = "/myRep:security/myRep:authorizables/myRep:users/my:remaptest/testUserNode";
+        String userId = createUserId();
+        User created = getUserManager(session).createUserWithAbsolutePath(
+                userId, null, getTestPrincipal(), jcrPath);
+        session.save();
+        try {
+            // getPath() via session returns the path in session-local namespace → not DEFAULT_USER_PATH
+            assertFalse(created.getPath().startsWith(UserConstants.DEFAULT_USER_PATH));
+            assertEquals(jcrPath, created.getPath());
+            assertNotNull(getUserManager(session).getAuthorizableByPath(jcrPath));
+        } finally {
+            created.remove();
+            session.save();
+        }
+    }
+
+    @Test
+    public void testCreateGroupWithAbsolutePath() throws Exception {
+        // Path uses session-local namespace prefixes: myRep: for rep:, my: for uTest:
+        String jcrPath = "/myRep:security/myRep:authorizables/myRep:groups/my:remaptest/testGroupNode";
+        String groupId = createGroupId();
+        Group created = getUserManager(session).createGroupWithAbsolutePath(
+                groupId, getTestPrincipal(), jcrPath);
+        session.save();
+        try {
+            assertFalse(created.getPath().startsWith(UserConstants.DEFAULT_GROUP_PATH));
+            assertEquals(jcrPath, created.getPath());
+            assertNotNull(getUserManager(session).getAuthorizableByPath(jcrPath));
+        } finally {
+            created.remove();
+            session.save();
+        }
+    }
+
+    @Test
+    public void testCreateUserWithAbsolutePathUnmappedPrefix() throws Exception {
+        // rep: is overridden by myRep: in session → using canonical rep: prefix must fail
+        try {
+            getUserManager(session).createUserWithAbsolutePath(
+                    createUserId(), null, getTestPrincipal(),
+                    UserConstants.DEFAULT_USER_PATH + "/testUserNode");
+            fail("path with unmapped prefix must throw RepositoryException");
+        } catch (RepositoryException e) {
+            // success
+        }
+    }
+
+    @Test
+    public void testCreateGroupWithAbsolutePathUnmappedPrefix() throws Exception {
+        // rep: is overridden by myRep: in session → using canonical rep: prefix must fail
+        try {
+            getUserManager(session).createGroupWithAbsolutePath(
+                    createGroupId(), getTestPrincipal(),
+                    UserConstants.DEFAULT_GROUP_PATH + "/testGroupNode");
+            fail("path with unmapped prefix must throw RepositoryException");
+        } catch (RepositoryException e) {
+            // success
         }
     }
 }


### PR DESCRIPTION
contribution by @nscendoni !

* Added UserManager API to create users and groups with oak path

* Added UserManagerDelegator implementation for createUser/GroupWithAbsolutePath



* OAK-12190: Use JCR path in createUser/GroupWithAbsolutePath API, provide default implementations, and convert to Oak path in UserManagerImpl

* OAK-12190: Extract getOakPath helper and remove duplication in createUser/GroupWithAbsolutePath

* Fix on node name

* OAK-12190: Create authorizable at exact absolute path; extract buildUser/buildGroup helpers; add unit tests

* Fixes from Angela

* updated Exception message

* Fixes on analyse-pr report

* OAK-12190: Add remapping tests for createUser/GroupWithAbsolutePath

Verify that absolute JCR paths supplied to the two new methods are properly converted from the session-local namespace mapping to the internal Oak path representation.



Ai-Assisted-By: claude

---------