### PR TITLE
OAK-12343: document and test that ORDER BY on a type=Date ordered property fails for non-date values

### DIFF
--- a/oak-doc/src/site/markdown/query/lucene.md
+++ b/oak-doc/src/site/markdown/query/lucene.md
@@ -503,6 +503,13 @@ type
   Mostly inferred from the indexed value. However in some cases where same property
   type is not used consistently across various nodes then it would recommended
   to specify the type explicitly.
+
+  Note: with `type=Date`, values that are not valid ISO-8601 dates are not indexed as dates, so
+  `order by` on the property gives the wrong order, or no results if the query relies on that
+  property to select nodes. For inconsistent values, leave `type` unset or use `type=String`;
+  string values sort lexicographically, which matches date order only for uniformly formatted
+  timestamps (same precision and zone, e.g. UTC `Z`).
+
   For binary properties, you do not need to index the property separately.
   Binary properties are automatically added to the fulltext index (but only there),
   if the following conditions are met:

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -73,6 +73,10 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     private static final String LOG_KEY_IGNORING_FACET_PROPERTY = "Ignoring facet property";
     private static final String LOG_KEY_UNKNOWN = "Unknown";
 
+    private static final String ORDERED_CONVERT_WARN =
+            "[{}] Ignoring ordered value for property {} (type {}): not convertible to the declared "
+            + "type {} at {}. ORDER BY may return incorrect or no results - leave type unset or use type=String.";
+
     public LuceneDocumentMaker(IndexDefinition definition,
                                IndexDefinition.IndexingRule indexingRule,
                                String path) {
@@ -336,20 +340,16 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
             if (!LOG_SILENCER.silence(key)) {
                 if (key.equals(LOG_KEY_UNKNOWN)) {
                     // unknown error, log with stack trace
-                    LOG.warn(
-                            "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}",
+                    LOG.warn(ORDERED_CONVERT_WARN,
                             getIndexName(), pname,
                             Type.fromTag(property.getType().tag(), false),
                             Type.fromTag(tag, false), path, e);
                 } else {
                     // log without stack trace (as it is known)
-                    LOG.warn(
-                            "[{}] Ignoring ordered property. Could not convert property {} of type {} to type {} for path {}, message {}",
+                    LOG.warn(ORDERED_CONVERT_WARN + " Message: {}",
                             getIndexName(), pname,
                             Type.fromTag(property.getType().tag(), false),
                             Type.fromTag(tag, false), path, e.getMessage());
-
-
                 }
             }
         }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneOrderByTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneOrderByTest.java
@@ -17,14 +17,19 @@
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
 import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.LuceneIndexOptions;
 import org.apache.jackrabbit.oak.plugins.index.OrderByCommonTest;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.jcr.PropertyType;
 import java.io.File;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -53,6 +58,72 @@ public class LuceneOrderByTest extends OrderByCommonTest {
     @Override
     public void orderByMultiProperties() throws Exception {
         super.orderByMultiProperties();
+    }
+
+    /**
+     * OAK-12343: type=Date on an ordered property requires every value to be a valid date. A value
+     * that is not (here "not-a-date") is dropped from the sort field and sorts as the epoch, so
+     * ORDER BY returns the wrong order. Lucene-specific (Elastic sorts such values last), so it
+     * lives here rather than in OrderByCommonTest. Workaround: declare the property as type=String
+     * (see query/lucene.md).
+     *
+     * TODO(OAK-12344): asserts current Lucene behaviour; update the expected order here if Lucene
+     *  is aligned with Elastic.
+     */
+    @Test
+    public void orderByNonDateValuesWithDateTypeIsIncorrect() throws Exception {
+        IndexDefinitionBuilder builder = createIndexDefinitionBuilder();
+        builder.evaluatePathRestrictions();
+        IndexDefinitionBuilder.IndexRule rule = builder.indexRule("nt:base");
+        rule.property("foo").propertyIndex();
+        rule.property("dt").propertyIndex().type(PropertyType.TYPENAME_DATE).ordered();
+        setIndex(UUID.randomUUID().toString(), createIndex(builder, false, "foo", "dt"));
+
+        Tree test = root.getTree("/").addChild("test");
+        Tree a = test.addChild("a");
+        a.setProperty("foo", "bar");
+        a.setProperty("dt", "2023-06-05T16:59:48.119Z");
+        Tree b = test.addChild("b");
+        b.setProperty("foo", "bar");
+        b.setProperty("dt", "2013-06-21T08:30:48.119Z");
+        Tree c = test.addChild("c");
+        c.setProperty("foo", "bar");
+        c.setProperty("dt", "not-a-date");
+        root.commit();
+
+        // "not-a-date" is dropped from the sort field and sorts as the epoch (first, ascending).
+        assertEventually(() -> assertOrderedQuery(
+                "select [jcr:path] from [nt:base] where foo = 'bar' order by [dt]",
+                List.of("/test/c", "/test/b", "/test/a")));
+    }
+
+    /**
+     * OAK-12343: worse symptom - no results at all. With type=Date and no path evaluation, ORDER BY
+     * is served by a numeric range on the property. The stored values aren't valid ISO-8601 dates,
+     * so none can be indexed as a number and the range matches nothing. Lucene-specific (Elastic
+     * returns the rows).
+     * Workaround: declare the property as type=String (see query/lucene.md).
+     *
+     * TODO(OAK-12344): asserts current Lucene behaviour; update the expectation here if Lucene is
+     *  aligned with Elastic.
+     */
+    @Test
+    public void orderByNonDateStringValuesWithDateTypeReturnsNoResults() throws Exception {
+        // no evaluatePathRestrictions, so the numeric range on the date property drives the query
+        IndexDefinitionBuilder builder = createIndexDefinitionBuilder();
+        builder.indexRule("nt:base").property("dt").propertyIndex().type(PropertyType.TYPENAME_DATE).ordered();
+        setIndex(UUID.randomUUID().toString(), createIndex(builder, false, "dt"));
+
+        Tree test = root.getTree("/").addChild("test");
+        test.addChild("a").setProperty("dt", "Mon Feb 24 2025 10:22:32 GMT+0000");
+        test.addChild("b").setProperty("dt", "Wed Jan 15 2025 09:00:00 GMT+0000");
+        test.addChild("c").setProperty("dt", "Fri Mar 07 2025 18:30:00 GMT+0000");
+        root.commit();
+
+        // option(traversal fail) forces the index to serve the query, so this asserts index behaviour
+        assertEventually(() -> assertOrderedQuery(
+                "select [jcr:path] from [nt:base] where isdescendantnode('/test') order by [dt] desc option(traversal fail)",
+                List.of()));
     }
 
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticOrderByTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticOrderByTest.java
@@ -17,8 +17,15 @@
 package org.apache.jackrabbit.oak.plugins.index.elastic;
 
 import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.plugins.index.OrderByCommonTest;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
 import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.jcr.PropertyType;
+import java.util.List;
+import java.util.UUID;
 
 public class ElasticOrderByTest extends OrderByCommonTest {
 
@@ -38,6 +45,41 @@ public class ElasticOrderByTest extends OrderByCommonTest {
     @Override
     protected void createTestIndexNode() {
         setTraversalEnabled(false);
+    }
+
+    /**
+     * OAK-12343: Elastic counterpart to the Lucene type=Date limitation. Elastic sorts missing
+     * (non-date) values last instead of as the epoch, so ORDER BY returns the valid dates in order
+     * with the non-date value last - it does not mis-order or drop rows the way Lucene does
+     * (LuceneOrderByTest#orderByNonDateValuesWithDateTypeIsIncorrect).
+     *
+     * TODO(OAK-12344): if Lucene is aligned with this, this becomes the shared expectation.
+     */
+    @Test
+    public void orderByNonDateValuesWithDateTypeSortsMissingLast() throws Exception {
+        IndexDefinitionBuilder builder = createIndexDefinitionBuilder();
+        builder.evaluatePathRestrictions();
+        IndexDefinitionBuilder.IndexRule rule = builder.indexRule("nt:base");
+        rule.property("foo").propertyIndex();
+        rule.property("dt").propertyIndex().type(PropertyType.TYPENAME_DATE).ordered();
+        setIndex(UUID.randomUUID().toString(), createIndex(builder, false, "foo", "dt"));
+
+        Tree test = root.getTree("/").addChild("test");
+        Tree a = test.addChild("a");
+        a.setProperty("foo", "bar");
+        a.setProperty("dt", "2023-06-05T16:59:48.119Z");
+        Tree b = test.addChild("b");
+        b.setProperty("foo", "bar");
+        b.setProperty("dt", "2013-06-21T08:30:48.119Z");
+        Tree c = test.addChild("c");
+        c.setProperty("foo", "bar");
+        c.setProperty("dt", "not-a-date");
+        root.commit();
+
+        // valid dates order chronologically; the non-date value sorts last (missing=_last).
+        assertEventually(() -> assertOrderedQuery(
+                "select [jcr:path] from [nt:base] where foo = 'bar' order by [dt]",
+                List.of("/test/b", "/test/a", "/test/c")));
     }
 
 }

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/OrderByCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/OrderByCommonTest.java
@@ -521,4 +521,18 @@ public abstract class OrderByCommonTest extends AbstractQueryTest {
         assertEquals(paths, result);
     }
 
+    // Passthroughs so subclasses in other packages can build indexes: the IndexOptions methods are
+    // protected and only reachable from this package.
+    protected IndexDefinitionBuilder createIndexDefinitionBuilder() {
+        return indexOptions.createIndexDefinitionBuilder();
+    }
+
+    protected IndexDefinitionBuilder createIndex(IndexDefinitionBuilder builder, boolean isAsync, String... propNames) {
+        return indexOptions.createIndex(builder, isAsync, propNames);
+    }
+
+    protected Tree setIndex(String name, IndexDefinitionBuilder builder) {
+        return indexOptions.setIndex(root, name, builder);
+    }
+
 }


### PR DESCRIPTION
An ordered Lucene property index declared with type=Date only works when every value is a valid ISO-8601 date. Non-date values are not indexed as dates, so ORDER BY on the property returns the wrong order, or no results when the query relies on that property to select nodes.

- Document the limitation and workarounds under the type option in `lucene.md`
- Add `LuceneOrderByTest` cases for both symptoms (wrong order / no results)
- Clarify the WARN in `LuceneDocumentMaker` to state the ORDER BY consequence
- Add protected passthrough helpers in `OrderByCommonTest` so `LuceneOrderByTest` can build indexes