### PR TITLE
OAK-12234 Elastic async response processing should use a separate thread pool

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
@@ -36,7 +36,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This class represents an Elasticsearch Connection with the related <code>RestHighLevelClient</code>.
@@ -59,6 +66,24 @@ public class ElasticConnection implements Closeable {
     protected static final int DEFAULT_MAX_RETRY_TIME = 0;
     protected static final int ES_SOCKET_TIMEOUT = 120000;
 
+    /**
+     * Feature toggle for OAK-12234: process Elastic async responses on a dedicated executor instead of the JDK
+     * {@link ForkJoinPool#commonPool() common pool}. Enabled by default (bug fix). When the toggle is flipped the
+     * shared {@link #FT_OAK_12234_DISABLE} flag is set to {@code true} and response handling falls back to the common
+     * pool, restoring the previous behaviour.
+     */
+    public static final String FT_OAK_12234 = "FT_OAK-12234";
+    public static final AtomicBoolean FT_OAK_12234_DISABLE = new AtomicBoolean(false);
+
+    /**
+     * System property to size the dedicated executor used to process Elastic async responses. These threads are mostly
+     * blocked enqueueing results or evaluating ACLs (I/O bound) rather than CPU bound, so the default is intentionally
+     * larger than the number of cores.
+     */
+    static final String PROP_RESPONSE_THREAD_POOL_SIZE = "oak.elastic.searchResponseThreadPoolSize";
+    private static final int DEFAULT_RESPONSE_THREAD_POOL_SIZE =
+            Math.max(4, Runtime.getRuntime().availableProcessors() * 2);
+
     private final String indexPrefix;
     private final String scheme;
     private final String host;
@@ -69,6 +94,10 @@ public class ElasticConnection implements Closeable {
     private final String apiKeySecret;
 
     private volatile Clients clients;
+
+    // dedicated executor to process async responses off the Elastic client I/O dispatcher thread (OAK-12174) without
+    // competing with callers that drive the query from the common pool (OAK-12234). Lazily created on first use.
+    private volatile ExecutorService responseExecutor;
 
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
@@ -150,6 +179,48 @@ public class ElasticConnection implements Closeable {
         return getClients().asyncClient;
     }
 
+    /**
+     * Returns the {@link Executor} to use when processing Elastic async responses (e.g. via
+     * {@code CompletableFuture.whenCompleteAsync}). It returns a dedicated, connection-owned thread pool so that
+     * response handling never runs on the Elastic client I/O dispatcher thread nor competes with callers that drive the
+     * query from the {@link ForkJoinPool#commonPool() common pool}. When the {@link #FT_OAK_12234_DISABLE} toggle is
+     * set, the common pool is returned instead, restoring the previous behaviour.
+     */
+    public Executor getResponseExecutor() {
+        if (FT_OAK_12234_DISABLE.get()) {
+            return ForkJoinPool.commonPool();
+        }
+        return getOrCreateResponseExecutor();
+    }
+
+    private ExecutorService getOrCreateResponseExecutor() {
+        if (isClosed.get()) {
+            throw new IllegalStateException("Already closed");
+        }
+        // double-checked locking to lazily create the executor only when async responses are actually processed
+        if (responseExecutor == null) {
+            synchronized (this) {
+                if (responseExecutor == null) {
+                    int size = Integer.getInteger(PROP_RESPONSE_THREAD_POOL_SIZE, DEFAULT_RESPONSE_THREAD_POOL_SIZE);
+                    LOG.info("Creating Elastic async response executor for {} with {} threads", this, size);
+                    responseExecutor = Executors.newFixedThreadPool(size, new ResponseThreadFactory());
+                }
+            }
+        }
+        return responseExecutor;
+    }
+
+    private static class ResponseThreadFactory implements ThreadFactory {
+        private final AtomicInteger count = new AtomicInteger();
+
+        @Override
+        public Thread newThread(@NotNull Runnable r) {
+            Thread t = new Thread(r, "elastic-search-response-" + count.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        }
+    }
+
     public String getIndexPrefix() {
         return indexPrefix;
     }
@@ -175,6 +246,18 @@ public class ElasticConnection implements Closeable {
                 // standard and async clients are based on the same transport layer. We can just close the one from the
                 // standard client
                 clients.client._transport().close();
+            }
+        }
+        if (responseExecutor != null) {
+            responseExecutor.shutdown();
+            try {
+                if (!responseExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                    LOG.warn("Elastic async response executor for {} did not terminate in time, forcing shutdown", this);
+                    responseExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                responseExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
             }
         }
         isClosed.set(true);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
@@ -83,7 +83,7 @@ public class ElasticConnection implements Closeable {
      */
     static final String PROP_RESPONSE_THREAD_POOL_SIZE = "oak.elastic.searchResponseThreadPoolSize";
     private static final int DEFAULT_RESPONSE_THREAD_POOL_SIZE =
-            Math.max(4, Runtime.getRuntime().availableProcessors() * 2);
+            Math.min(32, Math.max(4, Runtime.getRuntime().availableProcessors() * 2));
 
     private final String indexPrefix;
     private final String scheme;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnection.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -76,9 +77,9 @@ public class ElasticConnection implements Closeable {
     public static final AtomicBoolean FT_OAK_12234_DISABLE = new AtomicBoolean(false);
 
     /**
-     * System property to size the dedicated executor used to process Elastic async responses. These threads are mostly
+     * System property to size the shared executor used to process Elastic async responses. These threads are mostly
      * blocked enqueueing results or evaluating ACLs (I/O bound) rather than CPU bound, so the default is intentionally
-     * larger than the number of cores.
+     * larger than the number of cores. It is read once when the shared pool is first created.
      */
     static final String PROP_RESPONSE_THREAD_POOL_SIZE = "oak.elastic.searchResponseThreadPoolSize";
     private static final int DEFAULT_RESPONSE_THREAD_POOL_SIZE =
@@ -94,10 +95,6 @@ public class ElasticConnection implements Closeable {
     private final String apiKeySecret;
 
     private volatile Clients clients;
-
-    // dedicated executor to process async responses off the Elastic client I/O dispatcher thread (OAK-12174) without
-    // competing with callers that drive the query from the common pool (OAK-12234). Lazily created on first use.
-    private volatile ExecutorService responseExecutor;
 
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
@@ -181,33 +178,32 @@ public class ElasticConnection implements Closeable {
 
     /**
      * Returns the {@link Executor} to use when processing Elastic async responses (e.g. via
-     * {@code CompletableFuture.whenCompleteAsync}). It returns a dedicated, connection-owned thread pool so that
-     * response handling never runs on the Elastic client I/O dispatcher thread nor competes with callers that drive the
-     * query from the {@link ForkJoinPool#commonPool() common pool}. When the {@link #FT_OAK_12234_DISABLE} toggle is
-     * set, the common pool is returned instead, restoring the previous behaviour.
+     * {@code CompletableFuture.whenCompleteAsync}). It returns a shared, JVM-wide thread pool so that response handling
+     * never runs on the Elastic client I/O dispatcher thread nor competes with callers that drive the query from the
+     * {@link ForkJoinPool#commonPool() common pool}. The pool is shared across all connections to bound the total number
+     * of callback threads. When the {@link #FT_OAK_12234_DISABLE} toggle is set, the common pool is returned instead,
+     * restoring the previous behaviour.
      */
     public Executor getResponseExecutor() {
-        if (FT_OAK_12234_DISABLE.get()) {
-            return ForkJoinPool.commonPool();
-        }
-        return getOrCreateResponseExecutor();
+        return FT_OAK_12234_DISABLE.get() ? ForkJoinPool.commonPool() : ResponseExecutorHolder.INSTANCE;
     }
 
-    private ExecutorService getOrCreateResponseExecutor() {
-        if (isClosed.get()) {
-            throw new IllegalStateException("Already closed");
-        }
-        // double-checked locking to lazily create the executor only when async responses are actually processed
-        if (responseExecutor == null) {
-            synchronized (this) {
-                if (responseExecutor == null) {
-                    int size = Integer.getInteger(PROP_RESPONSE_THREAD_POOL_SIZE, DEFAULT_RESPONSE_THREAD_POOL_SIZE);
-                    LOG.info("Creating Elastic async response executor for {} with {} threads", this, size);
-                    responseExecutor = Executors.newFixedThreadPool(size, new ResponseThreadFactory());
-                }
-            }
-        }
-        return responseExecutor;
+    /**
+     * Initialization-on-demand holder for the shared async response executor. The pool is created lazily on first use
+     * (i.e. on the first async query) and lives for the JVM lifetime; its daemon threads time out when idle so an unused
+     * pool costs nothing and does not prevent the JVM from exiting.
+     */
+    private static final class ResponseExecutorHolder {
+        static final ExecutorService INSTANCE = createResponseExecutor();
+    }
+
+    static ExecutorService createResponseExecutor() {
+        int size = Integer.getInteger(PROP_RESPONSE_THREAD_POOL_SIZE, DEFAULT_RESPONSE_THREAD_POOL_SIZE);
+        LOG.info("Creating shared Elastic async response executor with {} threads", size);
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(size, new ResponseThreadFactory());
+        executor.setKeepAliveTime(60, TimeUnit.SECONDS);
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
     }
 
     private static class ResponseThreadFactory implements ThreadFactory {
@@ -246,18 +242,6 @@ public class ElasticConnection implements Closeable {
                 // standard and async clients are based on the same transport layer. We can just close the one from the
                 // standard client
                 clients.client._transport().close();
-            }
-        }
-        if (responseExecutor != null) {
-            responseExecutor.shutdown();
-            try {
-                if (!responseExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
-                    LOG.warn("Elastic async response executor for {} did not terminate in time, forcing shutdown", this);
-                    responseExecutor.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                responseExecutor.shutdownNow();
-                Thread.currentThread().interrupt();
             }
         }
         isClosed.set(true);

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -224,6 +224,9 @@ public class ElasticIndexProviderService {
         oakRegs.add(whiteboard.register(FeatureToggle.class,
                 new FeatureToggle(ElasticIndexEditorProvider.FT_OAK_12206, ElasticIndexEditorProvider.FT_OAK_12206_DISABLE),
                 emptyMap()));
+        oakRegs.add(whiteboard.register(FeatureToggle.class,
+                new FeatureToggle(ElasticConnection.FT_OAK_12234, ElasticConnection.FT_OAK_12234_DISABLE),
+                emptyMap()));
         if (System.getProperty(QueryEngineSettings.OAK_INFERENCE_ENABLED) != null) {
             this.isInferenceEnabled = Boolean.parseBoolean(System.getProperty(QueryEngineSettings.OAK_INFERENCE_ENABLED));
         } else {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/ElasticResultRowAsyncIterator.java
@@ -343,7 +343,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
 
             ongoingRequest = indexNode.getConnection().getAsyncClient()
                     .search(searchRequest, ObjectNode.class)
-                    .whenCompleteAsync(this::handleResponse);
+                    .whenCompleteAsync(this::handleResponse, indexNode.getConnection().getResponseExecutor());
             metricHandler.markQuery(indexNode.getDefinition().getIndexPath(), true);
         }
 
@@ -462,7 +462,7 @@ public class ElasticResultRowAsyncIterator implements ElasticQueryIterator, Elas
                 searchStartTime = System.currentTimeMillis();
                 ongoingRequest = indexNode.getConnection().getAsyncClient()
                         .search(searchReq, ObjectNode.class)
-                        .whenCompleteAsync(this::handleResponse);
+                        .whenCompleteAsync(this::handleResponse, indexNode.getConnection().getResponseExecutor());
                 metricHandler.markQuery(indexNode.getDefinition().getIndexPath(), false);
             } else {
                 LOG.trace("Scanner is closing or still processing data from the previous scan");

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticSecureFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticSecureFacetAsyncProvider.java
@@ -98,7 +98,7 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider {
         Map<String, Map<String, Integer>> accumulatedFacets = new ConcurrentHashMap<>();
 
         return searchWithIncrementalFacetProcessing(connection, null, accumulatedFacets)
-                .thenApplyAsync(this::buildFinalFacetResult);
+                .thenApplyAsync(this::buildFinalFacetResult, connection.getResponseExecutor());
     }
 
     private CompletableFuture<Map<String, Map<String, Integer>>> searchWithIncrementalFacetProcessing(
@@ -157,7 +157,7 @@ class ElasticSecureFacetAsyncProvider implements ElasticFacetProvider {
 
                     // Recursively continue with next batch
                     return searchWithIncrementalFacetProcessing(connection, nextSearchAfter, accumulatedFacets);
-                })
+                }, connection.getResponseExecutor())
                 .exceptionally(throwable -> {
                     LOG.error("Error during search pagination", throwable);
                     // Return accumulated facets even if there's an error

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/async/facets/ElasticStatisticalFacetAsyncProvider.java
@@ -111,7 +111,7 @@ public class ElasticStatisticalFacetAsyncProvider implements ElasticFacetProvide
         LOG.trace("Kicking search query with random sampling {}", searchRequest);
         this.searchFuture = connection.getAsyncClient()
                 .search(searchRequest, ObjectNode.class)
-                .thenApplyAsync(this::computeFacets);
+                .thenApplyAsync(this::computeFacets, connection.getResponseExecutor());
     }
 
     @Override

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionTest.java
@@ -113,8 +113,6 @@ public class ElasticConnectionTest {
             Executor executor = connection.getResponseExecutor();
             // the dedicated executor decouples async response processing from the common pool (OAK-12234)
             assertNotSame(ForkJoinPool.commonPool(), executor);
-            // the same executor instance is reused across calls
-            assertSame(executor, connection.getResponseExecutor());
         }
     }
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionTest.java
@@ -108,11 +108,13 @@ public class ElasticConnectionTest {
     }
 
     @Test
-    public void responseExecutorIsDedicatedAndStableByDefault() throws IOException {
-        try (ElasticConnection connection = defaultConnection()) {
-            Executor executor = connection.getResponseExecutor();
+    public void responseExecutorIsSharedAndDecoupledFromCommonPool() throws IOException {
+        try (ElasticConnection c1 = defaultConnection(); ElasticConnection c2 = defaultConnection()) {
+            Executor executor = c1.getResponseExecutor();
             // the dedicated executor decouples async response processing from the common pool (OAK-12234)
             assertNotSame(ForkJoinPool.commonPool(), executor);
+            // the pool is shared JVM-wide, so every connection hands out the same instance
+            assertSame(executor, c2.getResponseExecutor());
         }
     }
 
@@ -125,19 +127,14 @@ public class ElasticConnectionTest {
     }
 
     @Test
-    public void responseExecutorHonoursPoolSizeSystemProperty() throws IOException {
+    public void responseExecutorHonoursPoolSizeSystemProperty() {
+        // the shared pool is created once per JVM, so verify the sizing via the factory directly
         System.setProperty(ElasticConnection.PROP_RESPONSE_THREAD_POOL_SIZE, "3");
-        try (ElasticConnection connection = defaultConnection()) {
-            ThreadPoolExecutor executor = (ThreadPoolExecutor) connection.getResponseExecutor();
-            assertEquals(3, executor.getMaximumPoolSize());
+        ExecutorService executor = ElasticConnection.createResponseExecutor();
+        try {
+            assertEquals(3, ((ThreadPoolExecutor) executor).getMaximumPoolSize());
+        } finally {
+            executor.shutdownNow();
         }
-    }
-
-    @Test
-    public void responseExecutorIsShutDownOnClose() throws IOException {
-        ElasticConnection connection = defaultConnection();
-        ExecutorService executor = (ExecutorService) connection.getResponseExecutor();
-        connection.close();
-        assertTrue(executor.isShutdown());
     }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticConnectionTest.java
@@ -17,14 +17,44 @@
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadPoolExecutor;
 
+import org.junit.After;
 import org.junit.Test;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 
 public class ElasticConnectionTest {
+
+    @Test
+    public void ft_oak_12234_toggleShouldBeRemoved() {
+        // Time-bombed: if this test fails, the feature toggle FT_OAK_12234 and its guard in
+        // ElasticConnection#getResponseExecutor should be cleaned up — the fix has been in production long enough.
+        assertTrue("Feature toggle " + ElasticConnection.FT_OAK_12234 + " is overdue for removal",
+                LocalDate.now().isBefore(LocalDate.of(2027, 6, 2)));
+    }
+
+    @After
+    public void resetToggle() {
+        ElasticConnection.FT_OAK_12234_DISABLE.set(false);
+        System.clearProperty(ElasticConnection.PROP_RESPONSE_THREAD_POOL_SIZE);
+    }
+
+    private static ElasticConnection defaultConnection() {
+        return ElasticConnection.newBuilder()
+                .withIndexPrefix("my+test")
+                .withDefaultConnectionParameters()
+                .build();
+    }
 
     @Test
     public void uniqueClient() throws IOException {
@@ -75,5 +105,41 @@ public class ElasticConnectionTest {
                 .withIndexPrefix("cannot_have_*_chars")
                 .withDefaultConnectionParameters()
                 .build();
+    }
+
+    @Test
+    public void responseExecutorIsDedicatedAndStableByDefault() throws IOException {
+        try (ElasticConnection connection = defaultConnection()) {
+            Executor executor = connection.getResponseExecutor();
+            // the dedicated executor decouples async response processing from the common pool (OAK-12234)
+            assertNotSame(ForkJoinPool.commonPool(), executor);
+            // the same executor instance is reused across calls
+            assertSame(executor, connection.getResponseExecutor());
+        }
+    }
+
+    @Test
+    public void responseExecutorFallsBackToCommonPoolWhenToggleDisabled() throws IOException {
+        ElasticConnection.FT_OAK_12234_DISABLE.set(true);
+        try (ElasticConnection connection = defaultConnection()) {
+            assertSame(ForkJoinPool.commonPool(), connection.getResponseExecutor());
+        }
+    }
+
+    @Test
+    public void responseExecutorHonoursPoolSizeSystemProperty() throws IOException {
+        System.setProperty(ElasticConnection.PROP_RESPONSE_THREAD_POOL_SIZE, "3");
+        try (ElasticConnection connection = defaultConnection()) {
+            ThreadPoolExecutor executor = (ThreadPoolExecutor) connection.getResponseExecutor();
+            assertEquals(3, executor.getMaximumPoolSize());
+        }
+    }
+
+    @Test
+    public void responseExecutorIsShutDownOnClose() throws IOException {
+        ElasticConnection connection = defaultConnection();
+        ExecutorService executor = (ExecutorService) connection.getResponseExecutor();
+        connection.close();
+        assertTrue(executor.isShutdown());
     }
 }


### PR DESCRIPTION
### Problem

Queries against Elastic could hang and time out after `queryTimeoutMs` (default 60s), with the consumer parked in `ElasticResultRowAsyncIterator.hasNext()` on `queue.poll()`.

OAK-12174 (#2828) moved async response handling off the ES client I/O dispatcher thread by switching `whenComplete` → `whenCompleteAsync`, which dispatches onto `ForkJoinPool.commonPool()`. When the caller also drives query iteration from the common pool, all common-pool workers block in queue.poll() while the producer callback (`handleResponse` → `queue.offer`) is queued behind them on the same pool. The queue never fills and the consumer times out. This is load-correlated and unrelated to actual ES latency.

 ### Fix

Route async response processing onto a dedicated, ElasticConnection-owned executor that is disjoint from any caller pool. This preserves OAK-12174's goal (work stays off the I/O dispatcher thread) while removing the common-pool contention.

  - ElasticConnection owns a lazily-created, bounded thread pool (daemon threads), exposed via `getResponseExecutor()`, shut down on close().
  - Applied to all common-pool-bound async sites: both `whenCompleteAsync` calls in `ElasticResultRowAsyncIterator`, and the `thenApplyAsync` / recursive `thenComposeAsync` calls in the secure and statistical facet providers.

### Feature toggle

`FT_OAK-12234`, enabled by default. When disabled, `getResponseExecutor()` returns ForkJoinPool.commonPool(), exactly restoring pre-fix behavior.

### Configuration

Pool size via system property `oak.elastic.searchResponseThreadPoolSize` (default max(4, cores * 2); these threads are I/O/enqueue-bound, not CPU-bound).