### PR TITLE
OAK-12238: oak-upgrade: do not override Jackrabbit's Lucene version (…

### DIFF
--- a/oak-upgrade/pom.xml
+++ b/oak-upgrade/pom.xml
@@ -152,12 +152,16 @@
       <version>${jackrabbit.version}</version>
     </dependency>
 
-    <!-- it has to match the version used in jackrabbit-core -->
-    <dependency>
+    <!-- it has to match the version used in jackrabbit-core,
+         (https://issues.apache.org/jira/browse/OAK-6306).
+         Jackrabbit currently uses 3.6.2 as per
+         https://issues.apache.org/jira/browse/JCR-4352,
+         same as Oak thus commented out: https://issues.apache.org/jira/browse/OAK-12238 -->
+    <!-- <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
       <version>3.6.0</version>
-    </dependency>
+    </dependency> -->
 
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
…for now)