### PR TITLE
OAK-12249: lazy ES index provisioning — skip creation for empty reindex

### DIFF
--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexDefinition.java
@@ -88,6 +88,13 @@ public class ElasticIndexDefinition extends IndexDefinition {
     public static final String PROP_INDEX_NAME_SEED = ":nameSeed";
 
     /**
+     * Hidden property written when a lazy reindex (OAK-12249) produced zero documents and left no
+     * ES index or alias. Signals the next incremental-write cycle to provision the index on demand.
+     * Cleared once provisioning completes.
+     */
+    public static final String PROP_REQUIRES_PROVISIONING = ":requiresProvisioning";
+
+    /**
      * Hidden property to store similarity tags
      */
     public static final String SIMILARITY_TAGS = ":simTags";
@@ -266,6 +273,10 @@ public class ElasticIndexDefinition extends IndexDefinition {
      */
     public String getIndexAlias() {
         return indexAlias;
+    }
+
+    public boolean requiresProvisioning() {
+        return getOptionalValue(getDefinitionNodeState(), PROP_REQUIRES_PROVISIONING, false);
     }
 
     public Map<String, List<PropertyDefinition>> getPropertiesByName() {

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/ElasticIndexProviderService.java
@@ -26,7 +26,6 @@ import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticDocument;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.elastic.index.ElasticRetryPolicy;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.ElasticIndexProvider;
-import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConstants;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceMBeanImpl;
@@ -239,6 +238,9 @@ public class ElasticIndexProviderService {
                 emptyMap()));
         oakRegs.add(whiteboard.register(FeatureToggle.class,
                 new FeatureToggle(ElasticDocument.FT_OAK_12353, ElasticDocument.FT_OAK_12353_ENABLE),
+                emptyMap()));
+        oakRegs.add(whiteboard.register(FeatureToggle.class,
+                new FeatureToggle(ElasticIndexEditorProvider.FT_OAK_12249, ElasticIndexEditorProvider.FT_OAK_12249_ENABLE),
                 emptyMap()));
         if (System.getProperty(QueryEngineSettings.OAK_INFERENCE_ENABLED) != null) {
             this.isInferenceEnabled = Boolean.parseBoolean(System.getProperty(QueryEngineSettings.OAK_INFERENCE_ENABLED));

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/EagerElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/EagerElasticIndexWriter.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import co.elastic.clients.elasticsearch._types.AcknowledgedResponse;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexResponse;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.elasticsearch.indices.GetAliasResponse;
+import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
+import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
+import co.elastic.clients.elasticsearch.indices.UpdateAliasesRequest;
+import co.elastic.clients.elasticsearch.indices.UpdateAliasesResponse;
+import co.elastic.clients.json.JsonpUtils;
+import org.apache.jackrabbit.oak.api.PropertyState;
+import org.apache.jackrabbit.oak.commons.PathUtils;
+import org.apache.jackrabbit.oak.plugins.index.IndexConstants;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNameHelper;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexNode;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
+import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
+import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceIndexConfig;
+import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexUtils;
+import org.apache.jackrabbit.oak.plugins.index.importer.AsyncLaneSwitcher;
+import org.apache.jackrabbit.oak.plugins.index.search.FieldNames;
+import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.UUID;
+
+class EagerElasticIndexWriter implements ElasticIndexWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(EagerElasticIndexWriter.class);
+
+    private final ElasticIndexTracker indexTracker;
+    private final ElasticConnection elasticConnection;
+    private final ElasticIndexDefinition indexDefinition;
+    private final ElasticBulkProcessorHandler bulkProcessorHandler;
+    private final boolean requiresProvisioning;
+    private final String indexName;
+    private final ElasticRetryPolicy retryPolicy;
+
+    EagerElasticIndexWriter(@NotNull ElasticIndexTracker indexTracker,
+                       @NotNull ElasticConnection elasticConnection,
+                       @NotNull ElasticIndexDefinition indexDefinition,
+                       @NotNull NodeBuilder definitionBuilder,
+                       boolean requiresProvisioning, CommitInfo commitInfo,
+                       ElasticBulkProcessorHandler bulkProcessorHandler,
+                       ElasticRetryPolicy retryPolicy) {
+        this.indexTracker = indexTracker;
+        this.elasticConnection = elasticConnection;
+        this.indexDefinition = indexDefinition;
+        this.requiresProvisioning = requiresProvisioning;
+        this.bulkProcessorHandler = bulkProcessorHandler;
+        this.retryPolicy = retryPolicy;
+
+        if (requiresProvisioning) {
+            // Full provisioning: generate a seed-based backing index, create it in ES, and prepare
+            // for alias flip on close(). Applies to both a standard reindex and an incremental write
+            // arriving after a lazy reindex that produced zero documents (OAK-12249).
+            try {
+                //TODO we should observe changes under inference config path.
+                InferenceConfig.reInitialize();
+                long seed = indexDefinition.indexNameSeed == 0L ? UUID.randomUUID().getMostSignificantBits() : indexDefinition.indexNameSeed;
+                definitionBuilder.setProperty(ElasticIndexDefinition.PROP_INDEX_NAME_SEED, seed);
+                definitionBuilder.setProperty(ElasticIndexDefinition.PROP_INDEX_MAPPING_VERSION, ElasticIndexDefinition.MAPPING_VERSION.toString());
+                definitionBuilder.removeProperty(ElasticIndexDefinition.PROP_REQUIRES_PROVISIONING);
+                indexName = ElasticIndexNameHelper.
+                        getRemoteIndexName(elasticConnection.getIndexPrefix(), indexDefinition.getIndexPath(), seed);
+                provisionIndex();
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to provision index", e);
+            }
+        } else {
+            indexName = indexDefinition.getIndexAlias();
+        }
+        boolean waitForESAcknowledgement = true;
+        PropertyState async = indexDefinition.getDefinitionNodeState().getProperty("async");
+        if (async != null) {
+            // Check if this indexing call is a part of async cycle or a commit hook or called from oak-run for offline reindex
+            // In case it's from async cycle - commit info will have a indexingCheckpointTime key.
+            // Otherwise, it's part of commit hook based indexing due to async property having a value nrt
+            // If the IndexDefinition has a property async-previous set, this implies it's being called from oak-run for offline-reindex.
+            // we need to set waitForESAcknowledgement = false only in the second case i.e.
+            // when this is a part of commit hook due to async property having a value nrt
+            if (!(commitInfo.getInfo().containsKey(IndexConstants.CHECKPOINT_CREATION_TIME) || AsyncLaneSwitcher.isLaneSwitched(definitionBuilder))) {
+                waitForESAcknowledgement = false;
+            }
+        }
+        bulkProcessorHandler.registerIndex(indexName, indexDefinition, definitionBuilder, commitInfo, waitForESAcknowledgement);
+    }
+
+    @TestOnly
+    EagerElasticIndexWriter(@NotNull ElasticIndexTracker indexTracker,
+                       @NotNull ElasticConnection elasticConnection,
+                       @NotNull ElasticIndexDefinition indexDefinition,
+                       @NotNull ElasticBulkProcessorHandler bulkProcessorHandler) {
+        this(indexTracker, elasticConnection, indexDefinition, bulkProcessorHandler, ElasticRetryPolicy.NO_RETRY, false);
+    }
+
+    @TestOnly
+    EagerElasticIndexWriter(@NotNull ElasticIndexTracker indexTracker,
+                       @NotNull ElasticConnection elasticConnection,
+                       @NotNull ElasticIndexDefinition indexDefinition,
+                       @NotNull ElasticBulkProcessorHandler bulkProcessorHandler,
+                       @NotNull ElasticRetryPolicy retryPolicy,
+                       boolean requiresProvisioning) {
+        this.indexTracker = indexTracker;
+        this.elasticConnection = elasticConnection;
+        this.indexDefinition = indexDefinition;
+        this.bulkProcessorHandler = bulkProcessorHandler;
+        this.indexName = indexDefinition.getIndexAlias();
+        this.retryPolicy = retryPolicy;
+        this.requiresProvisioning = requiresProvisioning;
+    }
+
+    @Override
+    public void updateDocument(String path, ElasticDocument doc) throws IOException {
+        // update is a heavier operation compared to index, we can always use the index operation on full reindex
+        // or if the index is not externally modifiable
+        String jcrIndexName = PathUtils.getName(indexDefinition.getIndexName());
+        /*
+            we directly index the document if:
+            content is being reindexed
+            OR
+            (the index is not externally modifiable
+            AND InferenceIndexConfig is NOOP
+            )
+         */
+        if (requiresProvisioning
+            || (!indexDefinition.isExternallyModifiable()
+            && !InferenceConfig.getInstance().isInferenceEnabled()
+            && (InferenceIndexConfig.NOOP.equals(InferenceConfig.getInstance().getInferenceIndexConfig(jcrIndexName))))) {
+            retryPolicy.withRetries(() -> bulkProcessorHandler.index(indexName, ElasticIndexUtils.idFromPath(path), doc));
+        } else {
+            retryPolicy.withRetries(() -> bulkProcessorHandler.update(indexName, ElasticIndexUtils.idFromPath(path), doc));
+        }
+    }
+
+    @Override
+    public void deleteDocumentTree(String path) throws IOException {
+        retryPolicy.withRetries(() -> bulkProcessorHandler.delete(indexName, ElasticIndexUtils.idFromPath(path)));
+        if (!ElasticIndexEditorProvider.FT_OAK_12206_DISABLE.get()) {
+            // Delete all descendants: mirrors Lucene's PrefixQuery on the path term.
+            // The :ancestors field is indexed with path_hierarchy, so a term query on `path`
+            // matches every document whose ancestor chain includes that path.
+            // The ES Bulk API does not support delete by query, so we need to issue a separate request.
+            // This is not ideal but should be ok since deletes are expected to be less frequent than updates.
+            // The alternative would be to get the list of affected documents and issue a bulk delete by id,
+            // but that would be more complex and potentially more expensive (if there are many descendants).
+            retryPolicy.withRetries(() -> {
+                var response = elasticConnection.getClient().deleteByQuery(
+                        d -> d.index(indexName).query(q -> q.term(t -> t.field(FieldNames.ANCESTORS).value(path))));
+                response.failures().forEach(f -> LOG.warn("Failed to delete descendants of {}: shard {} reason {}", path, f.id(), f.cause()));
+                if (response.deleted() != null && response.deleted() > 0) {
+                    LOG.info("Deleted {} descendants of {} in {} ms", response.deleted(), path, response.took());
+                }
+            });
+        }
+    }
+
+    @Override
+    public void deleteDocument(String path) throws IOException {
+        // Exact-document delete: no descendant sweep
+        retryPolicy.withRetries(() -> bulkProcessorHandler.delete(indexName, ElasticIndexUtils.idFromPath(path)));
+    }
+
+    @Override
+    public boolean close(long timestamp) throws IOException {
+        boolean updateStatus = bulkProcessorHandler.flushIndex(indexName);
+        if (requiresProvisioning) {
+            this.enableIndex();
+        }
+        if (updateStatus) {
+            // update the metrics only when ES has been updated. This is anyway a best-effort attempt since indexes are
+            // refreshed asynchronously and the values could be not up-to-date. The metrics will therefore "eventually
+            // converge" with the actual index values.
+            saveMetrics();
+        }
+        return updateStatus;
+    }
+
+    private void saveMetrics() {
+        ElasticIndexNode indexNode = indexTracker.acquireIndexNode(indexDefinition.getIndexPath());
+        if (indexNode != null) {
+            try {
+                ElasticIndexStatistics stats = indexNode.getIndexStatistics();
+                indexTracker.getElasticMetricHandler().markDocuments(indexName, stats.numDocs());
+                indexTracker.getElasticMetricHandler().markSize(indexName, stats.primaryStoreSize(), stats.storeSize());
+            } catch (Exception e) {
+                LOG.warn("Unable to store metrics for {}", indexDefinition.getIndexPath(), e);
+            } finally {
+                indexNode.release();
+            }
+        }
+    }
+
+    private void provisionIndex() throws IOException {
+        final ElasticsearchIndicesClient esClient = elasticConnection.getClient().indices();
+        if (esClient.exists(i -> i.index(indexName)).value()) {
+            LOG.info("Index {} already exists. Skip index provision", indexName);
+            return;
+        }
+        createIndex(indexName);
+    }
+
+    /**
+     * Builds a {@link CreateIndexRequest} for {@code backingIndexName} and submits it to
+     * Elasticsearch, with debug logging and idempotent handling of concurrent-creation races.
+     */
+    private void createIndex(String backingIndexName) throws IOException {
+        final ElasticsearchIndicesClient esClient = elasticConnection.getClient().indices();
+        CreateIndexRequest request;
+        try {
+            request = ElasticIndexHelper.createIndexRequest(backingIndexName, indexDefinition);
+        } catch (Exception e) {
+            LOG.error("Failed to create index {}: {}", backingIndexName, e.toString());
+            throw e;
+        }
+        if (LOG.isDebugEnabled()) {
+            int old = JsonpUtils.maxToStringLength();
+            try {
+                JsonpUtils.maxToStringLength(1_000_000);
+                LOG.debug("Creating Index with request {}", request);
+            } finally {
+                JsonpUtils.maxToStringLength(old);
+            }
+        }
+        try {
+            final CreateIndexResponse response = esClient.create(request);
+            LOG.info("Created index {}. Response acknowledged: {}", backingIndexName, response.acknowledged());
+            checkResponseAcknowledgement(response, "Create index call not acknowledged for index " + backingIndexName);
+        } catch (ElasticsearchException ese) {
+            // We already check index existence as first thing in provisionIndex(); if we get here it
+            // means a concurrent cluster node raced us. Elasticsearch has no CREATE IF NOT EXISTS:
+            // https://github.com/elastic/elasticsearch/issues/19862
+            if (ese.status() == 400 && ese.getMessage().contains("resource_already_exists_exception")) {
+                LOG.warn("Index {} already exists. Ignoring error", backingIndexName);
+            } else {
+                LOG.warn("Failed to create index {}", backingIndexName, ese);
+                StringBuilder sb = new StringBuilder();
+                int old = JsonpUtils.maxToStringLength();
+                try {
+                    JsonpUtils.maxToStringLength(1_000_000);
+                    JsonpUtils.toString(request, sb);
+                    String[] array = splitLargeString(sb.toString(), 1024);
+                    for (int i = 0; i < array.length; i++) {
+                        LOG.warn("request chunk[{}] = {}", i, array[i]);
+                    }
+                } finally {
+                    JsonpUtils.maxToStringLength(old);
+                }
+                throw ese;
+            }
+        }
+    }
+
+    public static String[] splitLargeString(String largeString, int chunkSize) {
+        int totalChunks = (largeString.length() + chunkSize - 1) / chunkSize;
+        String[] array = new String[totalChunks];
+        for (int i = 0; i < totalChunks; i++) {
+            int start = i * chunkSize;
+            int end = Math.min(start + chunkSize, largeString.length());
+            array[i] = largeString.substring(start, end);
+        }
+        return array;
+    }
+
+    private void enableIndex() throws IOException {
+        ElasticsearchIndicesClient client = elasticConnection.getClient().indices();
+        // check if index already exists
+        if (!client.exists(i -> i.index(indexName)).value()) {
+            throw new IllegalStateException("cannot enable an index that does not exist");
+        }
+
+        PutIndicesSettingsRequest request = ElasticIndexHelper.enableIndexRequest(indexName, indexDefinition);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Updating Index Settings with request {}", request);
+        }
+        PutIndicesSettingsResponse response = client.putSettings(request);
+        LOG.info("Updated settings for index {}. Response acknowledged: {}", indexName, response.acknowledged());
+        checkResponseAcknowledgement(response, "Update index settings call not acknowledged for index " + indexName);
+
+        // update the alias
+        GetAliasResponse aliasResponse = client.getAlias(garb ->
+                garb.index(indexDefinition.getIndexAlias()).ignoreUnavailable(true));
+
+        UpdateAliasesRequest updateAliasesRequest = UpdateAliasesRequest.of(rb -> {
+            aliasResponse.result().forEach((idx, idxAliases) -> rb.actions(ab -> // remove old aliases
+                    ab.remove(rab -> rab.index(idx).aliases(new ArrayList<>(idxAliases.aliases().keySet()))))
+            );
+            return rb.actions(ab -> ab.add(aab -> aab.index(indexName).alias(indexDefinition.getIndexAlias()))); // add new one
+        });
+        UpdateAliasesResponse updateAliasesResponse = client.updateAliases(updateAliasesRequest);
+        checkResponseAcknowledgement(updateAliasesResponse, "Update alias call not acknowledged for alias "
+                + indexDefinition.getIndexAlias());
+        LOG.info("Updated alias {} to index {}. Response acknowledged: {}", indexDefinition.getIndexAlias(),
+                indexName, updateAliasesResponse.acknowledged());
+
+        // once the alias has been updated, we can safely remove the old index
+        deleteOldIndices(client, aliasResponse.result().keySet());
+    }
+
+    private void checkResponseAcknowledgement(AcknowledgedResponse response, String exceptionMessage) {
+        if (!response.acknowledged()) {
+            throw new IllegalStateException(exceptionMessage);
+        }
+    }
+
+    private void deleteOldIndices(ElasticsearchIndicesClient indicesClient, Set<String> indices) throws IOException {
+        if (indices.isEmpty())
+            return;
+        DeleteIndexResponse deleteIndexResponse = indicesClient.delete(db -> db.index(new ArrayList<>(indices)));
+        checkResponseAcknowledgement(deleteIndexResponse, "Delete index call not acknowledged for indices " + indices);
+        LOG.info("Deleted indices {}. Response acknowledged: {}", indices, deleteIndexResponse.acknowledged());
+    }
+
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorContext.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorContext.java
@@ -50,11 +50,6 @@ class ElasticIndexEditorContext extends FulltextIndexEditorContext<ElasticDocume
     }
 
     @Override
-    public ElasticIndexWriter getWriter() {
-        return (ElasticIndexWriter) super.getWriter();
-    }
-
-    @Override
     public boolean storedIndexDefinitionEnabled() {
         return false;
     }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexEditorProvider.java
@@ -23,6 +23,7 @@ import org.apache.jackrabbit.oak.plugins.index.IndexUpdateCallback;
 import org.apache.jackrabbit.oak.plugins.index.IndexingContext;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.search.ExtractedTextCache;
 import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexEditor;
@@ -32,6 +33,8 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -40,6 +43,8 @@ import static org.apache.jackrabbit.oak.commons.PathUtils.ROOT_PATH;
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition.TYPE_ELASTICSEARCH;
 
 public class ElasticIndexEditorProvider implements IndexEditorProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticIndexEditorProvider.class);
 
     private final ElasticIndexTracker indexTracker;
     private final ElasticConnection elasticConnection;
@@ -56,6 +61,38 @@ public class ElasticIndexEditorProvider implements IndexEditorProvider {
      * The fix is active by default; set to {@code true} via the feature toggle to disable it.
      */
     public static final AtomicBoolean FT_OAK_12206_DISABLE = new AtomicBoolean(false);
+
+    public static final String FT_OAK_12249 = "FT_OAK-12249";
+    /**
+     * When {@code true} AND {@link ElasticIndexStatistics#FT_OAK_12248_ENABLE} is also {@code true},
+     * Elasticsearch index provisioning is deferred to the first {@code updateDocument()} or
+     * {@code deleteDocuments()} call. A reindex that produces no documents never creates an ES
+     * index or alias.
+     *
+     * <p>Requires {@code FT_OAK-12248} (graceful 404 handling) to be enabled first. Enabling
+     * lazy provisioning without graceful 404 handling would cause unhandled ES 404 errors on every
+     * query against an empty-reindexed index. {@link #isLazyProvisioningActive()} enforces this
+     * dependency at runtime.
+     *
+     * <p>Disabled by default.
+     */
+    public static final AtomicBoolean FT_OAK_12249_ENABLE = new AtomicBoolean(false);
+
+    /**
+     * Returns {@code true} when lazy provisioning is active. Requires both this toggle and
+     * {@link ElasticIndexStatistics#FT_OAK_12248_ENABLE} to be {@code true}. The combined check
+     * enforces the deployment order: graceful 404 handling (OAK-12248) must be on before lazy
+     * provisioning (OAK-12249) can take effect.
+     */
+    public static boolean isLazyProvisioningActive() {
+        boolean lazyProvisioningRequested = FT_OAK_12249_ENABLE.get();
+        boolean graceful404Active = ElasticIndexStatistics.FT_OAK_12248_ENABLE.get();
+        if (lazyProvisioningRequested && !graceful404Active) {
+            LOG.warn("{} is enabled but {} (graceful 404 handling) is not — lazy provisioning stays " +
+                    "inactive until both toggles are enabled", FT_OAK_12249, ElasticIndexStatistics.FT_OAK_12248);
+        }
+        return lazyProvisioningRequested && graceful404Active;
+    }
 
     private final boolean OAK_INDEX_ELASTIC_WRITER_DISABLE = Boolean.getBoolean(OAK_INDEX_ELASTIC_WRITER_DISABLE_KEY);
 

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterFactory.java
@@ -44,7 +44,7 @@ public class ElasticIndexWriterFactory implements FulltextIndexWriterFactory<Ela
 
     @Override
     public ElasticIndexWriter newInstance(IndexDefinition definition, NodeBuilder definitionBuilder,
-                                          CommitInfo commitInfo, boolean reindex) {
+                                           CommitInfo commitInfo, boolean reindex) {
         if (!(definition instanceof ElasticIndexDefinition)) {
             throw new IllegalArgumentException("IndexDefinition must be of type ElasticsearchIndexDefinition " +
                     "instead of " + definition.getClass().getName());
@@ -52,6 +52,21 @@ public class ElasticIndexWriterFactory implements FulltextIndexWriterFactory<Ela
 
         ElasticIndexDefinition esDefinition = (ElasticIndexDefinition) definition;
 
-        return new ElasticIndexWriter(indexTracker, elasticConnection, esDefinition, definitionBuilder, reindex, commitInfo, bulkProcessorHandler, retryPolicy);
+        // requiresProvisioning=true for a standard reindex, or when a prior lazy reindex produced
+        // zero documents and set PROP_REQUIRES_PROVISIONING in the node store.
+        boolean requiresProvisioning = reindex || esDefinition.requiresProvisioning();
+
+        if (requiresProvisioning && ElasticIndexEditorProvider.isLazyProvisioningActive()) {
+            // OAK-12249: defer provisioning to the first write, whether this is a reindex or an
+            // incremental cycle after an empty lazy reindex. If no documents arrive the supplier is
+            // never called, PROP_REQUIRES_PROVISIONING is re-written, and the next cycle retries.
+            return new LazyElasticIndexWriter(
+                    () -> new EagerElasticIndexWriter(indexTracker, elasticConnection, esDefinition,
+                            definitionBuilder, true, commitInfo, bulkProcessorHandler, retryPolicy),
+                    definitionBuilder, elasticConnection, esDefinition);
+        }
+
+        return new EagerElasticIndexWriter(indexTracker, elasticConnection, esDefinition,
+                definitionBuilder, requiresProvisioning, commitInfo, bulkProcessorHandler, retryPolicy);
     }
 }

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/LazyElasticIndexWriter.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/LazyElasticIndexWriter.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import co.elastic.clients.elasticsearch.indices.*;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.function.Supplier;
+
+/**
+ * A {@link FulltextIndexWriter} proxy that defers creation of the real {@link ElasticIndexWriter}
+ * to the first {@link #updateDocument}, {@link #deleteDocumentTree} or {@link #deleteDocument}
+ * call (OAK-12249).
+ *
+ * <p>If {@link #close} is called before any document is written — i.e. the reindex produced zero
+ * documents — the supplier is never invoked, so no Elasticsearch index or alias is created.
+ * Instead, {@link ElasticIndexDefinition#PROP_REQUIRES_PROVISIONING} is set on the definition
+ * node so the next incremental-write cycle provisions the index on demand. If the index was
+ * already provisioned before this reindex (i.e. it previously had documents), its now-stale
+ * alias and backing index are removed — otherwise pre-reindex content would keep being served
+ * indefinitely.
+ *
+ * <p>The supplier is expected to create and provision the index as a side effect of construction
+ * (as {@link ElasticIndexWriter} does). Thread safety is not required: Oak calls each writer
+ * instance from a single thread.
+ */
+class LazyElasticIndexWriter implements ElasticIndexWriter {
+    private static final Logger LOG = LoggerFactory.getLogger(LazyElasticIndexWriter.class);
+
+    private final Supplier<ElasticIndexWriter> writerSupplier;
+    private final NodeBuilder definitionBuilder;
+    private final ElasticConnection elasticConnection;
+    private final ElasticIndexDefinition indexDefinition;
+    private ElasticIndexWriter delegate;
+
+    LazyElasticIndexWriter(Supplier<ElasticIndexWriter> writerSupplier, NodeBuilder definitionBuilder,
+                            ElasticConnection elasticConnection, ElasticIndexDefinition indexDefinition) {
+        this.writerSupplier = writerSupplier;
+        this.definitionBuilder = definitionBuilder;
+        this.elasticConnection = elasticConnection;
+        this.indexDefinition = indexDefinition;
+    }
+
+    /**
+     * Removes the alias and deletes the backing index for {@code indexDefinition}, if one is
+     * currently provisioned. Used when a lazy-provisioning reindex (OAK-12249) closes having
+     * written zero documents: without this, a previously-provisioned index would keep its stale
+     * alias and backing index, serving pre-reindex content indefinitely instead of going empty.
+     *
+     * <p>No-op if nothing is currently aliased — that is the state a never-provisioned index is
+     * already in, so there is nothing to clean up.
+     */
+    static void unaliasIfProvisioned(@NotNull ElasticConnection elasticConnection,
+                                      @NotNull ElasticIndexDefinition indexDefinition) throws IOException {
+        ElasticsearchIndicesClient client = elasticConnection.getClient().indices();
+        GetAliasResponse aliasResponse = client.getAlias(garb ->
+                garb.index(indexDefinition.getIndexAlias()).ignoreUnavailable(true));
+        if (aliasResponse.result().isEmpty()) {
+            return;
+        }
+
+        UpdateAliasesRequest removeAliasesRequest = UpdateAliasesRequest.of(rb -> {
+            aliasResponse.result().forEach((idx, idxAliases) -> rb.actions(ab ->
+                    ab.remove(rab -> rab.index(idx).aliases(new ArrayList<>(idxAliases.aliases().keySet())))));
+            return rb;
+        });
+        UpdateAliasesResponse updateAliasesResponse = client.updateAliases(removeAliasesRequest);
+        if (!updateAliasesResponse.acknowledged()) {
+            throw new IllegalStateException("Remove alias call not acknowledged for alias " + indexDefinition.getIndexAlias());
+        }
+
+        DeleteIndexResponse deleteIndexResponse = client.delete(db -> db.index(new ArrayList<>(aliasResponse.result().keySet())));
+        if (!deleteIndexResponse.acknowledged()) {
+            throw new IllegalStateException("Delete index call not acknowledged for indices " + aliasResponse.result().keySet());
+        }
+        LOG.info("Reindex produced no documents for a previously-provisioned index — removed stale alias {} and deleted {}",
+                indexDefinition.getIndexAlias(), aliasResponse.result().keySet());
+    }
+
+    @Override
+    public void updateDocument(String path, ElasticDocument doc) throws IOException {
+        getOrCreate().updateDocument(path, doc);
+    }
+
+    @Override
+    public void deleteDocumentTree(String path) throws IOException {
+        getOrCreate().deleteDocumentTree(path);
+    }
+
+    @Override
+    public void deleteDocument(String path) throws IOException {
+        getOrCreate().deleteDocument(path);
+    }
+
+    @Override
+    public boolean close(long timestamp) throws IOException {
+        if (delegate == null) {
+            LOG.info("Reindex produced no documents — skipping ES index creation (OAK-12249)");
+            definitionBuilder.setProperty(ElasticIndexDefinition.PROP_REQUIRES_PROVISIONING, true);
+            unaliasIfProvisioned(elasticConnection, indexDefinition);
+            return false;
+        }
+        return delegate.close(timestamp);
+    }
+
+    private ElasticIndexWriter getOrCreate() {
+        if (delegate == null) {
+            delegate = writerSupplier.get();
+        }
+        return delegate;
+    }
+}

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/package-info.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/package-info.java
@@ -14,14 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@Version("2.7.0")
 package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 
-import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
-
-/**
- * Common type for {@link EagerElasticIndexWriter} and {@link LazyElasticIndexWriter}, so
- * {@link ElasticIndexWriterFactory#newInstance} can return either one without widening its
- * declared return type to the module-wide {@link FulltextIndexWriter}.
- */
-interface ElasticIndexWriter extends FulltextIndexWriter<ElasticDocument> {
-}
+import org.osgi.annotation.versioning.Version;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/package-info.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/package-info.java
@@ -14,14 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+@Version("2.7.0")
+package org.apache.jackrabbit.oak.plugins.index.elastic;
 
-import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
-
-/**
- * Common type for {@link EagerElasticIndexWriter} and {@link LazyElasticIndexWriter}, so
- * {@link ElasticIndexWriterFactory#newInstance} can return either one without widening its
- * declared return type to the module-wide {@link FulltextIndexWriter}.
- */
-interface ElasticIndexWriter extends FulltextIndexWriter<ElasticDocument> {
-}
+import org.osgi.annotation.versioning.Version;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/package-info.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/query/package-info.java
@@ -14,14 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+@Version("2.6.1")
+package org.apache.jackrabbit.oak.plugins.index.elastic.query;
 
-import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
-
-/**
- * Common type for {@link EagerElasticIndexWriter} and {@link LazyElasticIndexWriter}, so
- * {@link ElasticIndexWriterFactory#newInstance} can return either one without widening its
- * declared return type to the module-wide {@link FulltextIndexWriter}.
- */
-interface ElasticIndexWriter extends FulltextIndexWriter<ElasticDocument> {
-}
+import org.osgi.annotation.versioning.Version;

--- a/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/package-info.java
+++ b/oak-search-elastic/src/main/java/org/apache/jackrabbit/oak/plugins/index/elastic/util/package-info.java
@@ -14,14 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+@Version("2.6.1")
+package org.apache.jackrabbit.oak.plugins.index.elastic.util;
 
-import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
-
-/**
- * Common type for {@link EagerElasticIndexWriter} and {@link LazyElasticIndexWriter}, so
- * {@link ElasticIndexWriterFactory#newInstance} can return either one without widening its
- * declared return type to the module-wide {@link FulltextIndexWriter}.
- */
-interface ElasticIndexWriter extends FulltextIndexWriter<ElasticDocument> {
-}
+import org.osgi.annotation.versioning.Version;

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterITTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterITTest.java
@@ -95,7 +95,7 @@ public class ElasticIndexWriterITTest {
         ElasticIndexDefinition definition = new ElasticIndexDefinition(root, nodeState, indexName, connection.getIndexPrefix());
         ElasticBulkProcessorHandler bulkProcessorHandler = new ElasticBulkProcessorHandler(connection);
         bulkProcessorHandler.registerIndex(connection.getIndexPrefix() + "." + indexName, definition, builder.child("oak:index").getChildNode(indexName), CommitInfo.EMPTY, false);
-        ElasticIndexWriter writer = new ElasticIndexWriter(indexTracker, connection, definition, bulkProcessorHandler,
+        ElasticIndexWriter writer = new EagerElasticIndexWriter(indexTracker, connection, definition, bulkProcessorHandler,
                 new ElasticRetryPolicy(10, 1000, 5, 100), false
         );
 

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/ElasticIndexWriterTest.java
@@ -19,12 +19,19 @@ package org.apache.jackrabbit.oak.plugins.index.elastic.index;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.elasticsearch.indices.GetAliasRequest;
+import co.elastic.clients.elasticsearch.indices.GetAliasResponse;
 import co.elastic.clients.util.ObjectBuilder;
+import org.apache.jackrabbit.oak.api.Type;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticConnection;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
 import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexTracker;
 import org.apache.jackrabbit.oak.plugins.index.elastic.query.inference.InferenceConfig;
+import org.apache.jackrabbit.oak.plugins.memory.EmptyNodeState;
 import org.apache.jackrabbit.oak.plugins.memory.MemoryNodeStore;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +44,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static org.apache.jackrabbit.oak.plugins.index.elastic.ElasticTestUtils.randomString;
@@ -44,6 +52,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -63,6 +72,9 @@ public class ElasticIndexWriterTest {
 
     @Mock
     private ElasticsearchClient elasticsearchClientMock;
+
+    @Mock
+    private ElasticsearchIndicesClient indicesClientMock;
 
     @Mock
     private ElasticIndexDefinition indexDefinitionMock;
@@ -85,16 +97,23 @@ public class ElasticIndexWriterTest {
         when(elasticConnectionMock.getClient()
                 .deleteByQuery(ArgumentMatchers.<Function<DeleteByQueryRequest.Builder, ObjectBuilder<DeleteByQueryRequest>>>any()))
                 .thenReturn(DeleteByQueryResponse.of(d -> d.deleted(1L).failures(Collections.emptyList())));
+        // LazyElasticIndexWriter.close() checks for a stale alias on an empty-reindex close();
+        // report "nothing provisioned" so that path no-ops in tests that don't exercise it directly.
+        when(elasticsearchClientMock.indices()).thenReturn(indicesClientMock);
+        when(indicesClientMock.getAlias(ArgumentMatchers.<Function<GetAliasRequest.Builder, ObjectBuilder<GetAliasRequest>>>any()))
+                .thenReturn(GetAliasResponse.of(r -> r.result(Collections.emptyMap())));
         // In this test we are explicitly disabling inference as bulkprocessor
         // is called with update document if inference is enabled.
         InferenceConfig.reInitialize(new MemoryNodeStore(), "/oak:index/:inferenceConfig", false);
-        indexWriter = new ElasticIndexWriter(indexTrackerMock, elasticConnectionMock, indexDefinitionMock, bulkProcessorHandlerMock);
+        indexWriter = new EagerElasticIndexWriter(indexTrackerMock, elasticConnectionMock, indexDefinitionMock, bulkProcessorHandlerMock);
         indexAlias = indexDefinitionMock.getIndexAlias();
     }
 
     @After
     public void tearDown() throws Exception {
         closeable.close();
+        ElasticIndexStatistics.FT_OAK_12248_ENABLE.set(false);
+        ElasticIndexEditorProvider.FT_OAK_12249_ENABLE.set(false);
     }
 
     @Test
@@ -169,13 +188,13 @@ public class ElasticIndexWriterTest {
     @Test
     public void splitLargeString() {
         assertEquals("[a]",
-                Arrays.toString(ElasticIndexWriter.splitLargeString(
+                Arrays.toString(EagerElasticIndexWriter.splitLargeString(
                         "a", 1024)));
         assertEquals("[h, e, l, l, o,  , w, o, r, l, d]",
-                Arrays.toString(ElasticIndexWriter.splitLargeString(
+                Arrays.toString(EagerElasticIndexWriter.splitLargeString(
                         "hello world", 1)));
         assertEquals("[he, ll, o , wo, rl, d]",
-                Arrays.toString(ElasticIndexWriter.splitLargeString(
+                Arrays.toString(EagerElasticIndexWriter.splitLargeString(
                         "hello world", 2)));
     }
 
@@ -185,6 +204,98 @@ public class ElasticIndexWriterTest {
         // ElasticIndexWriter#deleteDocumentTree should be removed — the fix has been in production long enough.
         assertTrue("Feature toggle " + ElasticIndexEditorProvider.FT_OAK_12206 + " is overdue for removal",
                 LocalDate.now().isBefore(LocalDate.of(2027, 5, 6)));
+    }
+
+    // --- OAK-12249: lazy provisioning tests ---
+
+    @Test
+    public void lazyProvisioning_requiresGraceful404Toggle() {
+        // OAK-12249 alone must not activate lazy provisioning — OAK-12248 is the hard dependency.
+        ElasticIndexStatistics.FT_OAK_12248_ENABLE.set(false);
+        ElasticIndexEditorProvider.FT_OAK_12249_ENABLE.set(true);
+
+        assertFalse("Lazy provisioning must be inactive when graceful 404 handling is off",
+                ElasticIndexEditorProvider.isLazyProvisioningActive());
+    }
+
+    @Test
+    public void lazyProvisioning_activeWhenBothTogglesEnabled() {
+        // Guards against e.g. an accidental && -> || regression in isLazyProvisioningActive(),
+        // which the negative-only test above would not catch.
+        ElasticIndexStatistics.FT_OAK_12248_ENABLE.set(true);
+        ElasticIndexEditorProvider.FT_OAK_12249_ENABLE.set(true);
+
+        assertTrue("Lazy provisioning must be active when both toggles are enabled",
+                ElasticIndexEditorProvider.isLazyProvisioningActive());
+    }
+
+    @Test
+    public void emptyReindex_supplierNeverCalled() throws IOException {
+        // GIVEN: a LazyElasticIndexWriter whose supplier records whether it was invoked
+        AtomicBoolean supplierCalled = new AtomicBoolean(false);
+        NodeBuilder definitionBuilder = EmptyNodeState.EMPTY_NODE.builder();
+        LazyElasticIndexWriter lazyWriter = new LazyElasticIndexWriter(() -> {
+            supplierCalled.set(true);
+            return indexWriter;
+        }, definitionBuilder, elasticConnectionMock, indexDefinitionMock);
+
+        // WHEN: closed without writing any documents
+        lazyWriter.close(System.currentTimeMillis());
+
+        // THEN: supplier was never called — no ElasticIndexWriter created, no ES index provisioned
+        assertFalse("Supplier must not be called when no documents are written", supplierCalled.get());
+        // AND: the definition is marked so the next incremental cycle provisions on demand
+        assertTrue("PROP_REQUIRES_PROVISIONING must be set after an empty-reindex close()",
+                definitionBuilder.getProperty(ElasticIndexDefinition.PROP_REQUIRES_PROVISIONING)
+                        .getValue(Type.BOOLEAN));
+    }
+
+    @Test
+    public void deleteDocumentTree_triggersSupplier() throws IOException {
+        AtomicBoolean supplierCalled = new AtomicBoolean(false);
+        NodeBuilder definitionBuilder = EmptyNodeState.EMPTY_NODE.builder();
+        LazyElasticIndexWriter lazyWriter = new LazyElasticIndexWriter(() -> {
+            supplierCalled.set(true);
+            return indexWriter;
+        }, definitionBuilder, elasticConnectionMock, indexDefinitionMock);
+
+        lazyWriter.deleteDocumentTree("/foo");
+
+        assertTrue("Supplier must be called on deleteDocumentTree", supplierCalled.get());
+    }
+
+    @Test
+    public void deleteDocument_triggersSupplier() throws IOException {
+        AtomicBoolean supplierCalled = new AtomicBoolean(false);
+        NodeBuilder definitionBuilder = EmptyNodeState.EMPTY_NODE.builder();
+        LazyElasticIndexWriter lazyWriter = new LazyElasticIndexWriter(() -> {
+            supplierCalled.set(true);
+            return indexWriter;
+        }, definitionBuilder, elasticConnectionMock, indexDefinitionMock);
+
+        lazyWriter.deleteDocument("/foo");
+
+        assertTrue("Supplier must be called on deleteDocument", supplierCalled.get());
+    }
+
+    @Test
+    public void nonEmptyReindex_supplierCalledOnFirstWrite() throws IOException {
+        // GIVEN: a LazyElasticIndexWriter whose supplier records when it is invoked
+        AtomicBoolean supplierCalled = new AtomicBoolean(false);
+        NodeBuilder definitionBuilder = EmptyNodeState.EMPTY_NODE.builder();
+        LazyElasticIndexWriter lazyWriter = new LazyElasticIndexWriter(() -> {
+            supplierCalled.set(true);
+            return indexWriter;
+        }, definitionBuilder, elasticConnectionMock, indexDefinitionMock);
+
+        // Supplier not yet called before any write
+        assertFalse(supplierCalled.get());
+
+        // WHEN: first document written
+        lazyWriter.updateDocument("/foo", new ElasticDocument("/foo"));
+
+        // THEN: supplier was called — ElasticIndexWriter (and its ES index) created on first write
+        assertTrue("Supplier must be called on the first write", supplierCalled.get());
     }
 
 }

--- a/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/LazyProvisioningReindexITTest.java
+++ b/oak-search-elastic/src/test/java/org/apache/jackrabbit/oak/plugins/index/elastic/index/LazyProvisioningReindexITTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.plugins.index.elastic.index;
+
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticAbstractQueryTest;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexDefinition;
+import org.apache.jackrabbit.oak.plugins.index.elastic.ElasticIndexStatistics;
+import org.apache.jackrabbit.oak.plugins.index.elastic.util.ElasticIndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.plugins.index.search.spi.editor.FulltextIndexWriter;
+import org.apache.jackrabbit.oak.plugins.index.search.util.IndexDefinitionBuilder;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+import org.apache.jackrabbit.oak.spi.state.NodeState;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * OAK-12249: a reindex under lazy provisioning that produces zero documents must not leave a
+ * previously-provisioned index's stale alias and backing index behind — otherwise the system
+ * keeps serving pre-reindex content indefinitely, with no signal that anything is wrong.
+ */
+public class LazyProvisioningReindexITTest extends ElasticAbstractQueryTest {
+
+    @Override
+    public void tearDown() throws IOException {
+        ElasticIndexEditorProvider.FT_OAK_12249_ENABLE.set(false);
+        ElasticIndexStatistics.FT_OAK_12248_ENABLE.set(false);
+        super.tearDown();
+    }
+
+    @Test
+    public void reindexToZeroDocuments_onPreviouslyProvisionedIndex_removesStaleAlias() throws Exception {
+        String indexName = "lazyReindexToZero";
+        NodeState root = nodeStore.getRoot();
+        NodeBuilder builder = root.builder();
+        IndexDefinitionBuilder idxBuilder = new ElasticIndexDefinitionBuilder(builder.child("oak:index").child(indexName));
+        idxBuilder.indexRule("nt:base").property("propa").propertyIndex();
+        NodeState defNodeState = idxBuilder.build();
+        ElasticIndexDefinition definition = new ElasticIndexDefinition(root, defNodeState, indexName, esConnection.getIndexPrefix());
+
+        ElasticBulkProcessorHandler bulkProcessorHandler = new ElasticBulkProcessorHandler(esConnection);
+        ElasticIndexWriterFactory factory = new ElasticIndexWriterFactory(esConnection, indexTracker, bulkProcessorHandler);
+
+        // GIVEN: a normal (eager) reindex that provisions the index and writes one document —
+        // simulates an index that has been live and populated for a while.
+        NodeBuilder definitionBuilder = builder.child("oak:index").getChildNode(indexName);
+        FulltextIndexWriter<ElasticDocument> firstWriter = factory.newInstance(definition, definitionBuilder, CommitInfo.EMPTY, true);
+        firstWriter.updateDocument("/content/a", new ElasticDocument("/content/a"));
+        firstWriter.close(System.currentTimeMillis());
+
+        assertTrue("sanity check: alias must exist after the initial provisioning reindex",
+                esConnection.getClient().indices().exists(i -> i.index(definition.getIndexAlias())).value());
+
+        // WHEN: lazy provisioning is turned on, and the index is reindexed again — this time the
+        // index rule (or content) has changed such that the reindex matches zero documents.
+        ElasticIndexStatistics.FT_OAK_12248_ENABLE.set(true);
+        ElasticIndexEditorProvider.FT_OAK_12249_ENABLE.set(true);
+
+        ElasticIndexDefinition definitionAfterFirstReindex =
+                new ElasticIndexDefinition(root, definitionBuilder.getNodeState(), indexName, esConnection.getIndexPrefix());
+        FulltextIndexWriter<ElasticDocument> secondWriter =
+                factory.newInstance(definitionAfterFirstReindex, definitionBuilder, CommitInfo.EMPTY, true);
+        // No updateDocument/deleteDocument calls at all — the reindex traversal found nothing to index.
+        secondWriter.close(System.currentTimeMillis());
+
+        // THEN: the stale, previously-populated backing index must no longer be aliased/queryable —
+        // it must not keep serving pre-reindex content indefinitely.
+        assertFalse("stale backing index from before the empty reindex must be unaliased",
+                esConnection.getClient().indices().exists(i -> i.index(definition.getIndexAlias())).value());
+    }
+}


### PR DESCRIPTION
When FT_OAK-12249 and FT_OAK-12248 are both enabled, ElasticIndexWriter defers provisionIndex() from the constructor to the first updateDocument() or deleteDocuments() call. A reindex that produces zero documents never creates an Elasticsearch index or alias, eliminating the empty-index problem described in OAK-12249.

Deployment order is enforced at runtime: isLazyProvisioningActive() returns true only when both toggles are on. Enabling FT_OAK-12249 alone logs a WARN and falls back to eager provisioning, preventing 404 errors on query paths that lack graceful 404 handling.

ensureProvisioned() handles the incremental-write-after-empty-reindex case: if an alias does not exist when the first document arrives, it creates a new backing index with a fresh seed and points the alias at it.