### PR TITLE
OAK-12396 : fix countDirectChildren depth

### DIFF
--- a/oak-run/src/main/js/oak-mongo.js
+++ b/oak-run/src/main/js/oak-mongo.js
@@ -135,7 +135,7 @@ var oak = (function(global){
      * @memberof oak
      * @method countDirectChildren
      * @param {string} path the path of a node.
-     * @returns {number} the number of children, including all descendant nodes.
+     * @returns {number} the number of direct child nodes.
      */
     api.countDirectChildren = function(path){
         if (path === undefined) {
@@ -145,7 +145,8 @@ var oak = (function(global){
         }
         var depth = pathDepth(path);
         var totalCount = 0;
-        var count = db.nodes.count({_id: pathFilter(depth + 1, path)});
+        var childDepth = path == "/" ? depth + 1 : depth;
+        var count = db.nodes.count({_id: pathFilter(childDepth, path)});
         totalCount += count;
         return totalCount;
     };

--- a/oak-run/src/main/js/oak-mongo.js
+++ b/oak-run/src/main/js/oak-mongo.js
@@ -140,15 +140,10 @@ var oak = (function(global){
     api.countDirectChildren = function(path){
         if (path === undefined) {
             return 0;
-        } else if (path != "/") {
-            path = path + "/";
         }
-        var depth = pathDepth(path);
-        var totalCount = 0;
-        var childDepth = path == "/" ? depth + 1 : depth;
-        var count = db.nodes.count({_id: pathFilter(childDepth, path)});
-        totalCount += count;
-        return totalCount;
+        var childDepth = pathDepth(path) + 1;
+        var prefix = path == "/" ? path : path + "/";
+        return db.nodes.count({_id: pathFilter(childDepth, prefix)});
     };
 
     /**


### PR DESCRIPTION
## Summary

Fix `oak.countDirectChildren` so non-root paths count direct child documents instead of the next depth level.

## Changes

- Correct depth selection in `oak-run/src/main/js/oak-mongo.js`.
- Preserve root-path behavior.
- Correct the method return documentation.

## Test Plan

- Verified against local MongoDB database `cm-p55811-e576007-database`.
- Verified root and non-root counts match equivalent raw MongoDB queries.
- Passed `node --check oak-run/src/main/js/oak-mongo.js`.

## Links

- Jira: https://issues.apache.org/jira/browse/OAK-12396

Co-Authored-By: OpenAI Codex <noreply@openai.com>