### PR TITLE
OAK-12314: Builds failing because request to https://www.slf4j.org/apidocs/ times out

### DIFF
--- a/oak-parent/pom.xml
+++ b/oak-parent/pom.xml
@@ -132,7 +132,6 @@
             <links>
               <link>https://s.apache.org/jcr-2.0-javadoc/</link>
               <link>https://jackrabbit.apache.org/api/2.20/</link>
-              <link>https://www.slf4j.org/apidocs/</link>
             </links>
             <!-- workaround for https://issues.apache.org/jira/browse/OAK-8517 -->
       	    <excludePackageNames>org.apache.jackrabbit.oak.plugins.index.*</excludePackageNames>


### PR DESCRIPTION
Removed the link.