### PR TITLE
OAK-12360: Support per-property analyzers in Lucene index definitions

### DIFF
--- a/oak-doc/src/site/markdown/query/elastic.md
+++ b/oak-doc/src/site/markdown/query/elastic.md
@@ -77,6 +77,28 @@ To use these values exclusively for influencing relevance without affecting matc
   can be changed by `suggestUpdateFrequencyMinutes` property in suggestion node under the index definition node.
   In Elastic indexes, there is no such delay and thus no need for the above config property. This is an improvement in ES over lucene.
 
+### Per-Property Analyzer Support
+
+`@since Oak 2.5, [OAK-12360]`
+
+Elasticsearch supports per-property analyzer configuration, allowing different properties to use different analyzers within the same index.
+This feature works identically to the Lucene equivalent for syntax and backward compatibility: set the `analyzer` attribute on a property definition node to specify a custom analyzer.
+For detailed configuration syntax and examples, see the [Lucene per-property analyzer documentation][lucene-per-property-analyzer].
+
+**Known Limitations**
+
+1. **Regular-expression properties:** Per-property analyzers are not supported for properties with `isRegexp = true`.
+   The default analyzer is used with a logged warning, and indexing proceeds normally.
+
+**Aggregated Fulltext Field Behavior**
+
+Unlike Lucene, where the aggregated `:fulltext` field always uses the default analyzer regardless of per-property settings, Elasticsearch supports more nuanced behavior.
+When a property is the sole analyzed `nodeScopeIndex` contributor (the only property with a custom analyzer; other properties, if any, use the default),
+that property's custom analyzer applies to aggregated fulltext queries (`jcr:contains(., ...)`) as well as property-specific queries.
+This is intentional and desirable: the query term is analyzed the same way the content was indexed, providing more accurate fulltext results.
+When multiple properties contribute to the aggregate field, standard ranking and term matching apply.
+
 [lucene]: https://jackrabbit.apache.org/oak/docs/query/lucene.html
+[lucene-per-property-analyzer]: https://jackrabbit.apache.org/oak/docs/query/lucene.html#per-property-analyzer
 [options]: https://www.elastic.co/guide/en/elasticsearch/reference/current/configure-text-analysis.html
 [flattened]: https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/flattened#supported-operations

--- a/oak-doc/src/site/markdown/query/lucene.md
+++ b/oak-doc/src/site/markdown/query/lucene.md
@@ -29,6 +29,7 @@
     * [Analyzers](#analyzers)
         * [Specify analyzer class directly](#analyzer-classes)
         * [Create analyzer via composition](#analyzer-composition)
+        * [Per-Property Analyzer](#per-property-analyzer)
     * [Codec](#codec)
     * [Boost and Search Relevancy](#boost)
     * [Effective Index Definition](#stored-index-definition)
@@ -899,6 +900,57 @@ all the other components (e.g. `charFilters`, `Synonym`) are optional.
             - synonyms = "synonym.txt"
             + synonym.txt (nt:file)
 ```
+
+##### <a name="per-property-analyzer"></a>Per-Property Analyzer
+
+`@since Oak 2.5, [OAK-12360]`
+
+In addition to configuring a single analyzer per index (via the `analyzers/default` or other sibling nodes),
+you can optionally specify a custom analyzer for individual properties. This allows different properties
+to be analyzed differently within the same index.
+
+To specify a custom analyzer for a property, set the `analyzer` attribute on the property definition node:
+
+```
+    + indexRules
+      - jcr:primaryType = "nt:unstructured"
+      + app:Asset
+        + properties
+          - jcr:primaryType = "nt:unstructured"
+          + title
+            - analyzed = true
+            - analyzer = "titleAnalyzer"
+          + description
+            - analyzed = true
+            - analyzer = "descriptionAnalyzer"
+    + analyzers
+      + default
+        - class = "org.apache.lucene.analysis.standard.StandardAnalyzer"
+      + titleAnalyzer
+        - class = "org.apache.lucene.analysis.en.EnglishAnalyzer"
+      + descriptionAnalyzer
+        + tokenizer
+          - name = "Standard"
+        + filters (nt:unstructured)
+          + LowerCase
+```
+
+The `analyzer` property value is a string that refers to a sibling analyzer node under the `analyzers` node.
+This feature is optional and fully backward compatible: properties that do not specify the `analyzer` attribute
+are unaffected and continue to use the index-wide default analyzer.
+
+**Known Limitations**
+
+1. **Aggregated fulltext field:** The aggregated `:fulltext` field used by cross-property fulltext queries
+   (e.g., `CONTAINS(*, 'text')`) always uses the single default analyzer from `analyzers/default`.
+   Per-property analyzers apply only to each property's own dedicated field. 
+   If a property defines a custom analyzer, it affects only queries on that specific property
+   (e.g., `CONTAINS(@title, 'text')`), not the aggregate fulltext search.
+
+2. **Regular-expression properties:** Per-property analyzers are not supported for regular-expression property definitions
+   (properties with `isRegexp = true`). When a regexp property rule matches multiple concrete property names across nodes,
+   there is no single fixed field to attach a custom analyzer to. In this case, the default analyzer is used
+   with a logged warning, and indexing proceeds normally.
 
 #### Examples
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinition.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinition.java
@@ -29,6 +29,7 @@ import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexFormatVersion;
+import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
 import org.apache.jackrabbit.oak.spi.state.ChildNodeEntry;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.lucene.analysis.Analyzer;
@@ -141,19 +142,71 @@ public class LuceneIndexDefinition extends IndexDefinition {
         if (analyzers.containsKey(ANL_DEFAULT)){
             defaultAnalyzer = analyzers.get(ANL_DEFAULT);
         }
-        if (!evaluatePathRestrictions()){
-            result = defaultAnalyzer;
-        } else {
-            Map<String, Analyzer> analyzerMap = Map.of(
-                    FieldNames.ANCESTORS, new TokenizerChain(new PathHierarchyTokenizerFactory(Collections.emptyMap())));
-            result = new PerFieldAnalyzerWrapper(defaultAnalyzer, analyzerMap);
+
+        Map<String, Analyzer> perFieldAnalyzers = new HashMap<>();
+        if (evaluatePathRestrictions()) {
+            perFieldAnalyzers.put(FieldNames.ANCESTORS,
+                    new TokenizerChain(new PathHierarchyTokenizerFactory(Collections.emptyMap())));
         }
+        perFieldAnalyzers.putAll(collectPerPropertyAnalyzers());
+
+        result = perFieldAnalyzers.isEmpty()
+                ? defaultAnalyzer
+                : new PerFieldAnalyzerWrapper(defaultAnalyzer, perFieldAnalyzers);
 
         //In case of negative value no limits would be applied
         if (maxFieldLength < 0){
             return result;
         }
         return new LimitTokenCountAnalyzer(result, maxFieldLength);
+    }
+
+    /**
+     * Per-property analyzer overrides ({@code indexRules/.../properties/<name>/analyzer}).
+     * A reference that doesn't resolve to a node under {@code analyzers/}, or a
+     * regular-expression property definition (which matches a different concrete
+     * property name per node, so has no single fixed field name to key on), falls
+     * back to the default analyzer for that property with a warning - it never
+     * fails the whole index definition.
+     */
+    private Map<String, Analyzer> collectPerPropertyAnalyzers() {
+        Map<String, Analyzer> result = new HashMap<>();
+        for (IndexingRule rule : getDefinedRules()) {
+            // Process regular properties. Regexp properties never appear here - they're
+            // stored in a separate list (namePatterns) - so they're handled below instead.
+            for (PropertyDefinition pd : rule.getProperties()) {
+                if (!pd.analyzed || pd.analyzerName == null) {
+                    continue;
+                }
+                Analyzer propAnalyzer = analyzers.get(pd.analyzerName);
+                if (propAnalyzer == null) {
+                    log.warn("Property [{}] in index rule [{}] references unknown analyzer [{}] - " +
+                            "falling back to the default analyzer. Index at {}",
+                            pd.name, rule.getNodeTypeName(), pd.analyzerName, getIndexPath());
+                    continue;
+                }
+                result.put(constructAnalyzedPropertyName(pd.name), propAnalyzer);
+            }
+
+            // Process regexp properties from namePatterns: warn if any declare an analyzer,
+            // since there's no fixed field name to bind the analyzer to
+            rule.getNamePatternsProperties().forEach(pd -> {
+                if (pd.analyzed && pd.analyzerName != null) {
+                    log.warn("Property [{}] in index rule [{}] declares analyzer [{}] but is a " +
+                            "regular-expression property definition, which is not supported for " +
+                            "per-property analyzers - falling back to the default analyzer. Index at {}",
+                            pd.name, rule.getNodeTypeName(), pd.analyzerName, getIndexPath());
+                }
+            });
+        }
+        return result;
+    }
+
+    private String constructAnalyzedPropertyName(String pname) {
+        if (getVersion().isAtLeast(IndexFormatVersion.V2)) {
+            return FieldNames.createAnalyzedFieldName(pname);
+        }
+        return pname;
     }
 
     private static Map<String, Analyzer> collectAnalyzers(NodeState defn) {

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneFullTextAnalyzerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneFullTextAnalyzerTest.java
@@ -17,9 +17,11 @@
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
 import org.apache.jackrabbit.oak.api.ContentRepository;
+import org.apache.jackrabbit.oak.api.Tree;
 import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.FullTextAnalyzerCommonTest;
 import org.apache.jackrabbit.oak.plugins.index.LuceneIndexOptions;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -80,5 +82,65 @@ public class LuceneFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
     @Ignore("Shingle does not seem to work well in lucene")
     public void fulltextSearchWithShingle() throws Exception {
         super.fulltextSearchWithShingle();
+    }
+
+    // OAK-12360: a property's own analyzer reference must apply at real index/query
+    // time (not just to the in-memory Analyzer object), while a sibling property
+    // without one keeps using the index's default analyzer.
+    @Test
+    public void perPropertyAnalyzerAppliesOnlyToDeclaredProperty() throws Exception {
+        Tree index = setup(List.of("title", "body"), idx -> {
+            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild("titleAnalyzer");
+            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+            idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                    .getChild(FulltextIndexConstants.PROP_NODE).getChild("title")
+                    .setProperty(FulltextIndexConstants.PROP_ANALYZER, "titleAnalyzer");
+        });
+
+        Tree content = root.getTree("/").addChild("content");
+        Tree a = content.addChild("a");
+        a.setProperty("title", "Hello World");
+        a.setProperty("body", "Hello World");
+        root.commit();
+
+        assertEventually(() -> {
+            // "title" uses the whitespace tokenizer (no lower-casing): case-sensitive match.
+            assertQuery("//*[jcr:contains(@title, 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@title, 'hello')]", XPATH, List.of());
+            // "body" keeps the index's default (lower-casing) analyzer: case-insensitive match.
+            assertQuery("//*[jcr:contains(@body, 'hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@body, 'Hello')]", XPATH, List.of("/content/a"));
+        });
+    }
+
+    // OAK-12360: the aggregated :fulltext field (jcr:contains(., ...)) is a known
+    // limitation - it always uses the index's default analyzer, even for a property
+    // that declares its own. Locks in the real end-to-end behavior, not just the
+    // in-memory Analyzer map construction.
+    @Test
+    public void perPropertyAnalyzerDoesNotApplyToAggregatedFulltextField() throws Exception {
+        setup(List.of("title"), idx -> {
+            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild("titleAnalyzer");
+            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+            idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                    .getChild(FulltextIndexConstants.PROP_NODE).getChild("title")
+                    .setProperty(FulltextIndexConstants.PROP_ANALYZER, "titleAnalyzer");
+        });
+
+        Tree content = root.getTree("/").addChild("content");
+        content.addChild("a").setProperty("title", "Hello World");
+        root.commit();
+
+        assertEventually(() -> {
+            // Property-specific field: custom analyzer, case-sensitive.
+            assertQuery("//*[jcr:contains(@title, 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@title, 'hello')]", XPATH, List.of());
+            // Aggregated :fulltext field: always the default analyzer, case-insensitive,
+            // regardless of "title"'s own override.
+            assertQuery("//*[jcr:contains(., 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(., 'hello')]", XPATH, List.of("/content/a"));
+        });
     }
 }

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinitionTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexDefinitionTest.java
@@ -18,19 +18,26 @@
  */
 package org.apache.jackrabbit.oak.plugins.index.lucene;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import javax.jcr.PropertyType;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.oak.api.Type;
+import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexDefinitionBuilder;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.TokenizerChain;
 import org.apache.jackrabbit.oak.plugins.index.lucene.writer.CommitMitigatingTieredMergePolicy;
 import org.apache.jackrabbit.oak.plugins.index.search.Aggregate;
+import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.IndexingRule;
@@ -44,6 +51,7 @@ import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.junit.Test;
+import org.slf4j.event.Level;
 
 import static javax.jcr.PropertyType.TYPENAME_LONG;
 import static javax.jcr.PropertyType.TYPENAME_STRING;
@@ -607,6 +615,151 @@ public class LuceneIndexDefinitionTest {
                 .setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
         LuceneIndexDefinition defn = new LuceneIndexDefinition(root, defnb.getNodeState(), "/foo");
         assertEquals(TokenizerChain.class.getName(), defn.getAnalyzer().getClass().getName());
+    }
+
+    @Test
+    public void perFieldAnalyzerAppliesToDeclaredProperty() throws Exception {
+        NodeBuilder defnb = newLuceneIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
+                "lucene", Set.of(TYPENAME_STRING));
+
+        //Set this to -1 to avoid wrapping by LimitAnalyzer
+        defnb.setProperty(FulltextIndexConstants.MAX_FIELD_LENGTH, -1);
+
+        //Custom analyzer: whitespace tokenizer only, no lowercasing (unlike the
+        //default OakAnalyzer) - same technique the existing customAnalyzer test uses.
+        defnb.child(ANALYZERS).child("frenchText")
+                .child(FulltextIndexConstants.ANL_TOKENIZER)
+                .setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+        NodeBuilder rules = defnb.child(INDEX_RULES);
+        TestUtil.child(rules, "nt:base/properties/title")
+                .setProperty(PROP_NAME, "title")
+                .setProperty(FulltextIndexConstants.PROP_ANALYZED, true)
+                .setProperty(FulltextIndexConstants.PROP_ANALYZER, "frenchText");
+        TestUtil.child(rules, "nt:base/properties/body")
+                .setProperty(PROP_NAME, "body")
+                .setProperty(FulltextIndexConstants.PROP_ANALYZED, true);
+
+        LuceneIndexDefinition defn = new LuceneIndexDefinition(root, defnb.getNodeState(), "/foo");
+        Analyzer analyzer = defn.getAnalyzer();
+
+        assertEquals("Custom analyzer for 'title' must not lower-case",
+                "Hello", firstToken(analyzer, "full:title", "Hello World"));
+        assertEquals("Property 'body' without an analyzer override keeps the default (lower-cased) analyzer",
+                "hello", firstToken(analyzer, "full:body", "Hello World"));
+    }
+
+    @Test
+    public void danglingAnalyzerReferenceFallsBackToDefaultWithWarning() throws Exception {
+        NodeBuilder defnb = newLuceneIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
+                "lucene", Set.of(TYPENAME_STRING));
+
+        //Set this to -1 to avoid wrapping by LimitAnalyzer
+        defnb.setProperty(FulltextIndexConstants.MAX_FIELD_LENGTH, -1);
+
+        NodeBuilder rules = defnb.child(INDEX_RULES);
+        TestUtil.child(rules, "nt:base/properties/title")
+                .setProperty(PROP_NAME, "title")
+                .setProperty(FulltextIndexConstants.PROP_ANALYZED, true)
+                .setProperty(FulltextIndexConstants.PROP_ANALYZER, "doesNotExist");
+
+        LogCustomizer customLogs = LogCustomizer.forLogger(LuceneIndexDefinition.class)
+                .enable(Level.WARN).create();
+        customLogs.starting();
+
+        LuceneIndexDefinition defn = new LuceneIndexDefinition(root, defnb.getNodeState(), "/foo");
+
+        List<String> logs = customLogs.getLogs();
+
+        //Verify that the property falls back to using the default analyzer (lowercase "hello")
+        //when the referenced analyzer does not exist.
+        assertEquals("Falls back to default analyzer when reference is dangling",
+                "hello", firstToken(defn.getAnalyzer(), "full:title", "Hello World"));
+
+        //Verify that a warning was logged about the unresolved analyzer reference
+        assertTrue("Expected a warning about the unresolved analyzer reference. Captured logs: " + logs,
+                logs.stream().anyMatch(m -> m.contains("doesNotExist")));
+    }
+
+    @Test
+    public void regexpPropertyWithAnalyzerFallsBackToDefaultWithWarning() throws Exception {
+        NodeBuilder defnb = newLuceneIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
+                "lucene", Set.of(TYPENAME_STRING));
+
+        //Set this to -1 to avoid wrapping by LimitAnalyzer
+        defnb.setProperty(FulltextIndexConstants.MAX_FIELD_LENGTH, -1);
+
+        NodeBuilder rules = defnb.child(INDEX_RULES);
+        TestUtil.child(rules, "nt:base/properties/allStrings")
+                .setProperty(PROP_NAME, ".*")
+                .setProperty(FulltextIndexConstants.PROP_IS_REGEX, true)
+                .setProperty(FulltextIndexConstants.PROP_ANALYZED, true)
+                .setProperty(FulltextIndexConstants.PROP_ANALYZER, "frenchText");
+        defnb.child(ANALYZERS).child("frenchText")
+                .child(FulltextIndexConstants.ANL_TOKENIZER)
+                .setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+        LogCustomizer customLogs = LogCustomizer.forLogger(LuceneIndexDefinition.class)
+                .enable(Level.WARN).create();
+        customLogs.starting();
+
+        LuceneIndexDefinition defn = new LuceneIndexDefinition(root, defnb.getNodeState(), "/foo");
+        Analyzer analyzer = defn.getAnalyzer();
+
+        //Verify that the property falls back to using the default analyzer (lowercase "hello")
+        //when regexp properties can't be statically bound to per-field analyzer entries
+        assertEquals("Falls back to default analyzer for regexp property",
+                "hello", firstToken(analyzer, "full:whatever", "Hello World"));
+
+        List<String> logs = customLogs.getLogs();
+
+        //Verify that a warning was logged about regexp properties not supporting per-field analyzers
+        assertTrue("Expected a warning about regexp properties not supporting per-field analyzers. Captured logs: " + logs,
+                logs.stream().anyMatch(m -> m.contains("regular-expression")));
+    }
+
+    @Test
+    public void fulltextAggregateFieldAlwaysUsesDefaultAnalyzer() throws Exception {
+        NodeBuilder defnb = newLuceneIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
+                "lucene", Set.of(TYPENAME_STRING));
+
+        //Set this to -1 to avoid wrapping by LimitAnalyzer
+        defnb.setProperty(FulltextIndexConstants.MAX_FIELD_LENGTH, -1);
+
+        //Custom analyzer: whitespace tokenizer only, no lowercasing (unlike the
+        //default OakAnalyzer)
+        defnb.child(ANALYZERS).child("frenchText")
+                .child(FulltextIndexConstants.ANL_TOKENIZER)
+                .setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+        NodeBuilder rules = defnb.child(INDEX_RULES);
+        TestUtil.child(rules, "nt:base/properties/title")
+                .setProperty(PROP_NAME, "title")
+                .setProperty(FulltextIndexConstants.PROP_ANALYZED, true)
+                .setProperty(FulltextIndexConstants.PROP_NODE_SCOPE_INDEX, true)
+                .setProperty(FulltextIndexConstants.PROP_ANALYZER, "frenchText");
+
+        LuceneIndexDefinition defn = new LuceneIndexDefinition(root, defnb.getNodeState(), "/foo");
+        Analyzer analyzer = defn.getAnalyzer();
+
+        //The property-specific field should use the custom frenchText analyzer (no lowercasing)
+        assertEquals("Custom analyzer for 'title' property field must not lower-case",
+                "Hello", firstToken(analyzer, "full:title", "Hello World"));
+
+        //The aggregate :fulltext field (used by CONTAINS(*, ...)) must always use the default
+        //analyzer, regardless of any per-property analyzer overrides. This is a locking test
+        //for a critical guarantee that should remain unchanged even if aggregation logic evolves.
+        assertEquals("Aggregate :fulltext field must always use default analyzer",
+                "hello", firstToken(analyzer, FieldNames.FULLTEXT, "Hello World"));
+    }
+
+    private static String firstToken(Analyzer analyzer, String field, String text) throws IOException {
+        try (TokenStream ts = analyzer.tokenStream(field, text)) {
+            CharTermAttribute term = ts.addAttribute(CharTermAttribute.class);
+            ts.reset();
+            assertTrue(ts.incrementToken());
+            return term.toString();
+        }
     }
 
     @Test

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzer.java
@@ -96,62 +96,80 @@ public class ElasticCustomAnalyzer {
     @Nullable
     public static IndexSettingsAnalysis.Builder buildCustomAnalyzers(NodeState state, String analyzerName) {
         if (state != null) {
-            NodeState defaultAnalyzer = state.getChildNode(FulltextIndexConstants.ANL_DEFAULT);
-            if (defaultAnalyzer.exists()) {
-                IndexSettingsAnalysis.Builder builder = new IndexSettingsAnalysis.Builder();
-                Map<String, Object> analyzer;
-                try {
-                    analyzer = convertNodeState(defaultAnalyzer);
-                } catch (IOException e) {
-                    LOG.warn("Can not load analyzer; using an empty configuration", e);
-                    analyzer = Map.of();
+            IndexSettingsAnalysis.Builder builder = null;
+            for (ChildNodeEntry cne : state.getChildNodeEntries()) {
+                if (builder == null) {
+                    builder = new IndexSettingsAnalysis.Builder();
                 }
-                String builtIn = defaultAnalyzer.getString(FulltextIndexConstants.ANL_CLASS);
-                if (builtIn == null) {
-                    builtIn = defaultAnalyzer.getString(FulltextIndexConstants.ANL_NAME);
-                }
-                if (builtIn != null) {
-                    analyzer.put(ANALYZER_TYPE, normalize(builtIn));
-
-                    // content params, usually stop words
-                    for (ChildNodeEntry nodeEntry : defaultAnalyzer.getChildNodeEntries()) {
-                        List<String> list;
-                        try {
-                            list = loadContent(nodeEntry.getNodeState(), nodeEntry.getName(), NOOP_TRANSFORMATION);
-                        } catch (IOException e) {
-                            LOG.warn("Unable to load analyzer content for entry '" + nodeEntry.getName() + "'; using empty list", e);
-                            list = List.of();
-                        }
-                        analyzer.put(normalize(nodeEntry.getName()), list);
-                    }
-
-                    builder.analyzer(analyzerName, new Analyzer(null, JsonData.of(analyzer)));
-                } else { // try to compose the analyzer
-                    builder.tokenizer("custom_tokenizer", tb ->
-                            tb.definition(loadTokenizer(defaultAnalyzer.getChildNode(FulltextIndexConstants.ANL_TOKENIZER))));
-
-                    LinkedHashMap<String, TokenFilterDefinition> tokenFilters = loadFilters(
-                            defaultAnalyzer.getChildNode(FulltextIndexConstants.ANL_FILTERS),
-                            TokenFilterFactory::lookupClass, TokenFilterDefinition::new
-                    );
-                    tokenFilters.forEach((key, value) -> builder.filter(key, fn -> fn.definition(value)));
-
-                    LinkedHashMap<String, CharFilterDefinition> charFilters = loadFilters(
-                            defaultAnalyzer.getChildNode(FulltextIndexConstants.ANL_CHAR_FILTERS),
-                            CharFilterFactory::lookupClass, CharFilterDefinition::new
-                    );
-                    charFilters.forEach((key, value) -> builder.charFilter(key, fn -> fn.definition(value)));
-
-                    builder.analyzer(analyzerName, bf -> bf.custom(CustomAnalyzer.of(cab ->
-                            cab.tokenizer("custom_tokenizer")
-                                    .filter(List.copyOf(tokenFilters.keySet()))
-                                    .charFilter(List.copyOf(charFilters.keySet()))
-                    )));
-                }
-                return builder;
+                String childName = cne.getName();
+                String targetName = FulltextIndexConstants.ANL_DEFAULT.equals(childName) ? analyzerName : childName;
+                // internal tokenizer/filter/char-filter keys are shared across all analyzers registered on the
+                // same builder, so they need to be prefixed per-analyzer to avoid collisions between them.
+                String namePrefix = childName + "_";
+                buildCustomAnalyzer(cne.getNodeState(), targetName, namePrefix, builder);
             }
+            return builder;
         }
         return null;
+    }
+
+    private static void buildCustomAnalyzer(NodeState analyzerState, String targetName, String namePrefix,
+                                             IndexSettingsAnalysis.Builder builder) {
+        Map<String, Object> analyzer;
+        try {
+            analyzer = convertNodeState(analyzerState);
+        } catch (IOException e) {
+            LOG.warn("Can not load analyzer; using an empty configuration", e);
+            analyzer = Map.of();
+        }
+        String builtIn = analyzerState.getString(FulltextIndexConstants.ANL_CLASS);
+        if (builtIn == null) {
+            builtIn = analyzerState.getString(FulltextIndexConstants.ANL_NAME);
+        }
+        if (builtIn != null) {
+            analyzer.put(ANALYZER_TYPE, normalize(builtIn));
+
+            // content params, usually stop words
+            for (ChildNodeEntry nodeEntry : analyzerState.getChildNodeEntries()) {
+                List<String> list;
+                try {
+                    list = loadContent(nodeEntry.getNodeState(), nodeEntry.getName(), NOOP_TRANSFORMATION);
+                } catch (IOException e) {
+                    LOG.warn("Unable to load analyzer content for entry '" + nodeEntry.getName() + "'; using empty list", e);
+                    list = List.of();
+                }
+                analyzer.put(normalize(nodeEntry.getName()), list);
+            }
+
+            builder.analyzer(targetName, new Analyzer(null, JsonData.of(analyzer)));
+        } else { // try to compose the analyzer
+            String tokenizerName = namePrefix + "tokenizer";
+            builder.tokenizer(tokenizerName, tb ->
+                    tb.definition(loadTokenizer(analyzerState.getChildNode(FulltextIndexConstants.ANL_TOKENIZER))));
+
+            LinkedHashMap<String, TokenFilterDefinition> tokenFilters = loadFilters(
+                    analyzerState.getChildNode(FulltextIndexConstants.ANL_FILTERS),
+                    TokenFilterFactory::lookupClass, TokenFilterDefinition::new
+            );
+            tokenFilters.forEach((key, value) -> builder.filter(namePrefix + key, fn -> fn.definition(value)));
+
+            LinkedHashMap<String, CharFilterDefinition> charFilters = loadFilters(
+                    analyzerState.getChildNode(FulltextIndexConstants.ANL_CHAR_FILTERS),
+                    CharFilterFactory::lookupClass, CharFilterDefinition::new
+            );
+            charFilters.forEach((key, value) -> builder.charFilter(namePrefix + key, fn -> fn.definition(value)));
+
+            List<String> filterNames = tokenFilters.keySet().stream()
+                    .map(key -> namePrefix + key).collect(Collectors.toList());
+            List<String> charFilterNames = charFilters.keySet().stream()
+                    .map(key -> namePrefix + key).collect(Collectors.toList());
+
+            builder.analyzer(targetName, bf -> bf.custom(CustomAnalyzer.of(cab ->
+                    cab.tokenizer(tokenizerName)
+                            .filter(filterNames)
+                            .charFilter(charFilterNames)
+            )));
+        }
     }
 
     @NotNull

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexHelper.java
@@ -47,8 +47,10 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.Inference
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceIndexConfig;
 import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
 import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.plugins.index.search.IndexDefinition.IndexingRule;
 import org.apache.jackrabbit.oak.plugins.index.search.PropertyDefinition;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -248,10 +250,21 @@ class ElasticIndexHelper {
     private static ObjectBuilder<IndexSettings> loadSettings(@NotNull IndexSettings.Builder builder,
                                                              @NotNull ElasticIndexDefinition indexDefinition) {
         // collect analyzer settings
+        NodeState analyzersNodeState = indexDefinition.getAnalyzersNodeState();
         IndexSettingsAnalysis.Builder analyzerBuilder =
-                ElasticCustomAnalyzer.buildCustomAnalyzers(indexDefinition.getAnalyzersNodeState(), "oak_analyzer");
+                ElasticCustomAnalyzer.buildCustomAnalyzers(analyzersNodeState, "oak_analyzer");
         if (analyzerBuilder == null) {
-            analyzerBuilder = new IndexSettingsAnalysis.Builder()
+            analyzerBuilder = new IndexSettingsAnalysis.Builder();
+        }
+        // "oak_analyzer" is the fallback default analyzer used by every property that doesn't declare its own
+        // analyzer reference. buildCustomAnalyzers only registers it under that name when an explicit
+        // analyzers/default node is configured (it now also registers any other named analyzer, e.g. one used
+        // only per-property via PROP_ANALYZER, so a non-null builder no longer implies "oak_analyzer" exists).
+        // Without an analyzers/default node, we still need to define it here so property mappings that reference
+        // "oak_analyzer" don't fail index creation.
+        boolean hasDefaultAnalyzer = analyzersNodeState != null && analyzersNodeState.hasChildNode(FulltextIndexConstants.ANL_DEFAULT);
+        if (!hasDefaultAnalyzer) {
+            analyzerBuilder
                     .filter(OAK_WORD_DELIMITER_GRAPH_FILTER,
                             tokenFilter -> tokenFilter.definition(
                                     tokenFilterDef -> tokenFilterDef.wordDelimiterGraph(
@@ -309,6 +322,12 @@ class ElasticIndexHelper {
                     builder.properties(FieldNames.FLATTENED_FIELD_PREFIX +
                             ElasticIndexUtils.fieldName(pd.nodeName), pBuilder.build());
                 }
+                if (pd.analyzed && pd.analyzerName != null) {
+                    LOG.warn("Property [{}] in index rule [{}] declares analyzer [{}] but is a " +
+                            "regular-expression property definition, which is not supported for " +
+                            "per-property analyzers - falling back to the default analyzer. Index at {}",
+                            pd.name, rule.getNodeTypeName(), pd.analyzerName, indexDefinition.getIndexPath());
+                }
             }
         }
         for (Map.Entry<String, List<PropertyDefinition>> entry : indexDefinition.getPropertiesByName().entrySet()) {
@@ -334,9 +353,32 @@ class ElasticIndexHelper {
                 pBuilder.boolean_(b -> b);
             } else {
                 if (indexDefinition.isAnalyzed(propertyDefinitions)) {
+                    String analyzerName = propertyDefinitions.stream().map(pd -> pd.analyzerName)
+                            .filter(Objects::nonNull).findFirst().orElse(null);
+                    String resolvedAnalyzerName = "oak_analyzer";
+                    if (analyzerName != null) {
+                        if (FulltextIndexConstants.ANL_DEFAULT.equals(analyzerName)) {
+                            // analyzers/default is always registered under the ES analyzer name
+                            // "oak_analyzer" (see ElasticCustomAnalyzer#buildCustomAnalyzers), never
+                            // literally as "default" - resolve it directly rather than through
+                            // hasChildNode, which would otherwise wrongly confirm "default" as a
+                            // valid ES analyzer name.
+                            resolvedAnalyzerName = "oak_analyzer";
+                        } else {
+                            NodeState analyzersNodeState = indexDefinition.getAnalyzersNodeState();
+                            if (analyzersNodeState != null && analyzersNodeState.hasChildNode(analyzerName)) {
+                                resolvedAnalyzerName = analyzerName;
+                            } else {
+                                LOG.warn("Property [{}] references unknown analyzer [{}] - falling back to " +
+                                        "the default analyzer. Index at {}",
+                                        propertyName, analyzerName, indexDefinition.getIndexPath());
+                            }
+                        }
+                    }
                     // always add keyword for sorting / faceting as sub-field
+                    String finalAnalyzerName = resolvedAnalyzerName;
                     pBuilder.text(
-                            b1 -> b1.analyzer("oak_analyzer")
+                            b1 -> b1.analyzer(finalAnalyzerName)
                                     .fields("keyword",
                                             b2 -> b2.keyword(
                                                     b3 -> b3.ignoreAbove(256))));

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticFullTextAnalyzerTest.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.commons.junit.LogCustomizer;
 import org.apache.jackrabbit.oak.plugins.index.FullTextAnalyzerCommonTest;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.async.ElasticResultRowAsyncIterator;
 import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -238,4 +239,180 @@ public class ElasticFullTextAnalyzerTest extends FullTextAnalyzerCommonTest {
     @Ignore("not supported in elasticsearch since hunspell resources need to be available on the server")
     @Override
     public void fullTextWithHunspell() {}
+
+    // OAK-12360: a property's own analyzer reference must apply at real index/query
+    // time (not just to the in-memory Analyzer object), while a sibling property
+    // without one keeps using the index's default analyzer.
+    @Test
+    public void perPropertyAnalyzerAppliesOnlyToDeclaredProperty() throws Exception {
+        setup(List.of("title", "body"), idx -> {
+            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild("titleAnalyzer");
+            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+            idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                    .getChild(FulltextIndexConstants.PROP_NODE).getChild("title")
+                    .setProperty(FulltextIndexConstants.PROP_ANALYZER, "titleAnalyzer");
+        });
+
+        Tree content = root.getTree("/").addChild("content");
+        Tree a = content.addChild("a");
+        a.setProperty("title", "Hello World");
+        a.setProperty("body", "Hello World");
+        root.commit();
+
+        assertEventually(() -> {
+            // "title" uses the whitespace tokenizer (no lower-casing): case-sensitive match.
+            assertQuery("//*[jcr:contains(@title, 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@title, 'hello')]", XPATH, List.of());
+            // "body" keeps the index's default (lower-casing) analyzer: case-insensitive match.
+            assertQuery("//*[jcr:contains(@body, 'hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@body, 'Hello')]", XPATH, List.of("/content/a"));
+        });
+    }
+
+    // OAK-12360: a property's analyzer reference that doesn't resolve to any node under
+    // analyzers/ must not fail index creation - it falls back to the default analyzer and
+    // logs a warning.
+    @Test
+    public void danglingAnalyzerReferenceFallsBackToDefaultWithWarning() throws Exception {
+        LogCustomizer customLogs = LogCustomizer
+                .forLogger("org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexHelper")
+                .enable(Level.WARN).create();
+        customLogs.starting();
+
+        try {
+            setup(List.of("title", "body"), idx ->
+                    idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                            .getChild(FulltextIndexConstants.PROP_NODE).getChild("title")
+                            .setProperty(FulltextIndexConstants.PROP_ANALYZER, "doesNotExist"));
+
+            Tree content = root.getTree("/").addChild("content");
+            Tree a = content.addChild("a");
+            a.setProperty("title", "Hello World");
+            root.commit();
+
+            assertEventually(() ->
+                    // falls back to the default (lower-casing) analyzer, so this still matches
+                    assertQuery("//*[jcr:contains(@title, 'hello')]", XPATH, List.of("/content/a")));
+
+            List<String> logs = customLogs.getLogs();
+            Assert.assertTrue("Expected a warning about the unresolved analyzer reference. Captured logs: " + logs,
+                    logs.stream().anyMatch(m -> m.contains("doesNotExist")));
+        } finally {
+            customLogs.finished();
+        }
+    }
+
+    // OAK-12360: regular-expression property definitions have no single fixed field name to
+    // bind a per-property analyzer to, so declaring one there is not supported - it falls back
+    // to the index's default handling and logs a warning (mirrors the Lucene-side limitation).
+    @Test
+    public void regexpPropertyWithAnalyzerFallsBackWithWarning() throws Exception {
+        LogCustomizer customLogs = LogCustomizer
+                .forLogger("org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexHelper")
+                .enable(Level.WARN).create();
+        customLogs.starting();
+
+        try {
+            setup(List.of("title"), idx -> {
+                Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild("frenchAnalyzer");
+                anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+                Tree allStrings = idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                        .getChild(FulltextIndexConstants.PROP_NODE).addChild("allStrings");
+                allStrings.setProperty(FulltextIndexConstants.PROP_NAME, FulltextIndexConstants.REGEX_ALL_PROPS);
+                allStrings.setProperty(FulltextIndexConstants.PROP_IS_REGEX, true);
+                allStrings.setProperty(FulltextIndexConstants.PROP_ANALYZED, true);
+                allStrings.setProperty(FulltextIndexConstants.PROP_NODE_SCOPE_INDEX, true);
+                allStrings.setProperty(FulltextIndexConstants.PROP_ANALYZER, "frenchAnalyzer");
+            });
+
+            Tree content = root.getTree("/").addChild("content");
+            Tree a = content.addChild("a");
+            a.setProperty("randomProp", "Hello World");
+            root.commit();
+
+            assertEventually(() ->
+                    // regexp properties don't get the per-property analyzer wired in - the index still
+                    // builds and queries successfully via the aggregate fulltext field (which always
+                    // uses the index's default, case-insensitive analyzer)
+                    assertQuery("//*[jcr:contains(., 'hello')]", XPATH, List.of("/content/a")));
+
+            List<String> logs = customLogs.getLogs();
+            Assert.assertTrue("Expected a warning about regexp properties not supporting per-field analyzers. Captured logs: " + logs,
+                    logs.stream().anyMatch(m -> m.contains("regular-expression")));
+        } finally {
+            customLogs.finished();
+        }
+    }
+
+    // OAK-12360: a property that explicitly references the literal "default" analyzer node
+    // (analyzers/default) must resolve to the same ES analyzer ("oak_analyzer") that
+    // ElasticCustomAnalyzer#buildCustomAnalyzers actually registers that node under - not to a
+    // literal ES analyzer named "default" (which is never registered and would make Elasticsearch
+    // reject index creation with "analyzer [default] not found").
+    @Test
+    public void explicitDefaultAnalyzerReferenceResolvesToRegisteredDefault() throws Exception {
+        setup(List.of("title", "body"), idx -> {
+            // Custom default analyzer: whitespace tokenizer only, no lower-casing - so we can tell
+            // whether "title" really ends up using it (same as "body", which has no override).
+            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild(FulltextIndexConstants.ANL_DEFAULT);
+            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+            idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                    .getChild(FulltextIndexConstants.PROP_NODE).getChild("title")
+                    .setProperty(FulltextIndexConstants.PROP_ANALYZER, FulltextIndexConstants.ANL_DEFAULT);
+        });
+
+        Tree content = root.getTree("/").addChild("content");
+        Tree a = content.addChild("a");
+        a.setProperty("title", "Hello World");
+        a.setProperty("body", "Hello World");
+        root.commit();
+
+        assertEventually(() -> {
+            // "title" (explicit "default" reference) and "body" (no override) must behave
+            // identically: both go through the custom, case-preserving default analyzer.
+            assertQuery("//*[jcr:contains(@title, 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@title, 'hello')]", XPATH, List.of());
+            assertQuery("//*[jcr:contains(@body, 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@body, 'hello')]", XPATH, List.of());
+        });
+    }
+
+    // OAK-12360: unlike Lucene (whose :fulltext field is always analyzed by the single index
+    // default, regardless of any property's own override), ES's aggregate FieldNames.FULLTEXT
+    // query is expanded at query time to also search each nodeScopeIndex-analyzed property's own
+    // field (ElasticRequestHandler#fullTextQuery, via IndexingRule#getNodeScopeAnalyzedProps) -
+    // because ElasticDocumentMaker never copies an analyzed property's text into :fulltext itself
+    // (isFulltextValuePersistedAtNode). When "title" is the sole such contributor (no sibling
+    // property sharing the default analyzer to fall back on), its own custom analyzer legitimately
+    // governs jcr:contains(., ...) too: the query term is analyzed the same way "title"'s content
+    // was, which is correct - not a leaky version of Lucene's guarantee, a genuinely different one.
+    @Test
+    public void perPropertyAnalyzerAppliesToAggregatedFulltextFieldWhenSoleContributor() throws Exception {
+        setup(List.of("title"), idx -> {
+            Tree anl = idx.addChild(FulltextIndexConstants.ANALYZERS).addChild("titleAnalyzer");
+            anl.addChild(FulltextIndexConstants.ANL_TOKENIZER).setProperty(FulltextIndexConstants.ANL_NAME, "whitespace");
+
+            idx.getChild(FulltextIndexConstants.INDEX_RULES).getChild("nt:base")
+                    .getChild(FulltextIndexConstants.PROP_NODE).getChild("title")
+                    .setProperty(FulltextIndexConstants.PROP_ANALYZER, "titleAnalyzer");
+        });
+
+        Tree content = root.getTree("/").addChild("content");
+        Tree a = content.addChild("a");
+        a.setProperty("title", "Hello World");
+        root.commit();
+
+        assertEventually(() -> {
+            // Property-specific field: custom (whitespace, non-lower-casing) analyzer, case-sensitive.
+            assertQuery("//*[jcr:contains(@title, 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(@title, 'hello')]", XPATH, List.of());
+            // Aggregated query: with "title" as the sole nodeScopeIndex-analyzed contributor, it
+            // correctly reflects "title"'s own (case-sensitive) analyzer too.
+            assertQuery("//*[jcr:contains(., 'Hello')]", XPATH, List.of("/content/a"));
+            assertQuery("//*[jcr:contains(., 'hello')]", XPATH, List.of());
+        });
+    }
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticCustomAnalyzerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import co.elastic.clients.elasticsearch._types.analysis.Analyzer;
+import co.elastic.clients.elasticsearch._types.analysis.CustomAnalyzer;
+import co.elastic.clients.elasticsearch.indices.IndexSettingsAnalysis;
+import org.apache.jackrabbit.oak.api.Tree;
+import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
+import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
+import org.apache.jackrabbit.oak.plugins.tree.factories.TreeFactory;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ElasticCustomAnalyzerTest {
+
+    private static final String CALLER_ANALYZER_NAME = "oak_analyzer";
+    private static final String TITLE_ANALYZER_NAME = "titleAnalyzer";
+
+    /**
+     * Builds an "analyzers" NodeState with two children:
+     * - {@code default}: a simple built-in class analyzer (french)
+     * - {@code titleAnalyzer}: a composed analyzer with its own tokenizer and a "LowerCase" filter
+     * and verifies that {@link ElasticCustomAnalyzer#buildCustomAnalyzers} registers BOTH analyzers,
+     * with the composed analyzer's internal tokenizer/filter names uniquely prefixed.
+     */
+    @Test
+    public void buildCustomAnalyzersRegistersAllNamedAnalyzers() {
+        NodeBuilder analyzersBuilder = EmptyNodeState.EMPTY_NODE.builder();
+        Tree analyzers = TreeFactory.createTree(analyzersBuilder);
+
+        Tree defaultAnalyzer = analyzers.addChild(FulltextIndexConstants.ANL_DEFAULT);
+        defaultAnalyzer.setProperty(FulltextIndexConstants.ANL_NAME, "french");
+
+        Tree titleAnalyzer = analyzers.addChild(TITLE_ANALYZER_NAME);
+        titleAnalyzer.addChild(FulltextIndexConstants.ANL_TOKENIZER)
+                .setProperty(FulltextIndexConstants.ANL_NAME, "Standard");
+        Tree filters = titleAnalyzer.addChild(FulltextIndexConstants.ANL_FILTERS);
+        filters.setOrderableChildren(true);
+        filters.addChild("LowerCase");
+
+        NodeState analyzersState = analyzersBuilder.getNodeState();
+
+        IndexSettingsAnalysis.Builder builder = ElasticCustomAnalyzer.buildCustomAnalyzers(analyzersState, CALLER_ANALYZER_NAME);
+        assertNotNull("builder should not be null when analyzers node has children", builder);
+
+        IndexSettingsAnalysis settings = builder.build();
+
+        // both the default (aliased to the caller-supplied name) and the extra named analyzer must be registered
+        assertEquals(Set.of(CALLER_ANALYZER_NAME, TITLE_ANALYZER_NAME), settings.analyzer().keySet());
+
+        Analyzer titleAnalyzerDef = settings.analyzer().get(TITLE_ANALYZER_NAME);
+        assertTrue("titleAnalyzer should be a composed (custom) analyzer", titleAnalyzerDef.isCustom());
+        CustomAnalyzer customAnalyzer = titleAnalyzerDef.custom();
+
+        // the internal tokenizer name must be prefixed with the JCR analyzer name, not the old shared literal
+        String tokenizerName = customAnalyzer.tokenizer();
+        assertEquals(TITLE_ANALYZER_NAME + "_tokenizer", tokenizerName);
+        assertTrue("prefixed tokenizer definition must round-trip into the settings' tokenizer map",
+                settings.tokenizer().containsKey(tokenizerName));
+
+        // the internal filter name(s) must be prefixed with the JCR analyzer name too
+        assertEquals(1, customAnalyzer.filter().size());
+        String filterName = customAnalyzer.filter().get(0);
+        assertTrue("filter name must be prefixed with the analyzer's own name",
+                filterName.startsWith(TITLE_ANALYZER_NAME + "_"));
+        assertTrue("prefixed filter definition must round-trip into the settings' filter map",
+                settings.filter().containsKey(filterName));
+
+        // no char filters were configured for titleAnalyzer
+        assertTrue(customAnalyzer.charFilter().isEmpty());
+    }
+}

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/FulltextIndexConstants.java
@@ -131,6 +131,14 @@ public interface FulltextIndexConstants {
 
     String PROP_ANALYZED = "analyzed";
 
+    /**
+     * Name of the analyzer (a sibling node under {@code analyzers}) to use for
+     * this property, overriding the index's {@code analyzers/default}.
+     * Optional; {@code null}/absent means the property uses the default
+     * analyzer, unchanged from today's behavior.
+     */
+    String PROP_ANALYZER = "analyzer";
+
     String RULE_INHERITED = "inherited";
 
     String PROP_ORDERED = "ordered";

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/PropertyDefinition.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/PropertyDefinition.java
@@ -90,6 +90,14 @@ public class PropertyDefinition {
 
     public final boolean analyzed;
 
+    /**
+     * Name of a custom analyzer configured under the index's {@code
+     * analyzers} node to use for this property instead of the default
+     * analyzer. {@code null} if not configured.
+     */
+    @Nullable
+    public final String analyzerName;
+
     public final boolean ordered;
 
     public final boolean nullCheckEnabled;
@@ -194,6 +202,8 @@ public class PropertyDefinition {
         } else {
             this.analyzed = getOptionalValueIfIndexed(defn, FulltextIndexConstants.PROP_ANALYZED, false);
         }
+
+        this.analyzerName = getOptionalValue(defn, FulltextIndexConstants.PROP_ANALYZER, null);
 
         this.ordered = getOptionalValueIfIndexed(defn, FulltextIndexConstants.PROP_ORDERED, false);
         this.includedPropertyTypes = IndexDefinition.getSupportedTypes(defn, FulltextIndexConstants.PROP_INCLUDED_TYPE,

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/PropertyDefinitionTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/search/PropertyDefinitionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.search;
+
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.junit.Test;
+
+import static org.apache.jackrabbit.JcrConstants.NT_BASE;
+import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PropertyDefinitionTest {
+
+    private NodeState root = INITIAL_CONTENT;
+
+    @Test
+    public void analyzerNameIsParsedFromPropertyDefinition() throws Exception {
+        IndexDefinitionBuilder builder = new IndexDefinitionBuilder();
+        builder.indexRule("nt:base")
+                .property("foo")
+                .analyzed()
+                .getBuilderTree()
+                .setProperty(FulltextIndexConstants.PROP_ANALYZER, "frenchText");
+
+        IndexDefinition defn = IndexDefinition.newBuilder(root, builder.build(), "/foo").build();
+        IndexDefinition.IndexingRule rule = defn.getApplicableIndexingRule(NT_BASE);
+        PropertyDefinition pd = rule.getConfig("foo");
+
+        assertEquals("frenchText", pd.analyzerName);
+    }
+
+    @Test
+    public void analyzerNameDefaultsToNull() throws Exception {
+        IndexDefinitionBuilder builder = new IndexDefinitionBuilder();
+        builder.indexRule("nt:base").property("foo").analyzed();
+
+        IndexDefinition defn = IndexDefinition.newBuilder(root, builder.build(), "/foo").build();
+        IndexDefinition.IndexingRule rule = defn.getApplicableIndexingRule(NT_BASE);
+        PropertyDefinition pd = rule.getConfig("foo");
+
+        assertNull(pd.analyzerName);
+    }
+}


### PR DESCRIPTION
[OAK-12360](https://issues.apache.org/jira/browse/OAK-12360)

## Problem

Today, an `oak:index` Lucene definition can declare a custom analyzer only under `analyzers/default`. Any other analyzer configured under `analyzers/<name>` is silently ignored — there's no way to apply a different tokenizer/stemmer/stopword-set to individual properties (e.g. a language-specific analyzer for one field while keeping the default for the rest of the index).

## Change

Adds a new optional `analyzer` string property on a property definition:

```
indexRules/<nodeType>/properties/<propName>/analyzer = "<name>"
```

referencing a sibling node `analyzers/<name>`, alongside the existing `analyzers/default`. `LuceneIndexDefinition.createAnalyzer()` builds a `PerFieldAnalyzerWrapper` entry for every analyzed property with a resolving `analyzer` reference, keyed by that property's actual Lucene field name (`full:<pname>` for index format V2+, `<pname>` for legacy V1) — the same name `LuceneDocumentMaker` writes documents under, so index-time and query-time (both already resolve through `LuceneIndexDefinition.getAnalyzer()`) stay consistent automatically.

Properties that don't set `analyzer` are completely unaffected — fully backward compatible, no feature toggle needed since the change is purely additive/opt-in.

**Error handling:** a property's `analyzer` reference that doesn't resolve to an existing `analyzers/<name>` node logs a warning and falls back to the default analyzer for that property only, rather than failing the index build — consistent with the existing convention for other dangling references in `IndexDefinition` (e.g. an aggregate rule referencing a missing property).

## Known limitations (explicitly out of scope for this PR)

* The aggregated `:fulltext` field (used by `CONTAINS(*, ...)`) collects raw text from every `nodeScopeIndex=true` property into one shared field, re-analyzed with a single analyzer — per-property analyzers can't differentiate text once merged into `:fulltext`.
* Regular-expression property definitions — since the rule matches a different concrete property per node, there's no single property to attach a custom analyzer to.

Both fall back to the default analyzer with a logged warning and are documented as known limitations in `oak-doc/src/site/markdown/query/lucene.md`.

## Out of scope

* Elasticsearch provider (`oak-search-elastic`) — tracked separately.

## Testing

New tests in `PropertyDefinitionTest` and `LuceneIndexDefinitionTest` cover: config parsing, the happy path (custom analyzer applied to the declared property's own field while a sibling property keeps the default), a dangling analyzer reference, regexp property definitions, and the `:fulltext` aggregate-field limitation. Full `oak-search` and `oak-lucene` module suites pass with no regressions.

Marked as draft while an internal CI pipeline runs against the branch.
