### PR TITLE
OAK-12372: ignore Lucene facet properties that are too long

### DIFF
--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -203,32 +203,16 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
                 getFacetsConfig().setMultiValued(pname, true);
                 Iterable<String> values = property.getValue(Type.STRINGS);
                 for (String value : values) {
-                    if (value != null && !value.isEmpty()) {
+                    if (isValidFacetProperty(pname, value)) {
                         doc.add(new SortedSetDocValuesFacetField(pname, value));
                     }
                 }
                 fieldAdded = true;
             } else if (tag == Type.STRING.tag()) {
                 String value = property.getValue(Type.STRING);
-                if (!value.isEmpty()) {
-                    if (FT_OAK_12372_DISABLE.get()) {
-                        // Legacy mode
-                        doc.add(new SortedSetDocValuesFacetField(pname, value));
-                        fieldAdded = true;
-                    } else {
-                        // Category path = pname + "/" + value --> cannot be longer than the Lucene limit of 8191
-                        int categoryPathLength = pname.length() + value.length() + 1;
-                        if (categoryPathLength > FacetLabel.MAX_CATEGORY_PATH_LENGTH) {
-                            if (!LOG_SILENCER.silence(LOG_KEY_IGNORING_LONG_FACET_PROPERTY)) {
-                                LOG.warn("[{}] Ignoring long facet property. Property {} is too long (name + value length: {})"
-                                                + " and cannot be used for facets",
-                                        getIndexName(), pname, categoryPathLength);
-                            }
-                        } else {
-                            doc.add(new SortedSetDocValuesFacetField(pname, value));
-                            fieldAdded = true;
-                        }
-                    }
+                if (isValidFacetProperty(pname, value)) {
+                    doc.add(new SortedSetDocValuesFacetField(pname, value));
+                    fieldAdded = true;
                 }
             }
 
@@ -241,6 +225,30 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
             }
         }
         return fieldAdded;
+    }
+
+    private boolean isValidFacetProperty(String pname, String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+
+        if (FT_OAK_12372_DISABLE.get()) {
+            // Legacy mode
+            return true;
+        }
+
+        // Category path = pname + "/" + value --> cannot be longer than the Lucene limit of 8191
+        int categoryPathLength = pname.length() + value.length() + 1;
+        if (categoryPathLength > FacetLabel.MAX_CATEGORY_PATH_LENGTH) {
+            if (!LOG_SILENCER.silence(LOG_KEY_IGNORING_LONG_FACET_PROPERTY)) {
+                LOG.warn("[{}] Ignoring long facet property. Property {} at path {} is too long (name + value length: {})"
+                                + " and cannot be used for facets",
+                        getIndexName(), pname, path, categoryPathLength);
+            }
+            return false; // Facet property too long --> ignore
+        }
+
+        return true;
     }
 
     @Override

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMaker.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.jackrabbit.oak.api.Blob;
 import org.apache.jackrabbit.oak.api.PropertyState;
@@ -43,6 +44,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.lucene.document.*;
 import org.apache.lucene.facet.FacetsConfig;
 import org.apache.lucene.facet.sortedset.SortedSetDocValuesFacetField;
+import org.apache.lucene.facet.taxonomy.FacetLabel;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.jetbrains.annotations.Nullable;
@@ -71,11 +73,21 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
     private static final String LOG_KEY_UNABLE_TO_PARSE = "Unable to parse the provided date field";
     private static final String LOG_KEY_FOR_INPUT_STRING = "For input string";
     private static final String LOG_KEY_IGNORING_FACET_PROPERTY = "Ignoring facet property";
+    private static final String LOG_KEY_IGNORING_LONG_FACET_PROPERTY = "Ignoring long facet property";
     private static final String LOG_KEY_UNKNOWN = "Unknown";
 
     private static final String ORDERED_CONVERT_WARN =
             "[{}] Ignoring ordered value for property {} (type {}): not convertible to the declared "
             + "type {} at {}. ORDER BY may return incorrect or no results - leave type unset or use type=String.";
+
+    /**
+     * Feature toggle for OAK-12372: ignore facet properties with category path longer than 8191 characters to
+     * prevent exceptions at the Lucene level. Enabled by default (bug fix). When the toggle is flipped the
+     * shared {@link #FT_OAK_12372_DISABLE} flag is set to {@code true} and long facet properties are indexed,
+     * restoring the previous behaviour (i.e., exception during indexing).
+     */
+    public static final String FT_OAK_12372 = "FT_OAK-12372";
+    public static final AtomicBoolean FT_OAK_12372_DISABLE = new AtomicBoolean(false);
 
     public LuceneDocumentMaker(IndexDefinition definition,
                                IndexDefinition.IndexingRule indexingRule,
@@ -199,8 +211,24 @@ public class LuceneDocumentMaker extends FulltextDocumentMaker<Document> {
             } else if (tag == Type.STRING.tag()) {
                 String value = property.getValue(Type.STRING);
                 if (!value.isEmpty()) {
-                    doc.add(new SortedSetDocValuesFacetField(pname, value));
-                    fieldAdded = true;
+                    if (FT_OAK_12372_DISABLE.get()) {
+                        // Legacy mode
+                        doc.add(new SortedSetDocValuesFacetField(pname, value));
+                        fieldAdded = true;
+                    } else {
+                        // Category path = pname + "/" + value --> cannot be longer than the Lucene limit of 8191
+                        int categoryPathLength = pname.length() + value.length() + 1;
+                        if (categoryPathLength > FacetLabel.MAX_CATEGORY_PATH_LENGTH) {
+                            if (!LOG_SILENCER.silence(LOG_KEY_IGNORING_LONG_FACET_PROPERTY)) {
+                                LOG.warn("[{}] Ignoring long facet property. Property {} is too long (name + value length: {})"
+                                                + " and cannot be used for facets",
+                                        getIndexName(), pname, categoryPathLength);
+                            }
+                        } else {
+                            doc.add(new SortedSetDocValuesFacetField(pname, value));
+                            fieldAdded = true;
+                        }
+                    }
                 }
             }
 

--- a/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexProviderService.java
+++ b/oak-lucene/src/main/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneIndexProviderService.java
@@ -387,6 +387,9 @@ public class LuceneIndexProviderService {
         oakRegs.add(whiteboard.register(FeatureToggle.class,
                 new FeatureToggle(FulltextIndexEditor.FT_OAK_12244, FulltextIndexEditor.FT_OAK_12244_DISABLE),
                 emptyMap()));
+        oakRegs.add(whiteboard.register(FeatureToggle.class,
+                new FeatureToggle(LuceneDocumentMaker.FT_OAK_12372, LuceneDocumentMaker.FT_OAK_12372_DISABLE),
+                emptyMap()));
         initializeIndexDir(bundleContext, config);
         initializeExtractedTextCache(bundleContext, config, statisticsProvider);
         tracker = createTracker(bundleContext, config);

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -156,17 +156,25 @@ public class LuceneDocumentMakerTest {
         LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("foo")
+                .property("bars")
                 .propertyIndex()
                 .facets();
 
         LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
-        LuceneDocumentMaker docMaker = new LuceneDocumentMaker(null, FacetsConfig::new, null, defn,
+        FacetsConfig facetsConfig = new FacetsConfig();
+        LuceneDocumentMaker docMaker = new LuceneDocumentMaker(null, () -> facetsConfig, null, defn,
                 defn.getApplicableIndexingRule("nt:base"), "/x");
 
         NodeBuilder test = EMPTY_NODE.builder();
         test.setProperty("foo", "a".repeat(8191 - 3)); // Max allowed path length + 1
 
+        test.setProperty("bars", List.of("abc", "a".repeat(10000)), Type.STRINGS);
+
         boolean originalFtValue = LuceneDocumentMaker.FT_OAK_12372_DISABLE.get();
+
+        LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(false); // fix enabled (default) -- still not guarded here
+        docMaker.makeDocument(test.getNodeState());
+
         try {
             LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(false); // default value --> ignore long facet properties
             docMaker.makeDocument(test.getNodeState());

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -27,10 +27,12 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.facet.FacetsConfig;
+import org.apache.lucene.index.FieldInfo;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
@@ -156,6 +158,9 @@ public class LuceneDocumentMakerTest {
         LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("foo")
+                .propertyIndex()
+                .facets();
+        builder.indexRule("nt:base")
                 .property("bars")
                 .propertyIndex()
                 .facets();
@@ -172,18 +177,26 @@ public class LuceneDocumentMakerTest {
 
         boolean originalFtValue = LuceneDocumentMaker.FT_OAK_12372_DISABLE.get();
 
-        LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(false); // fix enabled (default) -- still not guarded here
-        docMaker.makeDocument(test.getNodeState());
-
         try {
             LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(false); // default value --> ignore long facet properties
-            docMaker.makeDocument(test.getNodeState());
+            Document doc = docMaker.makeDocument(test.getNodeState());
+            assertNotNull(doc);
+            // "foo" is too long on its own and is dropped entirely
+            assertEquals(0, facetValueCount(doc, "foo"));
+            // "bars" keeps its short value and drops the too-long one
+            assertEquals(1, facetValueCount(doc, "bars"));
 
             LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(true); // legacy mode --> let Lucene throw exception
             assertThrows(IllegalArgumentException.class, () -> docMaker.makeDocument(test.getNodeState()));
         } finally {
             LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(originalFtValue);
         }
+    }
+
+    private static long facetValueCount(Document doc, String pname) {
+        return Arrays.stream(doc.getFields(FieldNames.createFacetFieldName(pname)))
+                .filter(field -> field.fieldType().docValueType() == FieldInfo.DocValuesType.SORTED_SET)
+                .count();
     }
 
     @Test

--- a/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
+++ b/oak-lucene/src/test/java/org/apache/jackrabbit/oak/plugins/index/lucene/LuceneDocumentMakerTest.java
@@ -26,8 +26,11 @@ import org.apache.jackrabbit.oak.plugins.index.search.FulltextIndexConstants;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.facet.FacetsConfig;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.apache.jackrabbit.oak.InitialContentHelper.INITIAL_CONTENT;
@@ -35,12 +38,14 @@ import static org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState.EMPTY_NODE
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class LuceneDocumentMakerTest {
     private final NodeState root = INITIAL_CONTENT;
 
     @Test
-    public void excludeSingleProperty() throws Exception{
+    public void excludeSingleProperty() throws Exception {
         LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("foo")
@@ -68,7 +73,7 @@ public class LuceneDocumentMakerTest {
     }
 
     @Test
-    public void similarityTagMaxLengthFiltering() throws Exception{
+    public void similarityTagMaxLengthFiltering() throws Exception {
         LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("jcr:primaryType")
@@ -103,7 +108,7 @@ public class LuceneDocumentMakerTest {
     }
 
     @Test
-    public void similarityTagCountLimit() throws Exception{
+    public void similarityTagCountLimit() throws Exception {
         LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
         builder.indexRule("nt:base")
                 .property("jcr:primaryType")
@@ -143,4 +148,41 @@ public class LuceneDocumentMakerTest {
         assertEquals(3, tags.length);
     }
 
+    // OAK-12372: a facet property value long enough that dimension + value + 1 exceeds
+    // Lucene's FacetLabel.MAX_CATEGORY_PATH_LENGTH (8191 bytes) should be ignored (with a warning) instead
+    // of triggering the exception at Lucene level
+    @Test
+    public void facetPropertyValueExceedingMaxCategoryPathLength() throws IOException {
+        LuceneIndexDefinitionBuilder builder = new LuceneIndexDefinitionBuilder();
+        builder.indexRule("nt:base")
+                .property("foo")
+                .propertyIndex()
+                .facets();
+
+        LuceneIndexDefinition defn = LuceneIndexDefinition.newLuceneBuilder(root, builder.build(), "/foo").build();
+        LuceneDocumentMaker docMaker = new LuceneDocumentMaker(null, FacetsConfig::new, null, defn,
+                defn.getApplicableIndexingRule("nt:base"), "/x");
+
+        NodeBuilder test = EMPTY_NODE.builder();
+        test.setProperty("foo", "a".repeat(8191 - 3)); // Max allowed path length + 1
+
+        boolean originalFtValue = LuceneDocumentMaker.FT_OAK_12372_DISABLE.get();
+        try {
+            LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(false); // default value --> ignore long facet properties
+            docMaker.makeDocument(test.getNodeState());
+
+            LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(true); // legacy mode --> let Lucene throw exception
+            assertThrows(IllegalArgumentException.class, () -> docMaker.makeDocument(test.getNodeState()));
+        } finally {
+            LuceneDocumentMaker.FT_OAK_12372_DISABLE.set(originalFtValue);
+        }
+    }
+
+    @Test
+    public void ftOak12372ToggleShouldBeRemoved() {
+        // Time-bombed: if this test fails, the feature toggle FT_OAK_12372 and its guard in
+        // LuceneDocumentMaker should be cleaned up — the fix has been in production long enough.
+        assertTrue("Feature toggle " + LuceneDocumentMaker.FT_OAK_12372 + " is overdue for removal",
+                LocalDate.now().isBefore(LocalDate.of(2027, 8, 25)));
+    }
 }


### PR DESCRIPTION
Lucene limits the lenght of the category path of a facet to 8191 characters. When Oak tries to index a property which name + value + 1 (path separator) exceeds this limit, Lucene throws an exception that aborts the indexing step. Since those kinds of facet properties are unlikely to be useful, it is better to ignore them and continue the indexing process. This patch does it but uses a feature flag to disable this new behaviour if ever needed (enabled by default).