### PR TITLE
OAK-12378: Avoid allocating a new Comparator on every PropertyTemplate.compareTo() call

### DIFF
--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/PropertyTemplate.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/PropertyTemplate.java
@@ -71,13 +71,15 @@ public class PropertyTemplate implements Comparable<PropertyTemplate> {
 
     //--------------------------------------------------------< Comparable >--
 
+    private static final Comparator<PropertyTemplate> COMPARATOR =
+            Comparator.comparingInt(PropertyTemplate::hashCode)
+                    .thenComparing(PropertyTemplate::getName)
+                    .thenComparing(PropertyTemplate::getType);
+
     @Override
     public int compareTo(@NotNull PropertyTemplate template) {
         requireNonNull(template);
-        return Comparator.comparingInt(PropertyTemplate::hashCode)
-                .thenComparing(PropertyTemplate::getName)
-                .thenComparing(PropertyTemplate::getType)
-                .compare(this, template);
+        return COMPARATOR.compare(this, template);
     }
 
     //------------------------------------------------------------< Object >--


### PR DESCRIPTION
## Motivation

[OAK-12378](https://issues.apache.org/jira/browse/OAK-12378): `PropertyTemplate.compareTo()` builds a fresh `Comparator` chain (3 objects, via `comparingInt()` + two `thenComparing()` calls) on every invocation instead of reusing a single instance. This method runs O(n log n) times when sorting templates during node writes, and is especially hot during compaction.

A Java Flight Recorder analysis found this allocation site responsible for ~81% of sampled allocation weight (~705 GB of allocation pressure) — by far the largest source in the recording. During compaction on a 1.2 GB heap this contributed to significant GC stress: 77 old-generation collections consuming 41.2s within a 300s window (13.7%), plus 200 evacuation failures and 4 concurrent mode failures indicating heap exhaustion.

## Summary
- `PropertyTemplate.compareTo()` allocated a new `Comparator` chain on every call. Hoist it into a static final field so it's built once.

## Test plan
- No behavior change; existing `PropertyTemplate` tests cover `compareTo()`.