### PR TITLE
OAK-12251: Consolidate test-scoped dependencies (Mockito, JUnit extras)

### DIFF
--- a/oak-jcr/pom.xml
+++ b/oak-jcr/pom.xml
@@ -505,7 +505,6 @@
     <dependency>
       <groupId>junit-addons</groupId>
       <artifactId>junit-addons</artifactId>
-      <version>1.4</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/oak-lucene/pom.xml
+++ b/oak-lucene/pom.xml
@@ -460,7 +460,6 @@
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -71,6 +71,7 @@
     <groovy.version>3.0.25</groovy.version>
     <netty.version>4.1.135.Final</netty.version>
     <aws.sdk.version>2.34.9</aws.sdk.version>
+    <mockito.version>5.23.0</mockito.version>
     <!-- determines the bytecode version (i.e. the minimum JRE required to run the build artifact) -->
     <javaTargetVersion>17</javaTargetVersion>
     <maven.compiler.release>${javaTargetVersion}</maven.compiler.release>
@@ -552,47 +553,14 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>3.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>5.14.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.mongodb</groupId>
         <artifactId>mongodb-driver-sync</artifactId>
         <version>${mongo.driver.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>5.6.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>5.23.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -623,18 +591,6 @@
         <groupId>org.apache.jclouds.provider</groupId>
         <artifactId>aws-s3</artifactId>
         <version>2.0.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.sling</groupId>
-        <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
-        <version>2.4.18</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.sling</groupId>
-        <artifactId>org.apache.sling.testing.osgi-mock.core</artifactId>
-        <version>2.4.18</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -756,13 +712,6 @@
         <artifactId>httpmime</artifactId>
         <version>4.5.14</version>
       </dependency>
-      <!-- Testcontainers dependency -->
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
-        <version>${testcontainers.version}</version>
-        <scope>test</scope>
-      </dependency>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-storage</artifactId>
@@ -863,7 +812,93 @@
         <scope>import</scope>
       </dependency>
 
-      <!-- Pax Exam Integration Test Dependencies -->
+      <!-- Test dependencies -->
+
+      <!-- JUnit -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>3.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.14.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Mockito -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.17.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>3.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.8</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- EasyMock -->
+      <dependency>
+        <groupId>org.easymock</groupId>
+        <artifactId>easymock</artifactId>
+        <version>5.6.0</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Test logging -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- OSGi mocks -->
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+        <version>2.4.18</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>org.apache.sling.testing.osgi-mock.core</artifactId>
+        <version>2.4.18</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Testcontainers -->
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Pax Exam -->
       <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.testing.paxexam</artifactId>
@@ -919,6 +954,24 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.ops4j.pax.url</groupId>
+        <artifactId>pax-url-commons</artifactId>
+        <version>${pax-url.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.swissbox</groupId>
+        <artifactId>pax-swissbox-tracker</artifactId>
+        <version>1.9.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.tinybundles</groupId>
+        <artifactId>tinybundles</artifactId>
+        <version>3.0.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.felix</groupId>
         <artifactId>org.apache.felix.framework</artifactId>
         <version>7.0.3</version>
@@ -930,10 +983,24 @@
         <version>1</version>
         <scope>test</scope>
       </dependency>
+
+      <!-- Misc test utilities -->
       <dependency>
         <groupId>com.github.stefanbirkner</groupId>
         <artifactId>system-rules</artifactId>
         <version>1.19.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit-addons</groupId>
+        <artifactId>junit-addons</artifactId>
+        <version>1.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mock-server</groupId>
+        <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
+        <version>5.14.0</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/oak-run-commons/pom.xml
+++ b/oak-run-commons/pom.xml
@@ -225,7 +225,6 @@
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -508,7 +508,6 @@
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -312,7 +312,6 @@
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/oak-segment-azure/pom.xml
+++ b/oak-segment-azure/pom.xml
@@ -428,7 +428,6 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
-            <version>5.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/oak-store-document/pom.xml
+++ b/oak-store-document/pom.xml
@@ -229,7 +229,6 @@
     <dependency>
       <groupId>junit-addons</groupId>
       <artifactId>junit-addons</artifactId>
-      <version>1.4</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -343,7 +342,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Centralises test dependency declarations in `oak-parent` `dependencyManagement` under a dedicated **Test dependencies** section, making it the single place to manage test library versions across all modules.

**What changes:**

- Moves JUnit (4.13.1 / JUnit BOM 5.14.2), Mockito, EasyMock, slf4j-simple, OSGi mocks, Testcontainers, pax-exam transitives, and misc test utilities into an explicit test-scoped `dependencyManagement` section.
- Extracts a `mockito.version` property (5.23.0) and pins Mockito's runtime transitives (`byte-buddy`, `objenesis`, `asm`) to matching versions.
- Pins pax-exam transitives (`pax-swissbox-tracker` 1.9.0, `tinybundles` 3.0.0, `pax-url-commons`) for deterministic resolution.
- Removes redundant inline version declarations from `oak-jcr`, `oak-lucene`, `oak-run`, `oak-run-commons`, `oak-search-elastic`, `oak-store-document`, and `oak-segment-azure` — those modules now inherit versions from the parent.

**Scope:** test infrastructure only; no changes to production code or OSGi bundle manifests.

JIRA: https://issues.apache.org/jira/browse/OAK-12251