### PR TITLE
OAK-12380: The export-package manifest header of oak-search-elastic contains a class name.

### DIFF
--- a/oak-search-elastic/pom.xml
+++ b/oak-search-elastic/pom.xml
@@ -50,9 +50,6 @@
               org.apache.jackrabbit.oak.plugins.index.elastic.query,
               org.apache.jackrabbit.oak.plugins.index.elastic.util
             </Export-Package>
-            <_exportcontents>
-              org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexProviderService
-            </_exportcontents>
             <Import-Package>
               !com.ibm.*, <!-- see OAK-11076 -->
               !org.apache.derby.*, <!-- see OAK-11076 -->


### PR DESCRIPTION
Fixed