### PR TITLE
OAK-12229 Rethrow IOException in JournalReader#computeNext

### DIFF
--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AbstractSegmentTarExplorerBackend.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/explorer/AbstractSegmentTarExplorerBackend.java
@@ -28,6 +28,7 @@ import org.apache.jackrabbit.oak.segment.SegmentId;
 import org.apache.jackrabbit.oak.segment.SegmentNodeState;
 import org.apache.jackrabbit.oak.segment.SegmentNodeStateHelper;
 import org.apache.jackrabbit.oak.segment.SegmentPropertyState;
+import org.apache.jackrabbit.oak.segment.file.JournalReadFailure;
 import org.apache.jackrabbit.oak.segment.file.JournalReader;
 import org.apache.jackrabbit.oak.segment.file.ReadOnlyFileStore;
 import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
@@ -89,7 +90,7 @@ public abstract class AbstractSegmentTarExplorerBackend implements ExplorerBacke
             } finally {
                 journalReader.close();
             }
-        } catch (IOException e) {
+        } catch (IOException | JournalReadFailure e) {
             e.printStackTrace();
         } finally {
             try {

--- a/oak-segment-tar/pom.xml
+++ b/oak-segment-tar/pom.xml
@@ -369,6 +369,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
             <scope>test</scope>

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/JournalReadFailure.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/JournalReadFailure.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.segment.file;
+
+import java.io.IOException;
+
+/**
+ * Thrown by {@link JournalReader} when an {@link IOException} occurs while
+ * reading the journal mid-iteration. Using an unchecked exception allows the
+ * failure to propagate through the {@code Iterator} contract without silently
+ * masking I/O errors as end-of-data.
+ */
+public class JournalReadFailure extends RuntimeException {
+
+    public JournalReadFailure(IOException cause) {
+        super("Failed to read journal file", cause);
+    }
+
+    @Override
+    public IOException getCause() {
+        return (IOException) super.getCause();
+    }
+}

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/JournalReader.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/JournalReader.java
@@ -46,8 +46,7 @@ public final class JournalReader extends AbstractIterator<JournalEntry> implemen
     }
 
     /**
-     * @throws IllegalStateException  if an {@code IOException} occurs while reading from
-     *                                the journal file.
+     * @throws JournalReadFailure if an {@link IOException} occurs while reading from the journal file.
      */
     @Override
     protected JournalEntry computeNext() {
@@ -76,6 +75,7 @@ public final class JournalReader extends AbstractIterator<JournalEntry> implemen
             }
         } catch (IOException e) {
             LOG.error("Error reading journal file", e);
+            throw new JournalReadFailure(e);
         }
         return endOfData();
     }

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/JournalReaderTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/file/JournalReaderTest.java
@@ -22,13 +22,19 @@ package org.apache.jackrabbit.oak.segment.file;
 import static org.apache.commons.io.FileUtils.write;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.jackrabbit.oak.commons.collections.IteratorUtils;
 import org.apache.jackrabbit.oak.segment.file.tar.LocalJournalFile;
+import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFile;
+import org.apache.jackrabbit.oak.segment.spi.persistence.JournalFileReader;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -37,6 +43,9 @@ public class JournalReaderTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder(new File("target"));
+
+    @Rule
+    public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Test
     public void testEmpty() throws IOException {
@@ -139,6 +148,19 @@ public class JournalReaderTest {
             assertTrue(IteratorUtils.contains(journalReader, new JournalEntry("three", 123L)));
             assertTrue(IteratorUtils.contains(journalReader, new JournalEntry("two", -1L)));
             assertTrue(IteratorUtils.contains(journalReader, new JournalEntry("one", -1L)));
+        }
+    }
+
+    @Test
+    public void testIOExceptionPropagatesAsJournalReadFailure() throws IOException {
+        JournalFileReader mockReader = mock(JournalFileReader.class);
+        when(mockReader.readLine()).thenThrow(new IOException("simulated transient I/O failure"));
+
+        JournalFile mockJournal = mock(JournalFile.class);
+        when(mockJournal.openJournalReader()).thenReturn(mockReader);
+
+        try (JournalReader journalReader = new JournalReader(mockJournal)) {
+            assertThrows(JournalReadFailure.class, journalReader::hasNext);
         }
     }
 


### PR DESCRIPTION
Rethrow IOException in JournalReader#computeNext instead of silently swallowing it.

Currently, an IOException while reading the journal is swallowed and is
interpreted as no/empty journal, which can lead to data loss. This
behavior was contradicted by JournalReader#computeNext own Javadoc.