### PR TITLE
OAK-12260 improve cleanup of expired tokens

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
@@ -109,6 +109,25 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
     static final long NO_TOKEN_CLEANUP = 0;
 
     /**
+     * Optional configuration parameter to define the maximum number of expired
+     * token nodes removed in a single cleanup run. Limiting the batch size
+     * bounds how long the node-store commit lock is held during cleanup, reducing
+     * the impact on concurrent token creation requests.
+     */
+    static final String PARAM_TOKEN_CLEANUP_BATCH_SIZE = "tokenCleanupBatchSize";
+
+    /**
+     * Default maximum number of expired tokens removed per cleanup run.
+     */
+    static final int DEFAULT_TOKEN_CLEANUP_BATCH_SIZE = 100;
+
+    /**
+     * If this number of token is crossed for a user, the system will start to
+     * log warnings.
+     */
+    static final int WARN_THRESHOLD_TOKEN_COUNT = 1000;
+
+    /**
      * Default expiration time in ms for login tokens is 2 hours.
      */
     static final long DEFAULT_TOKEN_EXPIRATION = 2 * 3600 * 1000;
@@ -124,6 +143,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
     private final UserManager userManager;
     private final IdentifierManager identifierManager;
     private final long cleanupThreshold;
+    private final int cleanupBatchSize;
 
     TokenProviderImpl(@NotNull Root root, @NotNull ConfigurationParameters options, @NotNull UserConfiguration userConfiguration) {
         this(root, options, userConfiguration, SimpleCredentialsSupport.getInstance());
@@ -137,6 +157,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         this.userManager = userConfiguration.getUserManager(root, NamePathMapper.DEFAULT);
         this.identifierManager = new IdentifierManager(root);
         this.cleanupThreshold = options.getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_THRESHOLD, NO_TOKEN_CLEANUP);
+        this.cleanupBatchSize = options.getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_BATCH_SIZE, DEFAULT_TOKEN_CLEANUP_BATCH_SIZE);
     }
 
     //------------------------------------------------------< TokenProvider >---
@@ -469,8 +490,17 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
             long active = 0;
             long expired = 0;
             try {
-                if (parent.getChildrenCount(cleanupThreshold) >= cleanupThreshold) {
+                long childrenCount = parent.getChildrenCount(cleanupThreshold);
+                if (childrenCount >= WARN_THRESHOLD_TOKEN_COUNT) {
+                    log.warn("Identified {} existing tokens stored for user {} while checking for expired tokens;"
+                            + " consider to reuse login-tokens instead of creating new ones for requests",
+                            childrenCount, userId);
+                }
+                if (childrenCount >= cleanupThreshold) {
                     for (Tree child : parent.getChildren()) {
+                        if (expired >= cleanupBatchSize) {
+                            break;
+                        }
                         if (isExpired(getExpirationTime(child, Long.MIN_VALUE), currentTime)) {
                             expired++;
                             child.remove();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/authentication/token/TokenProviderImpl.java
@@ -122,10 +122,16 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
     static final int DEFAULT_TOKEN_CLEANUP_BATCH_SIZE = 100;
 
     /**
-     * If this number of token is crossed for a user, the system will start to
-     * log warnings.
+     * Optional configuration parameter to define the number of token nodes for
+     * a user above which a warning is logged on cleanup, indicating excessive
+     * token creation instead of token reuse.
      */
-    static final int WARN_THRESHOLD_TOKEN_COUNT = 1000;
+    static final String PARAM_TOKEN_WARN_THRESHOLD = "tokenWarnThreshold";
+
+    /**
+     * Default number of tokens above which a warning is logged.
+     */
+    static final int DEFAULT_TOKEN_WARN_THRESHOLD = 1000;
 
     /**
      * Default expiration time in ms for login tokens is 2 hours.
@@ -144,6 +150,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
     private final IdentifierManager identifierManager;
     private final long cleanupThreshold;
     private final int cleanupBatchSize;
+    private final int warnThreshold;
 
     TokenProviderImpl(@NotNull Root root, @NotNull ConfigurationParameters options, @NotNull UserConfiguration userConfiguration) {
         this(root, options, userConfiguration, SimpleCredentialsSupport.getInstance());
@@ -158,6 +165,7 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
         this.identifierManager = new IdentifierManager(root);
         this.cleanupThreshold = options.getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_THRESHOLD, NO_TOKEN_CLEANUP);
         this.cleanupBatchSize = options.getConfigValueOrDefault(PARAM_TOKEN_CLEANUP_BATCH_SIZE, DEFAULT_TOKEN_CLEANUP_BATCH_SIZE);
+        this.warnThreshold = options.getConfigValueOrDefault(PARAM_TOKEN_WARN_THRESHOLD, DEFAULT_TOKEN_WARN_THRESHOLD);
     }
 
     //------------------------------------------------------< TokenProvider >---
@@ -490,8 +498,8 @@ class TokenProviderImpl implements TokenProvider, TokenConstants {
             long active = 0;
             long expired = 0;
             try {
-                long childrenCount = parent.getChildrenCount(cleanupThreshold);
-                if (childrenCount >= WARN_THRESHOLD_TOKEN_COUNT) {
+                long childrenCount = parent.getChildrenCount(Math.max(cleanupThreshold, warnThreshold));
+                if (childrenCount >= warnThreshold) {
                     log.warn("Identified {} existing tokens stored for user {} while checking for expired tokens;"
                             + " consider to reuse login-tokens instead of creating new ones for requests",
                             childrenCount, userId);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/token/TokenCleanupTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/token/TokenCleanupTest.java
@@ -17,10 +17,12 @@
 package org.apache.jackrabbit.oak.security.authentication.token;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Map;
 
 import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
 import org.apache.jackrabbit.oak.spi.security.authentication.credentials.SimpleCredentialsSupport;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenConstants;
@@ -28,6 +30,7 @@ import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenInfo;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenProvider;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+import org.slf4j.event.Level;
 
 public class TokenCleanupTest extends AbstractTokenTest {
 
@@ -122,5 +125,38 @@ public class TokenCleanupTest extends AbstractTokenTest {
 
         // only batchSize expired tokens should have been removed; the rest remain
         assertTokenNodes((expiredCount - batchSize) + extras);
+    }
+
+    @Test
+    public void testWarnThresholdLogged() {
+        int warnThreshold = 5;
+        TokenProviderImpl tp = createTokenProvider(root,
+                ConfigurationParameters.of(
+                        TokenProviderImpl.PARAM_TOKEN_CLEANUP_THRESHOLD, warnThreshold,
+                        TokenProviderImpl.PARAM_TOKEN_WARN_THRESHOLD, warnThreshold),
+                getUserConfiguration(), SimpleCredentialsSupport.getInstance());
+
+        LogCustomizer log = LogCustomizer
+                .forLogger(TokenProviderImpl.class.getName())
+                .enable(Level.WARN)
+                .create();
+        log.starting();
+        try {
+            // stay below warn threshold — no warning expected
+            for (int i = 0; i < warnThreshold - 1; i++) {
+                createTokenInfo(tp, userId);
+            }
+            assertEquals(0, log.getLogs().size());
+
+            // cross the warn threshold and trigger cleanup
+            boolean cleaned = false;
+            while (!cleaned) {
+                TokenInfo info = createTokenInfo(tp, userId);
+                cleaned = TokenProviderImpl.shouldRunCleanup(info.getToken());
+            }
+            assertFalse("expected a warn log entry for excessive token count", log.getLogs().isEmpty());
+        } finally {
+            log.finished();
+        }
     }
 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/token/TokenCleanupTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/authentication/token/TokenCleanupTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.spi.security.ConfigurationParameters;
+import org.apache.jackrabbit.oak.spi.security.authentication.credentials.SimpleCredentialsSupport;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenConstants;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenInfo;
 import org.apache.jackrabbit.oak.spi.security.authentication.token.TokenProvider;
@@ -90,5 +91,36 @@ public class TokenCleanupTest extends AbstractTokenTest {
             tokenProvider.createToken(userId, Map.of());
         }
         assertTokenNodes(10);
+    }
+
+    @Test
+    public void testBatchSizeLimitsCleanup() throws Exception {
+        int batchSize = 3;
+        TokenProviderImpl tp = createTokenProvider(root,
+                ConfigurationParameters.of(
+                        TokenProviderImpl.PARAM_TOKEN_CLEANUP_THRESHOLD, 5,
+                        TokenProviderImpl.PARAM_TOKEN_CLEANUP_BATCH_SIZE, batchSize),
+                getUserConfiguration(), SimpleCredentialsSupport.getInstance());
+
+        // create more expired tokens than the batch size
+        int expiredCount = batchSize + 2;
+        for (int i = 0; i < expiredCount; i++) {
+            TokenInfo info = tp.createToken(userId, Map.of(TokenProvider.PARAM_TOKEN_EXPIRATION, 2));
+            if (info != null) {
+                waitUntilExpired(info);
+            }
+        }
+
+        // create non-expired tokens until one triggers cleanup
+        int extras = 0;
+        boolean cleaned = false;
+        while (!cleaned && extras < 50) {
+            TokenInfo info = createTokenInfo(tp, userId);
+            cleaned = TokenProviderImpl.shouldRunCleanup(info.getToken());
+            extras++;
+        }
+
+        // only batchSize expired tokens should have been removed; the rest remain
+        assertTokenNodes((expiredCount - batchSize) + extras);
     }
 }


### PR DESCRIPTION
* Only delete a subset of all expired tokens to get have a smaller commit.
* WARN if a large amount of login-tokens are present (expired or not)