### PR TITLE
OAK-12269 : Add index tag support to user query (QueryBuilder#setIndexTag)

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManager.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManager.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
@@ -59,6 +60,13 @@ import static org.apache.jackrabbit.oak.security.user.query.QueryUtil.getID;
 public class UserQueryManager {
 
     private static final Logger log = LoggerFactory.getLogger(UserQueryManager.class);
+
+    /**
+     * Pattern an index tag must match before it is appended to the query as an
+     * {@code option(index tag <tag>)} clause. Restricting the value to word
+     * characters prevents query injection through the generated statement.
+     */
+    private static final Pattern INDEX_TAG_PATTERN = Pattern.compile("[a-zA-Z0-9_]+");
 
     private final UserManagerImpl userManager;
     private final NamePathMapper namePathMapper;
@@ -259,6 +267,14 @@ public class UserQueryManager {
                 statement.append(sortCol);
             }
             statement.append(' ').append(sortDir.getDirection());
+        }
+
+        String indexTag = builder.getIndexTag();
+        if (indexTag != null) {
+            if (!INDEX_TAG_PATTERN.matcher(indexTag).matches()) {
+                throw new RepositoryException("Invalid index tag '" + indexTag + "': must consist of word characters only.");
+            }
+            statement.append(" option(index tag ").append(indexTag).append(')');
         }
 
         return statement.toString();

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/XPathQueryBuilder.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/query/XPathQueryBuilder.java
@@ -38,6 +38,7 @@ class XPathQueryBuilder implements QueryBuilder<Condition> {
     private Value bound;
     private long offset;
     private long maxCount = Long.MAX_VALUE;
+    private String indexTag;
 
     //-------------------------------------------------------< QueryBuilder >---
     @Override
@@ -88,6 +89,11 @@ class XPathQueryBuilder implements QueryBuilder<Condition> {
         bound = null;
         this.offset = offset;
         setMaxCount(maxCount);
+    }
+
+    @Override
+    public void setIndexTag(@NotNull String indexTag) {
+        this.indexTag = indexTag;
     }
 
     @NotNull
@@ -217,6 +223,11 @@ class XPathQueryBuilder implements QueryBuilder<Condition> {
 
     long getMaxCount() {
         return maxCount;
+    }
+
+    @Nullable
+    String getIndexTag() {
+        return indexTag;
     }
 
     private void setMaxCount(long maxCount) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManagerTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/query/UserQueryManagerTest.java
@@ -65,6 +65,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * UserQueryManagerTest provides test cases for {@link UserQueryManager}.
@@ -334,6 +335,48 @@ public class UserQueryManagerTest extends AbstractUserTest {
 
         Iterator<Authorizable> result = queryMgr.findAuthorizables(q);
         assertResultContainsAuthorizables(result, user, g);
+    }
+
+    @Test
+    public void testQueryWithIndexTag() throws Exception {
+        Group g = createGroup(null, EveryonePrincipal.getInstance());
+        g.setProperty(propertyName, v);
+        user.setProperty(propertyName, v);
+        root.commit();
+
+        Query q = new Query() {
+            @Override
+            public <T> void build(@NotNull QueryBuilder<T> builder) {
+                builder.setCondition(builder.eq(propertyName, v));
+                builder.setIndexTag("myTag");
+            }
+        };
+
+        // no index is tagged with 'myTag' -> the option(index tag ...) clause is
+        // valid syntax and the query falls back to traversal (failTraversal=false)
+        Iterator<Authorizable> result = queryMgr.findAuthorizables(q);
+        assertResultContainsAuthorizables(result, user, g);
+    }
+
+    @Test
+    public void testQueryWithInvalidIndexTag() throws Exception {
+        user.setProperty(propertyName, v);
+        root.commit();
+
+        Query q = new Query() {
+            @Override
+            public <T> void build(@NotNull QueryBuilder<T> builder) {
+                builder.setCondition(builder.eq(propertyName, v));
+                builder.setIndexTag("invalid tag)");
+            }
+        };
+
+        try {
+            queryMgr.findAuthorizables(q);
+            fail("Invalid index tag must be rejected.");
+        } catch (RepositoryException e) {
+            // success
+        }
     }
 
     @Test

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/query/XPathQueryBuilderTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/security/user/query/XPathQueryBuilderTest.java
@@ -181,6 +181,17 @@ public class XPathQueryBuilderTest extends AbstractSecurityTest {
     }
 
     @Test
+    public void testGetIndexTag() {
+        assertNull(builder.getIndexTag());
+    }
+
+    @Test
+    public void testSetIndexTag() {
+        builder.setIndexTag("myIndexTag");
+        assertEquals("myIndexTag", builder.getIndexTag());
+    }
+
+    @Test
     public void testNameMatches() {
         Condition c = builder.nameMatches("pattern");
 

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/QueryBuilder.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/QueryBuilder.java
@@ -123,6 +123,30 @@ public interface QueryBuilder<T> {
     void setLimit(long offset, long maxCount);
 
     /**
+     * Set an index tag for the query. If set, the query that is executed to
+     * collect the result is augmented with an
+     * <code>option(index tag &lt;indexTag&gt;)</code> clause, forcing the query
+     * engine to use one of the indexes that are marked with the given tag. See
+     * the Oak documentation on the
+     * <a href="https://jackrabbit.apache.org/oak/docs/query/query-engine.html#query-option-index-tag">index tag query option</a>
+     * for further details.
+     * <p>
+     * The <code>indexTag</code> must be a valid identifier consisting of word
+     * characters only (<code>a-z</code>, <code>A-Z</code>, <code>0-9</code> and
+     * <code>_</code>); otherwise query execution will fail.
+     * <p>
+     * The default implementation ignores the index tag. This keeps the method
+     * backwards compatible with {@code QueryBuilder} implementations that do not
+     * support index tags (e.g. those backed by a query engine that has no
+     * notion of index tags).
+     *
+     * @param indexTag  The name of the index tag to use.
+     */
+    default void setIndexTag(@NotNull String indexTag) {
+        // default implementation ignores the index tag for backwards compatibility
+    }
+
+    /**
      * Create a condition which holds if the name of the {@link Authorizable}
      * matches a <code>pattern</code>.
      * The percent character "%" represents any string of zero or more characters and the

--- a/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/package-info.java
+++ b/oak-jackrabbit-api/src/main/java/org/apache/jackrabbit/api/security/user/package-info.java
@@ -18,5 +18,5 @@
 /**
  * Jackrabbit extensions for user management.
  */
-@org.osgi.annotation.versioning.Version("2.5.0")
+@org.osgi.annotation.versioning.Version("3.0.0")
 package org.apache.jackrabbit.api.security.user;


### PR DESCRIPTION
Allow user/group queries to force a specific index by exposing a new QueryBuilder#setIndexTag(String) method. When set, the generated XPath statement is augmented with an "option(index tag <tag>)" clause (see the Oak query-engine index-tag query option).

- oak-jackrabbit-api: add default no-op setIndexTag(String) to the QueryBuilder interface so existing implementors remain source/binary compatible; bump the exported package version (minor) accordingly.
- oak-core: XPathQueryBuilder stores the tag; UserQueryManager appends the option clause to the statement and validates the tag against [a-zA-Z0-9_]+ to prevent query injection.
- Tests for the new builder accessor and for the generated statement (valid tag executes, invalid tag is rejected).