### PR TITLE
OAK-12316 : removed FT_NOCOCLEANUP_OAK-10660 feature toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,8 @@ Toggles are disabled by default and can be enabled without redeployment.
 - Query engine toggles (`FT_OAK-11949`, `FT_OAK-12007`) registered in `oak-core/.../Oak.java`
 - Document store toggles (throttling, merge lock) in
   `oak-store-document/.../DocumentNodeStoreBuilder.java` (embedded verification and full GC are
-  controlled only via OSGi `embeddedVerificationEnabled` and `fullGCEnabled`, not runtime toggles)
+  controlled only via OSGi `embeddedVerificationEnabled` and `fullGCEnabled`, not runtime toggles;
+  child-order property cleanup is always enabled and has no toggle at all)
 - Some features also support a system property fallback (e.g., `oak.classicMove`)
 
 ## Code Conventions

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/OrderableNodesTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/OrderableNodesTest.java
@@ -18,7 +18,6 @@ package org.apache.jackrabbit.oak.jcr;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -32,10 +31,6 @@ import javax.jcr.Session;
 import org.apache.jackrabbit.commons.iterator.NodeIterable;
 import org.apache.jackrabbit.oak.fixture.DocumentRdbFixture;
 import org.apache.jackrabbit.oak.fixture.NodeStoreFixture;
-import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
-import org.apache.jackrabbit.oak.spi.state.NodeStore;
-import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
-import org.apache.jackrabbit.oak.spi.whiteboard.Tracker;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -180,31 +175,6 @@ public class OrderableNodesTest extends AbstractRepositoryTest {
         session.save();
         session.getWorkspace().copy("/test-0", "/test-1");
         session.save();
-    }
-
-    @Test
-    public void childOrderCleanupFeatureToggleTest() throws RepositoryException {
-        //init repository
-        getAdminSession();
-        NodeStore nodeStore = getNodeStore();
-        assertNotNull(nodeStore);
-        Tracker<FeatureToggle> track = fixture.getWhiteboard().track(FeatureToggle.class);
-        if (nodeStore instanceof DocumentNodeStore) {
-            DocumentNodeStore documentNodeStore = (DocumentNodeStore) nodeStore;
-            assertTrue(documentNodeStore.isChildOrderCleanupEnabled());
-            for (FeatureToggle toggle : track.getServices()) {
-                if ("FT_NOCOCLEANUP_OAK-10660".equals(toggle.getName())) {
-                    assertFalse(toggle.isEnabled());
-                    assertTrue(documentNodeStore.isChildOrderCleanupEnabled());
-                    toggle.setEnabled(true);
-                    assertTrue(toggle.isEnabled());
-                    assertFalse(documentNodeStore.isChildOrderCleanupEnabled());
-                    toggle.setEnabled(false);
-                    assertFalse(toggle.isEnabled());
-                    assertTrue(documentNodeStore.isChildOrderCleanupEnabled());
-                }
-            }
-        }
     }
 
     private void doTest(String nodeType) throws RepositoryException {

--- a/oak-store-document/AGENTS.md
+++ b/oak-store-document/AGENTS.md
@@ -227,6 +227,11 @@ property `oak.documentstore.fullGCEnabled`); there is no runtime whiteboard
 toggle. Deployments that previously relied on `FT_FULL_GC_OAK-10199` must set this
 config property instead.
 
+Child-order property cleanup (in `Commit`, on `:childOrder` updates) is always enabled;
+there is no runtime whiteboard toggle. Deployments that previously relied on
+`FT_NOCOCLEANUP_OAK-10660` to disable it have no replacement — cleanup can no longer be
+turned off.
+
 ## Throttling
 
 **MongoDB only** — throttling is not available for RDB. Enabled via `throttlingEnabled=true`.
@@ -367,7 +372,6 @@ Registered in `DocumentNodeStoreService`, wired into `DocumentNodeStoreBuilder`.
 | `FT_PREFETCH_OAK-9780` | `setPrefetchFeature` | Enable async pre-fetching of external changes |
 | `FT_THROTTLING_OAK-9909` | `setDocStoreThrottlingFeature` | Enable write throttling on MongoDB |
 | `FT_DISABLE_THROTTLING_OAK-12119` | `setDocStoreDisableThrottlingFeature` | Runtime kill-switch to disable throttling |
-| `FT_NOCOCLEANUP_OAK-10660` | `setNoChildOrderCleanupFeature` | Disable child-order property cleanup |
 | `FT_CANCELINVALIDATION_OAK-10595` | `setCancelInvalidationFeature` | Cancel in-flight cache invalidations |
 | `FT_AVOID_MERGE_LOCK_OAK-11720` | `setDocStoreAvoidMergeLockFeature` | Avoid acquiring merge lock where safe |
 | `FT_PREV_NO_PROP_OAK-11184` | `setPrevNoPropCacheFeature` | Skip caching previous documents with no properties |

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/Commit.java
@@ -362,34 +362,32 @@ public class Commit {
             NodeDocument.setCommitRoot(op, revision, commitRootDepth);
 
             // special case for :childOrder updates
-            if (nodeStore.isChildOrderCleanupEnabled()) {
-                final Branch localBranch = getBranch();
-                if (localBranch != null) {
-                    final NavigableSet<Revision> commits = new TreeSet<>(localBranch.getCommits());
-                    boolean removePreviousSetOperations = false;
-                    for (Map.Entry<Key, Operation> change : op.getChanges().entrySet()) {
-                        if (PROPERTY_NAME_CHILDORDER.equals(change.getKey().getName()) && Operation.Type.SET_MAP_ENTRY == change.getValue().type) {
-                            // we are setting child order, so we should remove previous set operations from the same branch
-                            removePreviousSetOperations = true;
-                            // branch.getCommits contains all revisions of the branch
-                            // including the new one we're about to make
-                            // so don't do a removeMapEntry for that
-                            commits.remove(change.getKey().getRevision().asBranchRevision());
-                        }
+            final Branch localBranch = getBranch();
+            if (localBranch != null) {
+                final NavigableSet<Revision> commits = new TreeSet<>(localBranch.getCommits());
+                boolean removePreviousSetOperations = false;
+                for (Map.Entry<Key, Operation> change : op.getChanges().entrySet()) {
+                    if (PROPERTY_NAME_CHILDORDER.equals(change.getKey().getName()) && Operation.Type.SET_MAP_ENTRY == change.getValue().type) {
+                        // we are setting child order, so we should remove previous set operations from the same branch
+                        removePreviousSetOperations = true;
+                        // branch.getCommits contains all revisions of the branch
+                        // including the new one we're about to make
+                        // so don't do a removeMapEntry for that
+                        commits.remove(change.getKey().getRevision().asBranchRevision());
                     }
-                    if (removePreviousSetOperations) {
-                        if (!commits.isEmpty()) {
-                            int countRemoves = 0;
-                            for (Revision rev : commits.descendingSet()) {
-                                op.removeMapEntry(PROPERTY_NAME_CHILDORDER, rev.asTrunkRevision());
-                                if (++countRemoves >= 256) {
-                                    LOG.debug("applyToDocumentStore : only cleaning up last {} branch commits.",
-                                            countRemoves);
-                                    break;
-                                }
+                }
+                if (removePreviousSetOperations) {
+                    if (!commits.isEmpty()) {
+                        int countRemoves = 0;
+                        for (Revision rev : commits.descendingSet()) {
+                            op.removeMapEntry(PROPERTY_NAME_CHILDORDER, rev.asTrunkRevision());
+                            if (++countRemoves >= 256) {
+                                LOG.debug("applyToDocumentStore : only cleaning up last {} branch commits.",
+                                        countRemoves);
+                                break;
                             }
-                            LOG.debug("applyToDocumentStore : childOrder-edited op is: {}", op);
                         }
+                        LOG.debug("applyToDocumentStore : childOrder-edited op is: {}", op);
                     }
                 }
             }

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStore.java
@@ -563,8 +563,6 @@ public final class DocumentNodeStore
 
     private final Feature cancelInvalidationFeature;
 
-    private final Feature noChildOrderCleanupFeature;
-
     private Boolean cancelInvalidationLogged;
 
     private CacheWarming cacheWarming;
@@ -642,7 +640,6 @@ public final class DocumentNodeStore
 
         this.prefetchFeature = builder.getPrefetchFeature();
         this.cancelInvalidationFeature = builder.getCancelInvalidationFeature();
-        this.noChildOrderCleanupFeature = builder.getNoChildOrderCleanupFeature();
         this.avoidMergeLock = isAvoidMergeLockEnabled(builder);
         this.cacheWarming = new CacheWarming(s);
 
@@ -877,10 +874,6 @@ public final class DocumentNodeStore
         }
     }
 
-
-    public boolean isChildOrderCleanupEnabled() {
-        return noChildOrderCleanupFeature == null || !noChildOrderCleanupFeature.isEnabled();
-    }
 
     public void dispose() {
         LOG.info("Starting disposal of DocumentNodeStore with clusterNodeId: {} ({})", clusterId,

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreBuilder.java
@@ -130,7 +130,6 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
     private boolean isReadOnlyMode = false;
     private Feature prefetchFeature;
     private Feature docStoreThrottlingFeature;
-    private Feature noChildOrderCleanupFeature;
     private Feature cancelInvalidationFeature;
     private Feature docStoreAvoidMergeLockFeature;
     private Feature prevNoPropCacheFeature;
@@ -482,16 +481,6 @@ public class DocumentNodeStoreBuilder<T extends DocumentNodeStoreBuilder<T>> {
     @Nullable
     public Feature getDocStoreThrottlingFeature() {
         return docStoreThrottlingFeature;
-    }
-
-    public T setNoChildOrderCleanupFeature(@Nullable Feature noChildOrderCleanupFeature) {
-        this.noChildOrderCleanupFeature = noChildOrderCleanupFeature;
-        return thisBuilder();
-    }
-
-    @Nullable
-    public Feature getNoChildOrderCleanupFeature() {
-        return noChildOrderCleanupFeature;
     }
 
     public T setCancelInvalidationFeature(@Nullable Feature cancelInvalidation) {

--- a/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
+++ b/oak-store-document/src/main/java/org/apache/jackrabbit/oak/plugins/document/DocumentNodeStoreService.java
@@ -207,8 +207,6 @@ public class DocumentNodeStoreService {
      */
     private static final String FT_NAME_DOC_STORE_THROTTLING = "FT_THROTTLING_OAK-9909";
 
-    private static final String FT_NAME_DOC_STORE_NOCOCLEANUP = "FT_NOCOCLEANUP_OAK-10660";
-
     /**
      * Feature toggle name to enable invalidation on cancel (due to a merge collision)
      */
@@ -269,7 +267,6 @@ public class DocumentNodeStoreService {
     private JournalPropertyHandlerFactory journalPropertyHandlerFactory = new JournalPropertyHandlerFactory();
     private Feature prefetchFeature;
     private Feature docStoreThrottlingFeature;
-    private Feature noChildOrderCleanupFeature;
     private Feature cancelInvalidationFeature;
     private Feature docStoreAvoidMergeLockFeature;
     private Feature prevNoPropCacheFeature;
@@ -307,7 +304,6 @@ public class DocumentNodeStoreService {
         documentStoreType = DocumentStoreType.fromString(this.config.documentStoreType());
         prefetchFeature = Feature.newFeature(FT_NAME_PREFETCH, whiteboard);
         docStoreThrottlingFeature = Feature.newFeature(FT_NAME_DOC_STORE_THROTTLING, whiteboard);
-        noChildOrderCleanupFeature = Feature.newFeature(FT_NAME_DOC_STORE_NOCOCLEANUP, whiteboard);
         cancelInvalidationFeature = Feature.newFeature(FT_NAME_CANCEL_INVALIDATION, whiteboard);
         docStoreAvoidMergeLockFeature = Feature.newFeature(FT_NAME_AVOID_MERGE_LOCK, whiteboard);
         prevNoPropCacheFeature = Feature.newFeature(FT_NAME_PREV_NO_PROP_CACHE, whiteboard);
@@ -543,7 +539,6 @@ public class DocumentNodeStoreService {
                 setLeaseCheckMode(ClusterNodeInfo.DEFAULT_LEASE_CHECK_DISABLED ? LeaseCheckMode.DISABLED : LeaseCheckMode.valueOf(config.leaseCheckMode())).
                 setPrefetchFeature(prefetchFeature).
                 setDocStoreThrottlingFeature(docStoreThrottlingFeature).
-                setNoChildOrderCleanupFeature(noChildOrderCleanupFeature).
                 setCancelInvalidationFeature(cancelInvalidationFeature).
                 setDocStoreAvoidMergeLockFeature(docStoreAvoidMergeLockFeature).
                 setPrevNoPropCacheFeature(prevNoPropCacheFeature).

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMemoryFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMemoryFixture.java
@@ -22,7 +22,6 @@ package org.apache.jackrabbit.oak.fixture;
 import org.apache.jackrabbit.oak.plugins.document.DocumentMK;
 import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
-import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
 
 public class DocumentMemoryFixture extends NodeStoreFixture {
@@ -32,7 +31,6 @@ public class DocumentMemoryFixture extends NodeStoreFixture {
         DocumentMK.Builder builder = new DocumentMK.Builder();
         //do not reuse the whiteboard
         setWhiteboard(new DefaultWhiteboard());
-        builder.setNoChildOrderCleanupFeature(Feature.newFeature("FT_NOCOCLEANUP_OAK-10660", getWhiteboard()));
         return builder.getNodeStore();
     }
 

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMongoFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentMongoFixture.java
@@ -28,7 +28,6 @@ import org.apache.jackrabbit.oak.plugins.document.DocumentNodeStore;
 import org.apache.jackrabbit.oak.plugins.document.MongoUtils;
 import org.apache.jackrabbit.oak.spi.blob.BlobStore;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
-import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
 import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
@@ -75,7 +74,6 @@ public class DocumentMongoFixture extends NodeStoreFixture {
             builder.setMongoDB(createClient(), getDBName(suffix));
             //do not reuse the whiteboard
             setWhiteboard(new DefaultWhiteboard());
-            builder.setNoChildOrderCleanupFeature(Feature.newFeature("FT_NOCOCLEANUP_OAK-10660", getWhiteboard()));
             DocumentNodeStore ns = builder.getNodeStore();
             suffixes.put(ns, suffix);
             return ns;

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentRdbFixture.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/fixture/DocumentRdbFixture.java
@@ -33,7 +33,6 @@ import org.apache.jackrabbit.oak.plugins.document.rdb.RDBDataSourceFactory;
 import org.apache.jackrabbit.oak.plugins.document.rdb.RDBDocumentNodeStoreBuilder;
 import org.apache.jackrabbit.oak.plugins.document.rdb.RDBOptions;
 import org.apache.jackrabbit.oak.spi.state.NodeStore;
-import org.apache.jackrabbit.oak.spi.toggle.Feature;
 import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
 
 public class DocumentRdbFixture extends NodeStoreFixture {
@@ -50,7 +49,6 @@ public class DocumentRdbFixture extends NodeStoreFixture {
         //do not reuse the whiteboard
         setWhiteboard(new DefaultWhiteboard());
         RDBDocumentNodeStoreBuilder builder = new RDBDocumentNodeStoreBuilder();
-        builder.setNoChildOrderCleanupFeature(Feature.newFeature("FT_NOCOCLEANUP_OAK-10660", getWhiteboard()));
         NodeStore result = builder.setPersistentCache("target/persistentCache,time")
                 .setRDBConnection(ds, options).build();
         this.dataSources.put(result, ds);

--- a/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CommitTest.java
+++ b/oak-store-document/src/test/java/org/apache/jackrabbit/oak/plugins/document/CommitTest.java
@@ -19,6 +19,11 @@
 
 package org.apache.jackrabbit.oak.plugins.document;
 
+import java.util.List;
+import java.util.Map;
+
+import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.plugins.document.util.Utils;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.commit.EmptyHook;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
@@ -27,10 +32,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.apache.jackrabbit.oak.plugins.document.TestUtils.merge;
+import static org.apache.jackrabbit.oak.plugins.document.TestUtils.persistToBranch;
 import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -164,5 +171,37 @@ public class CommitTest {
         } finally {
             ns.canceled(c);
         }
+    }
+
+    // OAK-12316
+    @Test
+    public void childOrderCleanupAlwaysEnabled() throws Exception {
+        DocumentNodeStore ns = builderProvider.newBuilder().getNodeStore();
+
+        NodeBuilder builder = ns.getRoot().builder();
+        builder.child("foo");
+        merge(ns, builder);
+
+        // set :childOrder twice within the same local branch, persisting each
+        // change as its own branch commit; the first branch commit's
+        // :childOrder entry is only removed once the second branch commit
+        // applies
+        NodeBuilder branchBuilder = ns.getRoot().builder();
+        branchBuilder.child("foo").setProperty(":childOrder", List.of("a", "b"), Type.NAMES);
+        persistToBranch(branchBuilder);
+        branchBuilder.child("foo").setProperty(":childOrder", List.of("b", "a"), Type.NAMES);
+        persistToBranch(branchBuilder);
+
+        merge(ns, branchBuilder);
+
+        // there is no more FT_NOCOCLEANUP_OAK-10660 toggle to disable this
+        // cleanup, so the first branch commit's :childOrder entry must have
+        // been removed by the second, leaving only the latest revision
+        NodeDocument doc = ns.getDocumentStore().find(Collection.NODES,
+                Utils.getIdFromPath("/foo"), 0);
+        assertNotNull(doc);
+        Map<Revision, String> childOrderRevisions = doc.getLocalMap(":childOrder");
+        assertEquals("Only the latest :childOrder revision must remain",
+                1, childOrderRevisions.size());
     }
 }


### PR DESCRIPTION
## Summary

Removes the `FT_NOCOCLEANUP_OAK-10660` feature toggle from `oak-store-document`, following the same pattern used in #2946 (removal of `FT_FULL_GC_OAK-10199`).

The toggle was a kill-switch that, when enabled, disabled cleanup of stale `:childOrder` branch-commit entries in `Commit#applyToDocumentStore`. Since the toggle defaults to disabled (i.e. cleanup is enabled by default today), removing it and making the cleanup unconditional preserves today's default behavior exactly — cleanup is now always on, with no way to turn it off.

## Changes

- `DocumentNodeStore` — removed `noChildOrderCleanupFeature` field and `isChildOrderCleanupEnabled()` method
- `Commit` — made the `:childOrder` branch-commit cleanup unconditional
- `DocumentNodeStoreBuilder` / `DocumentNodeStoreService` — removed the field, getter/setter, and toggle registration
- Test fixtures (`DocumentMemoryFixture`, `DocumentRdbFixture`, `DocumentMongoFixture`) — removed toggle wiring
- `OrderableNodesTest` — removed the toggle-flipping test (no toggle left to flip)
- `AGENTS.md` / `oak-store-document/AGENTS.md` — updated docs noting cleanup is now always on with no replacement config

## Test Plan

- [x] Added `CommitTest#childOrderCleanupAlwaysEnabled` — creates two branch commits that each set `:childOrder`, merges, then inspects the raw `NodeDocument` to confirm only the latest revision's entry remains. Verified this test fails when the cleanup logic is disabled, confirming it is a genuine regression detector.
- [x] `CommitTest`, `DocumentNodeStoreBuilderTest`, `DocumentNodeStoreServiceTest`, `DocumentNodeStoreBranchTest`, `DocumentNodeStoreBranchesTest`, `OrderableNodesTest` (oak-jcr) pass
- [x] Full `oak-store-document` test suite passes

## Links

- JIRA: https://issues.apache.org/jira/browse/OAK-12316

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>