### PR TITLE
OAK-12365: Delete stale index document when a node's last aggregated property is removed

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexProviderService.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexProviderService.java
@@ -390,6 +390,9 @@ public class LuceneIndexProviderService {
         oakRegs.add(whiteboard.register(FeatureToggle.class,
                 new FeatureToggle(LuceneDocumentMaker.FT_OAK_12372, LuceneDocumentMaker.FT_OAK_12372_DISABLE),
                 emptyMap()));
+        oakRegs.add(whiteboard.register(FeatureToggle.class,
+                new FeatureToggle(FulltextIndexEditor.FT_OAK_12365, FulltextIndexEditor.FT_OAK_12365_DISABLE),
+                emptyMap()));
         initializeIndexDir(bundleContext, config);
         initializeExtractedTextCache(bundleContext, config, statisticsProvider);
         tracker = createTracker(bundleContext, config);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditor2Test.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexEditor2Test.java
@@ -69,11 +69,13 @@ public class LuceneIndexEditor2Test {
     @Before
     public void resetToggles() {
         FulltextIndexEditor.FT_OAK_12244_DISABLE.set(false);
+        FulltextIndexEditor.FT_OAK_12365_DISABLE.set(false);
     }
 
     @After
     public void restoreToggles() {
         FulltextIndexEditor.FT_OAK_12244_DISABLE.set(false);
+        FulltextIndexEditor.FT_OAK_12365_DISABLE.set(false);
     }
 
     private final NodeState root = INITIAL_CONTENT;
@@ -306,6 +308,120 @@ public class LuceneIndexEditor2Test {
         builder.child("a").removeProperty(JcrConstants.JCR_MIXINTYPES);
         hook.processCommit(before, builder.getNodeState(), CommitInfo.EMPTY);
         assertFalse("Mixin tracking disabled: removing mixin should not trigger deleteDocument", writer.deletedPaths.contains("/a"));
+    }
+
+    @Test
+    public void nodeLosesLastAggregatedPropertyTriggersDocumentDeletion() throws Exception {
+        // OAK-12365: root's rule/type is unchanged; only the aggregated child content disappears.
+        LuceneIndexDefinitionBuilder defnb = new LuceneIndexDefinitionBuilder();
+        defnb.indexRule("nt:base").property("jcr:content/status").propertyIndex();
+        defnb.aggregateRule("nt:base").include("*");
+
+        NodeState defnState = defnb.build();
+        IndexDefinition defn = new IndexDefinition(root, defnState, indexPath);
+        LuceneIndexEditorContext ctx = newContext(defnState.builder(), defn, true);
+        EditorHook hook = createHook(ctx);
+
+        updateBefore(defnb);
+
+        // Commit 1: aggregated child property present — root must be indexed
+        NodeBuilder builder = before.builder();
+        builder.child("a").child("jcr:content").setProperty("status", "published");
+        before = hook.processCommit(root, builder.getNodeState(), CommitInfo.EMPTY);
+        assertTrue("Root with aggregated property should be indexed", writer.docs.containsKey("/a"));
+
+        // Commit 2: last aggregated property removed, root's own rule/type unchanged —
+        // stale root document must be deleted
+        builder = before.builder();
+        builder.child("a").child("jcr:content").removeProperty("status");
+        hook.processCommit(before, builder.getNodeState(), CommitInfo.EMPTY);
+        assertTrue("Removing the last aggregated property should trigger deleteDocument for the root",
+                writer.deletedPaths.contains("/a"));
+    }
+
+    @Test
+    public void nodeLosesLastAggregatedPropertyTriggersDocumentDeletionWhenMixinToggleDisabled() throws Exception {
+        // Fix lives in addOrUpdate(), so it also covers the legacy (FT_OAK_12244 disabled) path.
+        FulltextIndexEditor.FT_OAK_12244_DISABLE.set(true);
+
+        LuceneIndexDefinitionBuilder defnb = new LuceneIndexDefinitionBuilder();
+        defnb.indexRule("nt:base").property("jcr:content/status").propertyIndex();
+        defnb.aggregateRule("nt:base").include("*");
+
+        NodeState defnState = defnb.build();
+        IndexDefinition defn = new IndexDefinition(root, defnState, indexPath);
+        LuceneIndexEditorContext ctx = newContext(defnState.builder(), defn, true);
+        EditorHook hook = createHook(ctx);
+
+        updateBefore(defnb);
+
+        // Commit 1: aggregated child property present — root must be indexed
+        NodeBuilder builder = before.builder();
+        builder.child("a").child("jcr:content").setProperty("status", "published");
+        before = hook.processCommit(root, builder.getNodeState(), CommitInfo.EMPTY);
+        assertTrue("Root with aggregated property should be indexed", writer.docs.containsKey("/a"));
+
+        // Commit 2: last aggregated property removed — stale root document must still be
+        // deleted even with mixin-transition tracking disabled
+        builder = before.builder();
+        builder.child("a").child("jcr:content").removeProperty("status");
+        hook.processCommit(before, builder.getNodeState(), CommitInfo.EMPTY);
+        assertTrue("Removing the last aggregated property should trigger deleteDocument regardless of FT_OAK_12244",
+                writer.deletedPaths.contains("/a"));
+    }
+
+    @Test
+    public void nodeLosesLastAggregatedPropertyDoesNotTriggerDeletionWhenOak12365ToggleDisabled() throws Exception {
+        FulltextIndexEditor.FT_OAK_12365_DISABLE.set(true);
+
+        LuceneIndexDefinitionBuilder defnb = new LuceneIndexDefinitionBuilder();
+        defnb.indexRule("nt:base").property("jcr:content/status").propertyIndex();
+        defnb.aggregateRule("nt:base").include("*");
+
+        NodeState defnState = defnb.build();
+        IndexDefinition defn = new IndexDefinition(root, defnState, indexPath);
+        LuceneIndexEditorContext ctx = newContext(defnState.builder(), defn, true);
+        EditorHook hook = createHook(ctx);
+
+        updateBefore(defnb);
+
+        NodeBuilder builder = before.builder();
+        builder.child("a").child("jcr:content").setProperty("status", "published");
+        before = hook.processCommit(root, builder.getNodeState(), CommitInfo.EMPTY);
+        assertTrue("Root with aggregated property should be indexed", writer.docs.containsKey("/a"));
+
+        builder = before.builder();
+        builder.child("a").child("jcr:content").removeProperty("status");
+        hook.processCommit(before, builder.getNodeState(), CommitInfo.EMPTY);
+        assertFalse("OAK-12365 disabled: removing the last aggregated property should not trigger deleteDocument",
+                writer.deletedPaths.contains("/a"));
+    }
+
+    @Test
+    public void nodeKeepsOneOfMultipleAggregatedPropertiesDoesNotTriggerDeletion() throws Exception {
+        LuceneIndexDefinitionBuilder defnb = new LuceneIndexDefinitionBuilder();
+        defnb.indexRule("nt:base").property("jcr:content/status").propertyIndex();
+        defnb.indexRule("nt:base").property("jcr:content/type").propertyIndex();
+        defnb.aggregateRule("nt:base").include("*");
+
+        NodeState defnState = defnb.build();
+        IndexDefinition defn = new IndexDefinition(root, defnState, indexPath);
+        LuceneIndexEditorContext ctx = newContext(defnState.builder(), defn, true);
+        EditorHook hook = createHook(ctx);
+
+        updateBefore(defnb);
+
+        NodeBuilder builder = before.builder();
+        builder.child("a").child("jcr:content").setProperty("status", "published");
+        builder.child("a").child("jcr:content").setProperty("type", "page");
+        before = hook.processCommit(root, builder.getNodeState(), CommitInfo.EMPTY);
+        assertTrue("Root with aggregated properties should be indexed", writer.docs.containsKey("/a"));
+
+        builder = before.builder();
+        builder.child("a").child("jcr:content").removeProperty("status");
+        hook.processCommit(before, builder.getNodeState(), CommitInfo.EMPTY);
+        assertFalse("Removing one of several aggregated properties should not delete the root document",
+                writer.deletedPaths.contains("/a"));
     }
 
     private void updateBefore(LuceneIndexDefinitionBuilder defnb) {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -234,6 +234,9 @@ public class ElasticIndexProviderService {
                 new FeatureToggle(FulltextIndexEditor.FT_OAK_12244, FulltextIndexEditor.FT_OAK_12244_DISABLE),
                 emptyMap()));
         oakRegs.add(whiteboard.register(FeatureToggle.class,
+                new FeatureToggle(FulltextIndexEditor.FT_OAK_12365, FulltextIndexEditor.FT_OAK_12365_DISABLE),
+                emptyMap()));
+        oakRegs.add(whiteboard.register(FeatureToggle.class,
                 new FeatureToggle(ElasticIndexStatistics.FT_OAK_12248, ElasticIndexStatistics.FT_OAK_12248_ENABLE),
                 emptyMap()));
         oakRegs.add(whiteboard.register(FeatureToggle.class,

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/editor/FulltextIndexEditor.java
@@ -89,6 +89,22 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
      */
     public static final AtomicBoolean FT_OAK_12244_DISABLE = new AtomicBoolean(false);
 
+    /**
+     * Feature toggle name for OAK-12365.
+     * When active (default), a node whose last indexed property is removed (rule/type
+     * unchanged) has its stale index document deleted, instead of being silently left
+     * behind because {@code makeDocument()} now returns {@code null}.
+     */
+    public static final String FT_OAK_12365 = "FT_OAK-12365";
+
+    /**
+     * Kill switch for the OAK-12365 stale-document deletion. Set to {@code true} to
+     * revert to the pre-OAK-12365 behavior where a node losing its last indexed property
+     * leaves its previous document in the index. Default is {@code false} (deletion
+     * active). Wired to the {@link #FT_OAK_12365} feature toggle at runtime.
+     */
+    public static final AtomicBoolean FT_OAK_12365_DISABLE = new AtomicBoolean(false);
+
     private static final List<Aggregate.Matcher> EMPTY_AGGREGATE_MATCHER_LIST = List.of();
 
     private final FulltextIndexEditorContext<D> context;
@@ -376,6 +392,11 @@ public class FulltextIndexEditor<D> implements IndexEditor, Aggregate.AggregateR
                 context.indexUpdate();
                 context.getWriter().updateDocument(path, d);
                 return true;
+            } else if (isUpdate && !FT_OAK_12365_DISABLE.get()) {
+                // OAK-12365: node still matches the rule but has no content left to index.
+                log.debug("[{}] Deleting stale document for {}", getIndexName(), path);
+                context.indexUpdate();
+                context.getWriter().deleteDocument(path);
             }
         } catch (IOException e) {
             log.warn("Failed to index the node [{}] due to {}", path, e.toString());

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/PropertyIndexCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/PropertyIndexCommonTest.java
@@ -569,6 +569,33 @@ public abstract class PropertyIndexCommonTest extends AbstractQueryTest {
     }
 
     @Test
+    public void nodeLosesLastAggregatedPropertyDisappearsFromFulltextIndex() throws Exception {
+        // OAK-12365: root's rule/type is unchanged; only the aggregated child content
+        // disappears. CONTAINS() is required here since equality queries are revalidated
+        // against the live tree and wouldn't surface a stale document.
+        IndexDefinitionBuilder builder = indexOptions.createIndexDefinitionBuilder();
+        builder.noAsync(); // wildcard aggregateRule never converges on the async lane in time
+        builder.indexRule("nt:base").property("jcr:content/status").propertyIndex();
+        builder.aggregateRule("nt:base").include("*");
+        indexOptions.setIndex(root, "test1", builder);
+        root.commit();
+
+        Tree test = root.getTree("/").addChild("test");
+        test.addChild("a").addChild("jcr:content").setProperty("status", "published");
+        root.commit();
+
+        // ISCHILDNODE('/test'): the wildcard aggregate also propagates the fulltext
+        // content up to "/test" itself, so scope the query to exclude that ancestor.
+        String query = "select [jcr:path] from [nt:base] where ISCHILDNODE('/test') and CONTAINS(*, 'published')";
+        assertEventually(() -> assertQuery(query, List.of("/test/a")));
+
+        root.getTree("/test/a/jcr:content").removeProperty("status");
+        root.commit();
+
+        assertEventually(() -> assertQuery(query, List.of()));
+    }
+
+    @Test
     public void parentLosesMixinDoesNotCascadeDeleteChildWithSameMixin() throws Exception {
         indexOptions.setIndex(
                 root,


### PR DESCRIPTION
## Summary

`FulltextIndexEditor.addOrUpdate()` calls `makeDocument()` on every commit touching a node. When the node's indexing rule still matches but its last indexable content came from a relative/aggregated property that was just removed, `makeDocument()` returns `null` (nothing to index) and `addOrUpdate()` previously did nothing further — leaving the stale document in the index indefinitely.

A direct (non-relative) property removal on the same node was already handled correctly: `FulltextDocumentMaker.removeProperties()` forces `dirty=true` in that case, so a rebuilt document is written instead of `null`. The gap is specifically the aggregated-content case, where the root node's own `propertiesModified` list stays empty.

**Fix:** in `addOrUpdate()`, when `makeDocument()` returns `null` on an update to a previously-existing node, delete the stale document. Guarded by feature toggle `FT_OAK-12365` (enabled by default), following this codebase's convention for bug-fix toggles.

Covers both the OAK-12244 type-tracking-enabled path and the legacy (toggle-disabled) path, since both funnel through `addOrUpdate()`.

Related but distinct from OAK-12244 (mixin add/remove *rule* transitions): this is a *content* transition — the rule still matches throughout, but the document's content disappeared.

## Test plan

- [x] `LuceneIndexEditor2Test#nodeLosesLastAggregatedPropertyTriggersDocumentDeletion` — unit test verifying `deleteDocument()` is called (new, RED→GREEN)
- [x] `LuceneIndexEditor2Test#nodeLosesLastAggregatedPropertyTriggersDocumentDeletionWhenMixinToggleDisabled` — same, with `FT_OAK_12244` disabled to confirm the legacy path is also covered
- [x] `PropertyIndexCommonTest#nodeLosesLastAggregatedPropertyDisappearsFromFulltextIndex` — integration test using a fulltext `CONTAINS()` query (a plain equality query can't observe this bug, since Oak's query engine revalidates simple `WHERE` conditions against the live tree)
- [x] Full `oak-search` + `oak-lucene` suites: 1250 tests, 0 failures, 0 errors