### PR TITLE
OAK-12242: Remove embedded verification feature toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,9 @@ Toggles are disabled by default and can be enabled without redeployment.
 
 **Examples in the codebase:**
 - Query engine toggles (`FT_OAK-11949`, `FT_OAK-12007`) registered in `oak-core/.../Oak.java`
-- Document store toggles (throttling, full GC, embedded verification) in
-  `oak-store-document/.../DocumentNodeStoreBuilder.java`
+- Document store toggles (throttling, full GC) in
+  `oak-store-document/.../DocumentNodeStoreBuilder.java` (embedded verification is OSGi
+  `embeddedVerificationEnabled` config only, not a runtime toggle)
 - Some features also support a system property fallback (e.g., `oak.classicMove`)
 
 ## Code Conventions

--- a/oak-store-document/AGENTS.md
+++ b/oak-store-document/AGENTS.md
@@ -217,6 +217,11 @@ GC runs in two phases via `VersionGarbageCollector`, controlled by `VersionGCOpt
 | `fullGCGeneration` | `0` | Generation counter to scope Full GC runs |
 | `embeddedVerificationEnabled` | `true` | Verify cleaned documents are consistent before removing revisions |
 
+Embedded verification is controlled only by `embeddedVerificationEnabled` (OSGi or framework
+property `oak.documentstore.embeddedVerificationEnabled`); there is no runtime whiteboard
+toggle. Deployments that previously relied on `FT_EMBEDDED_VERIFICATION_OAK-10633` must set this
+config property instead.
+
 ## Throttling
 
 **MongoDB only** — throttling is not available for RDB. Enabled via `throttlingEnabled=true`.
@@ -360,7 +365,6 @@ Registered in `DocumentNodeStoreService`, wired into `DocumentNodeStoreBuilder`.
 | `FT_NOCOCLEANUP_OAK-10660` | `setNoChildOrderCleanupFeature` | Disable child-order property cleanup |
 | `FT_CANCELINVALIDATION_OAK-10595` | `setCancelInvalidationFeature` | Cancel in-flight cache invalidations |
 | `FT_FULL_GC_OAK-10199` | `setDocStoreFullGCFeature` | Enable Full GC phase (MongoDB only) |
-| `FT_EMBEDDED_VERIFICATION_OAK-10633` | `setDocStoreEmbeddedVerificationFeature` | Enable embedded verification during Full GC |
 | `FT_AVOID_MERGE_LOCK_OAK-11720` | `setDocStoreAvoidMergeLockFeature` | Avoid acquiring merge lock where safe |
 | `FT_PREV_NO_PROP_OAK-11184` | `setPrevNoPropCacheFeature` | Skip caching previous documents with no properties |
 

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -133,7 +133,6 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
     private Feature noChildOrderCleanupFeature;
     private Feature cancelInvalidationFeature;
     private Feature docStoreFullGCFeature;
-    private Feature docStoreEmbeddedVerificationFeature;
     private Feature docStoreAvoidMergeLockFeature;
     private Feature prevNoPropCacheFeature;
     private Weigher<CacheValue, CacheValue> weigher = new EmpiricalWeigher();
@@ -513,16 +512,6 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
 
     public Feature getDocStoreFullGCFeature() {
         return docStoreFullGCFeature;
-    }
-
-    public T setDocStoreEmbeddedVerificationFeature(@Nullable Feature getDocStoreEmbeddedVerification) {
-        this.docStoreEmbeddedVerificationFeature = getDocStoreEmbeddedVerification;
-        return thisBuilder();
-    }
-
-    @Nullable
-    public Feature getDocStoreEmbeddedVerificationFeature() {
-        return docStoreEmbeddedVerificationFeature;
     }
 
     public Feature getDocStoreAvoidMergeLockFeature() {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -223,11 +223,6 @@ public class DocumentNodeStoreService {
      */
     private static final String FT_NAME_AVOID_MERGE_LOCK = "FT_AVOID_MERGE_LOCK_OAK-11720";
 
-    /**
-     * Feature toggle name to enable embedded verification for full GC mode for Mongo Document Store
-     */
-    private static final String FT_NAME_EMBEDDED_VERIFICATION = "FT_EMBEDDED_VERIFICATION_OAK-10633";
-
     /** OAK-11246 : default millis for perflogger info */
     static final long DEFAULT_PERFLOGGER_INFO_MILLIS = Long.MAX_VALUE;
 
@@ -281,7 +276,6 @@ public class DocumentNodeStoreService {
     private Feature noChildOrderCleanupFeature;
     private Feature cancelInvalidationFeature;
     private Feature docStoreFullGCFeature;
-    private Feature docStoreEmbeddedVerificationFeature;
     private Feature docStoreAvoidMergeLockFeature;
     private Feature prevNoPropCacheFeature;
     private ComponentContext context;
@@ -321,7 +315,6 @@ public class DocumentNodeStoreService {
         noChildOrderCleanupFeature = Feature.newFeature(FT_NAME_DOC_STORE_NOCOCLEANUP, whiteboard);
         cancelInvalidationFeature = Feature.newFeature(FT_NAME_CANCEL_INVALIDATION, whiteboard);
         docStoreFullGCFeature = Feature.newFeature(FT_NAME_FULL_GC, whiteboard);
-        docStoreEmbeddedVerificationFeature = Feature.newFeature(FT_NAME_EMBEDDED_VERIFICATION, whiteboard);
         docStoreAvoidMergeLockFeature = Feature.newFeature(FT_NAME_AVOID_MERGE_LOCK, whiteboard);
         prevNoPropCacheFeature = Feature.newFeature(FT_NAME_PREV_NO_PROP_CACHE, whiteboard);
 
@@ -559,7 +552,6 @@ public class DocumentNodeStoreService {
                 setNoChildOrderCleanupFeature(noChildOrderCleanupFeature).
                 setCancelInvalidationFeature(cancelInvalidationFeature).
                 setDocStoreFullGCFeature(docStoreFullGCFeature).
-                setDocStoreEmbeddedVerificationFeature(docStoreEmbeddedVerificationFeature).
                 setDocStoreAvoidMergeLockFeature(docStoreAvoidMergeLockFeature).
                 setPrevNoPropCacheFeature(prevNoPropCacheFeature).
                 setThrottlingEnabled(config.throttlingEnabled()).
@@ -721,7 +713,7 @@ public class DocumentNodeStoreService {
         }
 
         closeFeatures(prefetchFeature, docStoreThrottlingFeature, cancelInvalidationFeature, docStoreFullGCFeature,
-                docStoreEmbeddedVerificationFeature, prevNoPropCacheFeature, docStoreAvoidMergeLockFeature);
+                prevNoPropCacheFeature, docStoreAvoidMergeLockFeature);
 
         unregisterNodeStore();
     }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilder.java
@@ -252,15 +252,4 @@ public class RDBDocumentNodeStoreBuilder
         // embeddedVerification is non supported for RDB since fullGC is not.
         return thisBuilder();
     }
-
-    @Override
-    public RDBDocumentNodeStoreBuilder setDocStoreEmbeddedVerificationFeature(@Nullable Feature getDocStoreEmbeddedVerification) {
-        return thisBuilder();
-    }
-
-    @Override
-    @Nullable
-    public Feature getDocStoreEmbeddedVerificationFeature() {
-        return null;
-    }
 }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/util/Utils.java
@@ -1108,6 +1108,10 @@ public class Utils {
 
     /**
      * Check whether full GC is enabled or not for document store.
+     * <p>
+     * Full GC is opt-in (default {@code false}) and may be enabled via OSGi
+     * {@code fullGCEnabled} / builder configuration or the runtime toggle
+     * {@code FT_FULL_GC_OAK-10199}.
      *
      * @param builder instance for DocumentNodeStoreBuilder
      * @return true if full GC is enabled else false
@@ -1119,13 +1123,17 @@ public class Utils {
 
     /**
      * Check whether embedded verification for full GC mode is enabled or not for document store.
+     * <p>
+     * Unlike {@link #isFullGCEnabled(DocumentNodeStoreBuilder)}, embedded verification has no
+     * runtime feature toggle. It is controlled only via OSGi {@code embeddedVerificationEnabled}
+     * / builder {@link DocumentNodeStoreBuilder#isEmbeddedVerificationEnabled()} (default
+     * {@code true}). RDB builders always return {@code false}.
      *
      * @param builder instance for DocumentNodeStoreBuilder
      * @return true if embedded verification is enabled else false
      */
     public static boolean isEmbeddedVerificationEnabled(final DocumentNodeStoreBuilder<?> builder) {
-        final Feature docStoreEmbeddedVerificationFeature = builder.getDocStoreEmbeddedVerificationFeature();
-        return builder.isEmbeddedVerificationEnabled() || (docStoreEmbeddedVerificationFeature != null && docStoreEmbeddedVerificationFeature.isEnabled());
+        return builder.isEmbeddedVerificationEnabled();
     }
 
     /**

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoDocumentNodeStoreBuilderTest.java
@@ -115,12 +115,6 @@ public class MongoDocumentNodeStoreBuilderTest {
     }
 
     @Test
-    public void embeddedVerificationFeatureToggleEnabled() {
-        MongoDocumentNodeStoreBuilder builder = new MongoDocumentNodeStoreBuilder();
-        assertNull(builder.getDocStoreEmbeddedVerificationFeature());
-    }
-
-    @Test
     public void avoidMergeLockFeatureToggleEnabled() {
         MongoDocumentNodeStoreBuilder builder = new MongoDocumentNodeStoreBuilder();
         assertNull(builder.getDocStoreAvoidMergeLockFeature());

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilderTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/rdb/RDBDocumentNodeStoreBuilderTest.java
@@ -107,15 +107,6 @@ public class RDBDocumentNodeStoreBuilderTest {
     }
 
     @Test
-    public void embeddedVerificationFeatureToggleDisabled() {
-        RDBDocumentNodeStoreBuilder builder = new RDBDocumentNodeStoreBuilder();
-        Feature embeddedVerificationFeature = mock(Feature.class);
-        when(embeddedVerificationFeature.isEnabled()).thenReturn(true);
-        builder.setDocStoreEmbeddedVerificationFeature(embeddedVerificationFeature);
-        assertNull(builder.getDocStoreEmbeddedVerificationFeature());
-    }
-
-    @Test
     public void avoidMergeLockFeatureToggleDisabled() {
         RDBDocumentNodeStoreBuilder builder = new RDBDocumentNodeStoreBuilder();
         Feature avoidMergeLockFeature = mock(Feature.class);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/util/UtilsTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/util/UtilsTest.java
@@ -347,42 +347,25 @@ public class UtilsTest {
     public void embeddedVerificationExplicitlyDisabled() {
         DocumentNodeStoreBuilder<?> builder = newDocumentNodeStoreBuilder();
         builder.setEmbeddedVerificationEnabled(false);
-        Feature docStoreEmbeddedVerificationFeature = mock(Feature.class);
-        when(docStoreEmbeddedVerificationFeature.isEnabled()).thenReturn(false);
-        builder.setDocStoreEmbeddedVerificationFeature(docStoreEmbeddedVerificationFeature);
         boolean embeddedVerificationEnabled = isEmbeddedVerificationEnabled(builder);
         assertFalse("Embedded Verification is disabled explicitly", embeddedVerificationEnabled);
     }
 
     @Test
-    public void embeddedVerificationEnabledViaConfiguration() {
-        DocumentNodeStoreBuilder<?> builder = newDocumentNodeStoreBuilder();
-        builder.setEmbeddedVerificationEnabled(true);
-        Feature docStoreEmbeddedVerificationFeature = mock(Feature.class);
-        when(docStoreEmbeddedVerificationFeature.isEnabled()).thenReturn(false);
-        builder.setDocStoreEmbeddedVerificationFeature(docStoreEmbeddedVerificationFeature);
-        boolean embeddedVerificationEnabled = isEmbeddedVerificationEnabled(builder);
-        assertTrue("Embedded Verification is enabled via configuration", embeddedVerificationEnabled);
-    }
-
-    @Test
-    public void embeddedVerificationEnabledViaFeatureToggle() {
+    public void embeddedVerificationConfigurationRoundTrip() {
         DocumentNodeStoreBuilder<?> builder = newDocumentNodeStoreBuilder();
         builder.setEmbeddedVerificationEnabled(false);
-        Feature docStoreEmbeddedVerificationFeature = mock(Feature.class);
-        when(docStoreEmbeddedVerificationFeature.isEnabled()).thenReturn(true);
-        builder.setDocStoreEmbeddedVerificationFeature(docStoreEmbeddedVerificationFeature);
-        boolean embeddedVerificationEnabled = isEmbeddedVerificationEnabled(builder);
-        assertTrue("Embedded Verification is enabled via Feature Toggle", embeddedVerificationEnabled);
+        assertFalse("Embedded Verification can be disabled via configuration",
+                isEmbeddedVerificationEnabled(builder));
+        builder.setEmbeddedVerificationEnabled(true);
+        assertTrue("Embedded Verification can be re-enabled via configuration",
+                isEmbeddedVerificationEnabled(builder));
     }
 
     @Test
     public void embeddedVerificationDisabledForRDB() {
         DocumentNodeStoreBuilder<?> builder = newRDBDocumentNodeStoreBuilder();
         builder.setEmbeddedVerificationEnabled(true);
-        Feature docStoreEmbeddedVerificationFeature = mock(Feature.class);
-        when(docStoreEmbeddedVerificationFeature.isEnabled()).thenReturn(true);
-        builder.setDocStoreEmbeddedVerificationFeature(docStoreEmbeddedVerificationFeature);
         boolean embeddedVerificationEnabled = isEmbeddedVerificationEnabled(builder);
         assertFalse("Embedded Verification is disabled for RDB Document Store", embeddedVerificationEnabled);
     }


### PR DESCRIPTION
## Summary
- Remove `FT_EMBEDDED_VERIFICATION_OAK-10633` and the `set/getDocStoreEmbeddedVerificationFeature` builder API from the document store.
- Embedded verification during Full GC is now controlled only via `embeddedVerificationEnabled` OSGi/builder configuration (default `true`), matching the existing `Configuration` property and `oak.documentstore.embeddedVerificationEnabled` framework property.
- Clean up orphaned builder state, toggle-specific tests, and update `AGENTS.md` / module docs with migration guidance and clarified Utils Javadoc (config-only vs Full GC runtime toggle).

## Test plan
- [x] `mvn test -pl oak-store-document -Dtest=UtilsTest#embeddedVerification*,MongoDocumentNodeStoreBuilderTest,RDBDocumentNodeStoreBuilderTest`
- [ ] Full `mvn test -pl oak-store-document` in CI

## Migration notes
Deployments that previously enabled embedded verification via `FT_EMBEDDED_VERIFICATION_OAK-10633` while keeping `embeddedVerificationEnabled=false` must set `embeddedVerificationEnabled=true` before upgrade. Default-on deployments are unchanged.

Made with [Cursor](https://cursor.com)