### PR TITLE
OAK-12348: Property and node type indexes support costPerEntry/costPerExecution overrides

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexConstants.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexConstants.java
@@ -56,6 +56,21 @@ public interface IndexConstants {
     String ENTRY_COUNT_PROPERTY_NAME = "entryCount";
 
     String KEY_COUNT_PROPERTY_NAME = "keyCount";
+
+    /**
+     * Multiplier (Double) applied to the estimated entry count when computing this
+     * index's query cost. Optional; defaults to 1.0 (no change to the estimate).
+     * Same property name as oak-search's FulltextIndexConstants#COST_PER_ENTRY,
+     * used for the same purpose on property/node type indexes.
+     */
+    String COST_PER_ENTRY = "costPerEntry";
+
+    /**
+     * Fixed cost (Double) added once per query plan that uses this index. Optional;
+     * defaults to the index's built-in overhead. Same property name as
+     * oak-search's FulltextIndexConstants#COST_PER_EXECUTION.
+     */
+    String COST_PER_EXECUTION = "costPerExecution";
     
     /**
      * The regular expression pattern of the values to be indexes.

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/IndexUtils.java
@@ -257,6 +257,24 @@ public final class IndexUtils {
     }
 
     /**
+     * Reads an optional double-valued property from an index definition node,
+     * falling back to a default when the property is absent. Mirrors the
+     * {@code getOptionalValue} helper oak-search's {@code IndexDefinition} uses
+     * for the same purpose ({@code costPerEntry}, {@code costPerExecution}, etc.)
+     * so index types outside oak-search (which cannot depend on it) can read
+     * the same kind of tunable index-definition properties.
+     *
+     * @param defn the index definition node
+     * @param propertyName the property name
+     * @param defaultValue the value to return if the property is not set
+     * @return the property's double value, or {@code defaultValue}
+     */
+    public static double getOptionalValue(NodeState defn, String propertyName, double defaultValue) {
+        PropertyState ps = defn.getProperty(propertyName);
+        return ps != null ? ps.getValue(Type.DOUBLE) : defaultValue;
+    }
+
+    /**
      * Retrieves the calling class and method from the call stack; this is determined by unwinding
      * the stack until it finds a combination of full qualified classname + method (separated by ".") which
      * do not start with any of the values provided by the ignoredJavaPackages parameters. If the provided

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndex.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndex.java
@@ -41,13 +41,25 @@ class NodeTypeIndex implements QueryIndex, JcrConstants {
 
     private final MountInfoProvider mountInfoProvider;
 
+    // OAK-12348: false (default) uses the configurable cost formula.
+    private final boolean disableConfigurableCosts;
+
+    // Value returned by getMinimumCost(), precomputed from disableConfigurableCosts.
+    private final double minimumCost;
+
     public NodeTypeIndex(MountInfoProvider mountInfoProvider) {
+        this(mountInfoProvider, false);
+    }
+
+    public NodeTypeIndex(MountInfoProvider mountInfoProvider, boolean disableConfigurableCosts) {
         this.mountInfoProvider = mountInfoProvider;
+        this.disableConfigurableCosts = disableConfigurableCosts;
+        this.minimumCost = disableConfigurableCosts ? NodeTypeIndexLookup.MINIMUM_COST : 0;
     }
 
     @Override
     public double getMinimumCost() {
-        return NodeTypeIndexLookup.MINIMUM_COST;
+        return minimumCost;
     }
 
     @Override
@@ -70,7 +82,7 @@ class NodeTypeIndex implements QueryIndex, JcrConstants {
             return Double.POSITIVE_INFINITY;
         }
         
-        NodeTypeIndexLookup lookup = new NodeTypeIndexLookup(root, mountInfoProvider);
+        NodeTypeIndexLookup lookup = new NodeTypeIndexLookup(root, mountInfoProvider, disableConfigurableCosts);
         if (lookup.isIndexed(filter.getPath(), filter)) {
             return lookup.getCost(filter);
         } else {
@@ -92,7 +104,7 @@ class NodeTypeIndex implements QueryIndex, JcrConstants {
 
     @Override
     public Cursor query(Filter filter, NodeState root) {
-        NodeTypeIndexLookup lookup = new NodeTypeIndexLookup(root, mountInfoProvider);
+        NodeTypeIndexLookup lookup = new NodeTypeIndexLookup(root, mountInfoProvider, disableConfigurableCosts);
         if (!hasNodeTypeRestriction(filter) || !lookup.isIndexed(filter.getPath(), filter)) {
             throw new IllegalStateException(
                     "NodeType index is used even when no index is available for filter " + filter);

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndexLookup.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndexLookup.java
@@ -32,7 +32,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 class NodeTypeIndexLookup implements JcrConstants {
 
     /**
-     * Derived from {@link #getCost(Filter)}
+     * The pre-OAK-12348 legacy floor. Derived from {@link #getCost(Filter)}.
      */
     static final double MINIMUM_COST = 2.05;
 
@@ -40,10 +40,19 @@ class NodeTypeIndexLookup implements JcrConstants {
 
     private final MountInfoProvider mountInfoProvider;
 
+    // OAK-12348: false (default) uses the configurable cost formula.
+    private final boolean disableConfigurableCosts;
+
     public NodeTypeIndexLookup(NodeState root,
             MountInfoProvider mountInfoProvider) {
+        this(root, mountInfoProvider, false);
+    }
+
+    public NodeTypeIndexLookup(NodeState root,
+            MountInfoProvider mountInfoProvider, boolean disableConfigurableCosts) {
         this.root = root;
         this.mountInfoProvider = mountInfoProvider;
+        this.disableConfigurableCosts = disableConfigurableCosts;
     }
 
     /**
@@ -55,7 +64,7 @@ class NodeTypeIndexLookup implements JcrConstants {
      *         otherwise.
      */
     public boolean isIndexed(String path, Filter f) {
-        PropertyIndexLookup lookup = new PropertyIndexLookup(root, mountInfoProvider);
+        PropertyIndexLookup lookup = new PropertyIndexLookup(root, mountInfoProvider, disableConfigurableCosts);
         if (lookup.isIndexed(JCR_PRIMARYTYPE, path, f)
                 && lookup.isIndexed(JCR_MIXINTYPES, path, f)) {
             return true;
@@ -70,12 +79,12 @@ class NodeTypeIndexLookup implements JcrConstants {
         }
 
         NodeState child = root.getChildNode(path.substring(0, slash));
-        return new NodeTypeIndexLookup(child, mountInfoProvider).isIndexed(
+        return new NodeTypeIndexLookup(child, mountInfoProvider, disableConfigurableCosts).isIndexed(
                 path.substring(slash), f);
     }
 
     public double getCost(Filter filter) {
-        PropertyIndexLookup lookup = new PropertyIndexLookup(root, mountInfoProvider);
+        PropertyIndexLookup lookup = new PropertyIndexLookup(root, mountInfoProvider, disableConfigurableCosts);
         return lookup.getCost(filter, JCR_PRIMARYTYPE, newName(filter.getPrimaryTypes()))
                 + lookup.getCost(filter, JCR_MIXINTYPES, newName(filter.getMixinTypes()));
     }
@@ -87,7 +96,7 @@ class NodeTypeIndexLookup implements JcrConstants {
      * @return the matched paths (the result might contain duplicate entries)
      */
     public Iterable<String> query(Filter filter) {
-        PropertyIndexLookup lookup = new PropertyIndexLookup(root, mountInfoProvider);
+        PropertyIndexLookup lookup = new PropertyIndexLookup(root, mountInfoProvider, disableConfigurableCosts);
         return IterableUtils.chainedIterable(
                 lookup.query(filter, JCR_PRIMARYTYPE, newName(filter.getPrimaryTypes())),
                 lookup.query(filter, JCR_MIXINTYPES, newName(filter.getMixinTypes())));

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndexProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndexProvider.java
@@ -18,16 +18,26 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.nodetype;
 
+import static org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexProvider.FT_OAK_12348;
+import static org.apache.jackrabbit.oak.spi.toggle.Feature.newFeature;
+
 import java.util.List;
 
+import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.mount.Mounts;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex;
 import org.apache.jackrabbit.oak.spi.query.QueryIndexProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.toggle.Feature;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -41,10 +51,36 @@ public class NodeTypeIndexProvider implements QueryIndexProvider {
     private MountInfoProvider mountInfoProvider = Mounts
             .defaultMountInfoProvider();
 
+    /**
+     * See {@link org.apache.jackrabbit.oak.plugins.index.property.PropertyIndexProvider#FT_OAK_12348}
+     * (OAK-12348) -- registered independently here rather than shared with
+     * PropertyIndexProvider, since the two are separate, independently
+     * activated components with no existing cross-component wiring in this
+     * codebase. Same toggle name, so an operator flipping one knows to check
+     * the other.
+     */
+    @Nullable
+    private Feature feature;
+
+    @Activate
+    private void activate(BundleContext bundleContext) {
+        Whiteboard whiteboard = new OsgiWhiteboard(bundleContext);
+        this.feature = newFeature(FT_OAK_12348, whiteboard);
+    }
+
+    @Deactivate
+    private void deactivate() {
+        if (feature != null) {
+            feature.close();
+            feature = null;
+        }
+    }
+
     @NotNull
     @Override
     public List<? extends QueryIndex> getQueryIndexes(NodeState nodeState) {
-        return List.of(new NodeTypeIndex(mountInfoProvider));
+        boolean disableConfigurableCosts = feature != null && feature.isEnabled();
+        return List.of(new NodeTypeIndex(mountInfoProvider, disableConfigurableCosts));
     }
 
     public NodeTypeIndexProvider with(MountInfoProvider mountInfoProvider) {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndex.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndex.java
@@ -88,13 +88,26 @@ class PropertyIndex implements QueryIndex {
 
     private final MountInfoProvider mountInfoProvider;
 
+    // OAK-12348: false (default) uses the configurable cost formula.
+    private final boolean disableConfigurableCosts;
+
+    // Lowest cost any plan can report under the active formula; used by
+    // getMinimumCost() and createPlan()'s early-break check.
+    private final double minimumCost;
+
     /**
      * Cached property index plan
      */
     private PropertyIndexPlan cachedPlan;
 
     PropertyIndex(MountInfoProvider mountInfoProvider) {
+        this(mountInfoProvider, false);
+    }
+
+    PropertyIndex(MountInfoProvider mountInfoProvider, boolean disableConfigurableCosts) {
         this.mountInfoProvider = mountInfoProvider;
+        this.disableConfigurableCosts = disableConfigurableCosts;
+        this.minimumCost = disableConfigurableCosts ? PropertyIndexPlan.COST_OVERHEAD : 0;
     }
 
     private PropertyIndexPlan getPlan(NodeState root, Filter filter) {
@@ -106,14 +119,13 @@ class PropertyIndex implements QueryIndex {
         if (plan != null && plan.getFilter().toString().equals(filter.toString())) {
             return plan;
         } else {
-            plan = createPlan(root, filter, mountInfoProvider);
+            plan = createPlan(root, filter);
             this.cachedPlan = plan;
             return plan;
         }
     }
 
-    private static PropertyIndexPlan createPlan(NodeState root, Filter filter,
-                                                MountInfoProvider mountInfoProvider) {
+    private PropertyIndexPlan createPlan(NodeState root, Filter filter) {
         PropertyIndexPlan bestPlan = null;
 
         // TODO support indexes on a path
@@ -127,14 +139,14 @@ class PropertyIndex implements QueryIndex {
             if (PROPERTY.equals(definition.getString(TYPE_PROPERTY_NAME))
                     && definition.hasChildNode(INDEX_CONTENT_NODE_NAME)) {
                 PropertyIndexPlan plan = new PropertyIndexPlan(
-                        entry.getName(), root, definition, filter, mountInfoProvider);
+                        entry.getName(), root, definition, filter, mountInfoProvider, disableConfigurableCosts);
                 if (plan.getCost() != Double.POSITIVE_INFINITY) {
                     LOG.debug("property cost for {} is {}",
                             plan.getName(), plan.getCost());
                     if (bestPlan == null || plan.getCost() < bestPlan.getCost()) {
                         bestPlan = plan;
-                        // Stop comparing if the costs are the minimum
-                        if (plan.getCost() == PropertyIndexPlan.COST_OVERHEAD) {
+                        // Stop comparing if the cost can't possibly be beaten
+                        if (plan.getCost() == minimumCost) {
                             break;
                         }
                     }
@@ -221,7 +233,7 @@ class PropertyIndex implements QueryIndex {
 
     @Override
     public double getMinimumCost() {
-        return PropertyIndexPlan.COST_OVERHEAD;
+        return minimumCost;
     }
 
     @Override

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexLookup.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexLookup.java
@@ -35,6 +35,7 @@ import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.commons.PathUtils;
 import org.apache.jackrabbit.oak.commons.collections.IterableUtils;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.IndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.property.strategy.IndexStoreStrategy;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.mount.Mounts;
@@ -79,13 +80,21 @@ public class PropertyIndexLookup {
 
     private final MountInfoProvider mountInfoProvider;
 
+    // OAK-12348: false (default) uses the configurable cost formula.
+    private final boolean disableConfigurableCosts;
+
     public PropertyIndexLookup(NodeState root) {
         this(root, Mounts.defaultMountInfoProvider());
     }
 
     public PropertyIndexLookup(NodeState root, MountInfoProvider mountInfoProvider) {
+        this(root, mountInfoProvider, false);
+    }
+
+    public PropertyIndexLookup(NodeState root, MountInfoProvider mountInfoProvider, boolean disableConfigurableCosts) {
         this.root = root;
         this.mountInfoProvider = mountInfoProvider;
+        this.disableConfigurableCosts = disableConfigurableCosts;
     }
 
     /**
@@ -135,18 +144,63 @@ public class PropertyIndexLookup {
                 definition, INDEX_CONTENT_NODE_NAME);
     }
 
+    /**
+     * Dispatches to {@link #getCostConfigurable} or {@link #getCostLegacy}
+     * based on {@code disableConfigurableCosts}.
+     */
     public double getCost(Filter filter, String propertyName, PropertyValue value) {
+        return disableConfigurableCosts
+                ? getCostLegacy(filter, propertyName, value)
+                : getCostConfigurable(filter, propertyName, value);
+    }
+
+    /**
+     * Original cost formula: {@code COST_OVERHEAD + entryCount}. Ignores
+     * {@code costPerEntry}/{@code costPerExecution} even if set on the index
+     * definition.
+     */
+    public double getCostLegacy(Filter filter, String propertyName, PropertyValue value) {
         NodeState indexMeta = getIndexNode(root, propertyName, filter);
         if (indexMeta == null) {
             return Double.POSITIVE_INFINITY;
         }
-        Set<IndexStoreStrategy> strategies = getStrategies(indexMeta);
-        ValuePattern pattern = new ValuePattern(indexMeta);
-        double cost = strategies.isEmpty() ? MAX_COST : COST_OVERHEAD;
-        for (IndexStoreStrategy s : strategies) {
-            cost += s.count(filter, root, indexMeta, encode(value, pattern), MAX_COST);
+        return getCost(indexMeta, filter, value, COST_OVERHEAD, 1.0);
+    }
+
+    /**
+     * {@code cost = costPerExecution + costPerEntry * entryCount}, both
+     * optionally configured on the index definition (OAK-12348). Defaults
+     * ({@code costPerEntry=1.0}, {@code costPerExecution=COST_OVERHEAD})
+     * reproduce {@link #getCostLegacy} exactly.
+     */
+    public double getCostConfigurable(Filter filter, String propertyName, PropertyValue value) {
+        NodeState indexMeta = getIndexNode(root, propertyName, filter);
+        if (indexMeta == null) {
+            return Double.POSITIVE_INFINITY;
         }
-        return cost;
+        double costPerEntry = IndexUtils.getOptionalValue(indexMeta, IndexConstants.COST_PER_ENTRY, 1.0);
+        double costPerExecution = IndexUtils.getOptionalValue(indexMeta, IndexConstants.COST_PER_EXECUTION, COST_OVERHEAD);
+        return getCost(indexMeta, filter, value, costPerExecution, costPerEntry);
+    }
+
+    // Shared by getCostLegacy/getCostConfigurable, which only differ in
+    // costPerExecution/costPerEntry -- legacy hardcodes them, configurable
+    // reads them from indexMeta (which is why they can't be precomputed
+    // earlier than this: they depend on which property's index definition
+    // this call resolved, and the same PropertyIndexLookup is reused across
+    // different property names, e.g. by NodeTypeIndexLookup).
+    private double getCost(NodeState indexMeta, Filter filter, PropertyValue value,
+            double costPerExecution, double costPerEntry) {
+        Set<IndexStoreStrategy> strategies = getStrategies(indexMeta);
+        if (strategies.isEmpty()) {
+            return MAX_COST;
+        }
+        ValuePattern pattern = new ValuePattern(indexMeta);
+        double entryCount = 0;
+        for (IndexStoreStrategy s : strategies) {
+            entryCount += s.count(filter, root, indexMeta, encode(value, pattern), MAX_COST);
+        }
+        return costPerExecution + costPerEntry * entryCount;
     }
 
     /**

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexPlan.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexPlan.java
@@ -67,27 +67,18 @@ public class PropertyIndexPlan {
 
     private final String name;
 
-    private final Set<String> properties;
-
     private final Set<IndexStoreStrategy> strategies;
 
     private final Filter filter;
-
-    private boolean matchesAllTypes;
-
-    private boolean matchesNodeTypes;
-
-    private final double cost;
 
     private final Set<String> values;
 
     private final int depth;
 
-    private final PathFilter pathFilter;
-
-    private final boolean unique;
-
     private final boolean deprecated;
+
+    // Value returned by getCost().
+    private final double cost;
 
     PropertyIndexPlan(String name, NodeState root, NodeState definition,
                       Filter filter){
@@ -96,24 +87,29 @@ public class PropertyIndexPlan {
 
     PropertyIndexPlan(String name, NodeState root, NodeState definition,
                       Filter filter, MountInfoProvider mountInfoProvider) {
+        this(name, root, definition, filter, mountInfoProvider, false);
+    }
+
+    PropertyIndexPlan(String name, NodeState root, NodeState definition,
+                      Filter filter, MountInfoProvider mountInfoProvider, boolean disableConfigurableCosts) {
         this.name = name;
-        this.unique = definition.getBoolean(IndexConstants.UNIQUE_PROPERTY_NAME);
+        boolean unique = definition.getBoolean(IndexConstants.UNIQUE_PROPERTY_NAME);
         this.definition = definition;
-        this.properties = SetUtils.toSet(definition.getNames(PROPERTY_NAMES));
-        pathFilter = PathFilter.from(definition.builder());
-        this.strategies = getStrategies(definition, mountInfoProvider);
+        Set<String> properties = SetUtils.toSet(definition.getNames(PROPERTY_NAMES));
+        PathFilter pathFilter = PathFilter.from(definition.builder());
+        this.strategies = getStrategies(definition, mountInfoProvider, unique);
         this.filter = filter;
 
         Iterable<String> types = definition.getNames(DECLARING_NODE_TYPES);
         // if there is no such property, then all nodetypes are matched
-        this.matchesAllTypes = !definition.hasProperty(DECLARING_NODE_TYPES);
+        boolean matchesAllTypes = !definition.hasProperty(DECLARING_NODE_TYPES);
         this.deprecated = definition.getBoolean(IndexConstants.INDEX_DEPRECATED);
-        this.matchesNodeTypes =
+        boolean matchesNodeTypes =
                 matchesAllTypes || StreamUtils.toStream(types).anyMatch(filter.getSupertypes()::contains);
 
         ValuePattern valuePattern = new ValuePattern(definition);
 
-        double bestCost = Double.POSITIVE_INFINITY;
+        double bestCount = Double.POSITIVE_INFINITY;
         Set<String> bestValues = emptySet();
         int bestDepth = 1;
 
@@ -168,22 +164,22 @@ public class PropertyIndexPlan {
                         }
                     }
                     values = PropertyIndexUtil.encode(values);
-                    double cost = strategies.isEmpty() ? MAX_COST : 0;
+                    double count = strategies.isEmpty() ? MAX_COST : 0;
                     for (IndexStoreStrategy strategy : strategies) {
-                        cost += strategy.count(filter, root, definition,
+                        count += strategy.count(filter, root, definition,
                                 values, MAX_COST);
                     }
-                    if (unique && cost <= 1) {
+                    if (unique && count <= 1) {
                         // for unique index, for the normal case
                         // (that is, for a regular lookup)
                         // no further reads are needed
-                        cost = 0;
+                        count = 0;
                     }
-                    if (cost < bestCost) {
+                    if (count < bestCount) {
                         bestDepth = depth;
                         bestValues = values;
-                        bestCost = cost;
-                        if (bestCost == 0) {
+                        bestCount = count;
+                        if (bestCount == 0) {
                             // shortcut: not possible to top this
                             break;
                         }
@@ -194,7 +190,7 @@ public class PropertyIndexPlan {
 
         this.depth = bestDepth;
         this.values = bestValues;
-        this.cost = COST_OVERHEAD + bestCost;
+        this.cost = disableConfigurableCosts ? getCostLegacy(bestCount) : getCostConfigurable(bestCount);
     }
 
     String getName() {
@@ -203,6 +199,30 @@ public class PropertyIndexPlan {
 
     double getCost() {
         return cost;
+    }
+
+    /**
+     * Original cost formula: {@code COST_OVERHEAD + bestCount}. Ignores
+     * {@code costPerEntry}/{@code costPerExecution} even if set on the index
+     * definition.
+     */
+    double getCostLegacy(double bestCount) {
+        return bestCount == Double.POSITIVE_INFINITY ? Double.POSITIVE_INFINITY : COST_OVERHEAD + bestCount;
+    }
+
+    /**
+     * {@code cost = costPerExecution + costPerEntry * bestCount}, both
+     * optionally configured on the index definition (OAK-12348). Defaults
+     * ({@code costPerEntry=1.0}, {@code costPerExecution=COST_OVERHEAD})
+     * reproduce {@link #getCostLegacy} exactly.
+     */
+    double getCostConfigurable(double bestCount) {
+        if (bestCount == Double.POSITIVE_INFINITY) {
+            return Double.POSITIVE_INFINITY;
+        }
+        double costPerEntry = IndexUtils.getOptionalValue(definition, IndexConstants.COST_PER_ENTRY, 1.0);
+        double costPerExecution = IndexUtils.getOptionalValue(definition, IndexConstants.COST_PER_EXECUTION, COST_OVERHEAD);
+        return costPerExecution + costPerEntry * bestCount;
     }
 
     Cursor execute() {
@@ -228,7 +248,7 @@ public class PropertyIndexPlan {
     }
 
     Set<IndexStoreStrategy> getStrategies(NodeState definition,
-            MountInfoProvider mountInfoProvider) {
+            MountInfoProvider mountInfoProvider, boolean unique) {
         return Multiplexers.getStrategies(unique, mountInfoProvider,
                 definition, INDEX_CONTENT_NODE_NAME);
     }
@@ -260,7 +280,7 @@ public class PropertyIndexPlan {
             }
         }
         buffer.append("\n");
-        buffer.append("    estimatedCost: ").append(cost).append("\n");
+        buffer.append("    estimatedCost: ").append(getCost()).append("\n");
         return buffer.toString();
     }
 

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexProvider.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexProvider.java
@@ -16,16 +16,25 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.property;
 
+import static org.apache.jackrabbit.oak.spi.toggle.Feature.newFeature;
+
 import java.util.List;
 
+import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.spi.mount.MountInfoProvider;
 import org.apache.jackrabbit.oak.spi.mount.Mounts;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex;
 import org.apache.jackrabbit.oak.spi.query.QueryIndexProvider;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.apache.jackrabbit.oak.spi.toggle.Feature;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -33,18 +42,46 @@ import org.osgi.service.component.annotations.Reference;
  * <br>
  * Even if there are multiple index definitions, there is only actually one
  * PropertyIndex instance, which is used for all indexes.
- * 
+ *
  * @see PropertyIndex
  */
 @Component(service = QueryIndexProvider.class)
 public class PropertyIndexProvider implements QueryIndexProvider {
 
+    /**
+     * Feature toggle name for the configurable costPerEntry/costPerExecution
+     * cost formula (OAK-12348). Flipping this toggle on via the whiteboard
+     * reverts PropertyIndex to the original hardcoded cost formula -- it is
+     * disabled (configurable formula active) by default. Not reachable in
+     * embedded/non-OSGi usage (no BundleContext to activate with), same
+     * limitation as {@link PropertyIndexEditorProvider#FT_OAK_12125}.
+     */
+    public static final String FT_OAK_12348 = "FT_OAK-12348";
+
     @Reference
     private MountInfoProvider mountInfoProvider = Mounts.defaultMountInfoProvider();
 
+    @Nullable
+    private Feature feature;
+
+    @Activate
+    private void activate(BundleContext bundleContext) {
+        Whiteboard whiteboard = new OsgiWhiteboard(bundleContext);
+        this.feature = newFeature(FT_OAK_12348, whiteboard);
+    }
+
+    @Deactivate
+    private void deactivate() {
+        if (feature != null) {
+            feature.close();
+            feature = null;
+        }
+    }
+
     @Override @NotNull
     public List<QueryIndex> getQueryIndexes(NodeState state) {
-        return List.of(new PropertyIndex(mountInfoProvider));
+        boolean disableConfigurableCosts = feature != null && feature.isEnabled();
+        return List.of(new PropertyIndex(mountInfoProvider, disableConfigurableCosts));
     }
 
     public PropertyIndexProvider with(MountInfoProvider mountInfoProvider) {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndexTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/nodetype/NodeTypeIndexTest.java
@@ -91,6 +91,80 @@ public class NodeTypeIndexTest {
         checkCursor(index.query(filter, rootState), "/folder-1", "/folder-2", "/file-1");
     }
 
+    /**
+     * NodeTypeIndex has no cost logic of its own: its cost is the sum of two
+     * {@code PropertyIndexLookup.getCost()} calls (jcr:primaryType, jcr:mixinTypes)
+     * against the single "nodetype" property index definition. Setting
+     * costPerEntry/costPerExecution on that definition must change the total,
+     * with no code changes needed in the nodetype package itself.
+     */
+    @Test
+    public void nodeTypeCostOverride() throws Exception {
+        NodeBuilder root = store.getRoot().builder();
+
+        // remove system security nodes to avoid skewing counts: rep:security's
+        // default authorizable store (rep:AuthorizableFolder, rep:User) also
+        // extends nt:hierarchyNode, so it would otherwise be counted by the
+        // NT_HIERARCHYNODE assertion below alongside the folders/file this test adds.
+        root.getChildNode("rep:security").remove();
+
+        NodeBuilder nodetypeIndex = root.getChildNode("oak:index").getChildNode("nodetype");
+        // set "entryCount", so the node type index counts the nodes
+        // and the approximation is not used
+        nodetypeIndex.setProperty("entryCount", -1);
+        nodetypeIndex.setProperty(org.apache.jackrabbit.oak.plugins.index.IndexConstants.COST_PER_ENTRY, 3.0);
+        nodetypeIndex.setProperty(org.apache.jackrabbit.oak.plugins.index.IndexConstants.COST_PER_EXECUTION, 10.0);
+
+        addFolder(root, "folder-1");
+        addFolder(root, "folder-2");
+        addFile(root, "file-1");
+
+        store.merge(root, new EditorHook(new IndexUpdateProvider(
+                new PropertyIndexEditorProvider())), CommitInfo.EMPTY);
+
+        NodeState rootState = store.getRoot();
+        NodeTypeIndex index = new NodeTypeIndex(
+                Mounts.defaultMountInfoProvider());
+        FilterImpl filter;
+
+        // NodeTypeIndex has no toggle of its own -- it inherits whichever formula
+        // PropertyIndexLookup.getCost() is currently dispatching to, driven by the
+        // disableConfigurableCosts boolean passed into NodeTypeIndex's constructor (OAK-12348),
+        // which defaults to false (configurable formula active) when not provided
+        // -- no opt-in needed here.
+
+        // default (see nodeType() above) is 2*COST_OVERHEAD(2) + entrySum;
+        // with the override it is 2*costPerExecution + costPerEntry*entrySum
+        filter = createFilter(rootState, JcrConstants.NT_FOLDER);
+        assertEquals(2 * 10.0 + 3.0 * 2, index.getCost(filter, rootState), 0.0);
+
+        filter = createFilter(rootState, JcrConstants.NT_FILE);
+        assertEquals(2 * 10.0 + 3.0 * 1, index.getCost(filter, rootState), 0.0);
+
+        filter = createFilter(rootState, JcrConstants.NT_HIERARCHYNODE);
+        assertEquals(2 * 10.0 + 3.0 * 3, index.getCost(filter, rootState), 0.0);
+    }
+
+    /**
+     * Same rationale as PropertyIndex#getMinimumCost -- see PropertyIndexTest#getMinimumCostIsZero.
+     */
+    @Test
+    public void getMinimumCostIsZero() {
+        NodeTypeIndex index = new NodeTypeIndex(Mounts.defaultMountInfoProvider());
+        assertEquals(0.0, index.getMinimumCost(), 0.0);
+    }
+
+    /**
+     * Companion to {@link #getMinimumCostIsZero()}: with the legacy-mode
+     * toggle enabled, getMinimumCost() must reproduce the exact
+     * pre-OAK-12348 value ({@link NodeTypeIndexLookup#MINIMUM_COST}), not 0.
+     */
+    @Test
+    public void getMinimumCostIsLegacyValueUnderLegacyMode() {
+        NodeTypeIndex index = new NodeTypeIndex(Mounts.defaultMountInfoProvider(), true);
+        assertEquals(NodeTypeIndexLookup.MINIMUM_COST, index.getMinimumCost(), 0.0);
+    }
+
     private static FilterImpl createFilter(NodeState root, String nodeTypeName) {
         NodeTypeInfoProvider nodeTypes = new NodeStateNodeTypeInfoProvider(root);
         NodeTypeInfo type = nodeTypes.getNodeTypeInfo(nodeTypeName);        

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/property/PropertyIndexTest.java
@@ -258,6 +258,302 @@ public class PropertyIndexTest {
                 cost < traversal);
     }
 
+    /**
+     * Default cost (no costPerEntry/costPerExecution set) must stay exactly
+     * COST_OVERHEAD + entryCount regardless of the FT_OAK_12348 toggle position,
+     * both via {@link PropertyIndexLookup#getCost} and via {@link PropertyIndex#getCost}
+     * (which goes through {@link PropertyIndexPlan}). The toggle is enabled by
+     * default, so this is what a fresh install sees with no properties set.
+     */
+    @Test
+    public void costPerEntryAndCostPerExecutionDefaultUnchanged() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
+                true, false, Set.of("foo"), null)
+                .setProperty("entryCount", -1);
+        NodeState before = builder.getNodeState();
+
+        for (int i = 0; i < 5; i++) {
+            builder.child("n" + i).setProperty("foo", "x1");
+        }
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        f.restrictPropertyAsList("foo", java.util.List.of(PropertyValues.newString("x1")));
+
+        PropertyIndexLookup lookup = new PropertyIndexLookup(indexed);
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+        assertEquals(7.0, lookup.getCost(f, "foo", PropertyValues.newString("x1")), 0.0);
+        assertEquals(7.0, pIndex.getCost(f, indexed), 0.0);
+
+        PropertyIndexLookup legacyLookup = new PropertyIndexLookup(indexed, Mounts.defaultMountInfoProvider(), true);
+        PropertyIndex pIndexLegacy = new PropertyIndex(Mounts.defaultMountInfoProvider(), true);
+        assertEquals(7.0, legacyLookup.getCost(f, "foo", PropertyValues.newString("x1")), 0.0);
+        assertEquals(7.0, pIndexLegacy.getCost(f, indexed), 0.0);
+    }
+
+    /**
+     * Setting costPerEntry/costPerExecution on the index definition changes the
+     * cost by the documented formula, {@code cost = costPerExecution + costPerEntry * entryCount},
+     * by default -- FT_OAK_12348 is enabled out of the box. Disabling it (the
+     * escape hatch) must fall back to the legacy value.
+     */
+    @Test
+    public void costPerEntryAndCostPerExecutionOverride() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
+                true, false, Set.of("foo"), null)
+                .setProperty("entryCount", -1)
+                .setProperty(IndexConstants.COST_PER_ENTRY, 2.0)
+                .setProperty(IndexConstants.COST_PER_EXECUTION, 10.0);
+        NodeState before = builder.getNodeState();
+
+        for (int i = 0; i < 5; i++) {
+            builder.child("n" + i).setProperty("foo", "x1");
+        }
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        f.restrictPropertyAsList("foo", java.util.List.of(PropertyValues.newString("x1")));
+
+        PropertyIndexLookup lookup = new PropertyIndexLookup(indexed);
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+
+        // enabled (default): override takes effect immediately, no opt-in needed
+        // -- 10.0 + 2.0 * 5 == 20.0 (legacy would have been 2.0 + 5 == 7.0).
+        assertEquals(20.0, lookup.getCost(f, "foo", PropertyValues.newString("x1")), 0.0);
+        assertEquals(20.0, pIndex.getCost(f, indexed), 0.0);
+        // getCostLegacy() is callable directly regardless of the toggle, and still
+        // gives the old value -- proves the escape hatch's formula is intact.
+        assertEquals(7.0, lookup.getCostLegacy(f, "foo", PropertyValues.newString("x1")), 0.0);
+
+        PropertyIndexLookup legacyLookup = new PropertyIndexLookup(indexed, Mounts.defaultMountInfoProvider(), true);
+        PropertyIndex pIndexLegacy = new PropertyIndex(Mounts.defaultMountInfoProvider(), true);
+        assertEquals(7.0, legacyLookup.getCost(f, "foo", PropertyValues.newString("x1")), 0.0);
+        assertEquals(7.0, pIndexLegacy.getCost(f, indexed), 0.0);
+    }
+
+    /**
+     * costPerEntry == 0 on an index that doesn't apply to the query must not turn
+     * POSITIVE_INFINITY into NaN (0 * Infinity == NaN in IEEE754) — an inapplicable
+     * index must never look "free". Exercises the default (enabled) toggle state.
+     */
+    @Test
+    public void costPerEntryZeroDoesNotCorruptInfinityCost() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "foo",
+                true, false, Set.of("foo"), null)
+                .setProperty("entryCount", -1)
+                .setProperty(IndexConstants.COST_PER_ENTRY, 0.0)
+                .setProperty(IndexConstants.COST_PER_EXECUTION, 0.0);
+        NodeState before = builder.getNodeState();
+        builder.child("n1").setProperty("foo", "x1");
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        // filter has no restriction on "foo" (or any other indexed property) at all,
+        // so no candidate property matches and PropertyIndexPlan's bestCost stays
+        // POSITIVE_INFINITY internally.
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+
+        double cost = pIndex.getCost(f, indexed);
+        assertFalse("cost must not be NaN", Double.isNaN(cost));
+        assertEquals(Double.POSITIVE_INFINITY, cost, 0.0);
+    }
+
+    /**
+     * The unique-index short circuit zeroes the raw per-property strategy count
+     * ({@code bestCost}) for a normal unique lookup — it never made the *final*
+     * cost 0 even before this change (default final cost was always
+     * {@code COST_OVERHEAD + 0 == COST_OVERHEAD}, i.e. 2.0, never 0.0). So the
+     * invariant an override must preserve is: the entry-count contribution stays
+     * zero (a huge costPerEntry must not blow up the cost of a unique lookup),
+     * while costPerExecution still applies as the flat cost of the lookup itself.
+     */
+    @Test
+    public void uniqueIndexShortCircuitZeroesEntryCountContributionUnderOverride() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "uuidIndex",
+                true, true, Set.of("foo"), null)
+                .setProperty(IndexConstants.COST_PER_ENTRY, 1000.0)
+                .setProperty(IndexConstants.COST_PER_EXECUTION, 3.0);
+        NodeState before = builder.getNodeState();
+        builder.child("n1").setProperty("foo", "x1");
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        f.restrictPropertyAsList("foo", java.util.List.of(PropertyValues.newString("x1")));
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+
+        // 3.0 + 1000.0 * 0 == 3.0 -- the huge costPerEntry must not apply, since
+        // the short circuit means there is no per-entry contribution to multiply.
+        assertEquals(3.0, pIndex.getCost(f, indexed), 0.0);
+    }
+
+    /**
+     * Same scenario without any override: default final cost for a unique
+     * short-circuited lookup is COST_OVERHEAD (2.0), not 0.0 -- documents the
+     * baseline the override test above is relative to.
+     */
+    @Test
+    public void uniqueIndexShortCircuitDefaultCostIsOverheadNotZero() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "uuidIndex",
+                true, true, Set.of("foo"), null);
+        NodeState before = builder.getNodeState();
+        builder.child("n1").setProperty("foo", "x1");
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        f.restrictPropertyAsList("foo", java.util.List.of(PropertyValues.newString("x1")));
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+        assertEquals(2.0, pIndex.getCost(f, indexed), 0.0);
+    }
+
+    /**
+     * Regression for the early-break in PropertyIndex#createPlan: under the
+     * configurable formula (OAK-12348), hitting the legacy COST_OVERHEAD (2.0)
+     * on one definition does not mean no other definition can be cheaper --
+     * costPerExecution can be configured below 2.0. bIndex is unique (so its
+     * one matching entry short-circuits to bestCount=0, giving the *default*
+     * cost of exactly COST_OVERHEAD with no override needed) and is the entry
+     * createPlan() scans first for this pair of names (child node order here
+     * is hash-based, not alphabetical), reproducing the exact old break
+     * condition. aIndex overrides costPerExecution to 0.5 and is genuinely
+     * cheaper, but the old break would stop scanning right after bIndex and
+     * never see it.
+     */
+    @Test
+    public void createPlanDoesNotBreakEarlyWhenCheaperOverrideFollows() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "bIndex",
+                true, true, Set.of("foo"), null);
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "aIndex",
+                true, false, Set.of("foo"), null)
+                .setProperty(IndexConstants.COST_PER_ENTRY, 0.0)
+                .setProperty(IndexConstants.COST_PER_EXECUTION, 0.5);
+        NodeState before = builder.getNodeState();
+
+        builder.child("n1").setProperty("foo", "x1");
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        f.restrictPropertyAsList("foo", java.util.List.of(PropertyValues.newString("x1")));
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+
+        assertEquals("aIndex", pIndex.getIndexName(f, indexed));
+        assertEquals(0.5, pIndex.getCost(f, indexed), 0.0);
+    }
+
+    /**
+     * Regression for the break condition's floor value under legacy mode, with
+     * two competing definitions present. Under the legacy formula, overrides
+     * are ignored entirely ({@code getCostLegacy()} = {@code COST_OVERHEAD +
+     * bestCount}, no override read at all), so the true minimum achievable
+     * legacy cost is always exactly {@code COST_OVERHEAD} -- a definition that
+     * hits it can never legitimately be beaten by another definition's legacy
+     * cost. That means the *winning* plan alone can't tell us which floor the
+     * break actually used: both the correct floor ({@code COST_OVERHEAD}) and
+     * a hypothetical reversed bug (a floor of 0 that never matches in legacy
+     * mode) produce the exact same winner here, since nothing can beat
+     * {@code COST_OVERHEAD} under legacy math regardless of the break.
+     * <p>
+     * What *does* distinguish them is whether the loop keeps scanning after
+     * bIndex hits {@code COST_OVERHEAD}: {@code LOG.debug} in
+     * {@code createPlan()} logs every candidate's cost unconditionally, before
+     * the break check runs. If the break correctly fires right after bIndex,
+     * aIndex is never even constructed/evaluated and its line never reaches
+     * the log. If the floor were wrongly 0 in legacy mode, the break would
+     * never fire on bIndex's 2.0, the loop would keep going, and aIndex's cost
+     * would be logged too -- even though it still can't win. This test asserts
+     * on that log evidence, since the winning plan/cost by itself would pass
+     * either way.
+     */
+    @Test
+    public void createPlanBreaksImmediatelyOnCostOverheadUnderLegacyModeWithMultipleDefinitions() throws Exception {
+        NodeState root = INITIAL_CONTENT;
+
+        NodeBuilder builder = root.builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "bIndex",
+                true, true, Set.of("foo"), null);
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME), "aIndex",
+                true, false, Set.of("foo"), null)
+                .setProperty(IndexConstants.COST_PER_ENTRY, 0.0)
+                .setProperty(IndexConstants.COST_PER_EXECUTION, 0.5);
+        NodeState before = builder.getNodeState();
+
+        builder.child("n1").setProperty("foo", "x1");
+        NodeState after = builder.getNodeState();
+        NodeState indexed = HOOK.processCommit(before, after, CommitInfo.EMPTY);
+
+        FilterImpl f = createFilter(indexed, NT_BASE);
+        f.restrictPropertyAsList("foo", java.util.List.of(PropertyValues.newString("x1")));
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider(), true);
+
+        LogCustomizer customLogs = LogCustomizer
+                .forLogger(PropertyIndex.class.getName()).enable(Level.DEBUG).create();
+        try {
+            customLogs.starting();
+
+            // Baseline correctness: under legacy math, bIndex's unique
+            // short-circuit still wins even with a second definition present.
+            assertEquals("bIndex", pIndex.getIndexName(f, indexed));
+            assertEquals(2.0, pIndex.getCost(f, indexed), 0.0);
+
+            assertTrue("Expected bIndex's cost to be logged",
+                    customLogs.getLogs().stream().anyMatch(msg -> msg.contains("bIndex")));
+            assertFalse("aIndex must never be evaluated -- the break must fire "
+                    + "immediately after bIndex hits COST_OVERHEAD under the legacy floor",
+                    customLogs.getLogs().stream().anyMatch(msg -> msg.contains("aIndex")));
+        } finally {
+            customLogs.finished();
+        }
+    }
+
+    /**
+     * getMinimumCost() takes no Filter/NodeState, so it cannot know whether any
+     * definition has overridden costPerExecution below the old hardcoded floor
+     * (OAK-12348) -- 0 is the only value that stays a sound lower bound in every
+     * configuration.
+     */
+    @Test
+    public void getMinimumCostIsZero() {
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider());
+        assertEquals(0.0, pIndex.getMinimumCost(), 0.0);
+    }
+
+    /**
+     * Companion to {@link #getMinimumCostIsZero()}: with the legacy-mode
+     * toggle enabled, getMinimumCost() must reproduce the exact
+     * pre-OAK-12348 value (COST_OVERHEAD), not 0 -- this is the
+     * toggle-fidelity property the toggle exists to guarantee (a toggle
+     * that doesn't restore the old behavior when disabled isn't a real
+     * escape hatch).
+     */
+    @Test
+    public void getMinimumCostIsCostOverheadUnderLegacyMode() {
+        PropertyIndex pIndex = new PropertyIndex(Mounts.defaultMountInfoProvider(), true);
+        assertEquals(PropertyIndexPlan.COST_OVERHEAD, pIndex.getMinimumCost(), 0.0);
+    }
+
     @Test
     public void testPropertyLookup() throws Exception {
         NodeState root = INITIAL_CONTENT;
@@ -421,7 +717,7 @@ public class PropertyIndexTest {
 
     private static FilterImpl createFilter(NodeState root, String nodeTypeName) {
         NodeTypeInfoProvider nodeTypes = new NodeStateNodeTypeInfoProvider(root);
-        NodeTypeInfo type = nodeTypes.getNodeTypeInfo(nodeTypeName);        
+        NodeTypeInfo type = nodeTypes.getNodeTypeInfo(nodeTypeName);
         SelectorImpl selector = new SelectorImpl(type, nodeTypeName);
         return new FilterImpl(selector, "SELECT * FROM [" + nodeTypeName + "]", new QueryEngineSettings());
     }

--- a/oak-doc/src/site/markdown/query/property-index.md
+++ b/oak-doc/src/site/markdown/query/property-index.md
@@ -82,6 +82,13 @@ Optionally you can specify:
   to override the cost estimation (a high key count means a lower cost and
   a low key count means a high cost
   when searching for specific keys; has no effect when searching for "is not null").
+* `costPerEntry` (Double): a multiplier applied to the estimated number of entries
+  when computing the cost (default `1.0`). Same property name and purpose as the
+  `costPerEntry` property already supported by `lucene`/`elastic` index definitions
+  (see [Lucene index](lucene.md)) — lets an admin correct a misestimated cost without
+  changing the query (OAK-12348).
+* `costPerExecution` (Double): a fixed cost added once to the estimate (default `2.0`,
+  the same value as the built-in overhead described below) (OAK-12348).
 * `reindex` (Boolean): if set to `true`, the full content is re-indexed.
   This can take a long time, and is run synchronously with storing the index
   (except with an async index). See "Reindexing" below for details.
@@ -168,9 +175,14 @@ The algorithm to calculate the estimated cost is roughly as follows (a bit simpl
   if the path filtering (`includedPaths` / `excludedPaths`) does not match the query.
 * For the nodetype index, the cost is the sum of the cost for the `jcr:primaryType` lookup
   (if the primary type is known),
-  plus the cost for the `jcr:mixinTypes` lookup (if that is known).
-* Otherwise, the cost is based on the overhead (which is 2), 
-  plus the estimated number of entries.
+  plus the cost for the `jcr:mixinTypes` lookup (if that is known). The nodetype index has
+  no cost logic of its own — set `costPerEntry`/`costPerExecution` (see above) on the
+  property index definitions for `jcr:primaryType` and/or `jcr:mixinTypes` to influence
+  nodetype index cost as well.
+* Otherwise, the cost is based on the overhead (which is 2, or the configured
+  `costPerExecution`),
+  plus the estimated number of entries (scaled by the configured `costPerEntry`,
+  default `1.0`).
 * For an "x is not null" condition, 
   the estimated number of entries is
   either the configured `entryCount` or, if not set, the 
@@ -187,6 +199,11 @@ The algorithm to calculate the estimated cost is roughly as follows (a bit simpl
   the estimated count depending on the approximate number of nodes
   in that subtree versus the approximate number of entries
   in the repository, using approximation available via the `counter` index.
+
+`costPerEntry`/`costPerExecution` are read by default (feature toggle `FT_OAK-12348`,
+enabled out of the box, since with no properties set the formula above is unchanged) —
+disable it only as an escape hatch if the new formula is ever suspected of causing a
+regression; the pre-existing hardcoded formula remains fully intact and reachable.
 
 For example, for a query with path restriction "/content/products/t-shirts" and property restriction
 "color = 'red'", if there is an index for the property "color", then


### PR DESCRIPTION
## What

`PropertyIndex`/`NodeTypeIndex` (`oak-core`) compute query cost purely from
indexed entry counts plus a fixed overhead of 2, with no way to influence
the estimate from the index definition — unlike Lucene/Elastic indexes
(`oak-search`), which already read `costPerEntry`/`costPerExecution`.

In production this let the `nodeType`/property index win a cost comparison
against a more selective, purpose-built index for the same query, because
the built-in entry-count estimate can be significantly wrong at scale (seen
in three related incidents on `rep:User`/`rep:Group` queries against a
tagged `authorizables` Lucene index). The workaround each time was a
manual `costPerEntry`/`costPerExecution` override — but that only exists on
the Lucene/Elastic side.

## How

`PropertyIndexPlan` and `PropertyIndexLookup` each split into:
- `getCostLegacy(...)` — the original hardcoded formula, unconditionally.
- `getCostConfigurable(...)` — `cost = costPerExecution + costPerEntry * entryCount`,
  both optionally set on the property index definition (new `IndexConstants.COST_PER_ENTRY`/
  `COST_PER_EXECUTION`, same property names `oak-search`'s `FulltextIndexConstants`
  already uses for Lucene/Elastic).
- `getCost(...)` — dispatches between the two based on `FT_OAK-12348`
  (`PropertyIndexLookup.FT_OAK_12348_ENABLE`), **enabled by default**: with
  no properties set, `getCostConfigurable()` reproduces `getCostLegacy()`
  exactly, so this is behavior-preserving for every existing index
  definition — the toggle is an escape hatch, not an opt-in gate.

`NodeTypeIndex` needs no code changes at all — its cost is the sum of two
`PropertyIndexLookup.getCost()` calls (`jcr:primaryType`, `jcr:mixinTypes`),
so it picks up the override transitively (covered by a dedicated test).

`IndexUtils` gains a small `getOptionalValue(NodeState, String, double)`
helper (mirrors `oak-search`'s `IndexDefinition.getOptionalValue`, which
`oak-core` can't depend on directly) instead of duplicating the same
property read in both classes.

Out of scope: `resultCacheSize` (mentioned in the originating request) is a
Lucene/Elastic query-result caching concept with no equivalent in
`PropertyIndex`'s `ContentMirrorStoreStrategy`-based lookup.

## Testing

New/updated tests in `PropertyIndexTest`, `PropertyIndexLookupTest` (unchanged,
still green), and `NodeTypeIndexTest` cover: default behavior unchanged
regardless of toggle position, override taking effect by default, the
toggle correctly falling back to the legacy formula when disabled, the
`costPerEntry=0` infinity-guard (must not become `NaN`), the unique-index
short-circuit surviving an override, and `NodeTypeIndex` picking up the
override with zero code changes in its own package.

Full `oak-core` suite: 4779 tests, 0 failures.