### PR TITLE
OAK-12093 Add maven-enforcer dependency convergence check

### DIFF
--- a/oak-blob-cloud-azure/pom.xml
+++ b/oak-blob-cloud-azure/pom.xml
@@ -285,7 +285,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.1.0-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/oak-examples/webapp/pom.xml
+++ b/oak-examples/webapp/pom.xml
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
-      <version>1.1</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -879,7 +879,11 @@
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
       </dependency>
-      <!-- oak-shaded-guava pulls 33.5.0-jre; azure-keyvault-core:1.2.6 pulls 30.1.1-jre -->
+      <!-- azure-keyvault-core:1.2.6 pulls guava:30.1.1-jre, conflicting with the direct guava
+           deps in oak-blob-cloud-azure and oak-segment-azure. Additionally, in reactor builds
+           Maven uses oak-shaded-guava's original pom.xml rather than dependency-reduced-pom.xml,
+           so guava:33.5.0-jre also appears as a transitive dep (making guava optional in
+           oak-shaded-guava would eliminate that false positive, but not the azure-keyvault conflict). -->
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -932,11 +932,13 @@
         <artifactId>log4j-api</artifactId>
         <version>2.17.2</version>
       </dependency>
-      <!-- oak-run has a direct dep on 1.3.4; aws-java-sdk-core:1.12.791 pulls 1.1.3, httpclient pulls 1.2 -->
+      <!-- aws-java-sdk-core:1.12.791 pulls 1.1.3; httpclient and dynamodb-lock-client pull 1.2.
+           Do not upgrade beyond 1.2: commons-logging 1.3+ changed Bundle-SymbolicName from
+           org.apache.commons.logging to org.apache.commons.commons-logging, breaking OSGi. -->
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.3.4</version>
+        <version>1.2</version>
       </dependency>
       <!-- azure-identity:1.11.3 pulls 5.13.0; tika-parsers:1.28.5 pulls 5.12.1 -->
       <dependency>

--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -477,6 +477,24 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-dependency-convergence</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <dependencyConvergence/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -706,6 +724,12 @@
         <artifactId>caffeine</artifactId>
         <version>3.1.8</version>
       </dependency>
+      <!-- guava:33.5.0-jre pulls 2.41.0; caffeine:3.1.8 pulls 2.21.1 -->
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.41.0</version>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
@@ -854,6 +878,162 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
+      </dependency>
+      <!-- oak-shaded-guava pulls 33.5.0-jre; azure-keyvault-core:1.2.6 pulls 30.1.1-jre -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.5.0-jre</version>
+      </dependency>
+      <!-- jackrabbit-core:2.22.3 pulls oak-jackrabbit-api:1.88.0 -->
+      <dependency>
+        <groupId>org.apache.jackrabbit</groupId>
+        <artifactId>oak-jackrabbit-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <!-- oak-auth-ldap has a direct dep on 2.12.0; api-all:2.0.1 pulls 2.8.0 -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-pool2</artifactId>
+        <version>2.12.0</version>
+      </dependency>
+      <!-- oak-auth-ldap has a direct dep on 2.1.12; api-all:2.0.1 pulls 2.1.3 -->
+      <dependency>
+        <groupId>org.apache.mina</groupId>
+        <artifactId>mina-core</artifactId>
+        <version>2.1.12</version>
+      </dependency>
+      <!-- parsson:1.0.5 pulls 2.0.2; elasticsearch-java:8.19.5 pulls 2.0.1 -->
+      <dependency>
+        <groupId>jakarta.json</groupId>
+        <artifactId>jakarta.json-api</artifactId>
+        <version>2.0.2</version>
+      </dependency>
+
+      <!-- jackrabbit-jcr-server:2.22.3 pulls tika-core:2.4.1; oak-lucene uses ${tika.version} -->
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-core</artifactId>
+        <version>${tika.version}</version>
+      </dependency>
+      <!-- jetty-annotations (via spring-boot-starter-jetty:2.7.18) pulls 9.6; tika-parsers:1.28.5 pulls 9.3 -->
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.6</version>
+      </dependency>
+      <!-- poi:5.2.2 and poi-scratchpad:5.2.2 pull 2.17.2; xmlbeans:5.0.3 (via poi-ooxml) pulls 2.17.1 -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.17.2</version>
+      </dependency>
+      <!-- oak-run has a direct dep on 1.3.4; aws-java-sdk-core:1.12.791 pulls 1.1.3, httpclient pulls 1.2 -->
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.3.4</version>
+      </dependency>
+      <!-- azure-identity:1.11.3 pulls 5.13.0; tika-parsers:1.28.5 pulls 5.12.1 -->
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>5.13.0</version>
+      </dependency>
+      <!-- jackson-dataformat-xml:2.19.4 (via oak-segment-azure) pulls 7.1.1; tika-parsers:1.28.5 pulls 6.3.1 -->
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>7.1.1</version>
+      </dependency>
+      <!-- aws-java-sdk-s3:1.12.791 pulls 2.12.7; edu.ucar:udunits (via tika-parsers) pulls 2.2 -->
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.12.7</version>
+      </dependency>
+      <!-- msal4j-persistence-extension:1.2.0 (via azure-identity) pulls 5.13.0; azure-identity:1.11.3 pulls 5.6.0 -->
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>5.13.0</version>
+      </dependency>
+      <!-- dynamodb-lock-client:1.1.0 pulls aws-java-sdk-core:1.11.475 and aws-java-sdk-dynamodb:1.11.475 -->
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-core</artifactId>
+        <version>1.12.791</version>
+      </dependency>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-dynamodb</artifactId>
+        <version>1.12.791</version>
+      </dependency>
+      <!-- awssdk:netty-nio-client:2.34.9 pulls 4.1.126.Final; azure-core-http-netty:1.14.1 pulls 4.1.101.Final -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-epoll</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>${netty.version}</version>
       </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>

--- a/oak-run-commons/pom.xml
+++ b/oak-run-commons/pom.xml
@@ -143,8 +143,8 @@
                 </exclusion>
                 <!-- jackrabbit-core:2.22.3 (via jackrabbit-parent) declares tika.version=2.4.1,
                      but this project uses Tika 1.x (see ${tika.version} in oak-parent).
-                     Exclude here to prevent jackrabbit-core from silently downgrading to 1.x at runtime,
-                     which could cause failures if jackrabbit-core's Tika 2.x code paths are exercised. -->
+                     Excluding prevents jackrabbit-core from pulling in Tika 2.x, which would be
+                     silently downgraded to 1.x at runtime and could cause failures. -->
                 <exclusion>
                     <groupId>org.apache.tika</groupId>
                     <artifactId>tika-core</artifactId>

--- a/oak-run-commons/pom.xml
+++ b/oak-run-commons/pom.xml
@@ -141,6 +141,10 @@
                     <groupId>org.apache.lucene</groupId>
                     <artifactId>lucene-core</artifactId>
                 </exclusion>
+                <!-- jackrabbit-core:2.22.3 (via jackrabbit-parent) declares tika.version=2.4.1,
+                     but this project uses Tika 1.x (see ${tika.version} in oak-parent).
+                     Exclude here to prevent jackrabbit-core from silently downgrading to 1.x at runtime,
+                     which could cause failures if jackrabbit-core's Tika 2.x code paths are exercised. -->
                 <exclusion>
                     <groupId>org.apache.tika</groupId>
                     <artifactId>tika-core</artifactId>

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -53,7 +53,7 @@
       + 41 MB build failing on the release profile (OAK-6250)
       + 38 MB. Initial value. Current 35MB plus a 10%
     -->
-    <max.jar.size>92274688</max.jar.size>
+    <max.jar.size>93323264</max.jar.size>
   </properties>
 
   <build>

--- a/oak-run/pom.xml
+++ b/oak-run/pom.xml
@@ -314,12 +314,11 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.14.5</version>
+      <version>2.14.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -332,7 +331,6 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileGenerator.java
+++ b/oak-run/src/main/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileGenerator.java
@@ -46,6 +46,8 @@ public class CSVFileGenerator {
             CSVPrinter printer = new CSVPrinter(new BufferedWriter(new FileWriter(outFile, StandardCharsets.UTF_8)),
                     CSVFileBinaryResourceProvider.FORMAT);
             closer.register(printer);
+            // commons-csv 1.2+ no longer auto-writes the header on construction; must be explicit
+            printer.printRecord((Object[]) CSVFileBinaryResourceProvider.FORMAT.getHeader());
             for (BinaryResource br : binaries){
                 count++;
                 printer.printRecord(

--- a/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileBinaryResourceProviderTest.java
+++ b/oak-run/src/test/java/org/apache/jackrabbit/oak/plugins/tika/CSVFileBinaryResourceProviderTest.java
@@ -41,6 +41,7 @@ public class CSVFileBinaryResourceProviderTest {
     public void testGetBinaries() throws Exception {
         StringBuilder sb = new StringBuilder();
         CSVPrinter p = new CSVPrinter(sb, CSVFileBinaryResourceProvider.FORMAT);
+        p.printRecord((Object[]) CSVFileBinaryResourceProvider.FORMAT.getHeader());
         // BLOB_ID, LENGTH, JCR_MIMETYPE, JCR_ENCODING, JCR_PATH
         p.printRecord("a", 123, "text/plain", null, "/a");
         p.printRecord("a2", 123, "text/plain", null, "/a/c");

--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -54,18 +54,35 @@
               org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService
             </_exportcontents>
             <Import-Package>
-              !com.ibm.*, <!-- see OAK-11076 -->
-              !org.apache.derby.*, <!-- see OAK-11076 -->
+              <!-- OAK-11076: IBM JDK classes referenced by embedded Derby JDBC driver; absent in standard JDKs -->
+              !com.ibm.*,
+              <!-- OAK-11076: Derby JDBC driver ends up on the classpath with -Prdb-derby -->
+              !org.apache.derby.*,
+              <!-- OpenTelemetry SDK autoconfigure: optional tracing wiring in elasticsearch-java; only the API is deployed, not the SDK -->
               !io.opentelemetry.sdk.autoconfigure.*,
+              <!-- JDK-internal socket options used by embedded httpasyncclient; unavailable as an OSGi package -->
               !jdk.net.*,
+              <!-- Avalon/commons-logging legacy bridge; optional logging backend, not used here -->
               !org.apache.log.*,
+              <!-- Log4j; optional backend picked up by embedded commons-logging; we use SLF4J/logback instead -->
               !org.apache.logging.*,
+              <!-- JDK-internal package; not available in OSGi -->
               !sun.misc.*,
+              <!-- lucene-analysis-common is embedded in Bundle-ClassPath, so no OSGi import is needed -->
               !org.apache.lucene.analysis.*,
+              <!-- OAK-12093: jakarta.json-api 2.0.2's JsonProvider uses Class.forName() on this for OSGi service lookup;
+                   parsson is embedded as the JSON provider so this lookup path is never exercised -->
+              !org.glassfish.hk2.*,
+              <!-- GlassFish reference JSON-P implementation; parsson is embedded as the actual provider instead -->
               !org.glassfish.json.*,
+              <!-- JDK-internal management extension package; not available in OSGi -->
               !com.sun.management.*,
+              <!-- Jakarta JSON Binding (JSON-B); distinct from JSON-P and not used by this bundle -->
               !jakarta.json.bind.*,
+              <!-- OAK-11245: Java 11 built-in HTTP client; elasticsearch-java's JdkHttpClient transport is optional,
+                   the bundle uses Apache HttpClient instead -->
               !java.net.http.*,
+              <!-- OAK-11464: Oracle Cloud Infrastructure SDK; optionally referenced when building with rdb-mysql profile -->
               !com.oracle.bmc.*,
               *
             </Import-Package>

--- a/oak-segment-azure/pom.xml
+++ b/oak-segment-azure/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-xml</artifactId>
-            <version>1.0.0</version>
+            <version>1.2.0</version>
         </dependency>
 
         <!-- Azure Identity Client for Microsoft Entra ID dependency -->
@@ -330,7 +330,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.1.0-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Update: right now the build fails. I will try to resolve the failures first, and then we can discuss about the changes. It might not make sense to discuss changes right now.

Adds the maven-enforcer-plugin to oak-parent with the dependencyConvergence rule, which fails the build if any dependency appears at more than one version in a module's resolved dependency tree. This catches transitive version conflicts at build time rather than at runtime.

Running the enforcer across all modules revealed 20 existing version conflicts. These are fixed by adding explicit version pins to dependencyManagement in oak-parent, with comments on each pin identifying the two conflicting sources so they can be removed when the underlying dependencies are upgraded.

A few modules had direct dependencies with stale explicit versions that were the root cause of their conflict; those versions are updated in place:

* oak-run: jline, commons-csv, commons-logging
* oak-segment-azure: guava
* oak-blob-cloud-azure: guava
* oak-examples/webapp: json-simple

A comment is also added to the existing tika-core exclusion in oak-run-commons explaining why the exclusion is necessary alongside the pin.

The Guava pin points to a bigger issue with different modules requiring different version of Guava. It should be resolved. The root cause is that azure-keyvault-core:1.2.6 is quite old and brings in a significantly outdated Guava (30.1.1-jre vs 33.5.0-jre). The pin papers over that mismatch. The real fix would be to upgrade azure-keyvault-core  or replace it, since that library has been deprecated in favour of the modern com.azure:azure-keyvault-keys / azure-keyvault-secrets SDK. Once that dependency is gone, the Guava pin would likely become unnecessary.