### PR TITLE
OAK-12364: XPath queries fail to parse if they contain invalid XML characters

### DIFF
--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java
@@ -589,6 +589,10 @@ public class Oak {
             LOG.info("Registered ignore limit in index selection feature: " + QueryEngineSettings.FT_IGNORE_LIMIT_IN_INDEX_SELECTION);
             closer.register(ignoreLimitInIndexSelection);
             queryEngineSettings.setIgnoreLimitInIndexSelectionFeature(ignoreLimitInIndexSelection);
+            Feature xmlNameCharsInPath = newFeature(QueryEngineSettings.FT_XML_NAME_CHARS_IN_PATH, whiteboard);
+            LOG.info("Registered XML name characters in path feature: " + QueryEngineSettings.FT_XML_NAME_CHARS_IN_PATH);
+            closer.register(xmlNameCharsInPath);
+            queryEngineSettings.setXmlNameCharsInPathFeature(xmlNameCharsInPath);
         }
 
         return this;
@@ -1007,6 +1011,10 @@ public class Oak {
 
         public void setIgnoreLimitInIndexSelectionFeature(@Nullable Feature feature) {
             settings.setIgnoreLimitInIndexSelectionFeature(feature);
+        }
+
+        public void setXmlNameCharsInPathFeature(@Nullable Feature feature) {
+            settings.setXmlNameCharsInPathFeature(feature);
         }
 
         @Override

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/QueryEngineSettings.java
@@ -67,6 +67,8 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
 
     public static final String FT_IGNORE_LIMIT_IN_INDEX_SELECTION = "FT_OAK-12057";
 
+    public static final String FT_XML_NAME_CHARS_IN_PATH = "FT_OAK-12364";
+
     public static final int DEFAULT_PREFETCH_COUNT = Integer.getInteger(OAK_QUERY_PREFETCH_COUNT, -1);
 
     public static final String OAK_QUERY_FAIL_TRAVERSAL = "oak.queryFailTraversal";
@@ -125,6 +127,7 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     private Feature sortUnionQueryLegacyModeFeature;
     private Feature optimizeXPathUnion;
     private Feature ignoreLimitInIndexSelectionFeature;
+    private Feature xmlNameCharsInPathFeature;
 
     private String autoOptionsMappingJson = "{}";
     private QueryOptions.AutomaticQueryOptionsMapping autoOptionsMapping = new QueryOptions.AutomaticQueryOptionsMapping(autoOptionsMappingJson);
@@ -255,6 +258,15 @@ public class QueryEngineSettings implements QueryEngineSettingsMBean, QueryLimit
     public boolean isIgnoreLimitInIndexSelection() {
         // enabled if the feature toggle is not used
         return ignoreLimitInIndexSelectionFeature == null || ignoreLimitInIndexSelectionFeature.isEnabled();
+    }
+
+    public void setXmlNameCharsInPathFeature(@Nullable Feature feature) {
+        this.xmlNameCharsInPathFeature = feature;
+    }
+
+    public boolean isXmlNameCharsInPathEnabled() {
+        // enabled if the feature toggle is not used
+        return xmlNameCharsInPathFeature == null || xmlNameCharsInPathFeature.isEnabled();
     }
 
     public String getStrictPathRestriction() {

--- a/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
+++ b/oak-core/src/main/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Converter.java
@@ -28,11 +28,12 @@ import org.apache.jackrabbit.oak.query.QueryOptions;
 import org.apache.jackrabbit.oak.query.QueryOptions.Traversal;
 import org.apache.jackrabbit.oak.query.xpath.Statement.UnionStatement;
 import org.apache.jackrabbit.util.ISO9075;
+import org.apache.jackrabbit.util.XMLChar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class can can convert a XPATH query to a SQL2 query.
+ * This class can convert a XPATH query to a SQL2 query.
  */
 public class XPathToSQL2Converter {
 
@@ -1005,6 +1006,9 @@ public class XPathToSQL2Converter {
                     type = CHAR_VALUE;
                 } else {
                     if (Character.isJavaIdentifierPart(c)) {
+                        type = CHAR_NAME;
+                    } else if ((settings == null || settings.isXmlNameCharsInPathEnabled()) && XMLChar.isName(c)) {
+                        // accept XML name characters that ISO9075 leaves unencoded, so they are not split off the name
                         type = CHAR_NAME;
                     }
                 }

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/XPathTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/XPathTest.java
@@ -325,6 +325,20 @@ public class XPathTest {
                 "/* xpath: /jcr:root/content// element(*, nt:folder) order by @jcr:score descending */");
     }
 
+    @Test
+    public void xmlNameCharsInPathAreConverted() throws ParseException {
+        verify("/jcr:root/content/m·d/element(*, nt:base)",
+                "select [jcr:path], [jcr:score], * " +
+                "from [nt:base] as a " +
+                "where ischildnode(a, '/content/m·d') " +
+                "/* xpath: /jcr:root/content/m·d/element(*, nt:base) */");
+        verify("/jcr:root/content/m·d",
+                "select [jcr:path], [jcr:score], * " +
+                "from [nt:base] as a " +
+                "where issamenode(a, '/content/m·d') " +
+                "/* xpath: /jcr:root/content/m·d */");
+    }
+
     private void verify(String xpath, String expectedSql2) throws ParseException {
         String sql2 = new XPathToSQL2Converter().convert(xpath);
         sql2 = formatSQL(sql2);

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/XPathTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/XPathTest.java
@@ -327,16 +327,16 @@ public class XPathTest {
 
     @Test
     public void xmlNameCharsInPathAreConverted() throws ParseException {
-        verify("/jcr:root/content/m·d/element(*, nt:base)",
+        verify("/jcr:root/content/m\u00b7d/element(*, nt:base)",
                 "select [jcr:path], [jcr:score], * " +
                 "from [nt:base] as a " +
-                "where ischildnode(a, '/content/m·d') " +
-                "/* xpath: /jcr:root/content/m·d/element(*, nt:base) */");
-        verify("/jcr:root/content/m·d",
+                "where ischildnode(a, '/content/m\u00b7d') " +
+                "/* xpath: /jcr:root/content/m\u00b7d/element(*, nt:base) */");
+        verify("/jcr:root/content/m\u00b7d",
                 "select [jcr:path], [jcr:score], * " +
                 "from [nt:base] as a " +
-                "where issamenode(a, '/content/m·d') " +
-                "/* xpath: /jcr:root/content/m·d */");
+                "where issamenode(a, '/content/m\u00b7d') " +
+                "/* xpath: /jcr:root/content/m\u00b7d */");
     }
 
     private void verify(String xpath, String expectedSql2) throws ParseException {

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/index/TraversingIndexQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/index/TraversingIndexQueryTest.java
@@ -502,11 +502,11 @@ public class TraversingIndexQueryTest extends AbstractQueryTest {
 
     @Test
     public void testXmlNameCharsInPathAreQueryable() throws Exception {
-        root.getTree("/").addChild("content").addChild("m·d").addChild("child");
+        root.getTree("/").addChild("content").addChild("m\u00b7d").addChild("child");
         root.commit();
 
-        assertQuery("/jcr:root/content/m·d/element(*, nt:base)", "xpath",
-                List.of("/content/m·d/child"));
+        assertQuery("/jcr:root/content/m\u00b7d/element(*, nt:base)", "xpath",
+                List.of("/content/m\u00b7d/child"));
     }
 
     @Test

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/index/TraversingIndexQueryTest.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/index/TraversingIndexQueryTest.java
@@ -501,6 +501,15 @@ public class TraversingIndexQueryTest extends AbstractQueryTest {
     }
 
     @Test
+    public void testXmlNameCharsInPathAreQueryable() throws Exception {
+        root.getTree("/").addChild("content").addChild("m·d").addChild("child");
+        root.commit();
+
+        assertQuery("/jcr:root/content/m·d/element(*, nt:base)", "xpath",
+                List.of("/content/m·d/child"));
+    }
+
+    @Test
     public void testLowercaseOnArrays() throws Exception {
         // OAK-1829
         Tree content = root.getTree("/").addChild("content");

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Test.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Test.java
@@ -17,6 +17,8 @@
 package org.apache.jackrabbit.oak.query.xpath;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 
@@ -142,6 +144,46 @@ public class XPathToSQL2Test {
                 "select ... where contains(*, 'test') or [type] = 'page' ");
     }
  
+    @Test
+    public void testXmlNameCharsInPathFeatureNotSet() throws ParseException {
+        String sql2 = new XPathToSQL2Converter(new QueryEngineSettings())
+                .convert("/jcr:root/a/m·d/element(*, nt:base)");
+        assertTrue(sql2.contains("'/a/m·d'"));
+    }
+
+    @Test
+    public void testXmlNameCharsInPathFeatureEnabled() throws ParseException {
+        QueryEngineSettings settings = new QueryEngineSettings();
+        settings.setXmlNameCharsInPathFeature(createFeature(true));
+        String sql2 = new XPathToSQL2Converter(settings)
+                .convert("/jcr:root/a/m·d/element(*, nt:base)");
+        assertTrue(sql2.contains("'/a/m·d'"));
+    }
+
+    @Test
+    public void testXmlNameCharsInPathFeatureDisabled() {
+        QueryEngineSettings settings = new QueryEngineSettings();
+        settings.setXmlNameCharsInPathFeature(createFeature(false));
+        try {
+            new XPathToSQL2Converter(settings)
+                    .convert("/jcr:root/a/m·d/element(*, nt:base)");
+            fail("expected ParseException");
+        } catch (ParseException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGenuineSpaceInPathStillFails() {
+        try {
+            new XPathToSQL2Converter(new QueryEngineSettings())
+                    .convert("/jcr:root/a/m d/element(*, nt:base)");
+            fail("expected ParseException");
+        } catch (ParseException expected) {
+            // expected
+        }
+    }
+
     /**
      * Helper method to create a Feature mock with the specified enabled state.
      */

--- a/oak-core/src/test/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Test.java
+++ b/oak-core/src/test/java/org/apache/jackrabbit/oak/query/xpath/XPathToSQL2Test.java
@@ -147,8 +147,8 @@ public class XPathToSQL2Test {
     @Test
     public void testXmlNameCharsInPathFeatureNotSet() throws ParseException {
         String sql2 = new XPathToSQL2Converter(new QueryEngineSettings())
-                .convert("/jcr:root/a/m·d/element(*, nt:base)");
-        assertTrue(sql2.contains("'/a/m·d'"));
+                .convert("/jcr:root/a/m\u00b7d/element(*, nt:base)");
+        assertTrue(sql2.contains("'/a/m\u00b7d'"));
     }
 
     @Test
@@ -156,8 +156,8 @@ public class XPathToSQL2Test {
         QueryEngineSettings settings = new QueryEngineSettings();
         settings.setXmlNameCharsInPathFeature(createFeature(true));
         String sql2 = new XPathToSQL2Converter(settings)
-                .convert("/jcr:root/a/m·d/element(*, nt:base)");
-        assertTrue(sql2.contains("'/a/m·d'"));
+                .convert("/jcr:root/a/m\u00b7d/element(*, nt:base)");
+        assertTrue(sql2.contains("'/a/m\u00b7d'"));
     }
 
     @Test
@@ -166,7 +166,7 @@ public class XPathToSQL2Test {
         settings.setXmlNameCharsInPathFeature(createFeature(false));
         try {
             new XPathToSQL2Converter(settings)
-                    .convert("/jcr:root/a/m·d/element(*, nt:base)");
+                    .convert("/jcr:root/a/m\u00b7d/element(*, nt:base)");
             fail("expected ParseException");
         } catch (ParseException expected) {
             // expected


### PR DESCRIPTION
XPath queries failed to parse when a path contained certain valid characters that XML allows in names but Java does not (such as the middle dot ·), because the parser treated them as spaces and split the path into two pieces, leaving a leftover token it couldn't make sense of. This fix changes the parser to accept those XML name characters, such that those paths can be queried.

The bug fix is very simple, but in a critical path of the code (XPath to SQL converter). Therefore, I decided to put the fix behind a feature toggle (but since it's a bug fix I have it on by default, as documented in Agents.md).

Issue: https://issues.apache.org/jira/browse/OAK-12364

Re-opens existing PR against a feature branch: https://github.com/apache/jackrabbit-oak/pull/3084
