### PR TITLE
OAK-12282 : defining a fixed bound for the AbstractDiskCache

### DIFF
--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
@@ -111,8 +111,8 @@ public class PersistentDiskCache extends AbstractPersistentCache {
                 () -> maxCacheSizeBytes,
                 () -> Long.valueOf(directory.listFiles().length),
                 () -> FileUtils.sizeOfDirectory(directory),
-                () -> evictionCount.get());
-        segmentCacheStats.setWriteDiscardCountSupplier(() -> discardCount.get());
+                () -> evictionCount.get(),
+                () -> discardCount.get());
     }
 
     @Override

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentDiskCache.java
@@ -112,6 +112,7 @@ public class PersistentDiskCache extends AbstractPersistentCache {
                 () -> Long.valueOf(directory.listFiles().length),
                 () -> FileUtils.sizeOfDirectory(directory),
                 () -> evictionCount.get());
+        segmentCacheStats.setWriteDiscardCountSupplier(() -> discardCount.get());
     }
 
     @Override

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCache.java
@@ -73,8 +73,7 @@ public class PersistentRedisCache extends AbstractPersistentCache {
         this.redisPool = new JedisPool(jedisPoolConfig, redisHost, redisPort, redisConnectionTimeout,
                 redisSocketTimeout, null, redisDBIndex, null);
         this.segmentCacheStats = new SegmentCacheStats(NAME, this::getRedisMaxMemory, this::getCacheElementCount,
-                this::getCurrentWeight, this::getNumberOfEvictedKeys);
-        this.segmentCacheStats.setWriteDiscardCountSupplier(() -> discardCount.get());
+                this::getCurrentWeight, this::getNumberOfEvictedKeys, () -> discardCount.get());
     }
 
     private long getCacheElementCount() {

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCache.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/PersistentRedisCache.java
@@ -74,6 +74,7 @@ public class PersistentRedisCache extends AbstractPersistentCache {
                 redisSocketTimeout, null, redisDBIndex, null);
         this.segmentCacheStats = new SegmentCacheStats(NAME, this::getRedisMaxMemory, this::getCacheElementCount,
                 this::getCurrentWeight, this::getNumberOfEvictedKeys);
+        this.segmentCacheStats.setWriteDiscardCountSupplier(() -> discardCount.get());
     }
 
     private long getCacheElementCount() {

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/RemotePersistentCacheService.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/RemotePersistentCacheService.java
@@ -24,6 +24,7 @@ import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.pio.Closer;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RoleStatisticsProvider;
+import org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache.AbstractPersistentCache;
 import org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache.PersistentCache;
 import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
 import org.apache.jackrabbit.oak.spi.whiteboard.Registration;
@@ -101,6 +102,12 @@ public class RemotePersistentCacheService {
                     new FeatureToggle(PersistentDiskCache.FT_OAK_12212, PersistentDiskCache.FT_OAK_12212_SKIP_MISSING_FILE_CHECK),
                     Collections.emptyMap()));
 
+            // OAK-12282: expose the bounded write-queue kill switch. Changing this
+            // flag requires a process restart since the executor is created at startup.
+            registerCloseable(osgiWhiteboard.register(FeatureToggle.class,
+                    new FeatureToggle(AbstractPersistentCache.FT_OAK_12282, AbstractPersistentCache.FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED),
+                    Collections.emptyMap()));
+
             CacheStatsMBean diskCacheStatsMBean = persistentDiskCache.getCacheStats();
             registerCloseable(registerMBean(CacheStatsMBean.class, diskCacheStatsMBean, CacheStats.TYPE, diskCacheStatsMBean.getName()));
 
@@ -119,6 +126,11 @@ public class RemotePersistentCacheService {
             PersistentRedisCache redisCache = new PersistentRedisCache(configuration.redisCacheHost(), configuration.redisCachePort(), configuration.redisCacheExpireSeconds(), configuration.redisSocketTimeout(), configuration.redisConnectionTimeout(),
                     configuration.redisMinConnections(), configuration.redisMaxConnections(), configuration.redisMaxTotalConnections(), configuration.redisDBIndex(), redisCacheIOMonitor);
             closer.register(redisCache);
+
+            // OAK-12282: expose the bounded write-queue kill switch. Requires a restart to take effect.
+            registerCloseable(osgiWhiteboard.register(FeatureToggle.class,
+                    new FeatureToggle(AbstractPersistentCache.FT_OAK_12282, AbstractPersistentCache.FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED),
+                    Collections.emptyMap()));
 
             CacheStatsMBean redisCacheStatsMBean = redisCache.getCacheStats();
             registerCloseable(registerMBean(CacheStatsMBean.class, redisCacheStatsMBean, CacheStats.TYPE, redisCacheStatsMBean.getName()));

--- a/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/RemotePersistentCacheService.java
+++ b/oak-segment-remote/src/main/java/org/apache/jackrabbit/oak/segment/remote/persistentcache/RemotePersistentCacheService.java
@@ -24,7 +24,6 @@ import org.apache.jackrabbit.oak.cache.CacheStats;
 import org.apache.jackrabbit.oak.commons.pio.Closer;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.segment.spi.monitor.RoleStatisticsProvider;
-import org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache.AbstractPersistentCache;
 import org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache.PersistentCache;
 import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
 import org.apache.jackrabbit.oak.spi.whiteboard.Registration;
@@ -102,12 +101,6 @@ public class RemotePersistentCacheService {
                     new FeatureToggle(PersistentDiskCache.FT_OAK_12212, PersistentDiskCache.FT_OAK_12212_SKIP_MISSING_FILE_CHECK),
                     Collections.emptyMap()));
 
-            // OAK-12282: expose the bounded write-queue kill switch. Changing this
-            // flag requires a process restart since the executor is created at startup.
-            registerCloseable(osgiWhiteboard.register(FeatureToggle.class,
-                    new FeatureToggle(AbstractPersistentCache.FT_OAK_12282, AbstractPersistentCache.FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED),
-                    Collections.emptyMap()));
-
             CacheStatsMBean diskCacheStatsMBean = persistentDiskCache.getCacheStats();
             registerCloseable(registerMBean(CacheStatsMBean.class, diskCacheStatsMBean, CacheStats.TYPE, diskCacheStatsMBean.getName()));
 
@@ -126,11 +119,6 @@ public class RemotePersistentCacheService {
             PersistentRedisCache redisCache = new PersistentRedisCache(configuration.redisCacheHost(), configuration.redisCachePort(), configuration.redisCacheExpireSeconds(), configuration.redisSocketTimeout(), configuration.redisConnectionTimeout(),
                     configuration.redisMinConnections(), configuration.redisMaxConnections(), configuration.redisMaxTotalConnections(), configuration.redisDBIndex(), redisCacheIOMonitor);
             closer.register(redisCache);
-
-            // OAK-12282: expose the bounded write-queue kill switch. Requires a restart to take effect.
-            registerCloseable(osgiWhiteboard.register(FeatureToggle.class,
-                    new FeatureToggle(AbstractPersistentCache.FT_OAK_12282, AbstractPersistentCache.FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED),
-                    Collections.emptyMap()));
 
             CacheStatsMBean redisCacheStatsMBean = redisCache.getCacheStats();
             registerCloseable(registerMBean(CacheStatsMBean.class, redisCacheStatsMBean, CacheStats.TYPE, redisCacheStatsMBean.getName()));

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
@@ -22,6 +22,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import org.apache.jackrabbit.oak.cache.AbstractCacheStats;
 import org.apache.jackrabbit.oak.commons.Buffer;
+import org.apache.jackrabbit.oak.commons.log.LogSilencer;
 import org.apache.jackrabbit.oak.commons.time.Stopwatch;
 import org.apache.jackrabbit.oak.segment.spi.RepositoryNotReachableException;
 import org.jetbrains.annotations.NotNull;
@@ -36,16 +37,17 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractPersistentCache implements PersistentCache, Closeable {
     private static final Logger logger = LoggerFactory.getLogger(AbstractPersistentCache.class);
 
     public static final int THREADS = Integer.getInteger("oak.segment.cache.threads", 10);
-    public static final int WRITE_QUEUE_SIZE = Integer.getInteger("oak.segment.cache.writeQueueSize", THREADS * 100);
+    public static final int WRITE_QUEUE_SIZE = Integer.getInteger("oak.segment.cache.writeQueueSize", 100);
 
     protected ExecutorService executor;
     protected AtomicLong cacheSize = new AtomicLong(0);
@@ -55,43 +57,27 @@ public abstract class AbstractPersistentCache implements PersistentCache, Closea
 
     protected SegmentCacheStats segmentCacheStats;
 
-    /**
-     * Name of the feature toggle for the OAK-12282 bounded write-queue fix.
-     * See {@link #FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED}.
-     */
-    public static final String FT_OAK_12282 = "FT_OAK-12282";
-
-    /**
-     * Whether the bounded write queue introduced in OAK-12282 is active.
-     * <p>
-     * When {@code true} (default), the executor uses a queue bounded to
-     * {@link #WRITE_QUEUE_SIZE} and silently discards write tasks when full,
-     * preventing OOM under high write load. This is safe because the disk
-     * cache is an optimisation only — a dropped write means the segment is
-     * fetched from remote storage on the next read.
-     * <p>
-     * Set to {@code false} via the {@link org.apache.jackrabbit.oak.spi.toggle.FeatureToggle}
-     * registered with the Whiteboard to revert to the pre-fix unbounded queue.
-     * <strong>Note:</strong> changing this flag requires a process restart, as
-     * the executor is created at startup.
-     */
-    public static final AtomicBoolean FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED = new AtomicBoolean(true);
+    private final LogSilencer writeQueueFullSilencer = new LogSilencer();
 
     public AbstractPersistentCache() {
-        // Formerly Executors.newFixedThreadPool() was used here, which creates an unbounded
-        // LinkedBlockingQueue — allowing unlimited segment buffers to pile up in memory under
-        // high write load. The bounded queue (gated by FT_OAK_12282) prevents OOM by dropping
-        // write tasks when full; this is safe because the disk cache is an optimisation only.
-        BlockingQueue<Runnable> writeQueue = FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED.get()
-                ? new LinkedBlockingQueue<>(WRITE_QUEUE_SIZE)
-                : new LinkedBlockingQueue<>();
+        AtomicInteger threadCount = new AtomicInteger(0);
+        ThreadFactory threadFactory = r -> {
+            Thread t = new Thread(r, "segment-cache-writer-" + threadCount.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
+        BlockingQueue<Runnable> writeQueue = new LinkedBlockingQueue<>(WRITE_QUEUE_SIZE);
         executor = new ThreadPoolExecutor(
                 THREADS, THREADS,
                 0L, TimeUnit.MILLISECONDS,
                 writeQueue,
+                threadFactory,
                 (r, e) -> {
                     discardCount.incrementAndGet();
-                    logger.debug("Segment write task discarded: write queue full (capacity={})", WRITE_QUEUE_SIZE);
+                    if (!writeQueueFullSilencer.silence("writeQueueFull")) {
+                        logger.warn("Segment write task discarded: write queue full (capacity={}, totalDiscarded={}){}",
+                                WRITE_QUEUE_SIZE, discardCount.get(), LogSilencer.SILENCING_POSTFIX);
+                    }
                 });
         writesPending = ConcurrentHashMap.newKeySet();
     }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
@@ -31,12 +31,14 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractPersistentCache implements PersistentCache, Closeable {
@@ -49,23 +51,48 @@ public abstract class AbstractPersistentCache implements PersistentCache, Closea
     protected AtomicLong cacheSize = new AtomicLong(0);
     protected PersistentCache nextCache;
     protected final Set<String> writesPending;
+    protected AtomicLong discardCount = new AtomicLong();
 
     protected SegmentCacheStats segmentCacheStats;
 
+    /**
+     * Name of the feature toggle for the OAK-12282 bounded write-queue fix.
+     * See {@link #FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED}.
+     */
+    public static final String FT_OAK_12282 = "FT_OAK-12282";
+
+    /**
+     * Whether the bounded write queue introduced in OAK-12282 is active.
+     * <p>
+     * When {@code true} (default), the executor uses a queue bounded to
+     * {@link #WRITE_QUEUE_SIZE} and silently discards write tasks when full,
+     * preventing OOM under high write load. This is safe because the disk
+     * cache is an optimisation only — a dropped write means the segment is
+     * fetched from remote storage on the next read.
+     * <p>
+     * Set to {@code false} via the {@link org.apache.jackrabbit.oak.spi.toggle.FeatureToggle}
+     * registered with the Whiteboard to revert to the pre-fix unbounded queue.
+     * <strong>Note:</strong> changing this flag requires a process restart, as
+     * the executor is created at startup.
+     */
+    public static final AtomicBoolean FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED = new AtomicBoolean(true);
+
     public AbstractPersistentCache() {
-        // Segment write-back tasks are queued here before being written to the local disk cache.
-        // Each queued task holds a copy of the segment buffer in memory until a thread processes it.
-        // Using a bounded queue (WRITE_QUEUE_SIZE) with DiscardPolicy prevents OOM under high load:
-        // when the queue is full, new write tasks are silently dropped rather than accumulating in
-        // memory. This is safe because the disk cache is an optimisation only — a dropped write
-        // means the segment is not cached locally and will be fetched from remote storage on the
-        // next read. Formerly Executors.newFixedThreadPool() was used here, which internally creates
-        // an unbounded LinkedBlockingQueue, allowing unlimited segment buffers to pile up in memory.
+        // Formerly Executors.newFixedThreadPool() was used here, which creates an unbounded
+        // LinkedBlockingQueue — allowing unlimited segment buffers to pile up in memory under
+        // high write load. The bounded queue (gated by FT_OAK_12282) prevents OOM by dropping
+        // write tasks when full; this is safe because the disk cache is an optimisation only.
+        BlockingQueue<Runnable> writeQueue = FT_OAK_12282_BOUNDED_WRITE_QUEUE_ENABLED.get()
+                ? new LinkedBlockingQueue<>(WRITE_QUEUE_SIZE)
+                : new LinkedBlockingQueue<>();
         executor = new ThreadPoolExecutor(
                 THREADS, THREADS,
                 0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(WRITE_QUEUE_SIZE),
-                new ThreadPoolExecutor.DiscardPolicy());
+                writeQueue,
+                (r, e) -> {
+                    discardCount.incrementAndGet();
+                    logger.debug("Segment write task discarded: write queue full (capacity={})", WRITE_QUEUE_SIZE);
+                });
         writesPending = ConcurrentHashMap.newKeySet();
     }
 
@@ -161,5 +188,9 @@ public abstract class AbstractPersistentCache implements PersistentCache, Closea
 
     public int getWritesPending() {
         return writesPending.size();
+    }
+
+    public long getWriteDiscardCount() {
+        return discardCount.get();
     }
 }

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/AbstractPersistentCache.java
@@ -34,7 +34,8 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -42,6 +43,7 @@ public abstract class AbstractPersistentCache implements PersistentCache, Closea
     private static final Logger logger = LoggerFactory.getLogger(AbstractPersistentCache.class);
 
     public static final int THREADS = Integer.getInteger("oak.segment.cache.threads", 10);
+    public static final int WRITE_QUEUE_SIZE = Integer.getInteger("oak.segment.cache.writeQueueSize", THREADS * 100);
 
     protected ExecutorService executor;
     protected AtomicLong cacheSize = new AtomicLong(0);
@@ -51,7 +53,19 @@ public abstract class AbstractPersistentCache implements PersistentCache, Closea
     protected SegmentCacheStats segmentCacheStats;
 
     public AbstractPersistentCache() {
-        executor = Executors.newFixedThreadPool(THREADS);
+        // Segment write-back tasks are queued here before being written to the local disk cache.
+        // Each queued task holds a copy of the segment buffer in memory until a thread processes it.
+        // Using a bounded queue (WRITE_QUEUE_SIZE) with DiscardPolicy prevents OOM under high load:
+        // when the queue is full, new write tasks are silently dropped rather than accumulating in
+        // memory. This is safe because the disk cache is an optimisation only — a dropped write
+        // means the segment is not cached locally and will be fetched from remote storage on the
+        // next read. Formerly Executors.newFixedThreadPool() was used here, which internally creates
+        // an unbounded LinkedBlockingQueue, allowing unlimited segment buffers to pile up in memory.
+        executor = new ThreadPoolExecutor(
+                THREADS, THREADS,
+                0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(WRITE_QUEUE_SIZE),
+                new ThreadPoolExecutor.DiscardPolicy());
         writesPending = ConcurrentHashMap.newKeySet();
     }
 

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/SegmentCacheStats.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/SegmentCacheStats.java
@@ -54,6 +54,9 @@ public class SegmentCacheStats extends AbstractCacheStats {
     @NotNull
     final AtomicLong missCount = new AtomicLong();
 
+    @NotNull
+    private Supplier<Long> writeDiscardCountSupplier = () -> 0L;
+
     public SegmentCacheStats(@NotNull String name,
                              @NotNull Supplier<Long> maximumWeight,
                              @NotNull Supplier<Long> elementCount,
@@ -76,6 +79,14 @@ public class SegmentCacheStats extends AbstractCacheStats {
                 loadTime.get(),
                 evictionCount.get()
         );
+    }
+
+    public void setWriteDiscardCountSupplier(@NotNull Supplier<Long> supplier) {
+        this.writeDiscardCountSupplier = requireNonNull(supplier);
+    }
+
+    public long getWriteDiscardCount() {
+        return writeDiscardCountSupplier.get();
     }
 
     @Override

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/SegmentCacheStats.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/SegmentCacheStats.java
@@ -55,18 +55,20 @@ public class SegmentCacheStats extends AbstractCacheStats {
     final AtomicLong missCount = new AtomicLong();
 
     @NotNull
-    private Supplier<Long> writeDiscardCountSupplier = () -> 0L;
+    private final Supplier<Long> writeDiscardCountSupplier;
 
     public SegmentCacheStats(@NotNull String name,
                              @NotNull Supplier<Long> maximumWeight,
                              @NotNull Supplier<Long> elementCount,
                              @NotNull Supplier<Long> currentWeight,
-                             @NotNull Supplier<Long> evictionCount) {
+                             @NotNull Supplier<Long> evictionCount,
+                             @NotNull Supplier<Long> writeDiscardCount) {
         super(name);
         this.maximumWeight = maximumWeight;
         this.elementCount = requireNonNull(elementCount);
         this.currentWeight = requireNonNull(currentWeight);
         this.evictionCount = evictionCount;
+        this.writeDiscardCountSupplier = requireNonNull(writeDiscardCount);
     }
 
     @Override
@@ -79,10 +81,6 @@ public class SegmentCacheStats extends AbstractCacheStats {
                 loadTime.get(),
                 evictionCount.get()
         );
-    }
-
-    public void setWriteDiscardCountSupplier(@NotNull Supplier<Long> supplier) {
-        this.writeDiscardCountSupplier = requireNonNull(supplier);
     }
 
     public long getWriteDiscardCount() {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("6.2.0")
+@Version("7.0.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 @Internal(since = "1.0.0")
-@Version("6.1.0")
+@Version("6.2.0")
 package org.apache.jackrabbit.oak.segment.spi.persistence.persistentcache;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/MemoryPersistentCache.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/MemoryPersistentCache.java
@@ -38,7 +38,8 @@ class MemoryPersistentCache extends AbstractPersistentCache {
                 () -> null,
                 () -> null,
                 () -> null,
-                () -> null);
+                () -> null,
+                () -> 0L);
     }
 
     @Override

--- a/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/PersistentCacheStatsTest.java
+++ b/oak-segment-tar/src/test/java/org/apache/jackrabbit/oak/segment/spi/persistence/persistentcache/PersistentCacheStatsTest.java
@@ -170,7 +170,7 @@ public class PersistentCacheStatsTest {
         HashMap<UUID, Buffer> segments = new HashMap<>();
 
         public PersistentCacheImpl() {
-            segmentCacheStats = new SegmentCacheStats("stats", () -> maximumWeight, () -> elementCount.get(), () -> currentWeight.get(), () -> evictionCount.get());
+            segmentCacheStats = new SegmentCacheStats("stats", () -> maximumWeight, () -> elementCount.get(), () -> currentWeight.get(), () -> evictionCount.get(), () -> 0L);
         }
 
         long maximumWeight = Long.MAX_VALUE;
@@ -179,7 +179,7 @@ public class PersistentCacheStatsTest {
         AtomicLong evictionCount = new AtomicLong();
 
         void AbstractPersistentCache() {
-            segmentCacheStats = new SegmentCacheStats("stats", () -> maximumWeight, () -> elementCount.get(), () -> currentWeight.get(), () -> evictionCount.get());
+            segmentCacheStats = new SegmentCacheStats("stats", () -> maximumWeight, () -> elementCount.get(), () -> currentWeight.get(), () -> evictionCount.get(), () -> 0L);
         }
 
         @Override


### PR DESCRIPTION
The AbstractPersistentCache is unbound leading to OOM exceptions.