### PR TITLE
Revert "OAK-12295 : bump mongo-driver-sync to 5.3.1"

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -57,7 +57,7 @@
     <mongo.version>3.6</mongo.version>
     <segment.db>SegmentMK</segment.db>
     <lucene.version>4.7.2</lucene.version>
-    <mongo.driver.version>5.3.1</mongo.driver.version>
+    <mongo.driver.version>5.2.1</mongo.driver.version>
     <slf4j.api.version>1.7.36</slf4j.api.version>
     <slf4j.version>1.7.36</slf4j.version> <!-- sync with logback version -->
     <logback.version>1.2.13</logback.version>

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoTestClient.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/mongo/MongoTestClient.java
@@ -33,9 +33,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCluster;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.MongoIterable;
-import com.mongodb.client.model.bulk.ClientBulkWriteOptions;
-import com.mongodb.client.model.bulk.ClientBulkWriteResult;
-import com.mongodb.client.model.bulk.ClientNamespacedWriteModel;
 import com.mongodb.connection.ClusterDescription;
 
 import org.bson.Document;
@@ -203,30 +200,6 @@ class MongoTestClient implements MongoClient {
     @Override
     public <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass) {
         return delegate.watch(clientSession, pipeline, resultClass);
-    }
-
-    @Override
-    public ClientBulkWriteResult bulkWrite(List<? extends ClientNamespacedWriteModel> models) {
-        return delegate.bulkWrite(models);
-    }
-
-    @Override
-    public ClientBulkWriteResult bulkWrite(List<? extends ClientNamespacedWriteModel> models,
-                                           ClientBulkWriteOptions options) {
-        return delegate.bulkWrite(models, options);
-    }
-
-    @Override
-    public ClientBulkWriteResult bulkWrite(ClientSession clientSession,
-                                           List<? extends ClientNamespacedWriteModel> models) {
-        return delegate.bulkWrite(clientSession, models);
-    }
-
-    @Override
-    public ClientBulkWriteResult bulkWrite(ClientSession clientSession,
-                                           List<? extends ClientNamespacedWriteModel> models,
-                                           ClientBulkWriteOptions options) {
-        return delegate.bulkWrite(clientSession, models, options);
     }
 
     @Override


### PR DESCRIPTION
Reverts apache/jackrabbit-oak#3001