### PR TITLE
OAK-12345: Change checkpoint lifetime of "async - force modified" to 4 days

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -117,6 +117,11 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
 
     private static final long DEFAULT_LIFETIME = TimeUnit.DAYS.toMillis(100);
 
+    // Lifetime for the checkpoint created by forceIndexLaneCatchup. Shorter than
+    // DEFAULT_LIFETIME so the checkpoint is released on its own if it is not removed
+    // explicitly.
+    private static final long FORCE_MODIFIED_CHECKPOINT_LIFETIME = TimeUnit.DAYS.toMillis(4);
+
     private static final CommitFailedException INTERRUPTED = new CommitFailedException(
             "Async", 1, "Indexing stopped forcefully");
 
@@ -1257,7 +1262,7 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
                 // Release lease for the paused lane
                 this.releaseLeaseForPausedLane();
                 log.info("Released lease for paused lane [{}]", name);
-                String newReferenceCheckpoint = store.checkpoint(lifetime, Map.of(
+                String newReferenceCheckpoint = store.checkpoint(FORCE_MODIFIED_CHECKPOINT_LIFETIME, Map.of(
                         "creator", AsyncIndexUpdate.class.getSimpleName(),
                         "created", now(),
                         "thread", Thread.currentThread().getName(),

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -661,6 +661,40 @@ public class AsyncIndexUpdateTest {
         assertFalse(async.isFailing());
     }
 
+    @Test
+    public void forceModifiedCheckpointUsesShortLifetime() throws Exception {
+        // Capture the lifetime used for the "async-forceModified" checkpoint.
+        long[] forceModifiedLifetime = {-1};
+        MemoryNodeStore delegate = new MemoryNodeStore();
+        NodeStore store = new ProxyNodeStore() {
+            @Override
+            protected NodeStore getNodeStore() {
+                return delegate;
+            }
+
+            @Override
+            public String checkpoint(long lifetime, @NotNull Map<String, String> properties) {
+                if ("async-forceModified".equals(properties.get("name"))) {
+                    forceModifiedLifetime[0] = lifetime;
+                }
+                return super.checkpoint(lifetime, properties);
+            }
+        };
+        IndexEditorProvider provider = new PropertyIndexEditorProvider();
+
+        NodeBuilder builder = store.getRoot().builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
+                "rootIndex", true, false, Set.of("foo"), null)
+                .setProperty(ASYNC_PROPERTY_NAME, "async");
+        store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+
+        AsyncIndexUpdate async = new AsyncIndexUpdate("async", store, provider);
+        async.run();
+        async.getIndexStats().forceIndexLaneCatchup("CONFIRM");
+
+        assertEquals(TimeUnit.DAYS.toMillis(4), forceModifiedLifetime[0]);
+    }
+
     private void assertNoConflictMarker(NodeBuilder builder) {
         for (String name : builder.getChildNodeNames()) {
             if (name.equals(ConflictAnnotatingRebaseDiff.CONFLICT)) {


### PR DESCRIPTION
The checkpoint created by AsyncIndexUpdate.forceIndexLaneCatchup used the default 100 day lifetime. Give it a shorter, dedicated 4 day lifetime so it is released on its own if it is not removed explicitly.

