### PR TITLE
OAK-10578 avoid access to the OSGI registry

### DIFF
--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModule.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModule.java
@@ -123,7 +123,7 @@ public class ExternalLoginModule extends AbstractLoginModule {
     private Set<? extends Principal> principals;
     private AuthInfo authInfo;
 
-    private ExternalIdentityMonitor monitor;
+    private ExternalIdentityMonitor monitor = ExternalIdentityMonitor.NOOP;
 
     /**
      * Default constructor for the OSGIi LoginModuleFactory case and the default non-OSGi JAAS case.
@@ -165,12 +165,13 @@ public class ExternalLoginModule extends AbstractLoginModule {
             log.debug("No 'SupportedCredentials' configured. Using default implementation supporting 'SimpleCredentials'.");
         }
 
-        if (monitor == null) {
-            monitor = WhiteboardUtils.getService(whiteboard, ExternalIdentityMonitor.class);
-        }
-        if (monitor == null) {
-            log.debug("No ExternalIdentityMonitor registered.");
-            monitor = ExternalIdentityMonitor.NOOP;
+        if (monitor == ExternalIdentityMonitor.NOOP) {
+            ExternalIdentityMonitor resolved = WhiteboardUtils.getService(whiteboard, ExternalIdentityMonitor.class);
+            if (resolved != null) {
+                monitor = resolved;
+            } else {
+                log.debug("No ExternalIdentityMonitor registered.");
+            }
         }
     }
     
@@ -535,7 +536,7 @@ public class ExternalLoginModule extends AbstractLoginModule {
         this.monitor = monitor;
     }
 
-    @Nullable
+    @NotNull
     ExternalIdentityMonitor getMonitor() {
         return monitor;
     }

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModule.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModule.java
@@ -165,7 +165,9 @@ public class ExternalLoginModule extends AbstractLoginModule {
             log.debug("No 'SupportedCredentials' configured. Using default implementation supporting 'SimpleCredentials'.");
         }
 
-        monitor = WhiteboardUtils.getService(whiteboard, ExternalIdentityMonitor.class);
+        if (monitor == null) {
+            monitor = WhiteboardUtils.getService(whiteboard, ExternalIdentityMonitor.class);
+        }
         if (monitor == null) {
             log.debug("No ExternalIdentityMonitor registered.");
             monitor = ExternalIdentityMonitor.NOOP;
@@ -527,5 +529,14 @@ public class ExternalLoginModule extends AbstractLoginModule {
 
     public void setIdpManager(@NotNull ExternalIdentityProviderManager idpManager) {
         this.idpManager = idpManager;
+    }
+
+    public void setMonitor(@NotNull ExternalIdentityMonitor monitor) {
+        this.monitor = monitor;
+    }
+
+    @Nullable
+    ExternalIdentityMonitor getMonitor() {
+        return monitor;
     }
 }

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModule.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModule.java
@@ -537,7 +537,7 @@ public class ExternalLoginModule extends AbstractLoginModule {
     }
 
     @NotNull
-    ExternalIdentityMonitor getMonitor() {
+    public ExternalIdentityMonitor getMonitor() {
         return monitor;
     }
 }

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactory.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactory.java
@@ -29,6 +29,8 @@ import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.SecurityProvider;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentityProviderManager;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.SyncManager;
+import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.monitor.ExternalIdentityMonitor;
+import org.osgi.util.tracker.ServiceTracker;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.basic.DefaultSyncConfig;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.jmx.SyncMBeanImpl;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.jmx.SynchronizationMBean;
@@ -136,6 +138,8 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
      */
     private volatile Registration mbeanRegistration;
 
+    private ServiceTracker<ExternalIdentityMonitor, ExternalIdentityMonitor> monitorTracker;
+
     //----------------------------------------------------< SCR integration >---
     /**
      * Activates the LoginModuleFactory service
@@ -149,10 +153,17 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
         this.syncManager = syncManager;
         this.idpManager = idpManager;
 
+        // TODO: context cannot be null, but tests are invoked with this being null. Tests should
+        // be adjusted accordingly, and then all these implicit and explicit null checks should be removed. 
         this.osgiConfig = Optional.ofNullable(context)
                 .map(ctx -> ConfigurationParameters.of(ctx.getProperties()))
                 .orElse(ConfigurationParameters.EMPTY);
         this.bundleContext = Optional.ofNullable(context).map(ComponentContext::getBundleContext).orElse(null);
+
+        if (this.bundleContext != null) {
+            monitorTracker = new ServiceTracker<>(this.bundleContext, ExternalIdentityMonitor.class, null);
+            monitorTracker.open();
+        }
 
         mayRegisterSyncMBean();
     }
@@ -161,6 +172,10 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
     @Deactivate
     private void deactivate() {
         unregisterSyncMBean();
+        if (monitorTracker != null) {
+            monitorTracker.close();
+            monitorTracker = null;
+        }
     }
 
     @SuppressWarnings("UnusedDeclaration")
@@ -245,6 +260,11 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
         ExternalLoginModule lm = new ExternalLoginModule(osgiConfig);
         lm.setIdpManager(idpManager);
         lm.setSyncManager(syncManager);
+        // TODO: the monitorTracker cannot be null either (see the TODO in the c'tor)
+        ExternalIdentityMonitor monitor = monitorTracker != null ? monitorTracker.getService() : null;
+        if (monitor != null) {
+            lm.setMonitor(monitor);
+        }
         return lm;
     }
 }

--- a/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactory.java
+++ b/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactory.java
@@ -29,9 +29,8 @@ import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.SecurityProvider;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalIdentityProviderManager;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.SyncManager;
-import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.monitor.ExternalIdentityMonitor;
-import org.osgi.util.tracker.ServiceTracker;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.basic.DefaultSyncConfig;
+import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.monitor.ExternalIdentityMonitor;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.jmx.SyncMBeanImpl;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.jmx.SynchronizationMBean;
 import org.apache.jackrabbit.oak.spi.whiteboard.Registration;
@@ -133,12 +132,12 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
 
     private final BundleContext bundleContext;
 
+    private volatile ExternalIdentityMonitor monitor;
+
     /**
      * whiteboard registration handle of the manager mbean
      */
     private volatile Registration mbeanRegistration;
-
-    private ServiceTracker<ExternalIdentityMonitor, ExternalIdentityMonitor> monitorTracker;
 
     //----------------------------------------------------< SCR integration >---
     /**
@@ -160,11 +159,6 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
                 .orElse(ConfigurationParameters.EMPTY);
         this.bundleContext = Optional.ofNullable(context).map(ComponentContext::getBundleContext).orElse(null);
 
-        if (this.bundleContext != null) {
-            monitorTracker = new ServiceTracker<>(this.bundleContext, ExternalIdentityMonitor.class, null);
-            monitorTracker.open();
-        }
-
         mayRegisterSyncMBean();
     }
 
@@ -172,10 +166,6 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
     @Deactivate
     private void deactivate() {
         unregisterSyncMBean();
-        if (monitorTracker != null) {
-            monitorTracker.close();
-            monitorTracker = null;
-        }
     }
 
     @SuppressWarnings("UnusedDeclaration")
@@ -202,6 +192,17 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
     public void unbindSecurityProvider(SecurityProvider securityProvider)  {
         this.securityProvider = null;
         unregisterSyncMBean();
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    @Reference(name = "monitor", cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    public void bindMonitor(ExternalIdentityMonitor monitor) {
+        this.monitor = monitor;
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public void unbindMonitor(ExternalIdentityMonitor monitor) {
+        this.monitor = null;
     }
 
     private void mayRegisterSyncMBean() {
@@ -260,8 +261,6 @@ public class ExternalLoginModuleFactory implements LoginModuleFactory, SyncHandl
         ExternalLoginModule lm = new ExternalLoginModule(osgiConfig);
         lm.setIdpManager(idpManager);
         lm.setSyncManager(syncManager);
-        // TODO: the monitorTracker cannot be null either (see the TODO in the c'tor)
-        ExternalIdentityMonitor monitor = monitorTracker != null ? monitorTracker.getService() : null;
         if (monitor != null) {
             lm.setMonitor(monitor);
         }

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactoryTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactoryTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -230,14 +231,15 @@ public class ExternalLoginModuleFactoryTest extends ExternalLoginTestBase {
     }
 
     @Test
-    public void testCreateLoginModuleNullBundleContextNoMonitor() {
-        // When created without a bundle context (non-OSGi path) createLoginModule()
-        // must not throw and the monitor falls back to the whiteboard lookup.
+    public void testCreateLoginModuleNoMonitorServiceFallsBackToNoop() {
+        // When no ExternalIdentityMonitor service is available (e.g. non-OSGi path or
+        // monitor not yet registered), createLoginModule() must still inject NOOP so that
+        // initialize() never needs to open a ServiceTracker via the whiteboard.
         ExternalLoginModuleFactory factory = new ExternalLoginModuleFactory(
                 mock(SyncManager.class), mock(ExternalIdentityProviderManager.class), null);
 
         ExternalLoginModule lm = (ExternalLoginModule) factory.createLoginModule();
-        assertNull(lm.getMonitor());
+        assertSame(ExternalIdentityMonitor.NOOP, lm.getMonitor());
     }
 
     private SynchronizationMBean getMBeanRegistration() throws Exception {

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactoryTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactoryTest.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalId
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalLoginTestBase;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.ExternalUser;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.SyncManager;
+import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.monitor.ExternalIdentityMonitor;
 import org.apache.jackrabbit.oak.spi.security.authentication.external.impl.jmx.SynchronizationMBean;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -211,6 +212,32 @@ public class ExternalLoginModuleFactoryTest extends ExternalLoginTestBase {
 
         factory.bindContentRepository(getContentRepository());
         assertSame(mbeanregistration, getMBeanRegistration());
+    }
+
+    @Test
+    public void testCreateLoginModuleInjectsMonitor() {
+        ExternalIdentityMonitor monitor = mock(ExternalIdentityMonitor.class);
+        context.registerService(ExternalIdentityMonitor.class, monitor);
+        context.registerService(SyncManager.class, mock(SyncManager.class));
+        context.registerService(ExternalIdentityProviderManager.class, mock(ExternalIdentityProviderManager.class));
+
+        ExternalLoginModuleFactory factory = context.registerInjectActivateService(ExternalLoginModuleFactory.class);
+        ExternalLoginModule lm = (ExternalLoginModule) factory.createLoginModule();
+
+        // The monitor must be pre-injected so that initialize() does not open a
+        // ServiceTracker on every login (which causes Felix EventDispatcher contention).
+        assertSame(monitor, lm.getMonitor());
+    }
+
+    @Test
+    public void testCreateLoginModuleNullBundleContextNoMonitor() {
+        // When created without a bundle context (non-OSGi path) createLoginModule()
+        // must not throw and the monitor falls back to the whiteboard lookup.
+        ExternalLoginModuleFactory factory = new ExternalLoginModuleFactory(
+                mock(SyncManager.class), mock(ExternalIdentityProviderManager.class), null);
+
+        ExternalLoginModule lm = (ExternalLoginModule) factory.createLoginModule();
+        assertNull(lm.getMonitor());
     }
 
     private SynchronizationMBean getMBeanRegistration() throws Exception {

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactoryTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactoryTest.java
@@ -43,7 +43,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -109,6 +108,7 @@ public class ExternalLoginModuleFactoryTest extends ExternalLoginTestBase {
         context.registerService(Repository.class, mock(Repository.class));
         context.registerService(SyncManager.class, new SyncManagerImpl(whiteboard));
         context.registerService(ExternalIdentityProviderManager.class, new ExternalIDPManagerImpl(whiteboard));
+        context.registerService(ExternalIdentityMonitor.class, mock(ExternalIdentityMonitor.class));
 
         final LoginModuleFactory lmf = context.registerInjectActivateService(ExternalLoginModuleFactory.class);
         options.put(ProxyLoginModule.PROP_LOGIN_MODULE_FACTORY, (ProxyLoginModule.BootLoginModuleFactory) lmf::createLoginModule);

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleTest.java
@@ -172,7 +172,7 @@ public class ExternalLoginModuleTest extends AbstractSecurityTest {
     }
 
     @Test
-    public void testSetMonitorSkipsWhiteboardLookup() throws LoginException {
+    public void testSetMonitorSkipsWhiteboardLookup() {
         // When the monitor is pre-injected (OSGi factory path), initialize() must
         // not open a ServiceTracker via the whiteboard — that is the source of
         // Felix EventDispatcher lock contention under concurrent logins.

--- a/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleTest.java
+++ b/oak-auth-external/src/test/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleTest.java
@@ -172,6 +172,22 @@ public class ExternalLoginModuleTest extends AbstractSecurityTest {
     }
 
     @Test
+    public void testSetMonitorSkipsWhiteboardLookup() throws LoginException {
+        // When the monitor is pre-injected (OSGi factory path), initialize() must
+        // not open a ServiceTracker via the whiteboard — that is the source of
+        // Felix EventDispatcher lock contention under concurrent logins.
+        ExternalIdentityMonitor preInjectedMonitor = mock(ExternalIdentityMonitor.class);
+        loginModule.setIdpManager(extIPMgr);
+        loginModule.setSyncManager(syncManager);
+        loginModule.setMonitor(preInjectedMonitor);
+
+        loginModule.initialize(new Subject(), createCallbackHandler(wb, null, null, null),
+                Collections.emptyMap(), Map.of(PARAM_IDP_NAME, "idp", PARAM_SYNC_HANDLER_NAME, "syncHandler"));
+
+        verify(wb, never()).track(ExternalIdentityMonitor.class);
+    }
+
+    @Test
     public void testInitializeMissingIdpSyncHandler() throws LoginException {
         loginModule.initialize(new Subject(), createCallbackHandler(wb, null, null, null), Collections.emptyMap(), Map.of(PARAM_IDP_NAME, "idp", PARAM_SYNC_HANDLER_NAME, "syncHandler"));
         assertFalse(loginModule.login());


### PR DESCRIPTION
avoid contention on the OSGI service registry when initializing an ExternalLoginModule; instead provide the required ``monitorService`` from the ExternalLoginModuleFactory.