### PR TITLE
OAK-12325: Use heap based comparison of blob content

### DIFF
--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/plugins/memory/AbstractBlob.java
@@ -19,12 +19,12 @@
 package org.apache.jackrabbit.oak.plugins.memory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
-import org.apache.commons.io.IOUtils;
+import java.util.Arrays;
 
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.commons.properties.SystemPropertySupplier;
@@ -75,9 +75,37 @@ public abstract class AbstractBlob implements Blob {
         }
 
         try {
-            return IOUtils.contentEquals(a.getNewStream(), b.getNewStream());
+            try (InputStream ais = a.getNewStream(); InputStream bis = b.getNewStream()) {
+                return contentEquals(ais, bis);
+            }
         } catch (IOException e) {
             throw new IllegalStateException("Blob equality check failed", e);
+        }
+    }
+
+    private static boolean contentEquals(InputStream is1, InputStream is2) throws IOException {
+        if (is1 == is2) {
+            return true;
+        }
+
+        byte[] buf1 = new byte[4096];
+        byte[] buf2 = new byte[4096];
+
+        while (true) {
+            // readNBytes handles "short reads" automatically, blocking until requested bytes or EOF
+            int read1 = is1.readNBytes(buf1, 0, buf1.length);
+            int read2 = is2.readNBytes(buf2, 0, buf2.length);
+
+            if (read1 != read2) {
+                return false; // Length mismatch
+            }
+            if (read1 == 0) {
+                return true; // Reached EOF on both streams identically
+            }
+            // Arrays.equals is highly optimized via CPU intrinsics
+            if (!Arrays.equals(buf1, 0, read1, buf2, 0, read2)) {
+                return false; // Content mismatch
+            }
         }
     }
 


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/OAK-12325

## Problem

`AbstractBlob.equal()`'s byte-wise fallback comparison (`IOUtils.contentEquals(InputStream, InputStream)`) allocates two direct `ByteBuffer`s per call when the underlying streams are file-backed (e.g. `FileChannel`-based NIO copies). This comparison runs on hot paths such as the segment writer's dedup check when writing an unchanged property and node-state diffing (rebase, commit diff). Under write-heavy load this becomes a significant source of native (off-heap) memory allocation — direct buffers are reclaimed only via GC-driven `Cleaner`/`PhantomReference` callbacks, which can lag behind allocation and drive up process RSS outside the JVM heap.

## Summary
- Replace `IOUtils.contentEquals` in `AbstractBlob.equal()` with a manual buffered comparison using `InputStream.readNBytes` and `Arrays.equals`, working entirely with heap `byte[]` buffers that are reclaimed by ordinary GC, avoiding the `commons-io` dependency on this hot path.
- Also close both input streams via try-with-resources, fixing a related stream leak in the previous implementation.
