### PR TITLE
OAK-12327: PropertyValueImpl with type restriction lost when "is not null"

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/SQL2Parser.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/SQL2Parser.java
@@ -543,11 +543,11 @@ public class SQL2Parser {
     }
 
     private PropertyExistenceImpl getPropertyExistence(PropertyValueImpl p) throws ParseException {
-        return factory.propertyExistence(p.getSelectorName(), p.getPropertyName());
+        return factory.propertyExistence(p);
     }
     
     private PropertyInexistenceImpl getPropertyInexistence(PropertyValueImpl p) throws ParseException {
-        return factory.propertyInexistence(p.getSelectorName(), p.getPropertyName());
+        return factory.propertyInexistence(p);
     }
 
     private ConstraintImpl parseConditionFunctionIf(String functionName) throws ParseException {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AndImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AndImpl.java
@@ -99,7 +99,7 @@ public class AndImpl extends ConstraintImpl {
 
     @Override
     public Set<PropertyExistenceImpl> getPropertyExistenceConditions() {
-        Set<PropertyExistenceImpl> result = new HashSet<>();
+        Set<PropertyExistenceImpl> result = new LinkedHashSet<>();
         for (ConstraintImpl constraint : constraints) {
             result.addAll(constraint.getPropertyExistenceConditions());
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AstElementFactory.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AstElementFactory.java
@@ -24,8 +24,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.PropertyType;
-
 /**
  * A factory for syntax tree elements.
  */

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AstElementFactory.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/AstElementFactory.java
@@ -18,10 +18,13 @@ import static java.util.Objects.requireNonNull;
 import java.util.ArrayList;
 
 import org.apache.jackrabbit.oak.api.PropertyValue;
+import org.apache.jackrabbit.oak.query.SQL2Parser;
 import org.apache.jackrabbit.oak.spi.query.QueryConstants;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jcr.PropertyType;
 
 /**
  * A factory for syntax tree elements.
@@ -146,12 +149,12 @@ public class AstElementFactory {
         return new OrImpl(constraint1, constraint2);
     }
 
-    public PropertyExistenceImpl propertyExistence(String selectorName, String propertyName) {
-        return new PropertyExistenceImpl(selectorName, propertyName);
+    public PropertyExistenceImpl propertyExistence(PropertyValueImpl propertyValue) {
+        return new PropertyExistenceImpl(propertyValue);
     }
 
-    public PropertyInexistenceImpl propertyInexistence(String selectorName, String propertyName) {
-        return new PropertyInexistenceImpl(selectorName, propertyName);
+    public PropertyInexistenceImpl propertyInexistence(PropertyValueImpl propertyValue) {
+        return new PropertyInexistenceImpl(propertyValue);
     }
 
     public PropertyValueImpl propertyValue(String selectorName, String propertyName) {
@@ -159,7 +162,7 @@ public class AstElementFactory {
     }
 
     public PropertyValueImpl propertyValue(String selectorName, String propertyName, String propertyType) {
-        return new PropertyValueImpl(selectorName, propertyName, propertyType);
+        return new PropertyValueImpl(selectorName, propertyName, SQL2Parser.getPropertyTypeFromName(propertyType));
     }
 
     public SameNodeImpl sameNode(String selectorName, String path) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/EquiJoinConditionImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/EquiJoinConditionImpl.java
@@ -152,11 +152,11 @@ public class EquiJoinConditionImpl extends JoinConditionImpl {
     public void restrictPushDown(SelectorImpl s) {
         // both properties may not be null
         if (s.equals(selector1)) {
-            PropertyExistenceImpl ex = new PropertyExistenceImpl(s.getSelectorName(), property1Name);
+            PropertyExistenceImpl ex = new PropertyExistenceImpl(new PropertyValueImpl(s.getSelectorName(), property1Name));
             ex.bindSelector(s);
             s.restrictSelector(ex);
         } else if (s.equals(selector2)) {
-            PropertyExistenceImpl ex = new PropertyExistenceImpl(s.getSelectorName(), property2Name);
+            PropertyExistenceImpl ex = new PropertyExistenceImpl(new PropertyValueImpl(s.getSelectorName(), property2Name));
             ex.bindSelector(s);
             s.restrictSelector(ex);
         }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/FullTextSearchImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/FullTextSearchImpl.java
@@ -31,6 +31,7 @@ import org.apache.jackrabbit.oak.spi.query.fulltext.FullTextExpression;
 import org.apache.jackrabbit.oak.spi.query.fulltext.FullTextParser;
 import org.apache.jackrabbit.oak.spi.query.fulltext.VectorQuery;
 
+import javax.jcr.PropertyType;
 import java.text.ParseException;
 import java.util.Collections;
 import java.util.Set;
@@ -103,7 +104,8 @@ public class FullTextSearchImpl extends ConstraintImpl {
         } else {
             fullName = propertyName;
         }
-        return Collections.singleton(new PropertyExistenceImpl(selector, selectorName, fullName));
+        PropertyValueImpl propertyValue = new PropertyValueImpl(selector, selectorName, fullName, PropertyType.UNDEFINED);
+        return Collections.singleton(new PropertyExistenceImpl(propertyValue));
     }
 
     @Override

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PropertyExistenceImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PropertyExistenceImpl.java
@@ -19,6 +19,7 @@
 package org.apache.jackrabbit.oak.query.ast;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.jackrabbit.oak.query.index.FilterImpl;
@@ -28,34 +29,25 @@ import org.apache.jackrabbit.oak.query.index.FilterImpl;
  */
 public class PropertyExistenceImpl extends ConstraintImpl {
 
-    private final String selectorName;
-    private final String propertyName;
-    private SelectorImpl selector;
+    private final PropertyValueImpl propertyValue;
 
-    public PropertyExistenceImpl(SelectorImpl selector, String selectorName, String propertyName) {
-        this.selector = selector;
-        this.selectorName = selectorName;
-        this.propertyName = propertyName;
-    }
-    
-    public PropertyExistenceImpl(String selectorName, String propertyName) {
-        this.selectorName = selectorName;
-        this.propertyName = propertyName;
+    public PropertyExistenceImpl(PropertyValueImpl propertyValue) {
+        this.propertyValue = propertyValue;
     }
 
     @Override
     public boolean evaluate() {
-        return selector.currentProperty(propertyName) != null;
+        return propertyValue.currentProperty() != null;
     }
 
     @Override
     public Set<PropertyExistenceImpl> getPropertyExistenceConditions() {
         return Collections.singleton(this);
     }
-    
+
     @Override
     public Set<SelectorImpl> getSelectors() {
-        return Collections.singleton(selector);
+        return propertyValue.getSelectors();
     }
 
     @Override
@@ -65,57 +57,43 @@ public class PropertyExistenceImpl extends ConstraintImpl {
 
     @Override
     public String toString() {
-        return quote(selectorName) + '.' + quote(propertyName) + " is not null";
+        return propertyValue + " is not null";
     }
 
     public void bindSelector(SourceImpl source) {
-        selector = source.getExistingSelector(selectorName);
+        propertyValue.bindSelector(source);
     }
 
     @Override
     public void restrict(FilterImpl f) {
-        if (f.getSelector().equals(selector)) {
-            String pn = normalizePropertyName(propertyName);
-            f.restrictProperty(pn, Operator.NOT_EQUAL, null);
-        }
+        propertyValue.restrict(f, Operator.NOT_EQUAL, null);
     }
 
     @Override
     public void restrictPushDown(SelectorImpl s) {
-        if (s.equals(selector)) {
+        if (propertyValue.canRestrictSelector(s)) {
             s.restrictSelector(this);
         }
     }
-    
+
     @Override
     public int hashCode() {
-        String pn = normalizePropertyName(propertyName);
-        return ((selectorName == null) ? 0 : selectorName.hashCode()) * 31 +
-                ((pn == null) ? 0 : pn.hashCode());
+        return Objects.hash(getClass().getName(), propertyValue);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
+        } else if (!(obj instanceof PropertyExistenceImpl)) {
             return false;
         }
         PropertyExistenceImpl other = (PropertyExistenceImpl) obj;
-        if (!equalsStrings(selectorName, other.selectorName)) {
-            return false;
-        }
-        String pn = normalizePropertyName(propertyName);
-        String pn2 = normalizePropertyName(other.propertyName);
-        return equalsStrings(pn, pn2);
-    }
-    
-    private static boolean equalsStrings(String a, String b) {
-        return a == null || b == null ? a == b : a.equals(b);
+        return propertyValue.equals(other.propertyValue);
     }
 
     @Override
     public AstElement copyOf() {
-        return new PropertyExistenceImpl(selectorName, propertyName);
+        return new PropertyExistenceImpl(propertyValue.createCopy());
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PropertyInexistenceImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PropertyInexistenceImpl.java
@@ -19,8 +19,12 @@
 package org.apache.jackrabbit.oak.query.ast;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
+import javax.jcr.PropertyType;
+
+import org.apache.jackrabbit.oak.api.PropertyState;
 import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.query.index.FilterImpl;
@@ -35,28 +39,20 @@ public class PropertyInexistenceImpl extends ConstraintImpl {
     //OAK-6838
     private final boolean USE_OLD_INEXISTENCE_CHECK = Boolean.getBoolean("oak.useOldInexistenceCheck");
 
-    private final String selectorName;
-    private final String propertyName;
-    private SelectorImpl selector;
+    private final PropertyValueImpl propertyValue;
 
-    public PropertyInexistenceImpl(SelectorImpl selector, String selectorName, String propertyName) {
-        this.selector = selector;
-        this.selectorName = selectorName;
-        this.propertyName = propertyName;
-    }
-    
-    public PropertyInexistenceImpl(String selectorName, String propertyName) {
-        this.selectorName = selectorName;
-        this.propertyName = propertyName;
+    public PropertyInexistenceImpl(PropertyValueImpl propertyValue) {
+        this.propertyValue = propertyValue;
     }
 
     @Override
     public boolean evaluate() {
+        String propertyName = propertyValue.getPropertyName();
         boolean isRelative = propertyName.indexOf('/') >= 0;
         if (!isRelative) {
-            return selector.currentProperty(propertyName) == null;
+            return propertyValue.currentProperty() == null;
         }
-        Tree t = selector.currentTree();
+        Tree t = propertyValue.getSelector().currentTree();
         if (t == null) {
             return true;
         }
@@ -77,20 +73,29 @@ public class PropertyInexistenceImpl extends ConstraintImpl {
         }
 
         if (USE_OLD_INEXISTENCE_CHECK) {
-            return t != null && t.exists() && !t.hasProperty(name);
+            return t != null && t.exists() && !hasProperty(t, name);
         } else {
-            return t == null || !t.exists() || !t.hasProperty(name);
+            return t == null || !t.exists() || !hasProperty(t, name);
         }
+    }
+
+    private boolean hasProperty(Tree t, String name) {
+        PropertyState p = t.getProperty(name);
+        if (p == null) {
+            return false;
+        }
+        int requiredPropertyType = propertyValue.getPropertyType();
+        return requiredPropertyType == PropertyType.UNDEFINED || requiredPropertyType == p.getType().tag();
     }
 
     @Override
     public Set<PropertyExistenceImpl> getPropertyExistenceConditions() {
         return Collections.emptySet();
     }
-    
+
     @Override
     public Set<SelectorImpl> getSelectors() {
-        return Collections.singleton(selector);
+        return propertyValue.getSelectors();
     }
 
     @Override
@@ -100,11 +105,11 @@ public class PropertyInexistenceImpl extends ConstraintImpl {
 
     @Override
     public String toString() {
-        return quote(selectorName) + '.' + quote(propertyName) + " is null";
+        return propertyValue + " is null";
     }
 
     public void bindSelector(SourceImpl source) {
-        selector = source.getExistingSelector(selectorName);
+        propertyValue.bindSelector(source);
     }
 
     @Override
@@ -118,13 +123,10 @@ public class PropertyInexistenceImpl extends ConstraintImpl {
         // must not result in the index to check for
         // "b.y is null", because that would alter the
         // result
-        if (selector.isOuterJoinRightHandSide()) {
+        if (propertyValue.getSelector().isOuterJoinRightHandSide()) {
             return;
         }
-        if (f.getSelector().equals(selector)) {
-            String pn = normalizePropertyName(propertyName);
-            f.restrictProperty(pn, Operator.EQUAL, null);
-        }        
+        propertyValue.restrict(f, Operator.EQUAL, null);
     }
 
     @Override
@@ -136,44 +138,33 @@ public class PropertyInexistenceImpl extends ConstraintImpl {
             // for example in:
             // "select * from a left outer join b on a.x = b.y
             // where b.y is null"
-            // must not check for "b.y is null" too early, 
+            // must not check for "b.y is null" too early,
             // because that would alter the result
             return;
         }
-        if (s.equals(selector)) {
+        if (propertyValue.canRestrictSelector(s)) {
             s.restrictSelector(this);
         }
     }
-    
+
     @Override
     public int hashCode() {
-        String pn = normalizePropertyName(propertyName);
-        return ((selectorName == null) ? 0 : selectorName.hashCode()) * 31 +
-                ((pn == null) ? 0 : pn.hashCode());
+        return Objects.hash(getClass().getName(), propertyValue);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
-        } else if (obj == null || getClass() != obj.getClass()) {
+        } else if (!(obj instanceof PropertyInexistenceImpl)) {
             return false;
         }
         PropertyInexistenceImpl other = (PropertyInexistenceImpl) obj;
-        if (!equalsStrings(selectorName, other.selectorName)) {
-            return false;
-        }
-        String pn = normalizePropertyName(propertyName);
-        String pn2 = normalizePropertyName(other.propertyName);
-        return equalsStrings(pn, pn2);
-    }
-    
-    private static boolean equalsStrings(String a, String b) {
-        return a == null || b == null ? a == b : a.equals(b);
+        return propertyValue.equals(other.propertyValue);
     }
 
     @Override
     public AstElement copyOf() {
-        return new PropertyInexistenceImpl(selectorName, propertyName);
+        return new PropertyInexistenceImpl(propertyValue.createCopy());
     }
 }

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PropertyValueImpl.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/ast/PropertyValueImpl.java
@@ -21,13 +21,13 @@ package org.apache.jackrabbit.oak.query.ast;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.jcr.PropertyType;
 
 import org.apache.jackrabbit.oak.api.PropertyValue;
 import org.apache.jackrabbit.oak.api.Type;
-import org.apache.jackrabbit.oak.query.SQL2Parser;
 import org.apache.jackrabbit.oak.query.index.FilterImpl;
 import org.apache.jackrabbit.oak.spi.query.Filter.PathRestriction;
 import org.apache.jackrabbit.oak.spi.query.QueryConstants;
@@ -44,15 +44,18 @@ public class PropertyValueImpl extends DynamicOperandImpl {
     private SelectorImpl selector;
 
     public PropertyValueImpl(String selectorName, String propertyName) {
-        this(selectorName, propertyName, null);
+        this(null, selectorName, propertyName, PropertyType.UNDEFINED);
     }
 
-    public PropertyValueImpl(String selectorName, String propertyName, String propertyType) {
+    public PropertyValueImpl(String selectorName, String propertyName, int propertyType) {
+        this(null, selectorName, propertyName, propertyType);
+    }
+
+    public PropertyValueImpl(SelectorImpl selector, String selectorName, String propertyName, int propertyType) {
+        this.selector = selector;
         this.selectorName = selectorName;
         this.propertyName = propertyName;
-        this.propertyType = propertyType == null ?
-                PropertyType.UNDEFINED :
-                SQL2Parser.getPropertyTypeFromName(propertyType);
+        this.propertyType = propertyType;
     }
 
     public String getSelectorName() {
@@ -93,7 +96,7 @@ public class PropertyValueImpl extends DynamicOperandImpl {
         if (propertyName.equals("*")) {
             return null;
         }
-        return new PropertyExistenceImpl(selector, selectorName, propertyName);
+        return new PropertyExistenceImpl(this);
     }
     
     @Override
@@ -114,6 +117,10 @@ public class PropertyValueImpl extends DynamicOperandImpl {
 
     public void bindSelector(SourceImpl source) {
         selector = source.getExistingSelector(selectorName);
+    }
+
+    SelectorImpl getSelector() {
+        return selector;
     }
 
     @Override
@@ -166,13 +173,13 @@ public class PropertyValueImpl extends DynamicOperandImpl {
     }
     
     @Override
-    int getPropertyType() {
+    public int getPropertyType() {
         return propertyType;
     }
     
     @Override
     public PropertyValueImpl createCopy() {
-        return new PropertyValueImpl(selectorName, propertyName);
+        return new PropertyValueImpl(selector, selectorName, propertyName, propertyType);
     }
 
     @Override
@@ -198,4 +205,22 @@ public class PropertyValueImpl extends DynamicOperandImpl {
         return normalizePropertyName(propertyName);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof PropertyValueImpl)) {
+            return false;
+        }
+        PropertyValueImpl other = (PropertyValueImpl) o;
+        return propertyType == other.propertyType
+                && Objects.equals(selectorName, other.selectorName)
+                && Objects.equals(propertyName, other.propertyName)
+                && Objects.equals(selector, other.selector);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(selectorName, propertyName, propertyType, selector);
+    }
 }

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -341,6 +342,25 @@ public class QueryTest extends AbstractRepositoryTest {
                 "from [nt:base] " +
                 "where path() >= '/test/b' " +
                 "order by path() desc", Query.JCR_SQL2));
+    }
+
+    @Test
+    public void propertyExistenceWithType() throws Exception {
+        Session session = getAdminSession();
+        Node root = session.getRootNode();
+
+        Node test = root.addNode("test");
+        test.addNode("a", "oak:Unstructured").setProperty("test", new String[]{"2025-10-14T20:32:01.481Z", "foo"});
+        test.addNode("b", "oak:Unstructured").setProperty("test", Calendar.getInstance());
+        test.addNode("c", "oak:Unstructured").setProperty("test", "/a/b/c");
+        session.save();
+
+        String nodeList = getNodeList(session,
+                "select [jcr:path] " +
+                        "from [nt:base] " +
+                        "where property([test], 'String') is not null " +
+                        "order by first([test])", Query.JCR_SQL2);
+        assertEquals("/test/c, /test/a", nodeList);
     }
 
     @Test

--- a/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
+++ b/oak-jcr/src/test/java/org/apache/jackrabbit/oak/jcr/query/QueryTest.java
@@ -364,6 +364,27 @@ public class QueryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void propertyInexistenceWithType() throws Exception {
+        Session session = getAdminSession();
+        Node root = session.getRootNode();
+
+        Node test = root.addNode("test");
+        test.addNode("a", "oak:Unstructured").setProperty("test", new String[]{"2025-10-14T20:32:01.481Z", "foo"});
+        test.addNode("b", "oak:Unstructured").setProperty("test", Calendar.getInstance());
+        test.addNode("c", "oak:Unstructured").setProperty("test", "/a/b/c");
+        test.addNode("d", "oak:Unstructured").setProperty("test", 42L);
+        session.save();
+
+        String nodeList = getNodeList(session,
+                "select [jcr:path] " +
+                        "from [nt:base] " +
+                        "where property([test], 'String') is null " +
+                        "and [test] is not null " +
+                        "order by [jcr:path]", Query.JCR_SQL2);
+        assertEquals("/test/b, /test/d", nodeList);
+    }
+
+    @Test
     public void twoSelectors() throws Exception {
         Session session = getAdminSession();
         Node root = session.getRootNode();


### PR DESCRIPTION
- support property type information for "is not null" and "is null" constraints
- unit tests