### PR TITLE
OAK-12394: Async indexing LAST_INDEXED_TIME metric should reflect durable repo property (#3112)

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java
@@ -1371,6 +1371,13 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
             private final MeterStats indexedNodeCountMeter;
             private final TimerStats indexerTimer;
             private final HistogramStats indexedNodePerCycleHisto;
+            /**
+             * Counter storing the last-indexed time as epoch millis. Initialised at
+             * construction from the durable ":async/&lt;lane&gt;-LastIndexedTo" repository
+             * property so that a correct non-zero value is visible immediately after a
+             * restart, even if the lane has not yet completed a successful cycle.
+             * Updated on every successful cycle via {@link #doneOneCycle}. See OAK-12394.
+             */
             private final CounterStats lastIndexedTime;
             private StatisticsProvider statisticsProvider;
 
@@ -1387,6 +1394,10 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
                 indexedNodePerCycleHisto = statsProvider.getHistogram(stats("INDEXER_NODE_COUNT_HISTO"), StatsOptions
                         .METRICS_ONLY);
                 lastIndexedTime = statsProvider.getCounterStats(stats("LAST_INDEXED_TIME"), StatsOptions.DEFAULT);
+                long initialMillis = readLastIndexedToMillis();
+                if (initialMillis > 0) {
+                    lastIndexedTime.inc(initialMillis);
+                }
                 try {
                     consolidatedType = new CompositeType("ConsolidatedStats",
                             "Consolidated stats", names,
@@ -1404,6 +1415,25 @@ public class AsyncIndexUpdate implements Runnable, Closeable {
                 indexedNodePerCycleHisto.update(updates);
                 long previousLastIndexedTime = lastIndexedTime.getCount();
                 lastIndexedTime.inc(System.currentTimeMillis() - previousLastIndexedTime);
+            }
+
+            /**
+             * Reads the persisted ":async/&lt;lane&gt;-LastIndexedTo" property as epoch millis,
+             * or 0 when it is absent or cannot be parsed (e.g. before the initial index).
+             * Used to initialise the {@code lastIndexedTime} counter at construction.
+             */
+            private long readLastIndexedToMillis() {
+                try {
+                    PropertyState ps = store.getRoot().getChildNode(ASYNC).getProperty(lastIndexedTo);
+                    if (ps == null) {
+                        return 0;
+                    }
+                    Calendar cal = ISO8601.parse(ps.getValue(Type.STRING));
+                    return cal != null ? cal.getTimeInMillis() : 0;
+                } catch (Exception e) {
+                    log.warn("[{}] Unable to read {} for LAST_INDEXED_TIME metric", name, lastIndexedTo, e);
+                    return 0;
+                }
             }
 
             public Counting getExecutionCounter() {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdateTest.java
@@ -1379,6 +1379,47 @@ public class AsyncIndexUpdateTest {
         assertEquals(0, lastExecutionStats(async.getIndexStats().getExecutionCount()));
     }
 
+    /**
+     * The LAST_INDEXED_TIME counter must be initialised from the durable
+     * {@code :async/<lane>-LastIndexedTo} repository property at construction time (OAK-12394).
+     * A fresh indexer instance simulating a process restart must report the persisted timestamp
+     * immediately, without needing to complete a successful cycle first.
+     */
+    @Test
+    public void lastIndexedTimeCounterInitialisedFromDurableProperty() throws Exception {
+        MemoryNodeStore store = new MemoryNodeStore();
+        IndexEditorProvider provider = new PropertyIndexEditorProvider();
+
+        NodeBuilder builder = store.getRoot().builder();
+        createIndexDefinition(builder.child(INDEX_DEFINITIONS_NAME),
+                "rootIndex", true, false, Set.of("foo"), null)
+                .setProperty(ASYNC_PROPERTY_NAME, "async");
+        builder.child("testRoot").setProperty("foo", "abc");
+        store.merge(builder, EmptyHook.INSTANCE, CommitInfo.EMPTY);
+
+        // Run one cycle to write the durable :async/async-LastIndexedTo property.
+        AsyncIndexUpdate async = new AsyncIndexUpdate("async", store, provider, statsProvider, false);
+        runOneCycle(async);
+
+        String persisted = async.getIndexStats().getLastIndexedTime();
+        assertNotNull("last indexed time property should be set after a cycle", persisted);
+        long expectedMillis = ISO8601.parse(persisted).getTimeInMillis();
+
+        // Fresh instance simulates a restart: constructs with a clean in-memory state.
+        // Counter must be initialised from the NodeStore, not start at 0.
+        MetricStatisticsProvider freshProvider = new MetricStatisticsProvider(
+                ManagementFactory.getPlatformMBeanServer(), executor);
+        try {
+            new AsyncIndexUpdate("async", store, provider, freshProvider, false);
+            long counterValue = freshProvider.getRegistry().getCounters()
+                    .get("async.LAST_INDEXED_TIME").getCount();
+            assertEquals("counter must reflect the durable property without running a cycle",
+                    expectedMillis, counterValue);
+        } finally {
+            freshProvider.close();
+        }
+    }
+
     @Test
     public void executionCountUpdatesOnRunWithoutAnyChangeInRepo() throws Exception {
         AsyncIndexUpdate async = new AsyncIndexUpdate("async",


### PR DESCRIPTION

* OAK-12394: Initialise LAST_INDEXED_TIME counter from durable repo property on startup

The LAST_INDEXED_TIME counter starts at 0 on every restart, so a lane that fails immediately after restart is invisible to monitoring — the counter never advances past 0 and the > 0 guard in alert queries silently drops it.

Initialise the counter at construction from the durable :async/<lane>-LastIndexedTo repository property. A correct non-zero value is then visible from the first scrape after startup, even if the lane has not yet completed a successful cycle.

* Update oak-core/src/main/java/org/apache/jackrabbit/oak/plugins/index/AsyncIndexUpdate.java



---------