### PR TITLE
OAK-11628: Make WARN/ENABLE path restriction lenient and add feature toggle to warn by default

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -589,6 +589,10 @@ public class Oak {
             LOG.info("Registered ignore limit in index selection feature: " + QueryEngineSettings.FT_IGNORE_LIMIT_IN_INDEX_SELECTION);
             closer.register(ignoreLimitInIndexSelection);
             queryEngineSettings.setIgnoreLimitInIndexSelectionFeature(ignoreLimitInIndexSelection);
+            Feature pathRestrictionWarnByDefault = newFeature(QueryEngineSettings.FT_PATH_RESTRICTION_WARN_BY_DEFAULT, whiteboard);
+            LOG.info("Registered path restriction warn by default feature: " + QueryEngineSettings.FT_PATH_RESTRICTION_WARN_BY_DEFAULT);
+            closer.register(pathRestrictionWarnByDefault);
+            queryEngineSettings.setPathRestrictionWarnByDefaultFeature(pathRestrictionWarnByDefault);
         }
 
         return this;
@@ -1007,6 +1011,10 @@ public class Oak {
 
         public void setIgnoreLimitInIndexSelectionFeature(@Nullable Feature feature) {
             settings.setIgnoreLimitInIndexSelectionFeature(feature);
+        }
+
+        public void setPathRestrictionWarnByDefaultFeature(@Nullable Feature feature) {
+            settings.setPathRestrictionWarnByDefaultFeature(feature);
         }
 
         @Override

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -67,6 +67,8 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String FT_IGNORE_LIMIT_IN_INDEX_SELECTION = "FT_OAK-12057";
 
+    public static final String FT_PATH_RESTRICTION_WARN_BY_DEFAULT = "FT_OAK-11628";
+
     public static final int DEFAULT_PREFETCH_COUNT = Integer.getInteger(OAK_QUERY_PREFETCH_COUNT, -1);
 
     public static final String OAK_QUERY_FAIL_TRAVERSAL = "oak.queryFailTraversal";
@@ -125,6 +127,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private Feature sortUnionQueryLegacyModeFeature;
     private Feature optimizeXPathUnion;
     private Feature ignoreLimitInIndexSelectionFeature;
+    private Feature pathRestrictionWarnByDefaultFeature;
 
     private String autoOptionsMappingJson = "{}";
     private QueryOptions.AutomaticQueryOptionsMapping autoOptionsMapping = new QueryOptions.AutomaticQueryOptionsMapping(autoOptionsMappingJson);
@@ -257,7 +260,18 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
         return ignoreLimitInIndexSelectionFeature == null || ignoreLimitInIndexSelectionFeature.isEnabled();
     }
 
+    public void setPathRestrictionWarnByDefaultFeature(@Nullable Feature feature) {
+        this.pathRestrictionWarnByDefaultFeature = feature;
+    }
+
     public String getStrictPathRestriction() {
+        // OAK-11628: when the toggle is enabled, the default (DISABLE) is raised to WARN so that
+        // path filter mismatches are logged.
+        if (strictPathRestriction == StrictPathRestriction.DISABLE
+                && pathRestrictionWarnByDefaultFeature != null
+                && pathRestrictionWarnByDefaultFeature.isEnabled()) {
+            return StrictPathRestriction.WARN.name();
+        }
         return strictPathRestriction.name();
     }
 

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/QueryEngineSettingsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.oak.query;
+
+import org.apache.jackrabbit.oak.api.StrictPathRestriction;
+import org.apache.jackrabbit.oak.spi.toggle.Feature;
+import org.apache.jackrabbit.oak.spi.toggle.FeatureToggle;
+import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
+import org.apache.jackrabbit.oak.spi.whiteboard.WhiteboardUtils;
+import org.junit.Test;
+
+import static org.apache.jackrabbit.oak.spi.toggle.Feature.newFeature;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class QueryEngineSettingsTest {
+
+    @Test
+    public void strictPathRestrictionDefaultsToDisable() {
+        QueryEngineSettings settings = new QueryEngineSettings();
+        assertEquals(StrictPathRestriction.DISABLE.name(), settings.getStrictPathRestriction());
+    }
+
+    @Test
+    public void toggleRaisesDefaultFromDisableToWarn() {
+        QueryEngineSettings settings = new QueryEngineSettings();
+        Whiteboard whiteboard = new DefaultWhiteboard();
+        Feature feature = newFeature(QueryEngineSettings.FT_PATH_RESTRICTION_WARN_BY_DEFAULT, whiteboard);
+        try {
+            settings.setPathRestrictionWarnByDefaultFeature(feature);
+            // registered but not yet enabled -> still the DISABLE default
+            assertEquals(StrictPathRestriction.DISABLE.name(), settings.getStrictPathRestriction());
+
+            FeatureToggle toggle = WhiteboardUtils.getService(whiteboard, FeatureToggle.class);
+            assertNotNull(toggle);
+
+            toggle.setEnabled(true);
+            assertEquals(StrictPathRestriction.WARN.name(), settings.getStrictPathRestriction());
+
+            toggle.setEnabled(false);
+            assertEquals(StrictPathRestriction.DISABLE.name(), settings.getStrictPathRestriction());
+        } finally {
+            feature.close();
+        }
+    }
+
+    @Test
+    public void toggleDoesNotOverrideExplicitSetting() {
+        QueryEngineSettings settings = new QueryEngineSettings();
+        Whiteboard whiteboard = new DefaultWhiteboard();
+        Feature feature = newFeature(QueryEngineSettings.FT_PATH_RESTRICTION_WARN_BY_DEFAULT, whiteboard);
+        try {
+            settings.setPathRestrictionWarnByDefaultFeature(feature);
+            settings.setStrictPathRestriction(StrictPathRestriction.ENABLE.name());
+
+            FeatureToggle toggle = WhiteboardUtils.getService(whiteboard, FeatureToggle.class);
+            assertNotNull(toggle);
+            toggle.setEnabled(true);
+
+            // an explicitly configured value is not raised to WARN by the toggle
+            assertEquals(StrictPathRestriction.ENABLE.name(), settings.getStrictPathRestriction());
+        } finally {
+            feature.close();
+        }
+    }
+}

--- a/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndexPlanner.java
+++ b/oak-search/src/main/java/org/apache/jackrabbit/oak/plugins/index/search/spi/query/FulltextIndexPlanner.java
@@ -396,9 +396,10 @@ public class FulltextIndexPlanner {
     }
 
     private boolean isPlanWithValidPathFilter() {
+        // OAK-11628: the check is lenient, i.e. excludedPaths are ignored.
         String pathFilter = filter.getPath();
         PathFilter definitionPathFilter = definition.getPathFilter();
-        return definitionPathFilter.areAllDescendantsIncluded(pathFilter);
+        return definitionPathFilter.areAllDescendantsIncluded(pathFilter, true);
     }
 
     private boolean matchesValuePattern(PropertyRestriction pr, PropertyDefinition pd) {

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexImproperUsageCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/IndexImproperUsageCommonTest.java
@@ -127,8 +127,9 @@ public abstract class IndexImproperUsageCommonTest extends AbstractQueryTest {
             // List appender should not have any warn logs as we are searching under right descendant as per path restrictions
             assertFalse(isWarnMessagePresent(listAppender, PATH_RESTRICTION_WARN_MESSAGE));
             assertTrue(explain("select [jcr:path] from [nt:base] where [propa] = 10").contains(indexOptions.getIndexType() + ":test1"));
-            // List appender now will have warn log as we are searching under root(/) but index definition have exclude path restriction.
-            assertTrue(isWarnMessagePresent(listAppender, PATH_RESTRICTION_WARN_MESSAGE));
+            // OAK-11628: excludedPaths are ignored by the (lenient) path filter check, so a query at
+            // the root no longer produces a path restriction warning for an exclude-only definition.
+            assertFalse(isWarnMessagePresent(listAppender, PATH_RESTRICTION_WARN_MESSAGE));
         });
     }
 

--- a/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/StrictPathRestrictionEnableCommonTest.java
+++ b/oak-search/src/test/java/org/apache/jackrabbit/oak/plugins/index/StrictPathRestrictionEnableCommonTest.java
@@ -43,6 +43,7 @@ import static org.apache.jackrabbit.oak.spi.filter.PathFilter.PROP_INCLUDED_PATH
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public abstract class StrictPathRestrictionEnableCommonTest extends AbstractQueryTest {
 
@@ -90,7 +91,9 @@ public abstract class StrictPathRestrictionEnableCommonTest extends AbstractQuer
         root.commit();
 
         assertEventually(() -> {
-            assertFalse(explain("select [jcr:path] from [nt:base] where [propa] = 10").contains(indexOptions.getIndexType() + ":test1"));
+            // OAK-11628: excludedPaths are ignored by the (lenient) path filter check, so the index
+            // is selected even for a query at the root despite the excluded subtree.
+            assertTrue(explain("select [jcr:path] from [nt:base] where [propa] = 10").contains(indexOptions.getIndexType() + ":test1"));
             assertThat(explain("select [jcr:path] from [nt:base] where [propa] = 10 and isDescendantNode('/test/c')"), containsString(indexOptions.getIndexType() + ":test1"));
 
             assertQuery("select [jcr:path] from [nt:base] where [propa] = 10 and isDescendantNode('/test/c')", singletonList("/test/c/d"));

--- a/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
+++ b/oak-store-spi/src/main/java/org/apache/jackrabbit/oak/spi/filter/PathFilter.java
@@ -180,14 +180,34 @@ public class PathFilter {
 
     /**
      * Check whether this node and all descendants are included in this filter.
+     * <p>
+     * Convenience for {@link #areAllDescendantsIncluded(String, boolean)} in strict mode.
      *
      * @param path the path
      * @return true if this and all descendants of this path are included in the filter
      */
     public boolean areAllDescendantsIncluded(String path) {
-        for (String excludedPath : excludedPaths) {
-            if (excludedPath.equals(path) || isAncestor(excludedPath, path) || isAncestor(path, excludedPath)) {
-                return false;
+        return areAllDescendantsIncluded(path, false);
+    }
+
+    /**
+     * Check whether this node and all descendants are included in this filter.
+     * <p>
+     * When {@code isLenient} is {@code false} (strict) the path is not included if it equals an
+     * excluded path, lies within an excluded subtree, or is an ancestor of an excluded path (so
+     * that some descendants are excluded). When {@code isLenient} is {@code true} excluded paths
+     * are ignored altogether and only the included paths are checked.
+     *
+     * @param path      the path
+     * @param isLenient if true, excluded paths are ignored and only inclusion is checked
+     * @return true if this and all descendants of this path are included in the filter
+     */
+    public boolean areAllDescendantsIncluded(String path, boolean isLenient) {
+        if (!isLenient) {
+            for (String excludedPath : excludedPaths) {
+                if (excludedPath.equals(path) || isAncestor(excludedPath, path) || isAncestor(path, excludedPath)) {
+                    return false;
+                }
             }
         }
         for (String includedPath : includedPaths) {

--- a/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
+++ b/oak-store-spi/src/test/java/org/apache/jackrabbit/oak/spi/filter/PathFilterTest.java
@@ -33,6 +33,8 @@ import static org.apache.jackrabbit.oak.plugins.memory.PropertyStates.createProp
 import static org.apache.jackrabbit.oak.spi.filter.PathFilter.PROP_EXCLUDED_PATHS;
 import static org.apache.jackrabbit.oak.spi.filter.PathFilter.PROP_INCLUDED_PATHS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class PathFilterTest {
@@ -189,6 +191,34 @@ public class PathFilterTest {
         NodeBuilder root = EMPTY_NODE.builder();
         @NotNull NodeBuilder b1 = root.setProperty(createProperty("propMultiple", 1L, Type.LONG));
         assertEquals(Set.of("default"), toSet(PathFilter.getStrings(root.getProperty("propMultiple"), Set.of("default"))));
+    }
+
+    @Test
+    public void areAllDescendantsIncludedStrict() {
+        PathFilter p = new PathFilter(Set.of("/content"), Set.of("/content/a/excluded"));
+        // fully inside an included subtree with no excluded descendants
+        assertTrue(p.areAllDescendantsIncluded("/content/b", false));
+        // the no-arg convenience overload is strict
+        assertTrue(p.areAllDescendantsIncluded("/content/b"));
+        // path outside any included subtree
+        assertFalse(p.areAllDescendantsIncluded("/var", false));
+        // path equal to / within an excluded subtree
+        assertFalse(p.areAllDescendantsIncluded("/content/a/excluded", false));
+        assertFalse(p.areAllDescendantsIncluded("/content/a/excluded/x", false));
+        // path is an ancestor of an excluded path: only partially included -> strict fails
+        assertFalse(p.areAllDescendantsIncluded("/content/a", false));
+        assertFalse(p.areAllDescendantsIncluded("/content/a"));
+    }
+
+    @Test
+    public void areAllDescendantsIncludedLenient() {
+        PathFilter p = new PathFilter(Set.of("/content"), Set.of("/content/a/excluded"));
+        // excluded paths are ignored entirely in lenient mode; only inclusion matters
+        assertTrue(p.areAllDescendantsIncluded("/content/a", true));
+        assertTrue(p.areAllDescendantsIncluded("/content/a/excluded", true));
+        assertTrue(p.areAllDescendantsIncluded("/content/a/excluded/x", true));
+        // a path outside the included subtree is still not included in lenient mode
+        assertFalse(p.areAllDescendantsIncluded("/var", true));
     }
 
     static private <T> Set<T> toSet(Iterable<T> iterable) {


### PR DESCRIPTION
## Feature toggle to warn by default
Adds FT_OAK-11628 (pathRestrictionWarnByDefault), off by default, which raises the default StrictPathRestriction from DISABLE to WARN at runtime — so path-filter mismatch warnings can be switched on/off without a redeploy. No behavior change when off.

## Lenient path filter check for WARN/ENABLE
WARN and ENABLE now use the same lenient check, ignoring excludedPaths, so they differ only in reaction (log vs. skip index). ⚠️ Intentional behavior change: under ENABLE, a query spanning an excluded subtree now uses the index instead of being rejected.

No SPI/API change, no OSGi version bump.

See [OAK-11628](https://issues.apache.org/jira/browse/OAK-11628).