### PR TITLE
OAK-12303 : Update mina-core dependency version to 2.1.15 (1.22 branch)

### DIFF
--- a/oak-auth-ldap/pom.xml
+++ b/oak-auth-ldap/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.1.12</version>
+            <version>2.1.15</version>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
mina-core 2.1.12 is affected by https://nvd.nist.gov/vuln/detail/CVE-2026-47065