### PR TITLE
OAK-12298: SystemPropertySupplier: allow to signal that property is not present (implies default value)

### DIFF
--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplier.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplier.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,26 +50,34 @@ public class SystemPropertySupplier<T> implements Supplier<T> {
     private final String propName;
     private final T defaultValue;
     private final Function<String, T> parser;
-
     private Logger log = LOG;
     private String successLogLevel = "INFO";
     private boolean hideValue = false;
-    private Predicate<T> validator = (a) -> true;
+    private Predicate<T> validator = a -> true;
     private Function<String, String> sysPropReader = System::getProperty;
     private BiFunction<String, T, String> setMessageFormatter = (a, b) -> String.format("System property %s found to be '%s'", a,
             hideValue ? HIDDEN_REPLACEMENT : b);
 
-    private SystemPropertySupplier(@NotNull String propName, @NotNull T defaultValue) {
+    private SystemPropertySupplier(@NotNull String propName, @Nullable T defaultValue, @Nullable Class<T> clazz) {
         this.propName = Objects.requireNonNull(propName, "propertyName must be non-null");
-        this.defaultValue = Objects.requireNonNull(defaultValue, "defaultValue must be non-null");
-        this.parser = getValueParser(defaultValue);
+        this.defaultValue = defaultValue;
+        this.parser = getValueParser(defaultValue, clazz);
     }
 
     /**
      * Create it for a given property name and default value.
      */
     public static <U> SystemPropertySupplier<U> create(@NotNull String propName, @NotNull U defaultValue) {
-        return new SystemPropertySupplier<>(propName, defaultValue);
+        return new SystemPropertySupplier<>(propName,
+                Objects.requireNonNull(defaultValue, "defaultValue must not be null"), null);
+    }
+
+    /**
+     * Create it for a given property name and no default value (but expected {@linkplain Class}).
+     */
+    public static <U> SystemPropertySupplier<U> create(@NotNull String propName, @NotNull Class<U> clazz) {
+        return new SystemPropertySupplier<>(propName, null,
+                Objects.requireNonNull(clazz, "clazz must not be null"));
     }
 
     /**
@@ -191,8 +200,12 @@ public class SystemPropertySupplier<T> implements Supplier<T> {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> Function<String, T> getValueParser(T defaultValue) {
-        if (defaultValue instanceof Boolean) {
+    private static <T> Function<String, T> getValueParser(T defaultValue, Class<T> type) {
+        Class<?> clazz = (defaultValue != null) ? defaultValue.getClass() : type;
+
+        if (clazz == null) {
+            throw new IllegalArgumentException("Cannot determine type: defaultValue is null and no type provided.");
+        } else if (Boolean.class.isAssignableFrom(clazz)) {
             return v -> (T) Boolean.valueOf(v);
         } else if (defaultValue instanceof Integer) {
             return v -> (T) Integer.valueOf(v);

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplier.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplier.java
@@ -172,7 +172,7 @@ public class SystemPropertySupplier<T> implements Supplier<T> {
                 log.error("Ignoring malformed value '{}' for system property {}", displayedValue, propName);
             }
 
-            if (!returnValue.equals(defaultValue)) {
+            if (!Objects.equals(returnValue, defaultValue)) {
                 String msg = setMessageFormatter.apply(propName, returnValue);
                 switch (successLogLevel) {
                     case "INFO":

--- a/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/properties/package-info.java
+++ b/oak-commons/src/main/java/org/apache/jackrabbit/oak/commons/properties/package-info.java
@@ -18,7 +18,7 @@
  * <em>For Oak internal use only. Do not use outside Oak components.</em>
  */
 @Internal(since = "1.1.0")
-@Version("2.1.0")
+@Version("2.2.0")
 package org.apache.jackrabbit.oak.commons.properties;
 
 import org.apache.jackrabbit.oak.commons.annotations.Internal;

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
@@ -157,4 +157,23 @@ public class SystemPropertySupplierTest {
         } catch (IllegalArgumentException expected) {
         }
     }
+
+    @Test
+    public void testCheckNoDefaultNotSet() {
+        try {
+            assertNull(SystemPropertySupplier.create("foo", Boolean.class).
+                    usingSystemPropertyReader((n) -> null).get());
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testCheckNoDefaultSet() {
+        try {
+            int value = SystemPropertySupplier.create("foo", Integer.class).
+                    usingSystemPropertyReader((n) -> "4217").get();
+            assertEquals(4217, value);
+        } catch (IllegalArgumentException expected) {
+        }
+    }
 }

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
@@ -170,4 +170,10 @@ public class SystemPropertySupplierTest {
             usingSystemPropertyReader((n) -> "4217").get();
         assertEquals(4217, value);
     }
+
+    @Test
+    public void testCheckNoDefaultSetInvalid() {
+        assertNull(SystemPropertySupplier.create("foo", Integer.class).
+                usingSystemPropertyReader((n) -> "abcd").get());
+    }
 }

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
@@ -176,4 +176,10 @@ public class SystemPropertySupplierTest {
         assertNull(SystemPropertySupplier.create("foo", Integer.class).
                 usingSystemPropertyReader((n) -> "abcd").get());
     }
+
+    @Test
+    public void testCheckNoDefaultValidatorRejects() {
+        assertNull(SystemPropertySupplier.create("foo", String.class).
+                usingSystemPropertyReader((n) -> "abcd").validateWith(x-> false) .get());
+    }
 }

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
@@ -160,20 +160,14 @@ public class SystemPropertySupplierTest {
 
     @Test
     public void testCheckNoDefaultNotSet() {
-        try {
-            assertNull(SystemPropertySupplier.create("foo", Boolean.class).
-                    usingSystemPropertyReader((n) -> null).get());
-        } catch (IllegalArgumentException expected) {
-        }
+        assertNull(SystemPropertySupplier.create("foo", Boolean.class).
+                usingSystemPropertyReader((n) -> null).get());
     }
 
     @Test
     public void testCheckNoDefaultSet() {
-        try {
-            int value = SystemPropertySupplier.create("foo", Integer.class).
-                    usingSystemPropertyReader((n) -> "4217").get();
-            assertEquals(4217, value);
-        } catch (IllegalArgumentException expected) {
-        }
+        int value = SystemPropertySupplier.create("foo", Integer.class).
+            usingSystemPropertyReader((n) -> "4217").get();
+        assertEquals(4217, value);
     }
 }

--- a/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
+++ b/oak-commons/src/test/java/org/apache/jackrabbit/oak/commons/properties/SystemPropertySupplierTest.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.commons.properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
@@ -146,5 +147,14 @@ public class SystemPropertySupplierTest {
                 usingSystemPropertyReader(y -> "2").
                 logSuccessAs("AWESOME").get();
         assertEquals(2 , x);
+    }
+
+    @Test
+    public void testCheckNullDefault() {
+        try {
+            assertNull(SystemPropertySupplier.create("foo", Boolean.class).
+                    usingSystemPropertyReader((n) -> null).get());
+        } catch (IllegalArgumentException expected) {
+        }
     }
 }


### PR DESCRIPTION
…t present (implies default value)